### PR TITLE
feat(skills): add tenero market analytics skill to directory and llms.txt

### DIFF
--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -271,6 +271,8 @@ npx skills add aibtcdev/skills/{skill-name}
 curl https://aibtc.com/skills
 \`\`\`
 
+Notable skills: btc (L1 balances/transfers), stx (STX transfers), sbtc (sBTC bridging), defi (DEX swaps), tenero (Stacks market analytics — token info, top gainers/losers, whale trades, holder stats), x402 (paid messaging), wallet (BIP39 key management), and more.
+
 Web directory: https://aibtc.com/skills
 Source: https://github.com/aibtcdev/skills
 

--- a/app/skills/SkillsDirectory.tsx
+++ b/app/skills/SkillsDirectory.tsx
@@ -68,6 +68,7 @@ const SHORT_DESC: Record<string, string> = {
   stacking: "STX stacking and PoX operations",
   "stacks-market": "Prediction market trading on Stacks",
   stackspot: "Stacking lottery pot participation",
+  tenero: "Stacks market analytics and token data",
   stx: "STX token balances and transfers",
   "taproot-multisig": "Taproot M-of-N multisig coordination",
   tokens: "Fungible token operations on Stacks",


### PR DESCRIPTION
## Summary

- Add `tenero` short description to `SkillsDirectory.tsx` SHORT_DESC map: "Stacks market analytics and token data"
- Add tenero mention in `llms.txt` skills directory section alongside other notable skills

## Context

skills-v0.21.0 (PRs #125, #130) added the tenero market analytics skill (formerly STXTools) to the aibtcdev/skills repo, but it was missing from the landing page skills directory short descriptions and llms.txt.

Tenero provides: token info, market stats, top gainers/losers, wallet holdings/trades, trending DEX pools, whale trades, holder distribution, and search across Stacks, Spark, and SportsFun chains. No API key required.

Closes gap identified in task #5640 (landing-page skills-v0.21.0 content audit).

## Test plan

- [ ] Visit /skills page and verify tenero shows its short description correctly
- [ ] `curl https://aibtc.com/llms.txt` and verify tenero is mentioned in the Skills Directory section

🤖 Generated with [Claude Code](https://claude.com/claude-code)