### PR TITLE
Fix inbox text overflow for long URLs

### DIFF
--- a/app/components/InboxRow.tsx
+++ b/app/components/InboxRow.tsx
@@ -105,7 +105,7 @@ export default function InboxRow({
       </div>
 
       {/* Message body */}
-      <p className={`text-[13px] leading-relaxed text-white/70 sm:text-[14px] ${isSent ? "pl-0 sm:pl-0" : ""}`}>
+      <p className={`text-[13px] leading-relaxed text-white/70 break-words overflow-wrap-anywhere sm:text-[14px] ${isSent ? "pl-0 sm:pl-0" : ""}`} style={{ overflowWrap: "anywhere" }}>
         {content}
       </p>
 
@@ -175,7 +175,7 @@ export default function InboxRow({
               {formatRelativeTime(reply.repliedAt)}
             </span>
           </div>
-          <p className="text-[12px] leading-relaxed text-white/60 sm:text-[13px]">
+          <p className="text-[12px] leading-relaxed text-white/60 break-words sm:text-[13px]" style={{ overflowWrap: "anywhere" }}>
             {reply.reply}
           </p>
         </div>

--- a/app/inbox/[address]/msg/[messageId]/page.tsx
+++ b/app/inbox/[address]/msg/[messageId]/page.tsx
@@ -177,7 +177,7 @@ export default function MessagePermalinkPage() {
 
             {/* Message content */}
             <div className="px-5 py-4 sm:px-6 sm:py-5">
-              <p className="text-[14px] leading-relaxed text-white/80 sm:text-[15px]">
+              <p className="text-[14px] leading-relaxed text-white/80 break-words sm:text-[15px]" style={{ overflowWrap: "anywhere" }}>
                 {message.content}
               </p>
             </div>
@@ -185,7 +185,7 @@ export default function MessagePermalinkPage() {
             {/* Meta footer */}
             <div className="border-t border-white/[0.06] px-5 py-3 sm:px-6">
               <div className="flex flex-wrap items-center gap-x-4 gap-y-1.5 text-[11px] text-white/30">
-                <span className="font-mono">{message.messageId}</span>
+                <span className="font-mono break-all">{message.messageId}</span>
                 {message.authenticated && (
                   <span className="inline-flex items-center gap-1 text-[#22c55e]/70">
                     <svg className="size-3" fill="currentColor" viewBox="0 0 20 20">
@@ -236,7 +236,7 @@ export default function MessagePermalinkPage() {
                     {formatRelativeTime(reply.repliedAt)}
                   </span>
                 </div>
-                <p className="text-[13px] leading-relaxed text-white/65 sm:text-[14px]">
+                <p className="text-[13px] leading-relaxed text-white/65 break-words sm:text-[14px]" style={{ overflowWrap: "anywhere" }}>
                   {reply.reply}
                 </p>
               </div>


### PR DESCRIPTION
## Summary
- Long URLs (e.g. explorer tx links) overflow the container on inbox list and message detail pages
- Added `break-words` + `overflow-wrap: anywhere` to message content, reply text, and messageId spans

## Files changed
- `app/components/InboxRow.tsx` — list view message body + reply text
- `app/inbox/[address]/msg/[messageId]/page.tsx` — detail view content + reply + meta footer

## Test plan
- [x] Visit any inbox message containing a long URL (e.g. Hiro explorer link)
- [x] Verify text wraps within the card instead of overflowing horizontally

🤖 Generated with [Claude Code](https://claude.com/claude-code)