### PR TITLE
ci: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          release-type: node


### PR DESCRIPTION
## Summary

- Adds Release Please GitHub Action for automated versioning and changelog generation
- Uses conventional commits to determine version bumps (fix → patch, feat → minor, breaking → major)
- Will update `package.json` version and generate `CHANGELOG.md` on release

## Post-merge setup required

Enable workflow permissions in repo settings:
**Settings → Actions → General → Workflow permissions**
Check: "Allow GitHub Actions to create and approve pull requests"

## Test plan

- [ ] Verify workflow file syntax is valid
- [ ] After merge, confirm Release Please action runs on next push to main
- [ ] Verify Release PR is created after a conventional commit is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)