### PR TITLE
fix(security): patch undici and flatted high-severity CVEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8036,9 +8036,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.3.3",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
-      "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
+      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -11822,9 +11822,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.18.2.tgz",
-      "integrity": "sha512-y+8YjDFzWdQlSE9N5nzKMT3g4a5UBX1HKowfdXh0uvAnTaqqwqB92Jt4UXBAeKekDs5IaDKyJFR4X1gYVCgXcw==",
+      "version": "7.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.1.tgz",
+      "integrity": "sha512-5xoBibbmnjlcR3jdqtY2Lnx7WbrD/tHlT01TmvqZUFVc9Q1w4+j5hbnapTqbcXITMH1ovjq/W7BkqBilHiVAaA==",
       "license": "MIT",
       "engines": {
         "node": ">=20.18.1"

--- a/package.json
+++ b/package.json
@@ -32,6 +32,10 @@
     "swr": "^2.4.0",
     "x402-stacks": "^2.0.1"
   },
+  "overrides": {
+    "undici": ">=7.24.0",
+    "flatted": ">=3.4.0"
+  },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",
     "patch-package": "^8.0.1",


### PR DESCRIPTION
## Summary

- Adds npm `overrides` to force safe transitive dependency versions
- **undici** `7.18.2` → `>=7.24.0` (resolves to `7.24.1`): fixes CVE-2026-1526, CVE-2026-2229, CVE-2026-1528 (CVSS 7.5, high severity via `miniflare`)
- **flatted** `3.3.3` → `>=3.4.0`: fixes GHSA-25h7-pfq9-p65f (unbounded recursion DoS in parse())

Both are transitive deps; no direct dependency changes were needed. `npm audit` reports 0 vulnerabilities after this change.

## Test plan

- [ ] `npm audit` returns 0 vulnerabilities
- [ ] `npm run build` succeeds
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)