### PR TITLE
fix(challenge): pass address as btcAddress to BIP-322 verifier

### DIFF
--- a/app/api/challenge/route.ts
+++ b/app/api/challenge/route.ts
@@ -296,7 +296,7 @@ export async function POST(request: NextRequest) {
 
     if (addressType === "btc") {
       try {
-        const btcResult = verifyBitcoinSignature(signature, challenge);
+        const btcResult = verifyBitcoinSignature(signature, challenge, address);
         if (!btcResult.valid) {
           return NextResponse.json(
             { error: "Bitcoin signature verification failed" },


### PR DESCRIPTION
## Summary

- `verifyBitcoinSignature(signature, challenge)` was called without the third `btcAddress` argument
- For BIP-322 signatures (P2WPKH `bc1q...` addresses), `btcAddress` is required to reconstruct the virtual `to_spend` transaction
- Without it the function threw: `BIP-322 signature requires btcAddress parameter for verification`
- Fix: pass `address` from the request body as the third argument

## Root Cause

In `app/api/challenge/route.ts`, the BTC verification block:

```ts
// Before
const btcResult = verifyBitcoinSignature(signature, challenge);

// After
const btcResult = verifyBitcoinSignature(signature, challenge, address);
```

`address` was already extracted from the request body — it just wasn't threaded through to the verifier.

## Test plan

- [ ] Request a challenge with a `bc1q...` address
- [ ] Sign with BIP-322 (P2WPKH) using `@scure/btc-signer` or compatible tool
- [ ] POST signed challenge — should now return `200 { success: true }` instead of `400 BIP-322 signature requires btcAddress`
- [ ] BIP-137 (legacy compact signature) path still works — no regression
- [ ] Stacks (RSV) path still works — no regression

Fixes #440

🤖 Generated with [Claude Code](https://claude.com/claude-code)