### PR TITLE
feat: show Nostr npub on agent profile page

### DIFF
--- a/app/agents/[address]/AgentProfile.tsx
+++ b/app/agents/[address]/AgentProfile.tsx
@@ -18,6 +18,7 @@ import { generateName } from "@/lib/name-generator";
 import type { AgentRecord } from "@/lib/types";
 import type { NextLevelInfo } from "@/lib/levels";
 import { truncateAddress, formatRelativeTime, getActivityStatus } from "@/lib/utils";
+import { deriveNpub } from "@/lib/nostr";
 
 interface ClaimInfo {
   status: "pending" | "verified" | "rewarded" | "failed";
@@ -66,6 +67,7 @@ export default function AgentProfile({
   const avatarUrl = `https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(agent.btcAddress)}`;
   const tweetText = `My AIBTC agent is ${displayName} \u{1F916}\u{20BF}\n\nCode: ${codeInput.trim().toUpperCase()}\n\n${profileUrl}\n\n${TWITTER_HANDLE}`;
   const tweetIntentUrl = `https://twitter.com/intent/tweet?text=${encodeURIComponent(tweetText)}`;
+  const npub = agent.btcPublicKey ? deriveNpub(agent.btcPublicKey) : null;
   const hasExistingClaim = claim && (claim.status === "verified" || claim.status === "rewarded" || claim.status === "pending");
 
   const handleValidateCode = async () => {
@@ -242,6 +244,19 @@ export default function AgentProfile({
                     {truncateAddress(agent.stxAddress)}
                   </span>
                 </a>
+                {npub && (
+                  <a
+                    href={`https://njump.me/${npub}`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="block rounded-lg border border-white/[0.08] bg-white/[0.02] p-4 transition-colors hover:border-white/[0.12]"
+                  >
+                    <span className="text-[10px] font-semibold uppercase tracking-widest text-white/40">Nostr</span>
+                    <span className="mt-0.5 block font-mono text-sm max-lg:text-xs text-[#8B5CF6]">
+                      {npub.slice(0, 12)}...{npub.slice(-8)}
+                    </span>
+                  </a>
+                )}
               </div>
 
               {/* Level progress */}

--- a/lib/__tests__/nostr.test.ts
+++ b/lib/__tests__/nostr.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from "vitest";
+import { deriveNpub } from "../nostr";
+
+describe("deriveNpub", () => {
+  it("derives correct npub from compressed pubkey", () => {
+    const npub = deriveNpub(
+      "032b4603d231d15f771ded3e6c1ee250d79bd9a8950dbaf2e76015d5bb5c65e198"
+    );
+    expect(npub).toBe(
+      "npub19drq8533690hw80d8ekpacjs67dan2y4pka09emqzh2mkhr9uxvqd4k3nn"
+    );
+  });
+
+  it("works with 03 prefix keys", () => {
+    const npub = deriveNpub(
+      "03ff2962f3ac2a2c055536ecb4e0d7cc89c0e192467c0b73a56e1a72c92b123456"
+    );
+    expect(npub).not.toBeNull();
+    expect(npub).toMatch(/^npub1/);
+  });
+
+  it("returns null for empty string", () => {
+    expect(deriveNpub("")).toBeNull();
+  });
+
+  it("returns null for wrong length", () => {
+    expect(deriveNpub("032b4603")).toBeNull();
+  });
+
+  it("returns null for uncompressed key (04 prefix)", () => {
+    expect(
+      deriveNpub(
+        "042b4603d231d15f771ded3e6c1ee250d79bd9a8950dbaf2e76015d5bb5c65e198"
+      )
+    ).toBeNull();
+  });
+
+  it("returns null for null/undefined", () => {
+    expect(deriveNpub(null as unknown as string)).toBeNull();
+    expect(deriveNpub(undefined as unknown as string)).toBeNull();
+  });
+});

--- a/lib/nostr.ts
+++ b/lib/nostr.ts
@@ -1,0 +1,29 @@
+import { bech32 } from "@scure/base";
+
+/**
+ * Derive a Nostr npub from a compressed BTC public key.
+ *
+ * Nostr uses x-only pubkeys (32 bytes) encoded as bech32 with "npub" prefix.
+ * A compressed BTC pubkey is 33 bytes (02/03 prefix + 32 bytes x-coordinate).
+ * We drop the prefix byte to get the x-only key.
+ *
+ * @param btcPublicKey - Compressed public key as hex (66 chars, starts with 02 or 03)
+ * @returns npub string, or null if the key is invalid
+ */
+export function deriveNpub(btcPublicKey: string): string | null {
+  if (!btcPublicKey || btcPublicKey.length !== 66) return null;
+
+  const prefix = btcPublicKey.slice(0, 2);
+  if (prefix !== "02" && prefix !== "03") return null;
+
+  // x-only pubkey: drop the 02/03 prefix
+  const xOnlyHex = btcPublicKey.slice(2);
+  const bytes = new Uint8Array(32);
+  for (let i = 0; i < 32; i++) {
+    bytes[i] = parseInt(xOnlyHex.slice(i * 2, i * 2 + 2), 16);
+  }
+
+  // Encode as bech32 with "npub" prefix (NIP-19)
+  const words = bech32.toWords(bytes);
+  return bech32.encode("npub", words, 1023);
+}


### PR DESCRIPTION
Closes #168

## What

Shows the agent's Nostr npub on their profile page, derived from `btcPublicKey`.

## How

Nostr uses the same secp256k1 curve as Bitcoin. A compressed BTC pubkey (33 bytes) becomes an x-only pubkey (32 bytes, drop the `02`/`03` prefix), which is then bech32-encoded as an `npub`.

### New files
- **`lib/nostr.ts`** — `deriveNpub(btcPublicKey)` utility, uses `@scure/base` (already a dependency)
- **`lib/__tests__/nostr.test.ts`** — 6 tests

### Changed files
- **`app/agents/[address]/AgentProfile.tsx`** — Shows npub in sidebar addresses section, links to njump.me

## Design decisions
- **No new data storage** — npub is derived client-side from the existing `btcPublicKey`
- **Only shows when `btcPublicKey` is available** (graceful fallback)
- **Links to njump.me** — universal Nostr content viewer
- **Purple color** (`#8B5CF6`) to visually distinguish from BTC orange and STX purple
- **Same truncation pattern** as other addresses