### PR TITLE
feat(achievements): add soul inscription achievement

### DIFF
--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -7,6 +7,7 @@ import {
 } from "@/lib/achievements";
 import {
   verifySenderAchievement,
+  verifyInscriberAchievement,
   setRateLimit,
   ACHIEVEMENT_VERIFY_RATE_LIMIT_MS,
 } from "@/lib/achievements/verify";
@@ -42,6 +43,14 @@ export function GET() {
             "Validates sBTC transfer transaction: must be successful contract_call to sbtc-token transfer function, sent from agent's STX address to another registered agent, with a memo present",
           note: "Requires providing a transaction ID (txid) in the POST request body",
         },
+        inscriber: {
+          id: "inscriber",
+          name: "Inscriber",
+          description: "Inscribed a soul document on Bitcoin L1",
+          verification:
+            "Verifies inscription ownership via Unisat API and checks content matches soul.md format (H1 agent name heading, H2 subheadings, minimum length)",
+          note: "Requires providing an inscription ID (inscriptionId) in the POST request body",
+        },
       },
       requestBody: {
         btcAddress: {
@@ -54,7 +63,13 @@ export function GET() {
           type: "string",
           required: false,
           description:
-            "Transaction ID (64-char hex) of sBTC transfer to verify for connector achievement. When omitted, only the sender achievement is checked.",
+            "Transaction ID (64-char hex) of sBTC transfer to verify for connector achievement. When omitted, connector is not checked.",
+        },
+        inscriptionId: {
+          type: "string",
+          required: false,
+          description:
+            "Ordinals inscription ID to verify for inscriber achievement (e.g. 'abc123...i0'). When omitted, inscriber is not checked.",
         },
       },
       behavior: {
@@ -62,6 +77,8 @@ export function GET() {
           "Always checked — queries mempool.space for outgoing BTC transactions from btcAddress",
         connector:
           "Only checked when txid is provided — validates the sBTC transfer to a registered agent",
+        inscriber:
+          "Only checked when inscriptionId is provided — verifies ownership via Unisat API and validates soul.md content format",
       },
       rateLimit: {
         description: "Per-achievement-type rate limit",
@@ -116,8 +133,9 @@ export async function POST(request: NextRequest) {
     const body = (await request.json()) as {
       btcAddress?: string;
       txid?: string;
+      inscriptionId?: string;
     };
-    const { btcAddress, txid } = body;
+    const { btcAddress, txid, inscriptionId } = body;
 
     if (!btcAddress || !btcAddress.startsWith("bc1")) {
       return NextResponse.json(
@@ -140,9 +158,21 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate inscriptionId if provided (ordinals format: <64-hex>i<number>)
+    if (inscriptionId && !/^[a-fA-F0-9]{64}i\d+$/.test(inscriptionId)) {
+      return NextResponse.json(
+        {
+          error:
+            "inscriptionId must be in ordinals format: 64-character hex followed by 'i' and an index (e.g. 'abc123...i0')",
+        },
+        { status: 400 }
+      );
+    }
+
     const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY as string | undefined;
+    const unisatApiKey = env.UNISAT_API_KEY as string | undefined;
 
     // Look up agent
     const agentData = await kv.get(`btc:${btcAddress}`);
@@ -176,7 +206,11 @@ export async function POST(request: NextRequest) {
     }
 
     // Per-achievement rate limit check
-    const achievementsToCheck = ["sender", ...(txid ? ["connector"] : [])];
+    const achievementsToCheck = [
+      "sender",
+      ...(txid ? ["connector"] : []),
+      ...(inscriptionId ? ["inscriber"] : []),
+    ];
     const rateLimitKeys = achievementsToCheck.map(
       (id) => `ratelimit:achievement-verify:${btcAddress}:${id}`
     );
@@ -447,6 +481,43 @@ export async function POST(request: NextRequest) {
         }
       } else {
         alreadyHad.push("connector");
+      }
+    }
+
+    // Check inscriber achievement (only if inscriptionId provided and not rate-limited)
+    if (inscriptionId && !rateLimited.includes("inscriber")) {
+      checked.push("inscriber");
+
+      await setRateLimit(kv, btcAddress, "inscriber");
+
+      const hasInscriber = await hasAchievement(kv, btcAddress, "inscriber");
+
+      if (!hasInscriber) {
+        const result = await verifyInscriberAchievement(
+          btcAddress,
+          inscriptionId,
+          kv,
+          unisatApiKey
+        );
+
+        if (!result.verified) {
+          return NextResponse.json(
+            { error: result.error ?? "Inscriber verification failed" },
+            { status: 400 }
+          );
+        }
+
+        const record = await grantAchievement(kv, btcAddress, "inscriber", {
+          inscriptionId,
+        });
+        const definition = getAchievementDefinition("inscriber");
+        earned.push({
+          id: "inscriber",
+          name: definition?.name ?? "Inscriber",
+          unlockedAt: record.unlockedAt,
+        });
+      } else {
+        alreadyHad.push("inscriber");
       }
     }
 

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -3,6 +3,7 @@ interface CloudflareEnv {
   VERIFIED_AGENTS: KVNamespace;
   ARC_ADMIN_API_KEY: string; // Admin API key for /api/admin/* endpoints
   HIRO_API_KEY?: string; // Hiro API key for authenticated Stacks API requests (set via wrangler secret)
+  UNISAT_API_KEY?: string; // Unisat API key for Ordinals/inscription lookups (set via wrangler secret)
   GITHUB_TOKEN?: string; // GitHub personal access token for authenticated API requests (raises rate limit from 60 to 5000 req/hr)
   LOGS?: unknown; // Worker-logs RPC service binding (type guarded via isLogsRPC)
   X402_NETWORK?: "mainnet" | "testnet"; // Stacks network for x402 verification

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -29,6 +29,7 @@ export {
 // Verification
 export {
   verifySenderAchievement,
+  verifyInscriberAchievement,
   checkRateLimit,
   setRateLimit,
   ACHIEVEMENT_VERIFY_RATE_LIMIT_MS,

--- a/lib/achievements/registry.ts
+++ b/lib/achievements/registry.ts
@@ -44,6 +44,12 @@ export const ACHIEVEMENTS: AchievementDefinition[] = [
     category: "onchain",
   },
   {
+    id: "inscriber",
+    name: "Inscriber",
+    description: "Inscribed a soul document on Bitcoin L1",
+    category: "onchain",
+  },
+  {
     id: "active",
     name: "Active",
     description: "Completed 10+ heartbeat check-ins",

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -10,6 +10,23 @@ import {
   setCachedTransaction,
 } from "@/lib/identity/kv-cache";
 
+/** Minimum content length (chars) to qualify as a soul document */
+const SOUL_MIN_LENGTH = 200;
+
+/**
+ * Check if text content resembles a soul.md document.
+ *
+ * A valid soul document must have:
+ * - An H1 heading (# Name) as the primary identifier
+ * - At least one H2 subheading (## Section) indicating structure
+ * - Minimum content length to rule out trivial inscriptions
+ */
+function isSoulDocument(content: string): boolean {
+  const hasH1 = /^#\s+\S+/m.test(content);
+  const hasH2 = /^##\s+\S+/m.test(content);
+  return hasH1 && hasH2 && content.length >= SOUL_MIN_LENGTH;
+}
+
 /** Rate limit window for achievement verification (5 minutes) */
 export const ACHIEVEMENT_VERIFY_RATE_LIMIT_MS = 5 * 60 * 1000;
 
@@ -108,5 +125,115 @@ export async function verifySenderAchievement(
   } catch (error) {
     console.error(`Failed to verify sender achievement for ${btcAddress}:`, error);
     return false;
+  }
+}
+
+/**
+ * Verify if an agent inscribed a soul document on Bitcoin L1 (Inscriber achievement).
+ *
+ * Checks two things:
+ * 1. The inscription is owned by the agent's Bitcoin address (via Unisat API)
+ * 2. The inscription content matches soul.md format (H1 + H2 headings, min length)
+ *
+ * @param btcAddress - Bitcoin address that should own the inscription
+ * @param inscriptionId - Ordinals inscription ID (e.g. "abc123...i0")
+ * @param kv - Cloudflare KV namespace
+ * @param unisatApiKey - Unisat API key for authenticated requests
+ * @returns Object with verified flag and optional error message
+ */
+export async function verifyInscriberAchievement(
+  btcAddress: string,
+  inscriptionId: string,
+  kv: KVNamespace,
+  unisatApiKey?: string
+): Promise<{ verified: boolean; error?: string }> {
+  try {
+    // 1. Verify inscription ownership via Unisat API
+    const cacheKey = `unisat-inscription:${inscriptionId}`;
+    type UnisatInscriptionInfo = {
+      address: string;
+      contentType: string;
+    };
+
+    let inscriptionInfo = await getCachedTransaction(
+      cacheKey,
+      kv
+    ) as UnisatInscriptionInfo | null;
+
+    if (!inscriptionInfo) {
+      const headers: Record<string, string> = {
+        Accept: "application/json",
+      };
+      if (unisatApiKey) {
+        headers["Authorization"] = `Bearer ${unisatApiKey}`;
+      }
+
+      const infoUrl = `https://open-api.unisat.io/v1/indexer/inscription/info/${inscriptionId}`;
+      const infoResp = await fetch(infoUrl, {
+        headers,
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (!infoResp.ok) {
+        return {
+          verified: false,
+          error: `Unisat API error: ${infoResp.status} ${infoResp.statusText}`,
+        };
+      }
+
+      const json = (await infoResp.json()) as {
+        code: number;
+        msg: string;
+        data: UnisatInscriptionInfo;
+      };
+
+      if (json.code !== 0) {
+        return { verified: false, error: `Unisat error: ${json.msg}` };
+      }
+
+      inscriptionInfo = json.data;
+      await setCachedTransaction(cacheKey, inscriptionInfo, kv);
+    }
+
+    if (inscriptionInfo.address !== btcAddress) {
+      return {
+        verified: false,
+        error: `Inscription is owned by ${inscriptionInfo.address}, not ${btcAddress}`,
+      };
+    }
+
+    // 2. Fetch inscription content from ordinals.com (public, no auth)
+    const contentUrl = `https://ordinals.com/content/${inscriptionId}`;
+    const contentResp = await fetch(contentUrl, {
+      signal: AbortSignal.timeout(10000),
+    });
+
+    if (!contentResp.ok) {
+      return {
+        verified: false,
+        error: `Failed to fetch inscription content: ${contentResp.status}`,
+      };
+    }
+
+    const content = await contentResp.text();
+
+    if (!isSoulDocument(content)) {
+      return {
+        verified: false,
+        error:
+          "Inscription content does not match soul.md format (requires H1 heading, H2 sections, minimum length)",
+      };
+    }
+
+    return { verified: true };
+  } catch (error) {
+    console.error(
+      `Failed to verify inscriber achievement for ${btcAddress}:`,
+      error
+    );
+    return {
+      verified: false,
+      error: `Verification failed: ${(error as Error).message}`,
+    };
   }
 }


### PR DESCRIPTION
## Summary

- Adds `inscriber` achievement to registry: agents who inscribed their soul.md on Bitcoin L1 as an ordinal
- `verifyInscriberAchievement()` in `verify.ts`: verifies inscription ownership via Unisat API, fetches content from ordinals.com, checks for soul.md format (H1 heading + H2 subheadings + min 200 chars)
- `POST /api/achievements/verify` now accepts `inscriptionId` param alongside existing `btcAddress`/`txid`
- `UNISAT_API_KEY` added to `cloudflare-env.d.ts` (optional, set via wrangler secret — falls back to unauthenticated at 5 req/s)

## Test plan

- [ ] `GET /api/achievements/verify` — confirm inscriber appears in achievements docs with correct description
- [ ] `POST /api/achievements/verify` with valid `btcAddress` + `inscriptionId` owned by that address containing soul.md format → grants `inscriber`, returns it in `earned`
- [ ] `POST` with `inscriptionId` not owned by `btcAddress` → 400 with ownership error
- [ ] `POST` with inscription content that lacks H1/H2 → 400 with format error
- [ ] `POST` with invalid `inscriptionId` format → 400 validation error
- [ ] Second request within 5 min → `inscriber` appears in `alreadyHad` (rate limit + idempotent grant)
- [ ] Set `UNISAT_API_KEY` wrangler secret for production (key in credentials store)

## Notes

- Starts with manual verification path (agent provides their inscription ID); automation can be added later
- Unisat rate limit: 5 req/s on free tier; production should set `UNISAT_API_KEY`
- Content fetched from public ordinals.com endpoint (no auth needed for content)
- Closes #419, supersedes #166
- Aligns with 00K competition on-chain identity requirement

🤖 Generated with [Claude Code](https://claude.com/claude-code)