### PR TITLE
feat(achievements): add sBTC Holder achievement

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -20,6 +20,7 @@ import { detectAgentIdentity } from "@/lib/identity/detection";
 import { IDENTITY_CHECK_TTL_MS } from "@/lib/identity/constants";
 import {
   verifySenderAchievement,
+  verifySbtcHolderAchievement,
   checkRateLimit,
   setRateLimit,
   hasAchievement,
@@ -404,6 +405,23 @@ export async function POST(request: NextRequest) {
     } catch (error) {
       // Best-effort: log and continue if achievement check fails
       console.error("Failed to check sender achievement during heartbeat:", error);
+    }
+
+    // Proactively check sbtc-holder achievement (sBTC balance > 0, best-effort)
+    try {
+      const rateLimit = await checkRateLimit(kv, btcAddress, "sbtc-holder");
+      if (rateLimit.allowed) {
+        const hasSbtcHolder = await hasAchievement(kv, btcAddress, "sbtc-holder");
+        if (!hasSbtcHolder) {
+          const holdsSbtc = await verifySbtcHolderAchievement(agent.stxAddress, kv, env.HIRO_API_KEY);
+          if (holdsSbtc) {
+            await grantAchievement(kv, btcAddress, "sbtc-holder");
+          }
+        }
+        await setRateLimit(kv, btcAddress, "sbtc-holder");
+      }
+    } catch (error) {
+      console.error("Failed to check sbtc-holder achievement during heartbeat:", error);
     }
 
     // Grant identified achievement if agent has an on-chain identity (best-effort)

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -29,6 +29,7 @@ export {
 // Verification
 export {
   verifySenderAchievement,
+  verifySbtcHolderAchievement,
   checkRateLimit,
   setRateLimit,
   ACHIEVEMENT_VERIFY_RATE_LIMIT_MS,

--- a/lib/achievements/registry.ts
+++ b/lib/achievements/registry.ts
@@ -44,6 +44,12 @@ export const ACHIEVEMENTS: AchievementDefinition[] = [
     category: "onchain",
   },
   {
+    id: "sbtc-holder",
+    name: "sBTC Holder",
+    description: "Holds a non-zero sBTC balance — bridged Bitcoin to Stacks",
+    category: "onchain",
+  },
+  {
     id: "active",
     name: "Active",
     description: "Completed 10+ heartbeat check-ins",

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -9,6 +9,12 @@ import {
   getCachedTransaction,
   setCachedTransaction,
 } from "@/lib/identity/kv-cache";
+import {
+  callReadOnly,
+  parseClarityValue,
+} from "@/lib/identity/stacks-api";
+import { principalCV } from "@stacks/transactions";
+import { SBTC_CONTRACTS } from "@/lib/inbox";
 
 /** Rate limit window for achievement verification (5 minutes) */
 export const ACHIEVEMENT_VERIFY_RATE_LIMIT_MS = 5 * 60 * 1000;
@@ -107,6 +113,50 @@ export async function verifySenderAchievement(
     return hasOutgoingTx;
   } catch (error) {
     console.error(`Failed to verify sender achievement for ${btcAddress}:`, error);
+    return false;
+  }
+}
+
+/**
+ * Verify if a Stacks address holds a non-zero sBTC balance (sBTC Holder achievement).
+ *
+ * Calls the sBTC token contract's get-balance read-only function and checks if
+ * the returned balance is greater than zero. Uses KV cache with 5-minute TTL.
+ *
+ * @param stxAddress - Stacks address to check
+ * @param kv - Cloudflare KV namespace
+ * @param hiroApiKey - Optional Hiro API key for higher rate limits
+ * @returns true if the address holds any sBTC, false otherwise
+ */
+export async function verifySbtcHolderAchievement(
+  stxAddress: string,
+  kv: KVNamespace,
+  hiroApiKey?: string
+): Promise<boolean> {
+  try {
+    const cacheKey = `sbtc-balance:${stxAddress}`;
+    let cachedBalance = await getCachedTransaction(cacheKey, kv);
+
+    if (!cachedBalance) {
+      const { address, name } = SBTC_CONTRACTS.mainnet;
+      const contract = `${address}.${name}`;
+      const response = await callReadOnly(
+        contract,
+        "get-balance",
+        [principalCV(stxAddress)],
+        hiroApiKey
+      );
+      cachedBalance = { balance: parseClarityValue(response) };
+      await setCachedTransaction(cacheKey, cachedBalance, kv);
+    }
+
+    const data = cachedBalance as { balance: string | null };
+    return !!data.balance && data.balance !== "0";
+  } catch (error) {
+    console.error(
+      `Failed to verify sbtc-holder achievement for ${stxAddress}:`,
+      error
+    );
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `sbtc-holder` achievement to the registry (category: onchain)
- Implements `verifySbtcHolderAchievement()` in `lib/achievements/verify.ts` — calls the sBTC SIP-010 `get-balance` read-only function via `callReadOnly`, caches result for 5 minutes, returns `true` if balance > 0
- Wires proactive check into the heartbeat POST handler (best-effort, rate-limited, same pattern as sender/stacker checks)
- Uses `SBTC_CONTRACTS.mainnet` constant from `@/lib/inbox` rather than hardcoding the contract address

## Test plan

- [ ] Heartbeat for an agent with sBTC grants `sbtc-holder` achievement on first check-in after acquiring balance
- [ ] Heartbeat for an agent without sBTC does not grant the achievement
- [ ] Rate limit (5 min) prevents redundant Stacks API calls per address
- [ ] Already-granted achievement skips verification (`hasAchievement` guard)
- [ ] TypeScript compiles cleanly (`bun run tsc --noEmit` — only pre-existing test file errors)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)