### PR TITLE
feat: add optional GITHUB_TOKEN for gist API rate limit (closes #405)

### DIFF
--- a/app/api/challenge/route.ts
+++ b/app/api/challenge/route.ts
@@ -365,8 +365,15 @@ export async function POST(request: NextRequest) {
     // Delete challenge (single-use)
     await deleteChallenge(kv, address);
 
-    // Execute action (inject challenge string so handlers can verify challenge content in external resources)
-    const actionResult = await executeAction(action, { ...params, challenge }, agent, kv);
+    // Execute action (inject challenge string and optional GitHub token so handlers can verify
+    // challenge content in external resources and authenticate GitHub API requests)
+    const githubToken = env.GITHUB_TOKEN;
+    const actionResult = await executeAction(
+      action,
+      { ...params, challenge, ...(githubToken ? { githubToken } : {}) },
+      agent,
+      kv
+    );
 
     if (!actionResult.success) {
       return NextResponse.json(

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -3,6 +3,7 @@ interface CloudflareEnv {
   VERIFIED_AGENTS: KVNamespace;
   ARC_ADMIN_API_KEY: string; // Admin API key for /api/admin/* endpoints
   HIRO_API_KEY?: string; // Hiro API key for authenticated Stacks API requests (set via wrangler secret)
+  GITHUB_TOKEN?: string; // GitHub personal access token for authenticated API requests (raises rate limit from 60 to 5000 req/hr)
   LOGS?: unknown; // Worker-logs RPC service binding (type guarded via isLogsRPC)
   X402_NETWORK?: "mainnet" | "testnet"; // Stacks network for x402 verification
   X402_RELAY_URL?: string; // x402 relay URL for all payment settlement (default: https://x402-relay.aibtc.com)

--- a/lib/challenge.ts
+++ b/lib/challenge.ts
@@ -531,16 +531,23 @@ async function handleLinkGitHub(
     files?: Record<string, { content?: string }>;
   };
 
+  // Use GITHUB_TOKEN if available to raise rate limit from 60 to 5000 req/hr
+  const githubToken = params.githubToken as string | undefined;
+  const gistHeaders: Record<string, string> = {
+    Accept: "application/vnd.github+json",
+    "User-Agent": "aibtcdev-landing-page",
+  };
+  if (githubToken) {
+    gistHeaders["Authorization"] = `token ${githubToken}`;
+  }
+
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), 5000);
 
   try {
     const gistResp = await fetch(`https://api.github.com/gists/${gistId}`, {
       signal: controller.signal,
-      headers: {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "aibtcdev-landing-page",
-      },
+      headers: gistHeaders,
     });
 
     if (!gistResp.ok) {


### PR DESCRIPTION
## Summary

- Adds optional `GITHUB_TOKEN` Cloudflare Worker binding to `cloudflare-env.d.ts`
- Passes the token from the challenge route into `handleLinkGitHub` via the existing `params` injection pattern (same pattern used for the `challenge` string)
- In `handleLinkGitHub`, conditionally adds `Authorization: token <value>` header to the GitHub gist fetch when the token is present

## Why it's optional

The token is **not required** — the code falls back to unauthenticated requests when `GITHUB_TOKEN` is not set. This avoids breaking existing deployments and keeps operator configuration voluntary. When deployed with the secret, rate limits on the GitHub API increase from 60 req/hr to 5000 req/hr for gist lookups.

## Changes

- `cloudflare-env.d.ts` — adds `GITHUB_TOKEN?: string` to `CloudflareEnv`
- `app/api/challenge/route.ts` — reads `env.GITHUB_TOKEN` and injects it into action params
- `lib/challenge.ts` — `handleLinkGitHub` reads `githubToken` from params and conditionally sets the `Authorization` header on the gist fetch

## Test plan

- [x] All 316 existing tests pass (`npm test`)
- [ ] Deploy with `GITHUB_TOKEN` secret set and verify gist fetch succeeds
- [ ] Deploy without `GITHUB_TOKEN` and verify gist fetch still works (unauthenticated fallback)

Closes #405

🤖 Generated with [Claude Code](https://claude.com/claude-code)