### PR TITLE
fix: unify agent count across home, health, and network pages

### DIFF
--- a/app/components/HomeHeroStats.tsx
+++ b/app/components/HomeHeroStats.tsx
@@ -15,12 +15,33 @@ interface HomeHeroStatsProps {
  * Displayed inline next to the avatar stack on desktop,
  * stacked vertically below avatars on mobile.
  *
+ * The `count` prop is an SSR-baked value used for the initial render.
+ * On mount, a client-side fetch to /api/health replaces it with a live
+ * count so the home page always matches the health endpoint and agent
+ * network page, even when Cloudflare has cached an older HTML response.
+ *
  * Listens for "activity-queued-registrations" custom events from the
  * ActivityFeed so the displayed count starts lower and counts up as
  * registration events drip through the feed.
  */
 export default function HomeHeroStats({ count }: HomeHeroStatsProps) {
+  const [liveCount, setLiveCount] = useState(count);
   const [queuedRegistrations, setQueuedRegistrations] = useState(0);
+
+  // Fetch the authoritative count from the health endpoint on mount.
+  // /api/health sets Cache-Control: no-cache so this is always fresh.
+  useEffect(() => {
+    fetch("/api/health")
+      .then((r) => r.json())
+      .then((data: unknown) => {
+        const live = (data as { services?: { kv?: { registeredCount?: unknown } } })
+          ?.services?.kv?.registeredCount;
+        if (typeof live === "number") setLiveCount(live);
+      })
+      .catch(() => {
+        // keep the SSR-baked count on network error
+      });
+  }, []);
 
   useEffect(() => {
     const handler = (e: Event) => {
@@ -33,7 +54,7 @@ export default function HomeHeroStats({ count }: HomeHeroStatsProps) {
     return () => window.removeEventListener("activity-queued-registrations", handler);
   }, []);
 
-  const displayCount = count - queuedRegistrations;
+  const displayCount = liveCount - queuedRegistrations;
   const spotsRemaining = Math.max(GENESIS_CAP - displayCount, 0);
 
   return (


### PR DESCRIPTION
## Summary

- Closes #356
- The home page SSR-bakes the agent count into the HTML at render time. When Cloudflare caches this response, the hero stat (84) becomes stale while `/api/health` and the `/agents` network page read KV fresh every request and show the correct number (86).
- `HomeHeroStats` now fetches `/api/health` on mount — which sets `Cache-Control: no-cache, no-store, must-revalidate` — and replaces the initial SSR prop with the live `registeredCount`. The SSR value is still used for the first paint to avoid layout shift; it is replaced silently once the fetch resolves. Falls back to the SSR value on network error.

## What changed

`app/components/HomeHeroStats.tsx`:
- Added `liveCount` state initialised from the `count` SSR prop
- Added a `useEffect` that fetches `/api/health` on mount and updates `liveCount` if `services.kv.registeredCount` is a number
- `displayCount` now derives from `liveCount` (instead of `count`) minus the queued-registration animation offset

## Test plan

- [ ] Load the home page — hero stat renders immediately (no layout shift) using the SSR value
- [ ] Inspect the network tab — one request to `/api/health` fires on mount with no-cache headers
- [ ] Verify the displayed count matches `GET /api/health` → `services.kv.registeredCount`
- [ ] Verify the displayed count matches the total shown on `/agents`
- [ ] Simulate network failure (DevTools offline) — SSR-baked count is shown, no console error

🤖 Generated with [Claude Code](https://claude.com/claude-code)