### PR TITLE
feat(leaderboard): rebalance scoring to incentivize economic activity

### DIFF
--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -4,7 +4,8 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { normalizeAgentRecord } from "@/lib/agents";
 import { computeLevel, LEVELS } from "@/lib/levels";
 import { ACTIVITY_THRESHOLDS } from "@/lib/utils";
-import { getAchievementCount } from "@/lib/achievements";
+import { getAgentAchievementIds } from "@/lib/achievements";
+import { SCORING, computeLevelBonus, computeCheckInBonus } from "@/lib/scoring";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -91,7 +92,7 @@ export async function GET(request: NextRequest) {
         },
       },
       sortingRules: [
-        "Default (sort=score): Composite activity score descending. Score = (level * 1000) + (achievements * 100) + checkIns + recency bonus (+50 active, +25 recent)",
+        "Default (sort=score): Composite activity score descending. Score = levelBonus (100 registered / 500 genesis) + (achievements * 100) + min(checkIns, 50) + bnsName (300) + recency bonus (+50 active, +25 recent)",
         "Registration (sort=registration): Primary sort by level (highest first), secondary sort by verifiedAt (earliest first, pioneer priority)",
         "Activity (sort=activity): Sort by lastActiveAt descending (most recently active first). Agents with no lastActiveAt sort last.",
       ],
@@ -185,31 +186,43 @@ export async function GET(request: NextRequest) {
       })
     );
 
-    // Fetch achievement counts for all agents
-    const achievementCounts = await Promise.all(
-      agents.map((agent) => getAchievementCount(kv, agent.btcAddress))
+    // Fetch achievement IDs and counts for all agents (single KV read per agent)
+    const agentAchievements = await Promise.all(
+      agents.map((agent) => getAgentAchievementIds(kv, agent.btcAddress))
     );
 
     // Compute levels and build ranked list with composite scores
     const now = Date.now();
     let ranked = agents.map((agent, i) => {
       const level = computeLevel(agent, claims[i]);
-      const achievementCount = achievementCounts[i];
+      const { count: achievementCount } = agentAchievements[i];
       const checkInCount = agent.checkInCount || 0;
 
-      // Calculate recency bonus
+      // Level bonus: 100 for registered, 500 for genesis (was level * 1000)
+      const levelBonus = computeLevelBonus(level);
+
+      // Check-in bonus: capped at 50 to reduce passive farming advantage
+      const checkInBonus = computeCheckInBonus(checkInCount);
+
+      // BNS name bonus: +300 for having a registered BNS name
+      const bnsBonus = agent.bnsName ? SCORING.BNS_NAME : 0;
+
+      // Achievement bonus: 100 per achievement
+      const achievementBonus = achievementCount * SCORING.ACHIEVEMENT_BASE;
+
+      // Recency bonus
       let recencyBonus = 0;
       if (agent.lastActiveAt) {
         const timeSinceActive = now - new Date(agent.lastActiveAt).getTime();
         if (timeSinceActive < ACTIVITY_THRESHOLDS.active) {
-          recencyBonus = 50; // Active within last hour
+          recencyBonus = SCORING.RECENCY_ACTIVE;
         } else if (timeSinceActive < ACTIVITY_THRESHOLDS.recent) {
-          recencyBonus = 25; // Active within last 6 hours
+          recencyBonus = SCORING.RECENCY_RECENT;
         }
       }
 
-      // Composite score: (level * 1000) + (achievements * 100) + checkIns + recency
-      const score = (level * 1000) + (achievementCount * 100) + checkInCount + recencyBonus;
+      // Composite score: levelBonus + checkInBonus + bnsBonus + achievementBonus + recencyBonus
+      const score = levelBonus + checkInBonus + bnsBonus + achievementBonus + recencyBonus;
 
       return {
         ...normalizeAgentRecord(agent),

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -22,6 +22,7 @@ export {
   getAgentAchievements,
   getAchievementRecord,
   getAchievementCount,
+  getAgentAchievementIds,
   hasAchievement,
   grantAchievement,
 } from "./kv";

--- a/lib/achievements/kv.ts
+++ b/lib/achievements/kv.ts
@@ -212,6 +212,29 @@ export async function getAchievementCount(
 }
 
 /**
+ * Get achievement IDs and count for an agent in a single KV read.
+ *
+ * Use this when you need both the count and specific achievement IDs
+ * (e.g., for per-achievement scoring in the leaderboard).
+ *
+ * @param kv - Cloudflare KV namespace
+ * @param btcAddress - Bitcoin address
+ * @returns Object with count and ids array
+ *
+ * @example
+ * const { count, ids } = await getAgentAchievementIds(kv, "bc1q...");
+ * const hasSender = ids.includes("sender");
+ */
+export async function getAgentAchievementIds(
+  kv: KVNamespace,
+  btcAddress: string
+): Promise<{ count: number; ids: string[] }> {
+  const index = await getAgentIndex(kv, btcAddress);
+  if (!index) return { count: 0, ids: [] };
+  return { count: index.achievementIds.length, ids: index.achievementIds };
+}
+
+/**
  * Update the agent achievement index.
  *
  * Adds a new achievement ID to the index or creates the index if it doesn't exist.

--- a/lib/scoring.ts
+++ b/lib/scoring.ts
@@ -1,0 +1,56 @@
+/**
+ * Leaderboard scoring constants.
+ *
+ * Rebalances score weights to incentivize economic activity over passive check-ins.
+ * See: https://github.com/aibtcdev/landing-page/issues/230
+ */
+export const SCORING = {
+  // Level bonuses
+  LEVEL_REGISTERED: 100, // Reached level 1 (was 1000)
+  LEVEL_GENESIS_BONUS: 400, // Additional bonus for reaching Genesis/level 2 (was 1000)
+
+  // Check-in bonus (capped to prevent passive farming)
+  CHECK_IN_BONUS: 1,
+  CHECK_IN_CAP: 50, // Max check-ins that contribute to score (was unlimited)
+
+  // On-chain identity bonus (new)
+  BNS_NAME: 300, // Agent has registered a BNS name
+
+  // Achievement bonus (per achievement)
+  ACHIEVEMENT_BASE: 100,
+
+  // Recency bonuses
+  RECENCY_ACTIVE: 50, // Active within last hour
+  RECENCY_RECENT: 25, // Active within last 6 hours
+
+  // --- Future bonuses (require additional data tracking, not yet implemented) ---
+  // FUND_WALLET: 500,             // First wallet funding event
+  // SEND_TX_BONUS: 100,           // Per BTC/STX transaction
+  // SEND_TX_DAILY_CAP: 10,        // Max transactions counted per day
+  // SEND_X402_BONUS: 50,          // Per x402 message sent
+  // SEND_X402_DAILY_CAP: 20,      // Max x402 messages counted per day
+  // RECEIVE_MESSAGE_BONUS: 25,    // Per inbox message received
+  // HOLD_BALANCE_DAILY: 200,      // Per day with balance > 0
+  // UNIQUE_PEER_TX_BONUS: 75,     // Per unique peer transacted with
+} as const;
+
+/**
+ * Compute the level bonus component of the composite score.
+ *
+ * Level 0 (Unverified): 0 pts
+ * Level 1 (Registered): 100 pts
+ * Level 2 (Genesis):    500 pts (100 registration + 400 genesis bonus)
+ */
+export function computeLevelBonus(level: number): number {
+  if (level >= 2) return SCORING.LEVEL_REGISTERED + SCORING.LEVEL_GENESIS_BONUS;
+  if (level >= 1) return SCORING.LEVEL_REGISTERED;
+  return 0;
+}
+
+/**
+ * Compute the check-in bonus component of the composite score.
+ * Check-ins are capped at CHECK_IN_CAP to reduce passive farming advantage.
+ */
+export function computeCheckInBonus(checkInCount: number): number {
+  return Math.min(checkInCount, SCORING.CHECK_IN_CAP) * SCORING.CHECK_IN_BONUS;
+}


### PR DESCRIPTION
Closes #230

## Summary

- **Level bonuses rebalanced**: Register 1000→100 pts, Genesis net 400 pts additional (500 total, was 2000)
- **Check-in cap**: +1/check-in capped at 50 total (was unlimited), preventing passive farming
- **BNS name bonus**: +300 pts for agents with a registered BNS name (new, uses existing `bnsName` field)
- **Scoring constants extracted** to `lib/scoring.ts` with named constants and helpers (`computeLevelBonus`, `computeCheckInBonus`)
- **`getAgentAchievementIds()`** added to achievements KV module — returns count + IDs in a single KV read, enabling per-achievement bonuses without extra round-trips

## What's not yet implemented (needs additional data tracking)

The following proposed bonuses from #230 require new infrastructure to count per-transaction events and enforce daily caps. They are stubbed as commented constants in `lib/scoring.ts` for a follow-up PR:

| Bonus | Requires |
|-------|---------|
| Fund wallet +500 | First-funding event tracking |
| Send BTC/STX +100/tx (10/day cap) | Per-agent tx count + daily window |
| Send x402 +50/msg (20/day cap) | Per-agent x402 message count + daily window |
| Receive message +25/msg | Inbox message count tracking |
| Hold balance +200/day | Daily balance snapshot |
| Unique peers +75/peer | Peer transaction index |

## Test plan

- [ ] Verify leaderboard scores decrease for agents with high check-in counts (cap kicks in)
- [ ] Verify agents with BNS names show +300 vs same agent without
- [ ] Verify Genesis agents score 500 (not 2000) and Registered agents score 100 (not 1000)
- [ ] Confirm no TypeScript errors introduced (`tsc --noEmit`)
- [ ] Confirm existing pre-existing TS errors in test files are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #230