### PR TITLE
feat(leaderboard): rebalance scoring to incentivize economic activity

### DIFF
--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -4,7 +4,7 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { normalizeAgentRecord } from "@/lib/agents";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { ACTIVITY_THRESHOLDS } from "@/lib/utils";
-import { getAchievementCount } from "@/lib/achievements";
+import { getAgentAchievementIds } from "@/lib/achievements";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
         },
       },
       sortingRules: [
-        "Default (sort=score): Composite activity score descending. Score = (level * 1000) + (achievements * 100) + checkIns + recency bonus (+50 active, +25 recent)",
+        "Default (sort=score): Composite activity score descending. Score = levelPoints + achievementScore + min(checkIns, 50) + bnsBonus + recencyBonus. Level: L1=100, L2=500. Achievement weights: sender=500, connector=400, communicator/identified=300, receiver/voucher=200, active=50, dedicated=75, devoted=100, tireless=125. BNS name: +300. Recency: +25 active (<1h), +10 recent (<6h).",
         "Registration (sort=registration): Primary sort by level (highest first), secondary sort by verifiedAt (earliest first, pioneer priority)",
         "Activity (sort=activity): Sort by lastActiveAt descending (most recently active first). Agents with no lastActiveAt sort last.",
       ],
@@ -185,31 +185,61 @@ export async function GET(request: NextRequest) {
       })
     );
 
-    // Fetch achievement counts for all agents
-    const achievementCounts = await Promise.all(
-      agents.map((agent) => getAchievementCount(kv, agent.btcAddress))
+    // Fetch achievement IDs for all agents (single KV read per agent)
+    const agentAchievementIds = await Promise.all(
+      agents.map((agent) => getAgentAchievementIds(kv, agent.btcAddress))
     );
+
+    // Per-achievement point values — economic activity weighted over passive behavior
+    const ACHIEVEMENT_WEIGHTS: Record<string, number> = {
+      sender: 500,        // Transferred BTC — skin in the game
+      connector: 400,     // Sent sBTC to a registered agent — economic + social
+      communicator: 300,  // Sent x402 inbox reply — paid economic activity
+      identified: 300,    // ERC-8004 on-chain identity — identity investment
+      receiver: 200,      // Received first inbox message — demand signal
+      voucher: 200,       // Referred another agent — network growth
+      active: 50,         // 10+ check-ins (tier 1)
+      dedicated: 75,      // 100+ check-ins (tier 2)
+      devoted: 100,       // 1000+ check-ins (tier 3)
+      tireless: 125,      // 5000+ check-ins (tier 4)
+    };
 
     // Compute levels and build ranked list with composite scores
     const now = Date.now();
     let ranked = agents.map((agent, i) => {
       const level = computeLevel(agent, claims[i]);
-      const achievementCount = achievementCounts[i];
+      const achievementIds = agentAchievementIds[i];
+      const achievementCount = achievementIds.length;
       const checkInCount = agent.checkInCount || 0;
 
-      // Calculate recency bonus
+      // Level points — register is low-barrier, Genesis meaningful but not dominant
+      const levelPoints = level === 2 ? 500 : level === 1 ? 100 : 0;
+
+      // Weighted achievement score — each achievement valued by economic signal
+      const achievementScore = achievementIds.reduce(
+        (sum, id) => sum + (ACHIEVEMENT_WEIGHTS[id] ?? 100),
+        0
+      );
+
+      // Check-ins capped at 50 — proves liveness but can't dominate ranking
+      const cappedCheckIns = Math.min(checkInCount, 50);
+
+      // BNS name signals identity investment
+      const bnsBonus = agent.bnsName ? 300 : 0;
+
+      // Recency bonus — reduced to prevent daily passive check-in farming
       let recencyBonus = 0;
       if (agent.lastActiveAt) {
         const timeSinceActive = now - new Date(agent.lastActiveAt).getTime();
         if (timeSinceActive < ACTIVITY_THRESHOLDS.active) {
-          recencyBonus = 50; // Active within last hour
+          recencyBonus = 25; // Active within last hour
         } else if (timeSinceActive < ACTIVITY_THRESHOLDS.recent) {
-          recencyBonus = 25; // Active within last 6 hours
+          recencyBonus = 10; // Active within last 6 hours
         }
       }
 
-      // Composite score: (level * 1000) + (achievements * 100) + checkIns + recency
-      const score = (level * 1000) + (achievementCount * 100) + checkInCount + recencyBonus;
+      // Composite score: economic activity > passive behavior
+      const score = levelPoints + achievementScore + cappedCheckIns + bnsBonus + recencyBonus;
 
       return {
         ...normalizeAgentRecord(agent),

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -22,6 +22,7 @@ export {
   getAgentAchievements,
   getAchievementRecord,
   getAchievementCount,
+  getAgentAchievementIds,
   hasAchievement,
   grantAchievement,
 } from "./kv";

--- a/lib/achievements/kv.ts
+++ b/lib/achievements/kv.ts
@@ -212,6 +212,29 @@ export async function getAchievementCount(
 }
 
 /**
+ * Get the IDs of all achievements unlocked by an agent.
+ *
+ * Single KV read — use this for per-achievement scoring (e.g., weighted
+ * leaderboard) without the overhead of fetching full achievement records.
+ *
+ * @param kv - Cloudflare KV namespace
+ * @param btcAddress - Bitcoin address
+ * @returns Array of achievement IDs (empty if none)
+ *
+ * @example
+ * const ids = await getAgentAchievementIds(kv, "bc1q...");
+ * // ids: ["sender", "communicator"]
+ */
+export async function getAgentAchievementIds(
+  kv: KVNamespace,
+  btcAddress: string
+): Promise<string[]> {
+  const index = await getAgentIndex(kv, btcAddress);
+  if (!index) return [];
+  return index.achievementIds;
+}
+
+/**
  * Update the agent achievement index.
  *
  * Adds a new achievement ID to the index or creates the index if it doesn't exist.


### PR DESCRIPTION
Closes #230.

## Summary

- **Cap check-ins at 50** — proves liveness but can't dominate ranking (was unlimited)
- **Per-achievement weights** replace flat 100pts/achievement — economic actions earn significantly more
- **Reduce level dominance** — L1=100pts, L2=500pts (down from 1000/2000)
- **BNS name bonus** — +300pts for identity investment (already tracked in agent record)
- **Recency bonus reduced** — +25/+10 (down from 50/25) to reduce passive daily check-in reward

## Achievement weights

| Achievement | Points | Rationale |
|-------------|--------|-----------|
| `sender` | 500 | BTC transfer — skin in the game |
| `connector` | 400 | Sent sBTC to agent — economic + social |
| `communicator` | 300 | x402 inbox reply — paid activity |
| `identified` | 300 | ERC-8004 on-chain identity |
| `receiver` | 200 | Received first message — demand signal |
| `voucher` | 200 | Referred another agent |
| `active` (10+ check-ins) | 50 | Tier 1 engagement |
| `dedicated` (100+) | 75 | Tier 2 engagement |
| `devoted` (1000+) | 100 | Tier 3 engagement |
| `tireless` (5000+) | 125 | Tier 4 engagement |

## Score comparison (new formula)

| Agent type | Score |
|-----------|-------|
| Genesis + 5000 check-ins, no economic activity | ~925 |
| Verified L1 + sender+connector+communicator+receiver+identified + BNS | ~2,260 |
| Genesis + all achievements + BNS | ~2,925 |

Economic activity now clearly outranks passive check-in farming.

## Implementation

- Added `getAgentAchievementIds()` to `lib/achievements/kv.ts` — single KV read returning `string[]`, same cost as the previous `getAchievementCount()` call it replaces
- Updated `app/api/leaderboard/route.ts` scoring formula
- No schema changes; all data already tracked

## Test plan
- [ ] Deploy to preview and verify leaderboard order shifts as expected (economic agents rise)
- [ ] Check that `achievementCount` field in response still returns correct count
- [ ] Verify BNS name bonus applies correctly to agents with `bnsName` set

🤖 Generated with [Claude Code](https://claude.com/claude-code)