### PR TITLE
fix: add AbortController timeout on gist fetch (closes #406)

### DIFF
--- a/lib/challenge.ts
+++ b/lib/challenge.ts
@@ -531,8 +531,12 @@ async function handleLinkGitHub(
     files?: Record<string, { content?: string }>;
   };
 
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 5000);
+
   try {
     const gistResp = await fetch(`https://api.github.com/gists/${gistId}`, {
+      signal: controller.signal,
       headers: {
         Accept: "application/vnd.github+json",
         "User-Agent": "aibtcdev-landing-page",
@@ -552,11 +556,20 @@ async function handleLinkGitHub(
       files?: Record<string, { content?: string }>;
     };
   } catch (e) {
+    if ((e as Error).name === "AbortError") {
+      return {
+        success: false,
+        updated: agent,
+        error: "GitHub API request timed out after 5 seconds. Please try again.",
+      };
+    }
     return {
       success: false,
       updated: agent,
       error: `Failed to fetch gist from GitHub: ${(e as Error).message}`,
     };
+  } finally {
+    clearTimeout(timeoutId);
   }
 
   // Verify gist owner matches the claimed GitHub username (case-insensitive)


### PR DESCRIPTION
## Summary

- Wraps the GitHub API gist fetch in `handleLinkGitHub()` (in `lib/challenge.ts`) with a 5-second `AbortController` timeout
- Detects `AbortError` in the catch block and returns a user-friendly error message instead of hanging
- Clears the timer in a `finally` block to prevent timer leaks

## Problem

The `link-github` challenge action fetches a public gist from the GitHub API to verify ownership. If the GitHub API is slow or unresponsive, the `fetch()` call can hang indefinitely, blocking the Cloudflare Worker for the entire request lifetime and potentially exhausting Worker CPU/wall-clock limits.

## Fix

```ts
const controller = new AbortController();
const timeoutId = setTimeout(() => controller.abort(), 5000);

try {
  const gistResp = await fetch(`https://api.github.com/gists/${gistId}`, {
    signal: controller.signal,
    // ... headers
  });
  // ... existing logic
} catch (e) {
  if ((e as Error).name === "AbortError") {
    return { success: false, updated: agent, error: "GitHub API request timed out after 5 seconds. Please try again." };
  }
  // ... existing error handling
} finally {
  clearTimeout(timeoutId);
}
```

## Test plan

- [ ] All existing tests pass (`npm run test` — 316 tests, 15 files, all green)
- [ ] Manual: submit `link-github` action with a valid gist → links successfully
- [ ] Manual: if GitHub API were slow (>5 s), user gets `"GitHub API request timed out after 5 seconds. Please try again."` instead of a hung request

Closes #406

🤖 Generated with [Claude Code](https://claude.com/claude-code)