### PR TITLE
refactor: move agent utilities to dedicated lib/agents module

### DIFF
--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
-import { normalizeAgentRecord } from "@/lib/types";
+import { normalizeAgentRecord } from "@/lib/agents";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { lookupBnsName } from "@/lib/bns";
 import { getAchievementCount } from "@/lib/achievements";

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
-import { normalizeAgentRecord } from "@/lib/types";
+import { normalizeAgentRecord } from "@/lib/agents";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { ACTIVITY_THRESHOLDS } from "@/lib/utils";
 import { getAchievementCount } from "@/lib/achievements";

--- a/lib/agents.ts
+++ b/lib/agents.ts
@@ -1,0 +1,27 @@
+import type { AgentRecord } from "@/lib/types";
+
+/**
+ * Normalize an AgentRecord so every key is always present.
+ * Optional fields default to null (strings/objects) or 0 (numbers).
+ * Ensures agents always receive a predictable shape from any endpoint.
+ */
+export function normalizeAgentRecord(agent: AgentRecord) {
+  return {
+    stxAddress: agent.stxAddress,
+    btcAddress: agent.btcAddress,
+    stxPublicKey: agent.stxPublicKey,
+    btcPublicKey: agent.btcPublicKey,
+    taprootAddress: agent.taprootAddress ?? null,
+    displayName: agent.displayName ?? null,
+    description: agent.description ?? null,
+    bnsName: agent.bnsName ?? null,
+    owner: agent.owner ?? null,
+    verifiedAt: agent.verifiedAt,
+    lastActiveAt: agent.lastActiveAt ?? null,
+    checkInCount: agent.checkInCount ?? 0,
+    erc8004AgentId: agent.erc8004AgentId ?? null,
+    nostrPublicKey: agent.nostrPublicKey ?? null,
+    lastIdentityCheck: agent.lastIdentityCheck ?? null,
+    referredBy: agent.referredBy ?? null,
+  };
+}

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -23,32 +23,6 @@ export interface AgentRecord {
 }
 
 /**
- * Normalize an AgentRecord so every key is always present.
- * Optional fields default to null (strings/objects) or 0 (numbers).
- * Ensures agents always receive a predictable shape from any endpoint.
- */
-export function normalizeAgentRecord(agent: AgentRecord) {
-  return {
-    stxAddress: agent.stxAddress,
-    btcAddress: agent.btcAddress,
-    stxPublicKey: agent.stxPublicKey,
-    btcPublicKey: agent.btcPublicKey,
-    taprootAddress: agent.taprootAddress ?? null,
-    displayName: agent.displayName ?? null,
-    description: agent.description ?? null,
-    bnsName: agent.bnsName ?? null,
-    owner: agent.owner ?? null,
-    verifiedAt: agent.verifiedAt,
-    lastActiveAt: agent.lastActiveAt ?? null,
-    checkInCount: agent.checkInCount ?? 0,
-    erc8004AgentId: agent.erc8004AgentId ?? null,
-    nostrPublicKey: agent.nostrPublicKey ?? null,
-    lastIdentityCheck: agent.lastIdentityCheck ?? null,
-    referredBy: agent.referredBy ?? null,
-  };
-}
-
-/**
  * Claim status record for viral tweet rewards (minimal type for level computation).
  * Used by computeLevel() to determine if an agent has reached Genesis (Level 2).
  */


### PR DESCRIPTION
## Summary

Closes #374.

- Creates `lib/agents.ts` with `normalizeAgentRecord` (extracted from `lib/types.ts`)
- Updates imports in `app/api/agents/route.ts` and `app/api/leaderboard/route.ts`
- Type definitions (`AgentRecord`, `ClaimRecord`, etc.) remain in `lib/types.ts`

This was flagged as a `[nit]` in the #373 review — `normalizeAgentRecord` is a utility function, not a type definition, so separating it keeps `lib/types.ts` focused on pure type declarations. As agent-related helpers grow, `lib/agents.ts` gives them a logical home.

## Test plan

- [ ] `bun run build` passes (type-check + compilation)
- [ ] `/api/agents` and `/api/leaderboard` responses unchanged — same normalized shape
- [ ] No other files import `normalizeAgentRecord` from `lib/types` (grep confirms 0 remaining)

🤖 Generated with [Claude Code](https://claude.com/claude-code)