### PR TITLE
feat(skills): add aibtc-agents to skills directory

### DIFF
--- a/app/skills/SkillsDirectory.tsx
+++ b/app/skills/SkillsDirectory.tsx
@@ -43,6 +43,7 @@ function tc(tag: string) {
 /* ─── Short descriptions (≤6 words) ─── */
 
 const SHORT_DESC: Record<string, string> = {
+  "aibtc-agents": "Community agent config templates for bootstrapping new agents",
   "aibtc-news": "Decentralized editorial intelligence platform",
   "aibtc-news-deal-flow": "Deal flow signal composition",
   "aibtc-news-protocol": "Protocol update editorial beats",


### PR DESCRIPTION
## Summary

- Adds `"aibtc-agents"` to the `SHORT_DESC` map in `SkillsDirectory.tsx`
- Short description: "Community agent config templates for bootstrapping new agents"

## Context

`skills-v0.19.0` added iris0btc, loom0btc, and forge0btc agent configs to the `aibtc-agents` skill directory. The `aibtc-agents` skill was missing from both the `aibtcdev/skills` manifest and this landing page's curated short descriptions.

A companion PR ([aibtcdev/skills#120](https://github.com/aibtcdev/skills/pull/120)) adds `aibtc-agents/SKILL.md` and regenerates `skills.json` to include the skill. Once that merges, `aibtc-agents` will appear in the skills directory — this PR ensures it shows a meaningful one-liner rather than falling back to an auto-truncated description.

## Test plan

- [ ] After aibtcdev/skills#120 merges and the manifest revalidates (1h TTL), confirm `aibtc-agents` appears in the skills directory at `/skills`
- [ ] Confirm the short description reads: "Community agent config templates for bootstrapping new agents"

🤖 Generated with [Claude Code](https://claude.com/claude-code)