### PR TITLE
fix(ui): improve hero and how-it-works mobile spacing

### DIFF
--- a/app/guide/claude/page.tsx
+++ b/app/guide/claude/page.tsx
@@ -168,14 +168,14 @@ export default function ClaudeGuide() {
       <main className="relative min-h-screen px-12 pb-24 pt-32 max-lg:px-8 max-md:px-6 max-md:pt-28">
         <div className="mx-auto max-w-[900px]">
           {/* Page Header */}
-          <div className="mb-12 text-center">
+          <div className="mb-12">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#F7931A]/30 bg-[#F7931A]/10 px-4 py-1.5">
               <span className="text-[13px] font-medium text-[#F7931A]">Claude Code Integration</span>
             </div>
             <h1 className="mb-4 text-[clamp(36px,4.5vw,56px)] font-medium leading-[1.1] text-white">
               Claude from Zero to Agent
             </h1>
-            <p className="mx-auto max-w-[600px] text-[18px] leading-[1.6] text-white/70">
+            <p className="max-w-[600px] text-[18px] leading-[1.6] text-white/70">
               Give Claude a Bitcoin wallet and earning power. Install the AIBTC MCP server to unlock native Bitcoin capabilities and x402 payment APIs.
             </p>
           </div>
@@ -353,12 +353,12 @@ export default function ClaudeGuide() {
                 <p>POST your signatures to <code className="rounded bg-white/10 px-1.5 py-0.5 text-[13px] text-[#F7931A]">/api/register</code> to claim your Genesis spot and earn up to 10k sats in viral rewards.</p>
               </div>
 
-              <div className="mt-4 flex items-center gap-2 rounded-lg border border-[#7DA2FF]/30 bg-[#7DA2FF]/5 px-4 py-3">
-                <svg className="size-5 shrink-0 text-[#7DA2FF]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+              <div className="mt-4 flex items-center gap-2 rounded-lg border border-[#F7931A]/30 bg-[#F7931A]/5 px-4 py-3">
+                <svg className="size-5 shrink-0 text-[#F7931A]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <p className="text-white/80">
-                  <strong className="text-white">Stuck?</strong> Join us on <a href="https://discord.gg/fyrsX3mtTk" target="_blank" rel="noopener noreferrer" className="text-[#7DA2FF] hover:underline">Discord</a> — the community is here to help
+                  <strong className="text-white">Stuck?</strong> Join us on <a href="https://discord.gg/fyrsX3mtTk" target="_blank" rel="noopener noreferrer" className="text-[#F7931A] hover:underline">Discord</a> — the community is here to help
                 </p>
               </div>
             </div>

--- a/app/guide/mcp/page.tsx
+++ b/app/guide/mcp/page.tsx
@@ -148,14 +148,14 @@ export default function McpGuide() {
       <main className="relative min-h-screen px-12 pb-24 pt-32 max-lg:px-8 max-md:px-6 max-md:pt-28">
         <div className="mx-auto max-w-[900px]">
           {/* Page Header */}
-          <div className="mb-12 text-center">
+          <div className="mb-12">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#F7931A]/30 bg-[#F7931A]/10 px-4 py-1.5">
               <span className="text-[13px] font-medium text-[#F7931A]">MCP Integration</span>
             </div>
             <h1 className="mb-4 text-[clamp(36px,4.5vw,56px)] font-medium leading-[1.1] text-white">
               Connect Anywhere
             </h1>
-            <p className="mx-auto max-w-[600px] text-[18px] leading-[1.6] text-white/70">
+            <p className="max-w-[600px] text-[18px] leading-[1.6] text-white/70">
               The AIBTC MCP server gives any compatible client native Bitcoin and Stacks capabilities. Same tools, same wallet, any client.
             </p>
           </div>

--- a/app/guide/openclaw/page.tsx
+++ b/app/guide/openclaw/page.tsx
@@ -168,14 +168,14 @@ export default function OpenClawGuide() {
       <main className="relative min-h-screen px-12 pb-24 pt-32 max-lg:px-8 max-md:px-6 max-md:pt-28">
         <div className="mx-auto max-w-[900px]">
           {/* Page Header */}
-          <div className="mb-12 text-center">
+          <div className="mb-12">
             <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-[#F7931A]/30 bg-[#F7931A]/10 px-4 py-1.5">
               <span className="text-[13px] font-medium text-[#F7931A]">OpenClaw Agent Framework</span>
             </div>
             <h1 className="mb-4 text-[clamp(36px,4.5vw,56px)] font-medium leading-[1.1] text-white">
               OpenClaw in One Command
             </h1>
-            <p className="mx-auto max-w-[600px] text-[18px] leading-[1.6] text-white/70">
+            <p className="max-w-[600px] text-[18px] leading-[1.6] text-white/70">
               Deploy your own Bitcoin-native AI agent with OpenClaw. Choose local development or production VPS deployment.
             </p>
           </div>
@@ -194,9 +194,9 @@ export default function OpenClawGuide() {
                 </ul>
               </div>
               <div>
-                <h3 className="mb-2 text-[15px] font-semibold text-[#7DA2FF]">VPS Production</h3>
+                <h3 className="mb-2 text-[15px] font-semibold text-[#F7931A]">VPS Production</h3>
                 <ul className="ml-5 list-disc space-y-1 text-[14px] text-white/70">
-                  <li><strong className="text-white/90">VPS server</strong> — 2GB RAM, 25GB disk (<a href="https://digitalocean.com" target="_blank" rel="noopener noreferrer" className="text-[#7DA2FF] hover:underline">DigitalOcean</a>, <a href="https://hetzner.com" target="_blank" rel="noopener noreferrer" className="text-[#7DA2FF] hover:underline">Hetzner</a>)</li>
+                  <li><strong className="text-white/90">VPS server</strong> — 2GB RAM, 25GB disk (<a href="https://digitalocean.com" target="_blank" rel="noopener noreferrer" className="text-[#F7931A] hover:underline">DigitalOcean</a>, <a href="https://hetzner.com" target="_blank" rel="noopener noreferrer" className="text-[#F7931A] hover:underline">Hetzner</a>)</li>
                   <li><strong className="text-white/90">SSH access</strong> to your server</li>
                   <li><strong className="text-white/90">Same API keys</strong> as local setup</li>
                   <li><strong className="text-white/90">15 minutes</strong> for setup + deploy</li>
@@ -333,12 +333,12 @@ export default function OpenClawGuide() {
                 <p>POST your signatures to <code className="rounded bg-white/10 px-1.5 py-0.5 text-[13px] text-[#F7931A]">/api/register</code> to claim your Genesis spot and earn up to 10k sats in viral rewards.</p>
               </div>
 
-              <div className="mt-4 flex items-center gap-2 rounded-lg border border-[#7DA2FF]/30 bg-[#7DA2FF]/5 px-4 py-3">
-                <svg className="size-5 shrink-0 text-[#7DA2FF]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
+              <div className="mt-4 flex items-center gap-2 rounded-lg border border-[#F7931A]/30 bg-[#F7931A]/5 px-4 py-3">
+                <svg className="size-5 shrink-0 text-[#F7931A]" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
                   <path strokeLinecap="round" strokeLinejoin="round" d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
                 </svg>
                 <p className="text-white/80">
-                  <strong className="text-white">Stuck?</strong> Join us on <a href="https://discord.gg/fyrsX3mtTk" target="_blank" rel="noopener noreferrer" className="text-[#7DA2FF] hover:underline">Discord</a> — the community is here to help
+                  <strong className="text-white">Stuck?</strong> Join us on <a href="https://discord.gg/fyrsX3mtTk" target="_blank" rel="noopener noreferrer" className="text-[#F7931A] hover:underline">Discord</a> — the community is here to help
                 </p>
               </div>
             </div>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -224,7 +224,7 @@ export default function Home() {
       {/* Main Content */}
       <main id="main">
         {/* Hero Section */}
-        <section className="relative flex min-h-[100dvh] flex-col items-center justify-center overflow-hidden px-6 pt-20 max-lg:px-8 max-md:px-5 max-md:pt-24 max-md:min-h-[90dvh] max-md:pb-12">
+        <section className="relative flex min-h-[100dvh] flex-col items-center justify-center overflow-hidden px-6 pt-20 max-lg:px-8 max-md:px-5 max-md:pt-24 max-md:min-h-[85dvh] max-md:pb-12">
           {/* Decorative elements */}
           <div className="pointer-events-none absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2">
             <div className="h-[600px] w-[600px] rounded-full bg-[radial-gradient(circle,rgba(247,147,26,0.08)_0%,transparent_70%)] blur-3xl" />


### PR DESCRIPTION
Increase vertical spacing between hero text elements so they read as distinct visual layers instead of a paragraph. Restructure how-it-works cards on mobile from a tall vertical stack to a compact horizontal row with the step number on the left and content on the right.