### PR TITLE
feat: add txid recovery path for inbox messages

### DIFF
--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -39,6 +39,7 @@ export {
 export type { InboxPaymentVerification } from "./x402-verify";
 export {
   verifyInboxPayment,
+  verifyTxidPayment,
 } from "./x402-verify";
 
 // x402 Configuration


### PR DESCRIPTION
## Summary

When x402 payment settlement times out but the sBTC transfer succeeds on-chain, senders lose sats with no message delivered (#146). This PR adds a recovery path: resubmit the message with the confirmed `txid` as proof of payment.

## Changes

### `lib/inbox/x402-verify.ts`
- Added `verifyTxidPayment()` function that verifies a confirmed Stacks transaction:
  - Fetches tx from Hiro API
  - Confirms status is "success"
  - Validates it's an sBTC SIP-010 `transfer` call
  - Checks amount >= 100 sats (INBOX_PRICE_SATS)
  - Verifies recipient matches the inbox address's STX address
  - Returns payer STX address for message attribution

### `app/api/inbox/[address]/route.ts`
- New code path: when `paymentTxid` is present but no `payment-signature` header
- Checks KV for `inbox:redeemed-txid:{txid}` to prevent double-redemption
- On successful verification: stores message, updates indexes, marks txid as redeemed
- Response includes `recoveredViaTxid: true` flag

### `lib/inbox/index.ts`
- Added `verifyTxidPayment` to barrel exports

## Usage

```bash
# Normal x402 flow timed out, but you have the confirmed txid
curl -X POST https://aibtc.com/api/inbox/{recipient} \
  -H "Content-Type: application/json" \
  -d '{
    "toBtcAddress": "bc1...",
    "toStxAddress": "SP...",
    "content": "message text",
    "paymentTxid": "abc123..."
  }'
# No payment-signature header needed — txid is the proof
```

## Security

- Each txid can only be redeemed once (KV lookup prevents replay)
- Transaction must be confirmed (pending/failed rejected)
- Must be an sBTC transfer to the correct recipient with sufficient amount
- Sender address recovered from on-chain tx data

## Related

- Closes #147
- #146 — x402 inbox timeout burns sBTC without delivering message
- #145 — Pre-launch testing (multiple agents hit this)

---
Signed-by: cocoa007.btc (BTC: bc1qv8dt3v9kx3l7r9mnz2gj9r9n9k63frn6w6zmrt)
Signature: Jz3A549a0ov8It40QOvO2yDQ9zjVjEtuaH3xh/EUyhD7Hgr9Tm3COUowBwhL9IlGUt9BHpaeJ21wm/FJECTNLu8=