### PR TITLE
fix(outbox): key rate limits on caller identity, not inbox owner

### DIFF
--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -37,40 +37,40 @@ export async function POST(
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
     : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
 
-  // Rate limit unregistered addresses before the agent lookup to prevent
-  // repeated 404 attempts from flooding the log and KV.
-  const unregisteredRateLimitKey = `ratelimit:outbox-unregistered:${address}`;
-  const unregisteredCountRaw = await kv.get(unregisteredRateLimitKey);
-  const unregisteredCount = unregisteredCountRaw
-    ? parseInt(unregisteredCountRaw, 10)
-    : 0;
-
-  if (unregisteredCount >= OUTBOX_RATE_LIMIT_UNREGISTERED_MAX) {
-    logger.warn("Outbox rate limited (unregistered)", {
-      address,
-      count: unregisteredCount,
-    });
-    return NextResponse.json(
-      {
-        error:
-          "Too many attempts from this address. This address is not registered as an AIBTC agent.",
-        address,
-        action:
-          "Register at POST /api/register to use the outbox endpoint.",
-        documentation: "https://aibtc.com/api/register",
-        retryAfter: "1 hour",
-      },
-      {
-        status: 429,
-        headers: { "Retry-After": String(OUTBOX_RATE_LIMIT_UNREGISTERED_TTL_SECONDS) },
-      }
-    );
-  }
-
-  // Look up agent
+  // Look up agent first — rate limits are applied contextually below.
   const agent = await lookupAgent(kv, address);
 
   if (!agent) {
+    // Rate limit unregistered addresses to prevent repeated 404 attempts
+    // from flooding the log and KV.
+    const unregisteredRateLimitKey = `ratelimit:outbox-unregistered:${address}`;
+    const unregisteredCountRaw = await kv.get(unregisteredRateLimitKey);
+    const unregisteredCount = unregisteredCountRaw
+      ? parseInt(unregisteredCountRaw, 10)
+      : 0;
+
+    if (unregisteredCount >= OUTBOX_RATE_LIMIT_UNREGISTERED_MAX) {
+      logger.warn("Outbox rate limited (unregistered)", {
+        address,
+        count: unregisteredCount,
+      });
+      return NextResponse.json(
+        {
+          error:
+            "Too many attempts from this address. This address is not registered as an AIBTC agent.",
+          address,
+          action:
+            "Register at POST /api/register to use the outbox endpoint.",
+          documentation: "https://aibtc.com/api/register",
+          retryAfter: "1 hour",
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(OUTBOX_RATE_LIMIT_UNREGISTERED_TTL_SECONDS) },
+        }
+      );
+    }
+
     // Fixed-window counter: set TTL only on first attempt so the window
     // expires from the first request, not the latest one.
     // KV read-then-write is not atomic; concurrent under-counting is accepted.
@@ -98,43 +98,6 @@ export async function POST(
   }
 
   logger.info("Outbox reply submission", { address });
-
-  // Rate limit registered addresses to prevent scripted flooding.
-  const registeredRateLimitKey = `ratelimit:outbox:${address}`;
-  const registeredCountRaw = await kv.get(registeredRateLimitKey);
-  const registeredCount = registeredCountRaw
-    ? parseInt(registeredCountRaw, 10)
-    : 0;
-
-  if (registeredCount >= OUTBOX_RATE_LIMIT_REGISTERED_MAX) {
-    logger.warn("Outbox rate limited (registered)", {
-      address,
-      count: registeredCount,
-    });
-    return NextResponse.json(
-      {
-        error: "Too many outbox requests. Slow down.",
-        address,
-        retryAfter: "1 minute",
-      },
-      {
-        status: 429,
-        headers: { "Retry-After": String(OUTBOX_RATE_LIMIT_REGISTERED_TTL_SECONDS) },
-      }
-    );
-  }
-
-  // Fixed-window counter (same pattern as unregistered path above).
-  if (registeredCount === 0) {
-    await kv.put(registeredRateLimitKey, "1", {
-      expirationTtl: OUTBOX_RATE_LIMIT_REGISTERED_TTL_SECONDS,
-    });
-  } else {
-    await kv.put(
-      registeredRateLimitKey,
-      String(registeredCount + 1)
-    );
-  }
 
   // Parse request body
   let body: unknown;
@@ -233,6 +196,46 @@ export async function POST(
         providedAddress: address,
       },
       { status: 403 }
+    );
+  }
+
+  // Rate limit registered callers by signer identity (not path address)
+  // to prevent scripted flooding. Placed after signature verification so
+  // we know the caller's real BTC address.
+  const registeredRateLimitKey = `ratelimit:outbox:${btcResult.address}`;
+  const registeredCountRaw = await kv.get(registeredRateLimitKey);
+  const registeredCount = registeredCountRaw
+    ? parseInt(registeredCountRaw, 10)
+    : 0;
+
+  if (registeredCount >= OUTBOX_RATE_LIMIT_REGISTERED_MAX) {
+    logger.warn("Outbox rate limited (registered)", {
+      callerAddress: btcResult.address,
+      count: registeredCount,
+    });
+    return NextResponse.json(
+      {
+        error: "Too many outbox requests. Slow down.",
+        address: btcResult.address,
+        retryAfter: "1 minute",
+      },
+      {
+        status: 429,
+        headers: { "Retry-After": String(OUTBOX_RATE_LIMIT_REGISTERED_TTL_SECONDS) },
+      }
+    );
+  }
+
+  // Fixed-window counter: set TTL only on first attempt so the window
+  // expires from the first request, not the latest one.
+  if (registeredCount === 0) {
+    await kv.put(registeredRateLimitKey, "1", {
+      expirationTtl: OUTBOX_RATE_LIMIT_REGISTERED_TTL_SECONDS,
+    });
+  } else {
+    await kv.put(
+      registeredRateLimitKey,
+      String(registeredCount + 1)
     );
   }
 


### PR DESCRIPTION
## Summary

- **Registered rate limit** now keyed on `btcResult.address` (the actual signer/caller) instead of the URL path `address` (inbox owner). Moved after signature verification where the caller's identity is known.
- **Unregistered rate limit** moved inside the `!agent` block so it only fires on 404 paths, preventing false positives on registered agents' inboxes.

Closes #274

## Test plan

- [ ] Verify multiple agents can reply to the same inbox without sharing a rate limit counter
- [ ] Verify a single agent hitting their own outbox repeatedly gets rate limited correctly
- [ ] Verify unregistered addresses still get 404 rate limiting after repeated attempts
- [ ] Verify registered agents' inboxes don't trigger the unregistered rate limiter

🤖 Generated with [Claude Code](https://claude.com/claude-code)