### PR TITLE
docs(llms): add skills-v0.27.0 Notable Skills (bounty-scanner, runes, aibtc-news)

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -913,6 +913,9 @@ curl https://aibtc.com/skills
 | pillar | Pillar smart wallet — sBTC operations, DCA, stacking with gasless signing |
 | contract | Contract deployment and interaction — deploy, call, and inspect Stacks smart contracts *(v0.25.0)* |
 | jingswap | Blind batch auction — sbtc-stx and sbtc-usdcx markets, Pyth oracle settlement *(v0.26.0)* |
+| bounty-scanner | Autonomous bounty hunting — scan bounty.drx4.xyz, claim and submit bounties *(v0.27.0)* |
+| runes | L1 Runes — balances, transfers, inscription ops via Unisat API *(v0.27.0, migrated from Hiro)* |
+| aibtc-news | AIBTC news aggregation — front-page stories, status filters, disclosure field *(v0.27.0)* |
 
 Web directory: https://aibtc.com/skills
 Source: https://github.com/aibtcdev/skills

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -271,7 +271,7 @@ npx skills add aibtcdev/skills/{skill-name}
 curl https://aibtc.com/skills
 \`\`\`
 
-Notable skills: btc (L1 balances/transfers), stx (STX transfers), sbtc (sBTC bridging), defi (DEX swaps), tenero (Stacks market analytics — token info, top gainers/losers, whale trades, holder stats), x402 (paid messaging), wallet (BIP39 key management), erc8004 (on-chain agent identity), transfer (STX/token/NFT transfers), psbt (PSBT construction/signing), openrouter (OpenRouter AI integration), relay-diagnostic (sponsor relay health/nonce recovery), inbox (x402-gated inbox), and more.
+Notable skills: btc (L1 balances/transfers), stx (STX transfers), sbtc (sBTC bridging), defi (DEX swaps), tenero (Stacks market analytics — token info, top gainers/losers, whale trades, holder stats), x402 (paid messaging), wallet (BIP39 key management), erc8004 (on-chain agent identity), transfer (STX/token/NFT transfers), psbt (PSBT construction/signing), openrouter (OpenRouter AI integration), relay-diagnostic (sponsor relay health/nonce recovery), inbox (x402-gated inbox), bounty-scanner (autonomous bounty hunting — bounty.drx4.xyz), runes (L1 Runes balances/transfers, inscription ops via Unisat API), aibtc-news (AIBTC news aggregation with front-page, status filters, disclosure), and more.
 
 Web directory: https://aibtc.com/skills
 Source: https://github.com/aibtcdev/skills


### PR DESCRIPTION
## Summary

- Adds three skills from [aibtcdev/skills v0.27.0](https://github.com/aibtcdev/skills/releases/tag/skills-v0.27.0) to `llms.txt` Notable Skills and `llms-full.txt` skills table
- **bounty-scanner** — autonomous bounty hunting via bounty.drx4.xyz (PR #91/#178)
- **runes** — L1 Runes balances/transfers/inscription ops, migrated from Hiro (shutdown 2026-03-09) to Unisat API (PR #170)
- **aibtc-news** — AIBTC news aggregation enhanced with front-page, status filter, disclosure field (PR #172); aibtc.news already in Ecosystem links

## Notes

The `runes` skill entry calls out the Unisat API migration explicitly — Hiro's Ordinals API shut down 2026-03-09, so this listing validates the migration and sets correct expectations for agents reading llms.txt.

## Test plan
- [ ] Verify `llms.txt` Notable Skills line contains all three new skills
- [ ] Verify `llms-full.txt` skills table has entries for bounty-scanner, runes, aibtc-news at v0.27.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)