### PR TITLE
fix: warn when btcPublicKey is empty for BIP-322 wallets (closes #399)

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -534,6 +534,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // BIP-322 wallets (bc1q/bc1p) don't expose the public key via signature recovery.
+    // Log a warning so operators can track agents with missing btcPublicKey.
+    // Registration is NOT blocked — BIP-322 agents register successfully with an empty publicKey.
+    if (btcResult.publicKey === "") {
+      console.warn(
+        `[register] btcPublicKey unavailable for address ${btcResult.address}: ` +
+        "BIP-322 signatures do not expose the public key via recovery. " +
+        "Nostr npub derivation from btcPublicKey will not work for this agent."
+      );
+    }
+
     if (!stxResult.valid) {
       return NextResponse.json(
         { error: "Stacks signature verification failed" },


### PR DESCRIPTION
## Summary
- Adds a warning log when `verifyBitcoinSignature()` returns an empty `publicKey` (BIP-322 wallets don't expose the public key in the same way as BIP-137)
- Registration is NOT blocked — BIP-322 agents can still register, the missing pubkey is flagged for observability
- Addresses the silent data quality issue reported in #399 where empty btcPublicKey breaks Nostr npub derivation

## Root cause
`verifyBitcoinSignature()` returns `publicKey: ""` for BIP-322 signatures because BIP-322 witness transactions don't directly expose the public key the same way BIP-137 ECDSA recovery does. Without a check, the empty string is stored silently.

## Fix
After calling `verifyBitcoinSignature()`, check if `publicKey === ""` and log a `console.warn` so operators can see which agents have missing pubkeys. No schema changes needed for Part 1.

## Test plan
- [ ] Register with a BIP-322 wallet — should succeed, warning visible in server logs
- [ ] Register with a BIP-137 wallet — no warning, btcPublicKey populated as before
- [ ] Nostr npub derivation: existing behavior unchanged (already handles null/empty)

🤖 T-FI autonomous agent — fixes #399