### PR TITLE
fix: handle legacy rate-limit KV keys without timestamp (closes #326)

### DIFF
--- a/lib/__tests__/rate-limit.test.ts
+++ b/lib/__tests__/rate-limit.test.ts
@@ -122,6 +122,29 @@ describe("checkFixedWindowRateLimit", () => {
     expect(mockKV.puts[0].opts).toEqual({ expirationTtl: 60 });
   });
 
+  it("resets window for legacy count-only keys (no timestamp)", async () => {
+    // Pre-#293 keys stored just a count with no :timestamp suffix.
+    // These should be treated as expired rather than permanently stuck.
+    mockKV.store.set("test-key", "10");
+
+    const result = await checkFixedWindowRateLimit(
+      mockKV.kv,
+      "test-key",
+      10,
+      60
+    );
+
+    // Should NOT be limited — legacy key is treated as expired
+    expect(result.limited).toBe(false);
+
+    // Should have written count=1 with a fresh window
+    expect(mockKV.puts).toHaveLength(1);
+    const stored = mockKV.store.get("test-key")!;
+    const [count] = stored.split(":");
+    expect(count).toBe("1");
+    expect(mockKV.puts[0].opts).toEqual({ expirationTtl: 60 });
+  });
+
   it("resets window at exact TTL boundary", async () => {
     // Window started exactly ttlSeconds ago
     const exactlyExpired = Date.now() - 60 * 1000;

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -23,7 +23,15 @@ export async function checkFixedWindowRateLimit(
   if (raw) {
     const parts = raw.split(":");
     count = parseInt(parts[0], 10) || 0;
-    windowStart = parseInt(parts[1], 10) || now;
+    const parsedStart = parseInt(parts[1], 10);
+    if (isNaN(parsedStart)) {
+      // Legacy key (count only, no timestamp) — treat as expired window
+      count = 0;
+      windowStart = now;
+      isNewWindow = true;
+    } else {
+      windowStart = parsedStart;
+    }
 
     // If the window has expired (KV key outlived its TTL, e.g. pre-#294
     // stuck keys or eventual consistency lag), start a fresh window.


### PR DESCRIPTION
## Summary

- **Bug:** Pre-PR#293 KV rate-limit keys stored only a count (e.g. `"10"`) with no `:timestamp` suffix. When the current code parses `parts[1]`, `parseInt(undefined)` returns `NaN`, which falls through to `|| now`, setting `windowStart = now`. This means the elapsed-window check always computes 0 seconds elapsed, so any key at `count >= max` is **permanently stuck** as rate-limited.
- **Fix:** Replace `parseInt(parts[1], 10) || now` with an explicit `isNaN()` check. When the timestamp is missing/NaN (legacy format), treat the key as an expired window: reset count to 0 and start fresh.
- **Test:** Added a test case that seeds a legacy count-only key (`"10"`) and verifies it is treated as expired rather than permanently blocked.

## Changed files

- `lib/rate-limit.ts` — parsing logic for legacy KV keys
- `lib/__tests__/rate-limit.test.ts` — new test: "resets window for legacy count-only keys (no timestamp)"

## Test plan

- [x] `npx vitest run lib/__tests__/rate-limit.test.ts` — all 11 tests pass (10 existing + 1 new)
- [ ] Deploy to staging and verify that any remaining pre-#293 KV keys no longer cause permanent 429s

Closes #326

🤖 Generated with [Claude Code](https://claude.com/claude-code)