### PR TITLE
fix(outbox): reject sentinel messageId values before KV lookup

### DIFF
--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -132,6 +132,31 @@ export async function POST(
     );
   }
 
+  // Sentinel check: detect placeholder messageId values before validation.
+  // Agents sometimes poll with messageId: "none" when they have no real ID to reply to.
+  // Reject early at DEBUG level (not WARN) — this is a client usage pattern, not a system error.
+  const SENTINEL_IDS = new Set(["none", "null", "undefined", "n/a", "na"]);
+  const rawBody = body as Record<string, unknown>;
+  if (
+    typeof rawBody?.messageId === "string" &&
+    SENTINEL_IDS.has(rawBody.messageId.trim().toLowerCase())
+  ) {
+    logger.debug("Sentinel messageId rejected (no KV lookup performed)", {
+      messageId: rawBody.messageId,
+      address,
+    });
+    return NextResponse.json(
+      {
+        error: "Invalid messageId: sentinel/placeholder value",
+        messageId: rawBody.messageId,
+        hint: 'You provided a placeholder value (like "none" or "null"). The messageId must be a real inbox message ID (format: msg_{timestamp}_{uuid}). To check for replies you have already sent, use GET /api/outbox/{yourAddress}. To find messages to reply to, retrieve your inbox first via GET /api/inbox/{yourAddress}.',
+        correctEndpoint: `GET /api/outbox/${address}`,
+        documentation: "https://aibtc.com/docs/messaging.txt",
+      },
+      { status: 400 }
+    );
+  }
+
   // Validate reply body
   const validation = validateOutboxReply(body);
   if (validation.errors) {

--- a/lib/inbox/validation.ts
+++ b/lib/inbox/validation.ts
@@ -11,6 +11,12 @@ import { validateSignatureFormat } from "@/lib/validation/signature";
 import { isStxAddress } from "@/lib/validation/address";
 
 /**
+ * Sentinel/placeholder messageId values that agents sometimes use when polling
+ * without a real message ID. Normalized to lowercase before comparison.
+ */
+const SENTINEL_MESSAGE_IDS = new Set(["none", "null", "undefined", "n/a", "na"]);
+
+/**
  * A structured hint attached to a validation error.
  * Tells the agent exactly what field failed, what format is expected,
  * and provides an example value so it can self-correct without human help.
@@ -436,6 +442,18 @@ export function validateOutboxReply(body: unknown):
         field: "messageId",
         message,
         hint: "The messageId must be a non-empty string matching an inbox message you received. Look up your messages at GET /api/inbox/{yourBtcAddress}.",
+        format: "msg_{timestamp}_{uuid}",
+        example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
+      },
+    });
+  } else if (SENTINEL_MESSAGE_IDS.has(b.messageId.trim().toLowerCase())) {
+    const message = "messageId is a sentinel/placeholder value";
+    fieldErrors.push({
+      message,
+      hint: {
+        field: "messageId",
+        message,
+        hint: 'You provided a placeholder value (like "none" or "null"). The messageId must be a real inbox message ID. To list messages you have sent replies to, use GET /api/outbox/{yourAddress}. To find messages to reply to, first retrieve your inbox via GET /api/inbox/{yourAddress}.',
         format: "msg_{timestamp}_{uuid}",
         example: "msg_1710000000000_550e8400-e29b-41d4-a716-446655440000",
       },


### PR DESCRIPTION
## Summary

- Detects placeholder/sentinel `messageId` values (`"none"`, `"null"`, `"undefined"`, `"n/a"`, `"na"`) in `POST /api/outbox/{address}` before any KV lookup
- Returns 400 with an agent-friendly hint including `correctEndpoint: "GET /api/outbox/{address}"`
- Logs at `DEBUG` level instead of `WARN` — this is a client usage pattern, not a system error
- Also adds sentinel detection to `validateOutboxReply()` in `lib/inbox/validation.ts` using the existing `ValidationHint` pattern

## Problem

Agent `SP1RHDCCVQ3SVV2DRSP2PJNXJCA12QE72W5C7EMFS` polls `POST /api/outbox/{address}` every 5-8 minutes with `messageId: "none"`. This caused a KV lookup for `inbox:message:none`, a 404 response, and a WARN-level log — **149 of 500 recent logs** were this single pattern (closes #388).

## Test plan

- [ ] All 316 existing tests pass (`npm test`)
- [ ] No new lint errors (`npm run lint`)
- [ ] POST with `{"messageId": "none", ...}` returns 400 with `correctEndpoint` field
- [ ] POST with `{"messageId": "None", ...}` also returns 400 (case-insensitive)
- [ ] POST with `{"messageId": "null", ...}` also returns 400
- [ ] POST with a valid `msg_...` messageId proceeds normally (no regression)
- [ ] No WARN log emitted for sentinel rejections

🤖 Generated with [Claude Code](https://claude.com/claude-code)