### PR TITLE
Fix navbar button sizing on medium screens

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -127,11 +127,11 @@ export default function Navbar() {
 
           {/* Desktop Navigation */}
           <nav
-            className="flex items-center gap-6 max-md:hidden"
+            className="flex items-center gap-2 lg:gap-6 max-md:hidden"
             role="navigation"
             aria-label="Main navigation"
           >
-            <div className="flex items-center gap-3">
+            <div className="flex items-center gap-3 max-lg:gap-2">
               <SocialLinks variant="header" />
             </div>
 
@@ -145,14 +145,14 @@ export default function Navbar() {
               <Link
                 key={link.href}
                 href={link.href}
-                className="inline-flex items-center justify-center rounded-lg border border-white/15 bg-[rgba(30,30,30,0.8)] backdrop-blur-sm px-4 py-2 text-sm font-medium text-white/80 transition-[background-color,border-color,color,transform] duration-200 hover:border-white/25 hover:bg-[rgba(45,45,45,0.85)] hover:text-white active:scale-[0.97]"
+                className="inline-flex items-center justify-center rounded-lg border border-white/15 bg-[rgba(30,30,30,0.8)] backdrop-blur-sm px-2.5 py-1.5 text-xs lg:px-4 lg:py-2 lg:text-sm font-medium text-white/80 transition-[background-color,border-color,color,transform] duration-200 hover:border-white/25 hover:bg-[rgba(45,45,45,0.85)] hover:text-white active:scale-[0.97]"
               >
                 {link.label}
               </Link>
             ))}
             <Link
               href="/guide"
-              className="inline-flex items-center justify-center rounded-lg border border-[#F7931A]/30 bg-[rgba(30,20,10,0.85)] px-4 py-2 text-sm font-medium text-[#F7931A] transition-[background-color,border-color,color,transform] duration-200 hover:border-[#F7931A]/50 hover:bg-[rgba(40,28,12,0.9)] hover:text-[#FFB347] active:scale-[0.97]"
+              className="inline-flex items-center justify-center rounded-lg border border-[#F7931A]/30 bg-[rgba(30,20,10,0.85)] px-2.5 py-1.5 text-xs lg:px-4 lg:py-2 lg:text-sm font-medium text-[#F7931A] transition-[background-color,border-color,color,transform] duration-200 hover:border-[#F7931A]/50 hover:bg-[rgba(40,28,12,0.9)] hover:text-[#FFB347] active:scale-[0.97]"
             >
               Get Started
             </Link>


### PR DESCRIPTION
## Summary
- Nav buttons (Agent Network, Activity Feed, Skills, Get Started) use fixed large padding/font at all desktop sizes
- On medium screens (768px–1024px) they look oversized and cramped
- Scaled down to `px-2.5 py-1.5 text-xs` on md, full `px-4 py-2 text-sm` on lg+
- Reduced nav gap from fixed `gap-6` to `gap-2 lg:gap-6`

## Test plan
- [x] Resize browser between 768px and 1024px — buttons should be compact
- [x] Above 1024px — buttons render at original size
- [x] Below 768px — mobile hamburger menu unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)