### PR TITLE
fix: improve inbox validation errors with agent-friendly hints (closes #389)

### DIFF
--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -128,7 +128,12 @@ export async function PATCH(
   const validation = validateMarkRead(body);
   if (validation.errors) {
     return NextResponse.json(
-      { error: validation.errors.join(", ") },
+      {
+        error: "Validation failed",
+        errors: validation.errors,
+        hints: validation.hints,
+        documentation: "https://aibtc.com/docs/messaging.txt",
+      },
       { status: 400 }
     );
   }

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -546,7 +546,12 @@ export async function POST(
   if (validation.errors) {
     logger.warn("Validation failed", { errors: validation.errors });
     return NextResponse.json(
-      { error: validation.errors.join(", ") },
+      {
+        error: "Validation failed",
+        errors: validation.errors,
+        hints: validation.hints,
+        documentation: "https://aibtc.com/docs/messaging.txt",
+      },
       { status: 400 }
     );
   }

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -163,12 +163,9 @@ export async function POST(
     logger.warn("Validation failed", { errors: validation.errors });
     return NextResponse.json(
       {
-        error: validation.errors.join(", "),
-        expectedBody: {
-          messageId: "string — the inbox message ID you are replying to (e.g. msg_...)",
-          reply: "string — your reply text (max 500 characters)",
-          signature: "string — BIP-137/BIP-322 signature over 'Inbox Reply | {messageId} | {reply}'",
-        },
+        error: "Validation failed",
+        errors: validation.errors,
+        hints: validation.hints,
         documentation: "https://aibtc.com/docs/messaging.txt",
       },
       { status: 400 }

--- a/lib/inbox/validation.ts
+++ b/lib/inbox/validation.ts
@@ -3,40 +3,90 @@
  *
  * Follows the pattern from lib/attention/validation.ts:
  * - Returns { data: T } on success
- * - Returns { errors: string[] } on validation failure
+ * - Returns { errors: string[], hints: ValidationHint[] } on validation failure
  */
 
 import { MAX_MESSAGE_LENGTH, MAX_REPLY_LENGTH } from "./constants";
 import { validateSignatureFormat } from "@/lib/validation/signature";
 import { isStxAddress } from "@/lib/validation/address";
 
+/**
+ * A structured hint attached to a validation error.
+ * Tells the agent exactly what field failed, what format is expected,
+ * and provides an example value so it can self-correct without human help.
+ */
+export interface ValidationHint {
+  /** The field that failed validation. */
+  field: string;
+  /** The human-readable error message (same as the string in `errors`). */
+  message: string;
+  /** A description of what the field is for and how to obtain the value. */
+  hint: string;
+  /** Optional regex pattern or format description for the expected value. */
+  format?: string;
+  /** Optional concrete example value for this field. */
+  example?: string;
+}
+
+/** Internal accumulator that pairs error strings with structured hints. */
+type FieldError = {
+  message: string;
+  hint: ValidationHint;
+};
+
 /** Validate Bitcoin address format (Native SegWit). */
-function validateBtcAddress(address: string, fieldName: string): string[] {
-  const errors: string[] = [];
+function validateBtcAddress(address: string, fieldName: string): FieldError[] {
+  const errors: FieldError[] = [];
   if (!/^bc1[a-z0-9]{39,59}$/.test(address)) {
-    errors.push(
-      `${fieldName} must be a valid Native SegWit address (bc1..., 42-62 lowercase alphanumeric characters)`
-    );
+    const message = `${fieldName} must be a valid Native SegWit address (bc1..., 42-62 lowercase alphanumeric characters)`;
+    errors.push({
+      message,
+      hint: {
+        field: fieldName,
+        message,
+        hint: "The recipient's Bitcoin Native SegWit address (bc1q... or bc1p...). Look up the recipient agent's profile at GET /api/verify/{address} to find their registered BTC address.",
+        format: "bc1[a-z0-9]{39,59}",
+        example: "bc1qq9vpsra2cjmuvlx623ltsnw04cfxl2xevuahw3",
+      },
+    });
   }
   return errors;
 }
 
 /** Validate Stacks address format. */
-function validateStxAddress(address: string, fieldName: string): string[] {
-  const errors: string[] = [];
+function validateStxAddress(address: string, fieldName: string): FieldError[] {
+  const errors: FieldError[] = [];
   if (!isStxAddress(address)) {
-    errors.push(
-      `${fieldName} must be a valid Stacks address (mainnet: SP/SM, 39-41 uppercase alphanumeric characters)`
-    );
+    const message = `${fieldName} must be a valid Stacks address (mainnet: SP/SM, 39-41 uppercase alphanumeric characters)`;
+    errors.push({
+      message,
+      hint: {
+        field: fieldName,
+        message,
+        hint: "The recipient's Stacks mainnet address (SP... or SM...). This must match the address registered for this agent. Look up the recipient agent at GET /api/verify/{btcAddress}.",
+        format: "SP[A-Z0-9]{38,40} or SM[A-Z0-9]{38,40}",
+        example: "SP1092FF21MZXE9D7SZ7F86WA3Q58BY9WCZ0T0DF7",
+      },
+    });
   }
   return errors;
 }
 
 /** Validate transaction ID format (64-char hex). */
-function validateTxid(txid: string, fieldName: string): string[] {
-  const errors: string[] = [];
+function validateTxid(txid: string, fieldName: string): FieldError[] {
+  const errors: FieldError[] = [];
   if (!/^[0-9a-fA-F]{64}$/.test(txid)) {
-    errors.push(`${fieldName} must be a 64-character hex string`);
+    const message = `${fieldName} must be a 64-character hex string`;
+    errors.push({
+      message,
+      hint: {
+        field: fieldName,
+        message,
+        hint: "The Bitcoin/Stacks transaction ID (txid) for the sBTC payment. This is the on-chain transaction hash from the sBTC transfer used to pay for inbox delivery.",
+        format: "[0-9a-fA-F]{64}",
+        example: "a3b1c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+      },
+    });
   }
   return errors;
 }
@@ -62,7 +112,7 @@ function validateTxid(txid: string, fieldName: string): string[] {
  * signature over "Inbox Message | {content}" and stores the recovered address as
  * senderBtcAddress on the message. Unsigned messages continue to work unchanged.
  *
- * Returns validated data on success, or field-level errors on failure.
+ * Returns validated data on success, or field-level errors and hints on failure.
  */
 export function validateInboxMessage(body: unknown):
   | {
@@ -76,69 +126,187 @@ export function validateInboxMessage(body: unknown):
         replyTo?: string;
       };
       errors?: never;
+      hints?: never;
     }
-  | { data?: never; errors: string[] } {
+  | { data?: never; errors: string[]; hints: ValidationHint[] } {
   if (!body || typeof body !== "object") {
-    return { errors: ["Request body must be a JSON object"] };
+    const message = "Request body must be a JSON object";
+    return {
+      errors: [message],
+      hints: [
+        {
+          field: "body",
+          message,
+          hint: "Ensure Content-Type: application/json is set and the request body is a valid JSON object with the required fields.",
+          example: JSON.stringify({
+            toBtcAddress: "bc1qq9vpsra2cjmuvlx623ltsnw04cfxl2xevuahw3",
+            toStxAddress: "SP1092FF21MZXE9D7SZ7F86WA3Q58BY9WCZ0T0DF7",
+            content: "Hello agent!",
+          }),
+        },
+      ],
+    };
   }
 
   const b = body as Record<string, unknown>;
-  const errors: string[] = [];
+  const fieldErrors: FieldError[] = [];
 
   // toBtcAddress — Native SegWit (bc1)
   if (typeof b.toBtcAddress !== "string") {
-    errors.push("toBtcAddress must be a string");
+    const message = "toBtcAddress must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "toBtcAddress",
+        message,
+        hint: "The recipient's Bitcoin Native SegWit address. Look up the recipient agent at GET /api/verify/{address} to find their registered btcAddress.",
+        format: "bc1[a-z0-9]{39,59}",
+        example: "bc1qq9vpsra2cjmuvlx623ltsnw04cfxl2xevuahw3",
+      },
+    });
   } else {
-    errors.push(...validateBtcAddress(b.toBtcAddress, "toBtcAddress"));
+    fieldErrors.push(...validateBtcAddress(b.toBtcAddress, "toBtcAddress"));
   }
 
   // toStxAddress — Stacks address (SP/SM)
   if (typeof b.toStxAddress !== "string") {
-    errors.push("toStxAddress must be a string");
+    const message = "toStxAddress must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "toStxAddress",
+        message,
+        hint: "The recipient's Stacks mainnet address. Look up the recipient agent at GET /api/verify/{btcAddress} to find their registered stxAddress.",
+        format: "SP[A-Z0-9]{38,40} or SM[A-Z0-9]{38,40}",
+        example: "SP1092FF21MZXE9D7SZ7F86WA3Q58BY9WCZ0T0DF7",
+      },
+    });
   } else {
-    errors.push(...validateStxAddress(b.toStxAddress, "toStxAddress"));
+    fieldErrors.push(...validateStxAddress(b.toStxAddress, "toStxAddress"));
   }
 
   // content — Non-empty string, max 500 chars
   if (typeof b.content !== "string") {
-    errors.push("content must be a string");
+    const message = "content must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "content",
+        message,
+        hint: "The message text you want to deliver. Must be a non-empty string of up to 500 characters.",
+        example: "Hello! I'd like to collaborate on a new project.",
+      },
+    });
   } else if (b.content.trim().length === 0) {
-    errors.push("content cannot be empty");
+    const message = "content cannot be empty";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "content",
+        message,
+        hint: "The message content must not be blank or whitespace-only.",
+        example: "Hello! I'd like to collaborate on a new project.",
+      },
+    });
   } else if (b.content.length > MAX_MESSAGE_LENGTH) {
-    errors.push(
-      `content exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`
-    );
+    const message = `content exceeds maximum length of ${MAX_MESSAGE_LENGTH} characters`;
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "content",
+        message,
+        hint: `Trim your message to ${MAX_MESSAGE_LENGTH} characters or fewer. Current length: ${b.content.length}.`,
+      },
+    });
   }
 
   // paymentTxid — optional, but if provided must be 64-char hex
   if (b.paymentTxid !== undefined) {
     if (typeof b.paymentTxid !== "string") {
-      errors.push("paymentTxid must be a string");
+      const message = "paymentTxid must be a string";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "paymentTxid",
+          message,
+          hint: "The transaction ID of the sBTC payment (on-chain txid recovery path). Must be a 64-character lowercase hex string.",
+          format: "[0-9a-fA-F]{64}",
+          example: "a3b1c2d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1b2",
+        },
+      });
     } else {
-      errors.push(...validateTxid(b.paymentTxid, "paymentTxid"));
+      fieldErrors.push(...validateTxid(b.paymentTxid, "paymentTxid"));
     }
   }
 
   // paymentSatoshis — optional, but if provided must be positive integer
   if (b.paymentSatoshis !== undefined) {
     if (typeof b.paymentSatoshis !== "number") {
-      errors.push("paymentSatoshis must be a number");
+      const message = "paymentSatoshis must be a number";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "paymentSatoshis",
+          message,
+          hint: "The amount paid in satoshis. Must be a positive integer. The required price is 100 satoshis.",
+          format: "positive integer",
+          example: "100",
+        },
+      });
     } else if (
       !Number.isInteger(b.paymentSatoshis) ||
       b.paymentSatoshis <= 0
     ) {
-      errors.push("paymentSatoshis must be a positive integer");
+      const message = "paymentSatoshis must be a positive integer";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "paymentSatoshis",
+          message,
+          hint: "The payment amount in satoshis must be a whole positive number. The required inbox price is 100 satoshis.",
+          format: "integer > 0",
+          example: "100",
+        },
+      });
     }
   }
 
   // replyTo — optional reference to another message (must match msg_ prefix)
   if (b.replyTo !== undefined) {
     if (typeof b.replyTo !== "string") {
-      errors.push("replyTo must be a string");
+      const message = "replyTo must be a string";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "replyTo",
+          message,
+          hint: "The message ID you are replying to (for threading). Retrieve message IDs from GET /api/inbox/{yourAddress}.",
+          format: "msg_{timestamp}_{uuid}",
+          example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+        },
+      });
     } else if (b.replyTo.trim().length === 0) {
-      errors.push("replyTo cannot be empty");
+      const message = "replyTo cannot be empty";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "replyTo",
+          message,
+          hint: "If provided, replyTo must be a valid message ID (msg_... format). Omit this field if you are not replying to a specific message.",
+        },
+      });
     } else if (!/^msg_/.test(b.replyTo)) {
-      errors.push("replyTo must be a valid message ID (msg_... format)");
+      const message = "replyTo must be a valid message ID (msg_... format)";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "replyTo",
+          message,
+          hint: "Message IDs are generated by the platform and always start with 'msg_'. Retrieve them from GET /api/inbox/{yourAddress}.",
+          format: "msg_{timestamp}_{uuid}",
+          example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+        },
+      });
     }
   }
 
@@ -146,14 +314,39 @@ export function validateInboxMessage(body: unknown):
   // Signed message format: "Inbox Message | {content}"
   if (b.signature !== undefined) {
     if (typeof b.signature !== "string") {
-      errors.push("signature must be a string");
+      const message = "signature must be a string";
+      fieldErrors.push({
+        message,
+        hint: {
+          field: "signature",
+          message,
+          hint: "A BIP-137 or BIP-322 signature over 'Inbox Message | {content}', signed with your Bitcoin private key. Provides optional sender authentication.",
+          format: "base64 (88 chars) or hex (130 chars)",
+          example: "H+base64encodedSignatureHere=",
+        },
+      });
     } else {
-      errors.push(...validateSignatureFormat(b.signature));
+      const sigErrors = validateSignatureFormat(b.signature);
+      for (const msg of sigErrors) {
+        fieldErrors.push({
+          message: msg,
+          hint: {
+            field: "signature",
+            message: msg,
+            hint: "Sign the string 'Inbox Message | {content}' with your Bitcoin private key using BIP-137 or BIP-322. The MCP tool 'sign_message' can produce this signature.",
+            format: "base64 (88 chars for BIP-137) or hex (130 chars for BIP-322)",
+            example: "H+base64encodedSignatureHere=",
+          },
+        });
+      }
     }
   }
 
-  if (errors.length > 0) {
-    return { errors };
+  if (fieldErrors.length > 0) {
+    return {
+      errors: fieldErrors.map((e) => e.message),
+      hints: fieldErrors.map((e) => e.hint),
+    };
   }
 
   return {
@@ -187,7 +380,7 @@ export function validateInboxMessage(body: unknown):
  *   signature: string    // BIP-137 signature (base64 or hex)
  * }
  *
- * Returns validated data on success, or field-level errors on failure.
+ * Returns validated data on success, or field-level errors and hints on failure.
  */
 export function validateOutboxReply(body: unknown):
   | {
@@ -197,42 +390,127 @@ export function validateOutboxReply(body: unknown):
         signature: string;
       };
       errors?: never;
+      hints?: never;
     }
-  | { data?: never; errors: string[] } {
+  | { data?: never; errors: string[]; hints: ValidationHint[] } {
   if (!body || typeof body !== "object") {
-    return { errors: ["Request body must be a JSON object"] };
+    const message = "Request body must be a JSON object";
+    return {
+      errors: [message],
+      hints: [
+        {
+          field: "body",
+          message,
+          hint: "Ensure Content-Type: application/json is set and the request body is a valid JSON object.",
+          example: JSON.stringify({
+            messageId: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+            reply: "Thanks for reaching out!",
+            signature: "<BIP-137 or BIP-322 signature>",
+          }),
+        },
+      ],
+    };
   }
 
   const b = body as Record<string, unknown>;
-  const errors: string[] = [];
+  const fieldErrors: FieldError[] = [];
 
   // messageId — Non-empty string
   if (typeof b.messageId !== "string") {
-    errors.push("messageId must be a string");
+    const message = "messageId must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "messageId",
+        message,
+        hint: "The ID of the inbox message you are replying to. Retrieve message IDs from GET /api/inbox/{yourAddress}.",
+        format: "msg_{timestamp}_{uuid}",
+        example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+      },
+    });
   } else if (b.messageId.trim().length === 0) {
-    errors.push("messageId cannot be empty");
+    const message = "messageId cannot be empty";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "messageId",
+        message,
+        hint: "The messageId must be a non-empty string matching an inbox message you received. Look up your messages at GET /api/inbox/{yourBtcAddress}.",
+        format: "msg_{timestamp}_{uuid}",
+        example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+      },
+    });
   }
 
   // reply — Non-empty string, max 500 chars
   if (typeof b.reply !== "string") {
-    errors.push("reply must be a string");
+    const message = "reply must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "reply",
+        message,
+        hint: "Your reply text. Must be a non-empty string of up to 500 characters.",
+        example: "Thanks for your message! I'm available to collaborate.",
+      },
+    });
   } else if (b.reply.trim().length === 0) {
-    errors.push("reply cannot be empty");
+    const message = "reply cannot be empty";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "reply",
+        message,
+        hint: "The reply must not be blank or whitespace-only. Write your response text here.",
+        example: "Thanks for your message!",
+      },
+    });
   } else if (b.reply.length > MAX_REPLY_LENGTH) {
-    errors.push(
-      `reply exceeds maximum length of ${MAX_REPLY_LENGTH} characters`
-    );
+    const message = `reply exceeds maximum length of ${MAX_REPLY_LENGTH} characters`;
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "reply",
+        message,
+        hint: `Trim your reply to ${MAX_REPLY_LENGTH} characters or fewer. Current length: ${b.reply.length}.`,
+      },
+    });
   }
 
   // signature — Base64 or hex-encoded (65 bytes)
   if (typeof b.signature !== "string") {
-    errors.push("signature must be a string");
+    const message = "signature must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "signature",
+        message,
+        hint: "A BIP-137 or BIP-322 signature proving you own the inbox. Sign the string 'Inbox Reply | {messageId} | {reply}' with your agent's Bitcoin private key. Use the MCP tool 'sign_message' to generate this.",
+        format: "base64 (88 chars for BIP-137) or hex (130 chars for BIP-322)",
+        example: "H+base64encodedSignatureHere=",
+      },
+    });
   } else {
-    errors.push(...validateSignatureFormat(b.signature));
+    const sigErrors = validateSignatureFormat(b.signature);
+    for (const msg of sigErrors) {
+      fieldErrors.push({
+        message: msg,
+        hint: {
+          field: "signature",
+          message: msg,
+          hint: "Sign the string 'Inbox Reply | {messageId} | {reply}' with your Bitcoin private key. The signing address must be your registered agent BTC address (bc1...).",
+          format: "base64 (88 chars for BIP-137) or hex (130 chars for BIP-322)",
+          example: "H+base64encodedSignatureHere=",
+        },
+      });
+    }
   }
 
-  if (errors.length > 0) {
-    return { errors };
+  if (fieldErrors.length > 0) {
+    return {
+      errors: fieldErrors.map((e) => e.message),
+      hints: fieldErrors.map((e) => e.hint),
+    };
   }
 
   return {
@@ -253,7 +531,7 @@ export function validateOutboxReply(body: unknown):
  *   signature: string    // BIP-137 signature (base64 or hex)
  * }
  *
- * Returns validated data on success, or field-level errors on failure.
+ * Returns validated data on success, or field-level errors and hints on failure.
  */
 export function validateMarkRead(body: unknown):
   | {
@@ -262,31 +540,91 @@ export function validateMarkRead(body: unknown):
         signature: string;
       };
       errors?: never;
+      hints?: never;
     }
-  | { data?: never; errors: string[] } {
+  | { data?: never; errors: string[]; hints: ValidationHint[] } {
   if (!body || typeof body !== "object") {
-    return { errors: ["Request body must be a JSON object"] };
+    const message = "Request body must be a JSON object";
+    return {
+      errors: [message],
+      hints: [
+        {
+          field: "body",
+          message,
+          hint: "Ensure Content-Type: application/json is set and the request body is a valid JSON object.",
+          example: JSON.stringify({
+            messageId: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+            signature: "<BIP-137 or BIP-322 signature>",
+          }),
+        },
+      ],
+    };
   }
 
   const b = body as Record<string, unknown>;
-  const errors: string[] = [];
+  const fieldErrors: FieldError[] = [];
 
   // messageId — Non-empty string
   if (typeof b.messageId !== "string") {
-    errors.push("messageId must be a string");
+    const message = "messageId must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "messageId",
+        message,
+        hint: "The ID of the message to mark as read. Retrieve message IDs from GET /api/inbox/{yourAddress}.",
+        format: "msg_{timestamp}_{uuid}",
+        example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+      },
+    });
   } else if (b.messageId.trim().length === 0) {
-    errors.push("messageId cannot be empty");
+    const message = "messageId cannot be empty";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "messageId",
+        message,
+        hint: "The messageId must be a non-empty string. Look up your messages at GET /api/inbox/{yourBtcAddress}.",
+        format: "msg_{timestamp}_{uuid}",
+        example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+      },
+    });
   }
 
   // signature — Base64 or hex-encoded (65 bytes)
   if (typeof b.signature !== "string") {
-    errors.push("signature must be a string");
+    const message = "signature must be a string";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "signature",
+        message,
+        hint: "A BIP-137 or BIP-322 signature proving you own the inbox. Sign the string 'Inbox Read | {messageId}' with your agent's Bitcoin private key.",
+        format: "base64 (88 chars for BIP-137) or hex (130 chars for BIP-322)",
+        example: "H+base64encodedSignatureHere=",
+      },
+    });
   } else {
-    errors.push(...validateSignatureFormat(b.signature));
+    const sigErrors = validateSignatureFormat(b.signature);
+    for (const msg of sigErrors) {
+      fieldErrors.push({
+        message: msg,
+        hint: {
+          field: "signature",
+          message: msg,
+          hint: "Sign the string 'Inbox Read | {messageId}' with your agent's Bitcoin private key. The MCP tool 'sign_message' can generate this.",
+          format: "base64 (88 chars for BIP-137) or hex (130 chars for BIP-322)",
+          example: "H+base64encodedSignatureHere=",
+        },
+      });
+    }
   }
 
-  if (errors.length > 0) {
-    return { errors };
+  if (fieldErrors.length > 0) {
+    return {
+      errors: fieldErrors.map((e) => e.message),
+      hints: fieldErrors.map((e) => e.hint),
+    };
   }
 
   return {


### PR DESCRIPTION
## Summary

- Adds a `ValidationHint` type to `lib/inbox/validation.ts` with fields: `field`, `message`, `hint`, `format`, and `example`
- Updates all three validation functions (`validateInboxMessage`, `validateOutboxReply`, `validateMarkRead`) to return both `errors: string[]` (unchanged, backward-compat) and `hints: ValidationHint[]` on failure
- Updates the three route handlers to surface `hints` and a proper `errors` array (instead of `errors.join(", ")`) in 400 responses, with a `documentation` link

**Example response after this change (missing toBtcAddress and toStxAddress):**
```json
{
  "error": "Validation failed",
  "errors": ["toBtcAddress must be a string", "toStxAddress must be a string"],
  "hints": [
    {
      "field": "toBtcAddress",
      "message": "toBtcAddress must be a string",
      "hint": "The recipient's Bitcoin Native SegWit address. Look up the recipient agent at GET /api/verify/{address} to find their registered btcAddress.",
      "format": "bc1[a-z0-9]{39,59}",
      "example": "bc1qq9vpsra2cjmuvlx623ltsnw04cfxl2xevuahw3"
    },
    {
      "field": "toStxAddress",
      "message": "toStxAddress must be a string",
      "hint": "The recipient's Stacks mainnet address. Look up the recipient agent at GET /api/verify/{btcAddress} to find their registered stxAddress.",
      "format": "SP[A-Z0-9]{38,40} or SM[A-Z0-9]{38,40}",
      "example": "SP1092FF21MZXE9D7SZ7F86WA3Q58BY9WCZ0T0DF7"
    }
  ],
  "documentation": "https://aibtc.com/docs/messaging.txt"
}
```

## Test plan

- [x] All 316 existing tests pass (`npm run test`)
- [x] Existing `errors: string[]` values are unchanged — no test regressions
- [x] The new `hints` array is parallel to `errors` (same order, one hint per error)
- [x] Route handlers updated for: `POST /api/inbox/[address]`, `POST /api/outbox/[address]`, `PATCH /api/inbox/[address]/[messageId]`

Closes #389

🤖 Generated with [Claude Code](https://claude.com/claude-code)