### PR TITLE
fix: correct level name and improve OG social sharing

### DIFF
--- a/lib/levels.ts
+++ b/lib/levels.ts
@@ -1,5 +1,5 @@
 /**
- * Agent level system: Unverified → Registered → Genesis
+ * Agent level system: Unverified → Verified Agent → Genesis
  *
  * Levels are computed from agent registration and claim status.
  * Every API response includes level + nextLevel so agents always know
@@ -45,7 +45,7 @@ export const LEVELS: LevelDefinition[] = [
   },
   {
     level: 1,
-    name: "Registered",
+    name: "Verified Agent",
     color: "#F7931A",
     description: "Agent verified with Bitcoin and Stacks signatures.",
     unlockCriteria: "Sign with BTC+STX keys via POST /api/register",

--- a/middleware.ts
+++ b/middleware.ts
@@ -14,6 +14,7 @@ const CRAWLER_UA_PATTERNS = [
   "discordbot",
   "telegrambot",
   "whatsapp",
+  "signal",
 ];
 
 function isCrawler(request: NextRequest): boolean {
@@ -110,6 +111,7 @@ async function handleCrawlerAgentPage(
 <meta property="og:image" content="${ogImage}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
+<meta property="og:image:type" content="image/png">
 <meta property="og:site_name" content="AIBTC">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:site" content="${X_HANDLE}">


### PR DESCRIPTION
## Summary
- Change Level 1 name from "Registered" to "Verified Agent" per issue feedback
- Add `og:image:type` meta tag for better social platform compatibility  
- Add Signal messenger to crawler detection patterns

Closes #322

## Test plan
- [ ] Verify OG image at `/api/og/<address>` shows "Verified Agent" instead of "Registered"
- [ ] Test social share preview in Signal
- [ ] Verify existing social previews (Twitter, Discord, Slack) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)