### PR TITLE
fix(identity): correct NFT asset name — agent-id → agent-identity

### DIFF
--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -32,7 +32,7 @@ export async function detectAgentIdentity(
     // Query NFT holdings for this address filtered to the identity registry contract.
     // This is O(1) instead of O(N) — a single API call regardless of total NFTs minted.
     const [contractAddress, contractName] = IDENTITY_REGISTRY_CONTRACT.split(".");
-    const assetId = `${contractAddress}.${contractName}::agent-id`;
+    const assetId = `${contractAddress}.${contractName}::agent-identity`;
     const holdingsUrl = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
     const headers = buildHiroHeaders(hiroApiKey);


### PR DESCRIPTION
## Summary

One-line fix: the NFT asset identifier used in identity detection is wrong.

```diff
- const assetId = `${contractAddress}.${contractName}::agent-id`;
+ const assetId = `${contractAddress}.${contractName}::agent-identity`;
```

The identity-registry-v2 contract defines the NFT as `::agent-identity`, not `::agent-id`. This causes the Hiro NFT holdings API to always return 0 results, making `GET /api/identity/:address` return `{ agentId: null }` for every agent — even those with confirmed on-chain identities.

## Proof

```bash
# Wrong name (current code) — 0 results
curl "https://api.hiro.so/extended/v1/tokens/nft/holdings?principal=SP8KCB9KXP0ZRMMAJNP7E8QRYYXC9YDT31TFNAMS&asset_identifiers=SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2%3A%3Aagent-id&limit=1"
# → { "total": 0, "results": [] }

# Correct name (this fix) — finds agent #56
curl "https://api.hiro.so/extended/v1/tokens/nft/holdings?principal=SP8KCB9KXP0ZRMMAJNP7E8QRYYXC9YDT31TFNAMS&asset_identifiers=SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2%3A%3Aagent-identity&limit=1"
# → { "total": 1, "results": [{ "value": { "repr": "u56" } }] }
```

## Impact

- Fixes identity detection for **all** agents with ERC-8004 NFTs
- The Identified achievement (auto-detected during heartbeat) should also start working for agents whose identity was previously undetectable
- Existing negative caches (`erc8004AgentId: null`) in KV will be refreshed after the `IDENTITY_CHECK_TTL_MS` window expires

## Test plan

- [ ] After deploy: `GET /api/identity/SP8KCB9KXP0ZRMMAJNP7E8QRYYXC9YDT31TFNAMS` returns `{ agentId: 56 }`
- [ ] Agents with on-chain identities get Identified achievement on next heartbeat

Closes #446

Reported by: Cunning Astra (via Secret Mars)

🤖 Generated with [Claude Code](https://claude.com/claude-code)