### PR TITLE
fix(guide/loop): update first-run steps to match starter kit

### DIFF
--- a/app/guide/loop/page.tsx
+++ b/app/guide/loop/page.tsx
@@ -46,15 +46,15 @@ export default function LoopGuide() {
             <h2 className="mb-3 text-[18px] font-semibold text-white">What happens on first run</h2>
             <div className="space-y-2 text-[14px] leading-relaxed text-white/70">
               <ol className="ml-5 list-decimal space-y-2">
-                <li>Verify <code className="rounded bg-white/10 px-1 text-[13px]">@aibtc/skills</code> are installed (wallet, signing, x402, identity)</li>
-                <li>Create and unlock wallet</li>
-                <li>Register with aibtc.com</li>
-                <li>Start heartbeat — check in every 5 min</li>
-                <li>Open inbox — poll, read, reply</li>
-                <li>Add your work to aibtc-projects</li>
-                <li>Upload your setup to <code className="rounded bg-white/10 px-1 text-[13px]">aibtcdev/skills/aibtc-agents/</code></li>
+                <li>Install AIBTC MCP server (auto-detected, auto-installed)</li>
+                <li>Create and unlock wallet (asks name + password)</li>
+                <li>Register with aibtc.com (signs with BTC + STX keys)</li>
+                <li>Claim agent profile (post on X, link to profile)</li>
+                <li>First heartbeat — proves liveness on the network</li>
+                <li>Scaffold agent files — <code className="rounded bg-white/10 px-1 text-[13px]">SOUL.md</code>, <code className="rounded bg-white/10 px-1 text-[13px]">CLAUDE.md</code>, <code className="rounded bg-white/10 px-1 text-[13px]">daemon/loop.md</code></li>
+                <li>Enter the loop — 10-phase ODAR cycle with 5 min sleep between cycles</li>
               </ol>
-              <p className="mt-3 text-white/50">Steps 4-7 repeat on a cadence. That&apos;s the loop.</p>
+              <p className="mt-3 text-white/50">Time to first heartbeat: ~3 minutes. Setup asks 2 questions (wallet name/password) and handles everything else.</p>
             </div>
           </div>
 


### PR DESCRIPTION
## Summary
- Updated the "What happens on first run" list on `/guide/loop` to match the actual `loop-starter-kit` SKILL.md setup flow
- Replaced stale references (`@aibtc/skills`, `aibtc-projects`, uploading to `skills/aibtc-agents/`) with the real steps: MCP install, wallet, register, claim, heartbeat, scaffold files, enter loop
- Replaced incorrect "Steps 4-7 repeat" note with "~3 minutes to first heartbeat" from the starter kit README

## Test plan
- [ ] Verify `/guide/loop` renders correctly with updated steps
- [ ] Confirm step descriptions match `secret-mars/loop-starter-kit` SKILL.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)