### PR TITLE
feat(api): return full agent record from all list endpoints

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
+import { normalizeAgentRecord } from "@/lib/types";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { lookupBnsName } from "@/lib/bns";
 import { getAchievementCount } from "@/lib/achievements";
@@ -42,15 +43,16 @@ export async function GET(request: NextRequest) {
             stxPublicKey: "string",
             btcPublicKey: "string",
             taprootAddress: "string | null",
-            displayName: "string (deterministic name from BTC address)",
+            displayName: "string | null (deterministic name from BTC address)",
             description: "string | null (agent-provided description)",
             bnsName: "string | null (Bitcoin Name Service name)",
             owner: "string | null (X/Twitter handle)",
             verifiedAt: "string (ISO 8601 timestamp)",
-            lastActiveAt: "string | undefined (ISO 8601 timestamp of last check-in)",
-            checkInCount: "number | undefined (total check-ins)",
+            lastActiveAt: "string | null (ISO 8601 timestamp of last check-in)",
+            checkInCount: "number (total check-ins, default 0)",
             erc8004AgentId: "number | null (on-chain identity NFT ID)",
-            referredBy: "string | undefined (BTC address of referrer)",
+            nostrPublicKey: "string | null (Nostr public key)",
+            referredBy: "string | null (BTC address of referrer)",
             level: "number (0-2)",
             levelName: "string (Unverified | Registered | Genesis)",
             achievementCount: "number (total achievements unlocked)",
@@ -202,7 +204,7 @@ export async function GET(request: NextRequest) {
     const agentsWithLevels = agents.map((agent, i) => {
       const level = computeLevel(agent, claimLookups[i]);
       return {
-        ...agent,
+        ...normalizeAgentRecord(agent),
         level,
         levelName: LEVELS[level].name,
         achievementCount: achievementCounts[i],

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,6 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
+import { normalizeAgentRecord } from "@/lib/types";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { ACTIVITY_THRESHOLDS } from "@/lib/utils";
 import { getAchievementCount } from "@/lib/achievements";
@@ -58,15 +59,16 @@ export async function GET(request: NextRequest) {
             stxPublicKey: "string",
             btcPublicKey: "string",
             taprootAddress: "string | null",
-            displayName: "string (deterministic name from BTC address)",
+            displayName: "string | null (deterministic name from BTC address)",
             description: "string | null (agent-provided description)",
             bnsName: "string | null (Bitcoin Name Service name)",
             owner: "string | null (X/Twitter handle)",
             verifiedAt: "string (ISO 8601 timestamp)",
-            lastActiveAt: "string | undefined (ISO 8601 timestamp of last check-in)",
-            checkInCount: "number | undefined (total check-ins)",
+            lastActiveAt: "string | null (ISO 8601 timestamp of last check-in)",
+            checkInCount: "number (total check-ins, default 0)",
             erc8004AgentId: "number | null (on-chain identity NFT ID)",
-            referredBy: "string | undefined (BTC address of referrer)",
+            nostrPublicKey: "string | null (Nostr public key)",
+            referredBy: "string | null (BTC address of referrer)",
             level: "number (0-2)",
             levelName: "string (Unverified | Registered | Genesis)",
             achievementCount: "number (total achievements unlocked)",
@@ -208,7 +210,7 @@ export async function GET(request: NextRequest) {
       const score = (level * 1000) + (achievementCount * 100) + checkInCount + recencyBonus;
 
       return {
-        ...agent,
+        ...normalizeAgentRecord(agent),
         level,
         levelName: LEVELS[level].name,
         achievementCount,

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,6 +23,31 @@ export interface AgentRecord {
 }
 
 /**
+ * Normalize an AgentRecord so every key is always present.
+ * Optional fields default to null (strings/objects) or 0 (numbers).
+ * Ensures agents always receive a predictable shape from any endpoint.
+ */
+export function normalizeAgentRecord(agent: AgentRecord) {
+  return {
+    stxAddress: agent.stxAddress,
+    btcAddress: agent.btcAddress,
+    stxPublicKey: agent.stxPublicKey,
+    btcPublicKey: agent.btcPublicKey,
+    taprootAddress: agent.taprootAddress ?? null,
+    displayName: agent.displayName ?? null,
+    description: agent.description ?? null,
+    bnsName: agent.bnsName ?? null,
+    owner: agent.owner ?? null,
+    verifiedAt: agent.verifiedAt,
+    lastActiveAt: agent.lastActiveAt ?? null,
+    checkInCount: agent.checkInCount ?? 0,
+    erc8004AgentId: agent.erc8004AgentId ?? null,
+    nostrPublicKey: agent.nostrPublicKey ?? null,
+    referredBy: agent.referredBy ?? null,
+  };
+}
+
+/**
  * Claim status record for viral tweet rewards (minimal type for level computation).
  * Used by computeLevel() to determine if an agent has reached Genesis (Level 2).
  */


### PR DESCRIPTION
## Summary
- Leaderboard endpoint (`/api/leaderboard`) was cherry-picking agent fields, omitting `owner` (X handle), `description`, public keys, `taprootAddress`, `erc8004AgentId`, and `referredBy`
- Changed to spread full `AgentRecord` so agents get the same data shape from `/api/agents` and `/api/leaderboard`
- Updated self-documenting `?docs=1` responses on both endpoints to list all fields accurately

## Test plan
- [ ] Verify `/api/agents` returns full agent records with `owner` field
- [ ] Verify `/api/leaderboard` returns full agent records with `owner` field
- [ ] Verify `?docs=1` on both endpoints reflects the complete field set

Closes #347

🤖 Generated with [Claude Code](https://claude.com/claude-code)