### PR TITLE
feat(achievements): implement sBTC Holder achievement

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -21,6 +21,7 @@ import { IDENTITY_CHECK_TTL_MS } from "@/lib/identity/constants";
 import {
   verifySenderAchievement,
   verifyStackerAchievement,
+  verifySbtcHolderAchievement,
   checkRateLimit,
   setRateLimit,
   hasAchievement,
@@ -426,6 +427,27 @@ export async function POST(request: NextRequest) {
       }
     } catch (error) {
       console.error("Failed to check stacker achievement during heartbeat:", error);
+    }
+
+    // Proactively check sbtc-holder achievement (best-effort)
+    try {
+      const rateLimit = await checkRateLimit(kv, btcAddress, "sbtc-holder");
+      if (rateLimit.allowed && agent.stxAddress) {
+        const hasSbtcHolder = await hasAchievement(kv, btcAddress, "sbtc-holder");
+        if (!hasSbtcHolder) {
+          const holdsSbtc = await verifySbtcHolderAchievement(
+            agent.stxAddress,
+            kv,
+            env.HIRO_API_KEY
+          );
+          if (holdsSbtc) {
+            await grantAchievement(kv, btcAddress, "sbtc-holder");
+          }
+          await setRateLimit(kv, btcAddress, "sbtc-holder");
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check sbtc-holder achievement during heartbeat:", error);
     }
 
     // Grant identified achievement if agent has an on-chain identity (best-effort)

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -30,6 +30,7 @@ export {
 export {
   verifySenderAchievement,
   verifyStackerAchievement,
+  verifySbtcHolderAchievement,
   checkRateLimit,
   setRateLimit,
   ACHIEVEMENT_VERIFY_RATE_LIMIT_MS,

--- a/lib/achievements/registry.ts
+++ b/lib/achievements/registry.ts
@@ -50,6 +50,12 @@ export const ACHIEVEMENTS: AchievementDefinition[] = [
     category: "onchain",
   },
   {
+    id: "sbtc-holder",
+    name: "sBTC Holder",
+    description: "Holds a non-zero sBTC balance — bridged Bitcoin to Stacks",
+    category: "onchain",
+  },
+  {
     id: "active",
     name: "Active",
     description: "Completed 10+ heartbeat check-ins",

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -5,11 +5,17 @@
  * Used by manual verification endpoint and proactive checks during heartbeat/profile loading.
  */
 
+import { principalCV } from "@stacks/transactions";
 import {
   getCachedTransaction,
   setCachedTransaction,
 } from "@/lib/identity/kv-cache";
-import { buildHiroHeaders } from "@/lib/identity/stacks-api";
+import {
+  buildHiroHeaders,
+  callReadOnly,
+  parseClarityValue,
+} from "@/lib/identity/stacks-api";
+import { getSBTCAsset } from "@/lib/inbox/x402-config";
 
 /** Rate limit window for achievement verification (5 minutes) */
 export const ACHIEVEMENT_VERIFY_RATE_LIMIT_MS = 5 * 60 * 1000;
@@ -159,6 +165,48 @@ export async function verifyStackerAchievement(
     return locked !== "0" && locked !== "";
   } catch (error) {
     console.error(`Failed to verify stacker achievement for ${stxAddress}:`, error);
+    return false;
+  }
+}
+
+/**
+ * Verify if an agent holds a non-zero sBTC balance (sBTC Holder achievement).
+ *
+ * Calls the `get-balance` read-only function on the sBTC contract on mainnet.
+ * Uses KV cache with 5-minute TTL to avoid excessive API calls.
+ *
+ * @param stxAddress - Stacks address to check
+ * @param kv - Cloudflare KV namespace
+ * @param hiroApiKey - Optional Hiro API key for higher rate limits
+ * @returns true if the agent holds any sBTC, false otherwise
+ */
+export async function verifySbtcHolderAchievement(
+  stxAddress: string,
+  kv: KVNamespace,
+  hiroApiKey?: string
+): Promise<boolean> {
+  try {
+    const cacheKey = `sbtc-balance:${stxAddress}`;
+    let cachedBalance = await getCachedTransaction(cacheKey, kv);
+
+    if (cachedBalance === null) {
+      const contract = getSBTCAsset("mainnet");
+      const response = await callReadOnly(
+        contract,
+        "get-balance",
+        [principalCV(stxAddress)],
+        hiroApiKey
+      );
+
+      const balance = parseClarityValue(response);
+      cachedBalance = balance ?? "0";
+      await setCachedTransaction(cacheKey, cachedBalance, kv);
+    }
+
+    const balanceStr = String(cachedBalance ?? "0");
+    return balanceStr !== "0" && balanceStr !== "";
+  } catch (error) {
+    console.error(`Failed to verify sbtc-holder achievement for ${stxAddress}:`, error);
     return false;
   }
 }


### PR DESCRIPTION
## Summary

- Adds `sbtc-holder` achievement to the registry (onchain category)
- Implements `verifySbtcHolderAchievement()` that calls `get-balance` on the mainnet sBTC token contract
- Hooks into the heartbeat auto-grant flow with 5-minute rate limiting and KV caching
- Reuses `getSBTCAsset("mainnet")` from existing inbox utilities

## Test plan

- [ ] Heartbeat check-in for an agent with sBTC balance grants the achievement
- [ ] Heartbeat check-in for an agent with zero sBTC does not grant
- [ ] Second heartbeat within 5 minutes skips verification (rate limit)
- [ ] Achievement appears in agent profile under onchain category
- [ ] Manual verify endpoint also picks up sbtc-holder (via existing `/api/achievements/verify` flow)

Closes #418

🤖 Generated with [Claude Code](https://claude.com/claude-code)