### PR TITLE
feat(achievements): add streak badges (7d/30d)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -488,6 +488,30 @@ export async function POST(request: NextRequest) {
       console.error("Failed to check tireless achievement during heartbeat:", error);
     }
 
+    // Grant streak-7d achievement if agent has 7+ consecutive days (best-effort)
+    try {
+      if ((checkInRecord.currentStreak ?? 0) >= 7) {
+        const hasStreak7 = await hasAchievement(kv, btcAddress, "streak-7d");
+        if (!hasStreak7) {
+          await grantAchievement(kv, btcAddress, "streak-7d", { streak: checkInRecord.currentStreak });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check streak-7d achievement during heartbeat:", error);
+    }
+
+    // Grant streak-30d achievement if agent has 30+ consecutive days (best-effort)
+    try {
+      if ((checkInRecord.currentStreak ?? 0) >= 30) {
+        const hasStreak30 = await hasAchievement(kv, btcAddress, "streak-30d");
+        if (!hasStreak30) {
+          await grantAchievement(kv, btcAddress, "streak-30d", { streak: checkInRecord.currentStreak });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check streak-30d achievement during heartbeat:", error);
+    }
+
     // Update agent record with lastActiveAt, checkInCount, and identity data
     const updatedAgent = {
       ...agent,

--- a/lib/achievements/registry.ts
+++ b/lib/achievements/registry.ts
@@ -78,6 +78,18 @@ export const ACHIEVEMENTS: AchievementDefinition[] = [
     tier: 4,
   },
   {
+    id: "streak-7d",
+    name: "Weekly Streaker",
+    description: "7 consecutive days of check-ins",
+    category: "engagement",
+  },
+  {
+    id: "streak-30d",
+    name: "Monthly Streaker",
+    description: "30 consecutive days of check-ins",
+    category: "engagement",
+  },
+  {
     id: "voucher",
     name: "Voucher",
     description: "Referred another agent to the platform",

--- a/lib/heartbeat/kv-helpers.ts
+++ b/lib/heartbeat/kv-helpers.ts
@@ -6,6 +6,18 @@ import { CHECK_IN_PREFIX } from "./constants";
 import type { CheckInRecord } from "./types";
 
 /**
+ * Get the ISO date string for the day before the given date.
+ *
+ * @param isoDate - Date in YYYY-MM-DD format
+ * @returns Previous day in YYYY-MM-DD format
+ */
+function getPreviousDate(isoDate: string): string {
+  const date = new Date(isoDate + "T00:00:00Z");
+  date.setUTCDate(date.getUTCDate() - 1);
+  return date.toISOString().split("T")[0];
+}
+
+/**
  * Fetch the check-in record for a specific Bitcoin address.
  *
  * @param kv - Cloudflare KV namespace
@@ -57,17 +69,32 @@ export async function updateCheckInRecord(
 ): Promise<CheckInRecord> {
   const current = existing !== undefined ? existing : await getCheckInRecord(kv, btcAddress);
 
-  const record: CheckInRecord = current
-    ? {
-        btcAddress,
-        checkInCount: current.checkInCount + 1,
-        lastCheckInAt: timestamp,
-      }
-    : {
-        btcAddress,
-        checkInCount: 1,
-        lastCheckInAt: timestamp,
-      };
+  const today = new Date().toISOString().split("T")[0];
+  let currentStreak: number;
+
+  if (!current) {
+    currentStreak = 1;
+  } else {
+    const lastDate = current.lastCheckInDate;
+    if (lastDate === today) {
+      // Already checked in today — keep existing streak
+      currentStreak = current.currentStreak ?? 1;
+    } else if (lastDate === getPreviousDate(today)) {
+      // Consecutive day — increment streak
+      currentStreak = (current.currentStreak ?? 1) + 1;
+    } else {
+      // Gap > 1 day — reset streak
+      currentStreak = 1;
+    }
+  }
+
+  const record: CheckInRecord = {
+    btcAddress,
+    checkInCount: current ? current.checkInCount + 1 : 1,
+    lastCheckInAt: timestamp,
+    lastCheckInDate: today,
+    currentStreak,
+  };
 
   const key = `${CHECK_IN_PREFIX}${btcAddress}`;
   await kv.put(key, JSON.stringify(record));

--- a/lib/heartbeat/types.ts
+++ b/lib/heartbeat/types.ts
@@ -16,6 +16,10 @@ export interface CheckInRecord {
   btcAddress: string;
   checkInCount: number;
   lastCheckInAt: string;
+  /** ISO date (YYYY-MM-DD) of the last check-in, used for streak tracking. */
+  lastCheckInDate?: string;
+  /** Number of consecutive calendar days with at least one check-in. */
+  currentStreak?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Adds streak tracking to the heartbeat check-in flow — each check-in compares today's date against the last check-in date to maintain a consecutive-day counter
- Grants `streak-7d` (Weekly Streaker) and `streak-30d` (Monthly Streaker) achievements when streak thresholds are met
- Backward-compatible: existing `CheckInRecord` entries without streak fields default to streak of 1 on next check-in

## Changes
- **lib/heartbeat/types.ts** — Added `lastCheckInDate` and `currentStreak` fields to `CheckInRecord`
- **lib/heartbeat/kv-helpers.ts** — Streak logic in `updateCheckInRecord`: same-day no-op, consecutive-day increment, gap reset
- **lib/achievements/registry.ts** — Registered `streak-7d` and `streak-30d` achievement definitions (category: engagement)
- **app/api/heartbeat/route.ts** — Best-effort streak achievement grants after existing achievement checks

## Test plan
- [ ] Verify first check-in sets `currentStreak: 1` and `lastCheckInDate` to today
- [ ] Verify same-day check-in does not increment streak
- [ ] Verify next-day check-in increments streak
- [ ] Verify gap > 1 day resets streak to 1
- [ ] Verify `streak-7d` achievement is granted at streak >= 7
- [ ] Verify `streak-30d` achievement is granted at streak >= 30
- [ ] Verify existing agents without streak fields get streak initialized on next check-in

Closes #434

🤖 Generated with [Claude Code](https://claude.com/claude-code)