### PR TITLE
Fix x402 sponsored tx detection for mainnet inbox

### DIFF
--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -168,7 +168,11 @@ export async function verifyInboxPayment(
       // Map relay response to SettlementResponseV2 format.
       // Relay returns {success, txid, settlement: {sender, recipient, amount, ...}}
       // but SettlementResponseV2 expects {success, transaction, payer, network}.
-      const relayData = await relayResponse.json();
+      const relayData = (await relayResponse.json()) as {
+        success: boolean;
+        txid?: string;
+        settlement?: { sender?: string };
+      };
       settleResult = {
         success: relayData.success,
         transaction: relayData.txid || "",


### PR DESCRIPTION
## Summary
- Sponsored transaction detection was checking for testnet prefix (`0x80000005`) — never matches on mainnet where sponsored txs start with `0x000000000105`
- Relay request body didn't match the relay's actual API spec
- Relay response wasn't mapped to the expected `SettlementResponseV2` format

## What was broken
All inbox x402 payments on mainnet routed to the facilitator (which returns `unexpected_settle_error`). The sponsored transaction path — which uses the working relay at `x402-relay.aibtc.com` — never triggered because the prefix check was wrong.

## The fix
1. **Detection**: Check auth type byte at the correct position in the Stacks transaction hex (offset 12-14 = `"05"` for sponsored), works on both mainnet and testnet
2. **Request**: Send `{transaction, settle: {expectedRecipient, minAmount, tokenType}}` per the relay's OpenAPI spec
3. **Response**: Map `{txid, settlement.sender}` → `{transaction, payer}` for `SettlementResponseV2`

## Verified
- The relay successfully settles sponsored sBTC transfers on mainnet (tested with txid `0xa0ba30f9...`, confirmed block 6,517,447)
- The facilitator's `/verify` confirms our transactions are valid, but `/settle` returns 500 — so routing through the relay is the correct path

## Test plan
- [ ] Deploy to preview and test sponsored inbox message send
- [ ] Verify non-sponsored transactions still fall through to facilitator path
- [ ] Confirm relay response is correctly mapped (payer address populated)

Fixes #116

🤖 Generated with [Claude Code](https://claude.com/claude-code)