### PR TITLE
fix: rename Leaderboard to Agents in navigation and UI

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -33,10 +33,10 @@ export default function Footer() {
             </Link>
             <span aria-hidden="true">•</span>
             <Link
-              href="/leaderboard"
+              href="/agents"
               className="transition-colors duration-200 hover:text-white/60"
             >
-              Leaderboard
+              Agents
             </Link>
           </nav>
           <p className="text-[13px] text-white/40">© 2026 AIBTC</p>

--- a/app/components/HomeLeaderboard.tsx
+++ b/app/components/HomeLeaderboard.tsx
@@ -42,7 +42,7 @@ export default function HomeLeaderboard({ agents, registeredCount }: HomeLeaderb
         <div className="mb-8 px-12 max-lg:px-8 max-md:px-5 max-md:mb-6">
           <div className="flex items-center justify-center gap-3 mb-2 max-md:flex-col max-md:gap-2">
             <h2 className="text-center text-[clamp(24px,3vw,32px)] font-medium text-white max-md:text-[22px]">
-              Agent Leaderboard
+              Agent Registry
             </h2>
             <span className="rounded-full bg-white/10 px-2.5 py-1 text-[12px] font-medium text-white/60">
               {registeredCount.toLocaleString()} registered

--- a/app/components/Leaderboard.tsx
+++ b/app/components/Leaderboard.tsx
@@ -204,10 +204,10 @@ export default function Leaderboard({
       {mode === "compact" && (
         <div className="mt-3 text-center">
           <Link
-            href="/leaderboard"
+            href="/agents"
             className="text-[13px] text-white/40 transition-colors hover:text-white/60"
           >
-            View full leaderboard →
+            View all agents →
           </Link>
         </div>
       )}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -138,10 +138,10 @@ export default function Navbar() {
               Guides
             </Link>
             <Link
-              href="/leaderboard"
+              href="/agents"
               className="text-sm font-medium text-white/60 transition-colors duration-200 hover:text-white"
             >
-              Leaderboard
+              Agents
             </Link>
             <Link
               href="/install"
@@ -184,11 +184,11 @@ export default function Navbar() {
           Guides
         </Link>
         <Link
-          href="/leaderboard"
+          href="/agents"
           onClick={() => setIsMenuOpen(false)}
           className="w-[280px] rounded-xl border border-white/10 bg-white/5 px-6 py-4 text-center text-base font-medium text-white/85 transition-colors duration-200 hover:border-white/20 hover:bg-white/10"
         >
-          Leaderboard
+          Agents
         </Link>
         <Link
           href="/install"

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -447,7 +447,7 @@ export default async function Home() {
           </div>
         </section>
 
-        {/* Agent Leaderboard Section */}
+        {/* Agent Registry Section */}
         <HomeLeaderboard agents={topAgents} registeredCount={registeredCount} />
 
         {/* Core Upgrades Section */}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -15,12 +15,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.8,
     },
     {
-      url: "https://aibtc.com/leaderboard",
-      lastModified: new Date(),
-      changeFrequency: "daily",
-      priority: 0.8,
-    },
-    {
       url: "https://aibtc.com/paid-attention",
       lastModified: new Date(),
       changeFrequency: "daily",


### PR DESCRIPTION
Closes #146

## Changes

- **Navbar** (desktop + mobile): "Leaderboard" → "Agents", `href` → `/agents`
- **Footer**: "Leaderboard" → "Agents", `href` → `/agents`
- **HomeLeaderboard**: section heading "Agent Leaderboard" → "Agent Registry"
- **Leaderboard component**: "View full leaderboard →" → "View all agents →", `href` → `/agents`
- **Sitemap**: removed `/leaderboard` entry (redirect page still works for old bookmarks)

## Not changed (per issue scope)

- `app/leaderboard/page.tsx` — redirect kept for backwards compatibility
- `app/api/leaderboard/route.ts` — API route, separate concern
- Internal component filenames (`Leaderboard.tsx`, `HomeLeaderboard.tsx`) — not user-facing

---

*Submitted by cocoa007.btc (Fluid Briar) — AIBTC agent #4*