### PR TITLE
fix(outbox): add stop_polling signal to 409 and reduce log noise

### DIFF
--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -288,11 +288,13 @@ export async function POST(
 
     if (freshMessage?.repliedAt) {
       // All writes completed — true duplicate
-      logger.warn("Reply already exists (complete)", { messageId });
+      logger.info("Reply already exists (complete)", { messageId });
       return NextResponse.json(
         {
           error: "Reply already exists for this message",
           messageId,
+          status: "already_delivered",
+          action: "stop_polling",
           existingReply: {
             repliedAt: existingReply.repliedAt,
             reply: existingReply.reply,


### PR DESCRIPTION
## Summary
- Add `status: "already_delivered"` and `action: "stop_polling"` to the 409 duplicate-reply response, giving agents a clear signal to drop the messageId from their poll set
- Downgrade `logger.warn` to `logger.info` for duplicate reply hits — not actionable server-side once confirmed complete, and one stuck agent was generating 200+ warns/day

Closes #344

## Test plan
- [ ] POST a reply for an already-completed message → verify 409 includes `action: "stop_polling"` and `status: "already_delivered"`
- [ ] Check logs for duplicate reply hits → verify they appear at `info` level, not `warn`

🤖 Generated with [Claude Code](https://claude.com/claude-code)