### PR TITLE
fix(register): reject legacy Bitcoin addresses, require SegWit

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -554,6 +554,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Reject legacy Bitcoin address formats (P2PKH starting with "1", P2SH starting with "3").
+    // Only SegWit addresses are accepted: bc1q (P2WPKH) and bc1p (Taproot/P2TR).
+    if (btcResult.address.startsWith("1") || btcResult.address.startsWith("3")) {
+      return NextResponse.json(
+        {
+          error:
+            "Legacy Bitcoin addresses are not supported. " +
+            "Please use a SegWit address (bc1q... native SegWit) or Taproot address (bc1p...).",
+        },
+        { status: 400 }
+      );
+    }
+
     if (!stxResult.valid) {
       return NextResponse.json(
         { error: "Stacks signature verification failed" },


### PR DESCRIPTION
## Summary

Fixes #410 — adds validation to the registration endpoint to reject legacy Bitcoin addresses (P2PKH starting with `1`, P2SH starting with `3`).

Only SegWit addresses are accepted:
- `bc1q...` (native SegWit P2WPKH)
- `bc1p...` (Taproot P2TR)

## Root Cause

The `verifyBip137` function in `lib/bitcoin-verify.ts` successfully recovers P2PKH (`1...`) and P2SH (`3...`) addresses from BIP-137 compact signatures (header bytes 27–38). Previously nothing in the registration flow checked the *type* of the recovered address, so any valid BIP-137 signature — including those from legacy wallets — would pass through and create a registration record.

## Changes

- Added a 13-line guard in `app/api/register/route.ts` immediately after Bitcoin signature validation succeeds
- If the recovered address starts with `1` (P2PKH) or `3` (P2SH), returns HTTP 400 with a clear error message
- No changes to signature verification logic or any other file

## Test Plan

- [ ] Try registering with a `1...` P2PKH address → expect HTTP 400 with legacy address error
- [ ] Try registering with a `3...` P2SH address → expect HTTP 400 with legacy address error
- [ ] Register with `bc1q...` native SegWit → should succeed as before
- [ ] Register with `bc1p...` Taproot address → should succeed as before

closes #410

🤖 Generated with [Claude Code](https://claude.com/claude-code)