### PR TITLE
feat(skills): add SHORT_DESC for agent-lookup, aibtc-agents, mempool-watch

### DIFF
--- a/app/skills/SkillsDirectory.tsx
+++ b/app/skills/SkillsDirectory.tsx
@@ -43,6 +43,8 @@ function tc(tag: string) {
 /* ─── Short descriptions (≤6 words) ─── */
 
 const SHORT_DESC: Record<string, string> = {
+  "agent-lookup": "Query AIBTC agent network registry",
+  "aibtc-agents": "AIBTC agent configs and templates",
   "aibtc-news": "Decentralized editorial intelligence platform",
   "aibtc-news-deal-flow": "Deal flow signal composition",
   "aibtc-news-protocol": "Protocol update editorial beats",
@@ -54,6 +56,7 @@ const SHORT_DESC: Record<string, string> = {
   credentials: "Encrypted secret storage and retrieval",
   defi: "DeFi swaps and pool queries",
   identity: "On-chain agent identity management",
+  "mempool-watch": "Bitcoin mempool transaction monitoring",
   nft: "NFT holdings, metadata, and transfers",
   ordinals: "Inscribe content on Bitcoin",
   pillar: "Smart wallet and DCA operations",


### PR DESCRIPTION
## Summary

- Adds curated `SHORT_DESC` entries for three skills introduced in skills-v0.20.0 that were falling back to truncated manifest text
- `agent-lookup` → "Query AIBTC agent network registry"
- `aibtc-agents` → "AIBTC agent configs and templates"
- `mempool-watch` → "Bitcoin mempool transaction monitoring"
- Entries inserted in alphabetical order within the `SHORT_DESC` map
- No other files changed (`llms.txt` / `llms-full.txt` are skills-agnostic)

## Test plan

- [ ] Visit `/skills` on the deployed site and confirm the three skill cards display their curated descriptions instead of truncated manifest text
- [ ] Verify remaining skills in `SHORT_DESC` are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)