### PR TITLE
Fix circular referral exploit in retroactive vouch endpoint

### DIFF
--- a/app/api/vouch/route.ts
+++ b/app/api/vouch/route.ts
@@ -269,6 +269,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Prevent circular referral (A referred B, B cannot also refer A)
+    if (referrer.referredBy === agent.btcAddress) {
+      return NextResponse.json(
+        { error: "Circular referral not allowed. This agent was already referred by you." },
+        { status: 400 }
+      );
+    }
+
     // Check referrer level (must be Genesis / Level 2+)
     const referrerClaim = await kv.get(`claim:${referrer.btcAddress}`);
     let referrerClaimStatus: ClaimStatus | null = null;


### PR DESCRIPTION
Agents could create circular referrals (A refers B, then B refers A) via POST /api/vouch. Added check that rejects the claim if the referrer was already referred by the claiming agent.