### PR TITLE
feat(outbox): add per-address rate limiting to prevent log flooding

### DIFF
--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -134,37 +134,23 @@ export const RELAY_SETTLE_TIMEOUT_MS = 30_000;
 export const REDEEMED_TXID_TTL_SECONDS = 90 * 24 * 60 * 60; // 7,776,000 seconds
 
 /**
- * Maximum number of outbox POST attempts allowed per unregistered address
- * before rate limiting kicks in.
- *
- * When an address that is not registered as an AIBTC agent sends repeated
- * outbox requests, they receive 404 responses. After this many attempts,
- * they receive a 429 with instructions to register.
+ * Max outbox POST attempts per unregistered address before 429.
+ * After this many 404 responses, the address receives rate-limit instructions.
  */
 export const OUTBOX_RATE_LIMIT_UNREGISTERED_MAX = 5;
 
 /**
- * TTL in seconds for the unregistered address outbox rate limit counter.
- *
- * After this window expires (1 hour), the counter resets and the address
- * may try again. This gives automated agents time to register and retry.
+ * TTL (seconds) for the unregistered outbox rate limit counter (1 hour).
  */
 export const OUTBOX_RATE_LIMIT_UNREGISTERED_TTL_SECONDS = 3600;
 
 /**
- * Maximum number of outbox POST requests allowed per registered address
- * per rate limit window.
- *
- * This prevents registered agents from flooding the outbox endpoint.
- * Legitimate agents send at most a handful of replies per minute.
+ * Max outbox POST requests per registered address per rate limit window.
  */
 export const OUTBOX_RATE_LIMIT_REGISTERED_MAX = 10;
 
 /**
- * TTL in seconds for the registered address outbox rate limit window.
- *
- * Counter resets after this many seconds (1 minute), allowing burst
- * of up to OUTBOX_RATE_LIMIT_REGISTERED_MAX requests per minute.
+ * TTL (seconds) for the registered outbox rate limit window (1 minute).
  */
 export const OUTBOX_RATE_LIMIT_REGISTERED_TTL_SECONDS = 60;
 


### PR DESCRIPTION
## Summary

- Moves logger.info("Outbox reply submission") to after the agent lookup guard, eliminating info-level log entries for every unregistered 404 attempt
- Adds per-address KV rate limiting for unregistered callers: 5 attempts per hour, then 429 with registration instructions and Retry-After: 3600
- Adds per-address KV rate limiting for registered callers: 10 requests per minute, then 429 with Retry-After: 60
- Both 404 and 429 responses for unregistered addresses now include action and documentation fields pointing to POST /api/register

## Background

Log review of logs.aibtc.com revealed 395 flooding attempts from 8 unregistered bc1q addresses in a single session, all targeting Dual Cougar outbox endpoint. Every attempt generated an info-level log entry because the logger fired before the agent lookup guard. Six of the eight addresses each made exactly 47 attempts, indicating automated parallel execution with a retry cap.

## Test plan

- [x] Verify npm test passes (637 tests, same pre-existing failure in ax-ux-audit worktree)
- [ ] Manual: POST to /api/outbox/{unregistered-address} 5 times gives 404 with action field; 6th gives 429 with registration instructions and Retry-After: 3600
- [ ] Manual: POST to /api/outbox/{registered-address} 10 times rapidly gives 429 with Retry-After: 60
- [ ] Manual: Confirm logger.info("Outbox reply submission") appears in logs AFTER agent lookup for registered callers

Generated with Claude Code