### PR TITLE
fix: auto-check connector achievement + support relay-mediated sBTC

### DIFF
--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -453,10 +453,20 @@ export async function POST(request: NextRequest) {
             );
           }
 
-          if (tx.sender_address !== agent.stxAddress) {
+          // Check sender: accept either tx.sender_address or the "sender" function arg
+          // (relay-mediated transfers have the relay as tx.sender_address but the agent as the sender arg)
+          const senderArg = tx.contract_call.function_args?.find(
+            (arg) => arg.name === "sender"
+          );
+          const senderArgAddress = senderArg?.repr.replace(/^'/, "");
+          const isSender =
+            tx.sender_address === agent.stxAddress ||
+            senderArgAddress === agent.stxAddress;
+
+          if (!isSender) {
             return NextResponse.json(
               {
-                error: `Transaction ${txid} sender (${tx.sender_address}) does not match agent STX address (${agent.stxAddress})`,
+                error: `Transaction ${txid} sender (${tx.sender_address}) and sender arg (${senderArgAddress ?? "missing"}) do not match agent STX address (${agent.stxAddress})`,
               },
               { status: 400 }
             );

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -21,6 +21,7 @@ import { IDENTITY_CHECK_TTL_MS } from "@/lib/identity/constants";
 import {
   verifySenderAchievement,
   verifyStackerAchievement,
+  verifyConnectorAchievement,
   checkRateLimit,
   setRateLimit,
   hasAchievement,
@@ -426,6 +427,30 @@ export async function POST(request: NextRequest) {
       }
     } catch (error) {
       console.error("Failed to check stacker achievement during heartbeat:", error);
+    }
+
+    // Proactively check connector achievement (best-effort)
+    try {
+      const rateLimit = await checkRateLimit(kv, btcAddress, "connector");
+      if (rateLimit.allowed && agent.stxAddress) {
+        const hasConnector = await hasAchievement(kv, btcAddress, "connector");
+        if (!hasConnector) {
+          const connectorResult = await verifyConnectorAchievement(
+            agent.stxAddress,
+            kv,
+            env.HIRO_API_KEY
+          );
+          if (connectorResult) {
+            await grantAchievement(kv, btcAddress, "connector", {
+              txid: connectorResult.txid,
+              recipientAddress: connectorResult.recipientAddress,
+            });
+          }
+          await setRateLimit(kv, btcAddress, "connector");
+        }
+      }
+    } catch (error) {
+      console.error("Failed to check connector achievement during heartbeat:", error);
     }
 
     // Grant identified achievement if agent has an on-chain identity (best-effort)

--- a/lib/achievements/index.ts
+++ b/lib/achievements/index.ts
@@ -30,6 +30,7 @@ export {
 export {
   verifySenderAchievement,
   verifyStackerAchievement,
+  verifyConnectorAchievement,
   checkRateLimit,
   setRateLimit,
   ACHIEVEMENT_VERIFY_RATE_LIMIT_MS,

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -175,6 +175,119 @@ export async function verifyStackerAchievement(
  * @param unisatApiKey - Unisat API key (Bearer token)
  * @returns true if the inscription is owned by btcAddress, false otherwise
  */
+/**
+ * sBTC token contract identifier used for connector achievement verification.
+ */
+const SBTC_CONTRACT_ID =
+  "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
+
+/**
+ * Verify if an agent has sent an sBTC transfer with memo to a registered agent (Connector achievement).
+ *
+ * Scans the agent's recent Stacks transactions for qualifying sBTC transfers.
+ * A qualifying transfer must:
+ * - Be a successful contract_call to sbtc-token transfer
+ * - Have the agent as the sender (via function args, to support relay-mediated txs)
+ * - Have a registered agent as the recipient
+ * - Include a memo
+ *
+ * @param stxAddress - Agent's Stacks address
+ * @param kv - Cloudflare KV namespace (to check recipient registration)
+ * @param hiroApiKey - Optional Hiro API key for higher rate limits
+ * @returns Object with qualifying txid and recipientAddress, or null if none found
+ */
+export async function verifyConnectorAchievement(
+  stxAddress: string,
+  kv: KVNamespace,
+  hiroApiKey?: string
+): Promise<{ txid: string; recipientAddress: string } | null> {
+  try {
+    const cacheKey = `stx-txs:${stxAddress}`;
+    let txs = await getCachedTransaction(cacheKey, kv);
+
+    if (!txs) {
+      const txsUrl = `https://api.hiro.so/extended/v1/address/${stxAddress}/transactions?limit=50`;
+      const resp = await fetch(txsUrl, {
+        headers: buildHiroHeaders(hiroApiKey),
+        signal: AbortSignal.timeout(10000),
+      });
+
+      if (!resp.ok) {
+        console.error(
+          `Failed to fetch transactions for ${stxAddress}: ${resp.status}`
+        );
+        return null;
+      }
+
+      const data = (await resp.json()) as {
+        results: Array<{
+          tx_id: string;
+          tx_status: string;
+          tx_type: string;
+          sender_address: string;
+          contract_call?: {
+            contract_id: string;
+            function_name: string;
+            function_args?: Array<{ name: string; repr: string }>;
+          };
+        }>;
+      };
+      txs = data.results;
+      await setCachedTransaction(cacheKey, txs, kv);
+    }
+
+    // Find a qualifying sBTC transfer
+    for (const tx of txs as Array<{
+      tx_id: string;
+      tx_status: string;
+      tx_type: string;
+      sender_address: string;
+      contract_call?: {
+        contract_id: string;
+        function_name: string;
+        function_args?: Array<{ name: string; repr: string }>;
+      };
+    }>) {
+      if (tx.tx_status !== "success") continue;
+      if (tx.tx_type !== "contract_call") continue;
+      if (!tx.contract_call) continue;
+      if (tx.contract_call.contract_id !== SBTC_CONTRACT_ID) continue;
+      if (tx.contract_call.function_name !== "transfer") continue;
+
+      const args = tx.contract_call.function_args;
+      if (!args) continue;
+
+      // Check sender arg matches agent (supports relay-mediated transfers)
+      const senderArg = args.find((a) => a.name === "sender");
+      if (!senderArg) continue;
+      const senderAddress = senderArg.repr.replace(/^'/, "");
+      if (senderAddress !== stxAddress) continue;
+
+      // Check memo is present
+      const memoArg = args.find((a) => a.name === "memo");
+      if (!memoArg || memoArg.repr.includes("none")) continue;
+
+      // Check recipient is a registered agent
+      const recipientArg = args.find((a) => a.name === "recipient");
+      if (!recipientArg) continue;
+      const recipientAddress = recipientArg.repr.replace(/^'/, "");
+
+      const recipientData = await kv.get(`stx:${recipientAddress}`);
+      if (!recipientData) continue;
+
+      return { txid: tx.tx_id, recipientAddress };
+    }
+
+    return null;
+  } catch (error) {
+    console.error(
+      `Failed to verify connector achievement for ${stxAddress}:`,
+      error
+    );
+    return null;
+  }
+}
+
 const INSCRIPTION_ID_RE = /^[a-fA-F0-9]{64}i\d+$/;
 
 export async function verifyInscriberAchievement(


### PR DESCRIPTION
## Summary

- **Auto-check Connector during heartbeat**: Added `verifyConnectorAchievement()` that scans an agent's recent Stacks transactions for qualifying sBTC transfers (successful `sbtc-token.transfer` contract calls with a memo to a registered agent). The heartbeat now proactively checks this achievement using the same best-effort, rate-limited pattern as sender and stacker.
- **Support relay-mediated sBTC transfers**: The verify endpoint's sender check now accepts either `tx.sender_address` OR the `sender` function argument from the contract call. This fixes x402 sponsor relay payments where the relay is `tx.sender_address` but the agent is the contract call's sender arg.

## Changes

| File | Change |
|------|--------|
| `lib/achievements/verify.ts` | New `verifyConnectorAchievement()` — scans address txs for qualifying sBTC transfers |
| `lib/achievements/index.ts` | Export `verifyConnectorAchievement` |
| `app/api/heartbeat/route.ts` | Add connector auto-check block (same pattern as sender/stacker) |
| `app/api/achievements/verify/route.ts` | Fix sender check to accept relay-mediated transfers via sender function arg |

## Test plan

- [ ] Verify heartbeat auto-grants connector to agent with qualifying sBTC transfer (e.g. txid `0xdf926fb3b37abba7eb342f8a02ce7a2f21982dd64005119d0ee811ada3452ace`)
- [ ] Verify manual verify endpoint accepts relay-mediated transfers (sender arg matches agent, tx.sender_address is relay)
- [ ] Verify direct transfers still work (tx.sender_address matches agent)
- [ ] Verify rate limiting prevents excessive API calls during heartbeat
- [ ] CI passes

Closes #444

🤖 Generated with [Claude Code](https://claude.com/claude-code)