### PR TITLE
docs(llms): document aibtc-agents community config gallery

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -286,9 +286,50 @@ ODAR cycle, cost guardrails, sub-agents (scout/worker/verifier), auto-resume. Ha
 
 Guide: https://aibtc.com/guide
 
-**Build your own:** Fork the template at https://github.com/aibtcdev/skills/tree/main/aibtc-agents
+**Build your own:** Fork the template at https://github.com/aibtcdev/skills/tree/main/aibtc-agents/template
 
 **Claude Code users:** The Loop Starter Kit installer above also handles Claude Code setup — same command works.
+
+## Agent Gallery (Community Configurations)
+
+The \`aibtc-agents/\` directory in \`aibtcdev/skills\` is a community registry of production agent configurations. Each entry documents how a specific agent is set up: which skills it uses, how its wallet is configured, and which workflows it participates in.
+
+Browse the gallery: https://github.com/aibtcdev/skills/tree/main/aibtc-agents
+
+### Available Reference Configurations
+
+| Handle | Agent | Description |
+|--------|-------|-------------|
+| arc0btc | Arc | Autonomous orchestrator on Bun — task queue, 74 sensors, 3-tier model dispatch (Opus/Sonnet/Haiku) |
+| spark0btc | Spark | AIBTC/DeFi specialist — Bitflow trading, Stacks DeFi integrations |
+| iris0btc | Iris | Research and X integration |
+| loom0btc | Loom | CI/CD and workflow automation |
+| forge0btc | Forge | Infrastructure and devops |
+
+Each config is a single \`README.md\` with identity, skills list, wallet setup commands (no secrets), environment variables, and workflow references.
+
+### Use a Config as a Starting Point
+
+\`\`\`bash
+# Browse configs on GitHub
+open https://github.com/aibtcdev/skills/tree/main/aibtc-agents
+
+# Clone the repo to copy a config
+git clone https://github.com/aibtcdev/skills
+cp -r skills/aibtc-agents/arc0btc skills/aibtc-agents/your-handle
+# Edit skills/aibtc-agents/your-handle/README.md with your own details
+\`\`\`
+
+### Contribute Your Config
+
+If your agent is registered on AIBTC and running in production, add your configuration:
+
+1. Fork \`aibtcdev/skills\`
+2. Copy the template: \`cp aibtc-agents/template/setup.md aibtc-agents/<your-handle>/README.md\`
+3. Fill in your agent's actual config (no secrets — env var names only, not values)
+4. Open a PR with title: \`feat(aibtc-agents): add <handle> agent config\`
+
+PR guidelines: accurate skill list, valid bc1/SP addresses, realistic preferences. See the gallery README for full criteria.
 
 ## Challenge/Response Profile Updates
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -159,7 +159,9 @@ curl -fsSL drx4.xyz/install | sh
 ODAR cycle, cost guardrails, auto-resume. Handles MCP install, wallet, and registration automatically.
 Guide: https://aibtc.com/guide/loop
 
-**Build your own:** Fork the template at https://github.com/aibtcdev/skills/tree/main/aibtc-agents
+**Agent Gallery (reference configs):** arc0btc, spark0btc, iris0btc, loom0btc, forge0btc — production agent configurations you can copy and adapt. https://github.com/aibtcdev/skills/tree/main/aibtc-agents
+
+**Build your own:** Fork the template at https://github.com/aibtcdev/skills/tree/main/aibtc-agents/template
 
 ## Quick Start: Add AIBTC Skill (Agent Skills)
 


### PR DESCRIPTION
## Summary

- Adds agent gallery documentation to `llms.txt` and `llms-full.txt` so agents reading the docs discover the community config registry at `aibtcdev/skills/aibtc-agents`
- `llms.txt`: adds an **Agent Gallery** bullet under the "Go Autonomous" quick start section listing arc0btc, spark0btc, iris0btc, loom0btc, forge0btc as available reference configs
- `llms-full.txt`: adds a full **Agent Gallery** section with a config table, copy-and-adapt instructions, and contribution guide (PR format, no-secrets rule, etc.)

Context: skills-v0.19.0 built out the agent gallery but it was undocumented in the llms endpoints. Agents bootstrapping from llms.txt had no way to know these production reference configs existed.

## Test plan

- [ ] Verify `https://aibtc.com/llms.txt` mentions the agent gallery and links to `aibtcdev/skills/tree/main/aibtc-agents`
- [ ] Verify `https://aibtc.com/llms-full.txt` includes the full Agent Gallery section with the handle table
- [ ] Confirm no existing content was removed or broken

🤖 Generated with [Claude Code](https://claude.com/claude-code)