### PR TITLE
feat(achievements): add streak-7d and streak-30d badges

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -535,6 +535,30 @@ export async function POST(request: NextRequest) {
       console.error("Failed to check tireless achievement during heartbeat:", error);
     }
 
+    // Grant streak-7d achievement if agent has 7+ consecutive days (best-effort)
+    try {
+      if ((checkInRecord.currentStreak ?? 0) >= 7) {
+        const hasStreak7d = await hasAchievement(kv, btcAddress, "streak-7d");
+        if (!hasStreak7d) {
+          await grantAchievement(kv, btcAddress, "streak-7d", { currentStreak: checkInRecord.currentStreak });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check streak-7d achievement during heartbeat:", error);
+    }
+
+    // Grant streak-30d achievement if agent has 30+ consecutive days (best-effort)
+    try {
+      if ((checkInRecord.currentStreak ?? 0) >= 30) {
+        const hasStreak30d = await hasAchievement(kv, btcAddress, "streak-30d");
+        if (!hasStreak30d) {
+          await grantAchievement(kv, btcAddress, "streak-30d", { currentStreak: checkInRecord.currentStreak });
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check streak-30d achievement during heartbeat:", error);
+    }
+
     // Update agent record with lastActiveAt, checkInCount, and identity data
     const updatedAgent = {
       ...agent,

--- a/lib/achievements/registry.ts
+++ b/lib/achievements/registry.ts
@@ -102,6 +102,18 @@ export const ACHIEVEMENTS: AchievementDefinition[] = [
     description: "Received a paid x402 inbox message",
     category: "onchain",
   },
+  {
+    id: "streak-7d",
+    name: "Weekly Streaker",
+    description: "7 consecutive days with a heartbeat check-in",
+    category: "engagement",
+  },
+  {
+    id: "streak-30d",
+    name: "Monthly Streaker",
+    description: "30 consecutive days with a heartbeat check-in",
+    category: "engagement",
+  },
 ];
 
 /**

--- a/lib/heartbeat/kv-helpers.ts
+++ b/lib/heartbeat/kv-helpers.ts
@@ -49,6 +49,25 @@ export async function getCheckInRecord(
  * const record = await updateCheckInRecord(kv, "bc1q...", "2026-02-10T12:00:00.000Z");
  * console.log(`Check-in count: ${record.checkInCount}`);
  */
+/**
+ * Compute the UTC date string (YYYY-MM-DD) from an ISO timestamp.
+ */
+function toDateString(isoTimestamp: string): string {
+  return isoTimestamp.slice(0, 10);
+}
+
+/**
+ * Check if two date strings represent consecutive days.
+ *
+ * @returns true if dateB is exactly 1 day after dateA
+ */
+function isConsecutiveDay(dateA: string, dateB: string): boolean {
+  const a = new Date(dateA + "T00:00:00Z");
+  const b = new Date(dateB + "T00:00:00Z");
+  const diffMs = b.getTime() - a.getTime();
+  return diffMs === 86_400_000;
+}
+
 export async function updateCheckInRecord(
   kv: KVNamespace,
   btcAddress: string,
@@ -56,18 +75,43 @@ export async function updateCheckInRecord(
   existing?: CheckInRecord | null
 ): Promise<CheckInRecord> {
   const current = existing !== undefined ? existing : await getCheckInRecord(kv, btcAddress);
+  const todayDate = toDateString(timestamp);
 
-  const record: CheckInRecord = current
-    ? {
-        btcAddress,
-        checkInCount: current.checkInCount + 1,
-        lastCheckInAt: timestamp,
-      }
-    : {
-        btcAddress,
-        checkInCount: 1,
-        lastCheckInAt: timestamp,
-      };
+  let currentStreak: number;
+  let longestStreak: number;
+
+  if (!current) {
+    // First ever check-in
+    currentStreak = 1;
+    longestStreak = 1;
+  } else {
+    const lastDate = current.lastCheckInDate;
+    const prevStreak = current.currentStreak ?? 1;
+    const prevLongest = current.longestStreak ?? prevStreak;
+
+    if (lastDate === todayDate) {
+      // Same day — idempotent, no streak change
+      currentStreak = prevStreak;
+      longestStreak = prevLongest;
+    } else if (lastDate && isConsecutiveDay(lastDate, todayDate)) {
+      // Consecutive day — extend streak
+      currentStreak = prevStreak + 1;
+      longestStreak = Math.max(prevLongest, currentStreak);
+    } else {
+      // Gap > 1 day — reset streak
+      currentStreak = 1;
+      longestStreak = prevLongest;
+    }
+  }
+
+  const record: CheckInRecord = {
+    btcAddress,
+    checkInCount: current ? current.checkInCount + 1 : 1,
+    lastCheckInAt: timestamp,
+    lastCheckInDate: todayDate,
+    currentStreak,
+    longestStreak,
+  };
 
   const key = `${CHECK_IN_PREFIX}${btcAddress}`;
   await kv.put(key, JSON.stringify(record));

--- a/lib/heartbeat/types.ts
+++ b/lib/heartbeat/types.ts
@@ -16,6 +16,12 @@ export interface CheckInRecord {
   btcAddress: string;
   checkInCount: number;
   lastCheckInAt: string;
+  /** ISO date string (YYYY-MM-DD) of the last check-in day, used for streak tracking */
+  lastCheckInDate?: string;
+  /** Current consecutive-day check-in streak */
+  currentStreak?: number;
+  /** Longest consecutive-day check-in streak ever achieved */
+  longestStreak?: number;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds `lastCheckInDate`, `currentStreak`, and `longestStreak` fields to `CheckInRecord` for tracking consecutive-day check-in streaks
- Implements streak logic in `updateCheckInRecord`: increments on consecutive days, resets on gaps, idempotent on same-day re-check-ins
- Registers `streak-7d` (Weekly Streaker) and `streak-30d` (Monthly Streaker) achievement definitions
- Grants streak achievements during heartbeat when thresholds are met (7 and 30 consecutive days)
- Backwards-compatible: existing records without streak fields default to streak=1

Closes #434

## Test plan

- [x] All 330 existing tests pass (15 test files)
- [ ] CI passes on this branch
- [ ] Manual verification: new agent check-in creates record with `currentStreak: 1`
- [ ] Verify consecutive-day check-in increments `currentStreak`
- [ ] Verify gap >1 day resets `currentStreak` to 1
- [ ] Verify same-day re-check-in does not change streak (idempotent)
- [ ] Verify `streak-7d` achievement granted at `currentStreak >= 7`
- [ ] Verify `streak-30d` achievement granted at `currentStreak >= 30`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes #434