### PR TITLE
Fix 409 on repeat inbox sends: stop using resource.url as messageId

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -547,9 +547,10 @@ export async function POST(
   // Extract sender address from payment (payer's STX address from x402 settlement)
   const fromAddress = paymentResult.payerStxAddress || "unknown";
 
-  // Generate message ID (use memo if present, otherwise generate)
-  const messageId =
-    paymentResult.messageId || `msg_${Date.now()}_${crypto.randomUUID()}`;
+  // Always generate a unique message ID server-side.
+  // Never trust client-supplied IDs — the x402 resource.url is the endpoint
+  // path, not a message ID, and reusing it causes 409 collisions.
+  const messageId = `msg_${Date.now()}_${crypto.randomUUID()}`;
 
   // Check for duplicate message
   const existingMessage = await kv.get(`inbox:message:${messageId}`);

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -35,7 +35,8 @@ export interface InboxPaymentVerification {
   success: boolean;
   payerStxAddress?: string;
   paymentTxid?: string;
-  messageId?: string; // Extracted from payment memo (resource field)
+  /** @deprecated Message IDs are now always generated server-side in the route handler. */
+  messageId?: string;
   error?: string;
   errorCode?: string;
   settleResult?: SettlementResponseV2;
@@ -113,13 +114,8 @@ export async function verifyInboxPayment(
     };
   }
 
-  // Extract message ID from payment resource (if present in v2)
-  let messageId: string | undefined;
-  if (paymentPayload.resource?.url) {
-    // In v2, message ID might be in resource.url
-    messageId = paymentPayload.resource.url;
-    log.debug("Extracted resource from payload", { messageId });
-  }
+  // Message IDs are generated server-side in the route handler (not here).
+  // paymentPayload.resource.url is the endpoint URL, not a message ID.
 
   // Determine if transaction is sponsored using stacks.js deserialization
   const txHex = paymentPayload.payload.transaction;
@@ -238,7 +234,6 @@ export async function verifyInboxPayment(
   log.info("Inbox payment verified", {
     payerStxAddress,
     paymentTxid,
-    messageId,
     recipientStxAddress,
   });
 
@@ -246,7 +241,6 @@ export async function verifyInboxPayment(
     success: true,
     payerStxAddress,
     paymentTxid,
-    messageId,
     settleResult,
   };
 }


### PR DESCRIPTION
## Summary

- **`lib/inbox/x402-verify.ts`**: Remove `resource.url` → `messageId` extraction entirely. The resource URL is the endpoint path (e.g. `https://aibtc.com/api/inbox/bc1q...`), not a message identifier. Deprecated the `messageId` field on `InboxPaymentVerification`.
- **`app/api/inbox/[address]/route.ts`**: Always generate a unique `msg_<timestamp>_<uuid>` server-side. Previously this was a fallback (`paymentResult.messageId || msg_...`) — now it's the default. Client-supplied IDs are never trusted.

## Root Cause

1. MCP `send_inbox_message` POSTs to `/api/inbox/{btcAddress}` → gets 402 with `resource.url = "https://aibtc.com/api/inbox/bc1q..."`
2. MCP echoes `resource` back in the payment payload (per x402 v2 spec)
3. `verifyInboxPayment()` extracted `resource.url` and returned it as `messageId`
4. Route handler stored message with `messageId = "https://aibtc.com/api/inbox/bc1q..."` 
5. Next send to same recipient → same URL → same KV key → **409**

## Why `resource.url` was used as `messageId`

The original intent was **idempotency for payment retries** — a standard pattern in payment systems. The idea: a client embeds a unique ID in `resource.url` so if the same payment is retried (network timeout, etc.), the server detects the duplicate and avoids storing the message twice.

The mismatch:
- **Server expected**: client puts a unique `msg_xxx` in `resource.url`
- **MCP client actually does**: echoes back the 402 challenge's `resource` verbatim, which is just the endpoint URL (`https://aibtc.com/api/inbox/bc1q...`)

So the dedup mechanism accidentally became a permanent block — every send to the same recipient produced the same "idempotency key."

## Fix

Message ID generation is now entirely the server's responsibility:
- `x402-verify.ts` no longer returns a `messageId` from the payment payload
- `route.ts` always generates `msg_${Date.now()}_${crypto.randomUUID()}` — no fallback path, no client override

If idempotency is needed in the future, it should use a dedicated field (e.g. `x-idempotency-key` header) rather than overloading `resource.url`.

## Test Plan

- [ ] Send a message to a recipient → succeeds with unique `msg_` ID
- [ ] Send a second message to the same recipient → succeeds (no 409)
- [ ] Verify both messages appear in recipient's inbox with distinct `msg_` IDs

Fixes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)