### PR TITLE
feat(inbox): accept STX address in inbox/outbox URL and resolve to agent

### DIFF
--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -26,7 +26,6 @@ import {
   grantAchievement,
   getAchievementDefinition,
 } from "@/lib/achievements";
-import { isStxAddress } from "@/lib/validation/address";
 import { checkFixedWindowRateLimit } from "@/lib/rate-limit";
 
 export async function POST(
@@ -90,15 +89,11 @@ export async function POST(
       );
     }
 
-    const isStx = isStxAddress(address);
     logger.warn("Agent not found", { address });
     return NextResponse.json(
       {
         error: "Agent not found",
         address,
-        ...(isStx && {
-          hint: "You provided a Stacks address. Try your BTC address (bc1...) instead — the outbox endpoint uses Bitcoin signatures for authentication.",
-        }),
         action:
           "Register at POST /api/register to use the outbox endpoint.",
         documentation: "https://aibtc.com/api/register",
@@ -265,7 +260,6 @@ export async function POST(
 
   // Verify path address resolves to the same agent as the signer
   if (btcResult.address !== agent.btcAddress) {
-    const isStx = isStxAddress(address);
     logger.warn("Path address does not match signer", {
       pathAddress: address,
       pathAgentBtc: agent.btcAddress,
@@ -276,9 +270,7 @@ export async function POST(
         error: "Path address does not match signer.",
         expectedAddress: btcResult.address,
         providedAddress: address,
-        hint: isStx
-          ? `You provided a Stacks address in the URL. Use your BTC address instead: POST /api/outbox/${agent.btcAddress}`
-          : `Use your own outbox endpoint: POST /api/outbox/${btcResult.address}`,
+        hint: `The address in the URL resolved to a different agent than the signature. Use your own outbox endpoint: POST /api/outbox/${btcResult.address}`,
       },
       { status: 403 }
     );


### PR DESCRIPTION
## Summary

- Removes the misleading hint in `POST /api/outbox/[address]` that told agents "You provided a Stacks address. Try your BTC address (bc1...) instead" — this hint was wrong because `lookupAgent()` already handles STX addresses via the `stx:` KV index written during registration
- Removes the STX-specific branch in the path-vs-signer mismatch check that unnecessarily suggested switching to BTC address in the URL
- Removes the now-unused `isStxAddress` import from the outbox route

Both `GET /api/inbox/[address]` and `GET /api/outbox/[address]` already work correctly with STX addresses (they call `lookupAgent` directly). The only broken experience was the error hint in `POST /api/outbox/[address]` that actively misdirected agents.

Closes #453

## Root Cause

`lookupAgent(kv, address)` in `lib/agent-lookup.ts` tries both `kv.get("btc:${address}")` AND `kv.get("stx:${address}")` in parallel, and `app/api/register/route.ts` writes `stx:{stxAddress}` to KV during registration. So STX address lookup already works end-to-end.

The bug was purely in the outbox POST error responses, which told agents the wrong thing when lookup failed (for any reason, including simply not being registered yet).

## Test Plan

- [ ] `GET /api/inbox/SP...` — should return agent inbox (was already working)
- [ ] `GET /api/outbox/SP...` — should return agent replies (was already working)
- [ ] `POST /api/outbox/SP...` with valid body and signature — should accept the request and process the reply (previously returned 404 with misleading BTC-address hint for unregistered agents; now returns a clean 404 with registration action)
- [ ] `POST /api/outbox/SP...` where SP resolves to agent A but signature is from agent B — should return 403 with clear mismatch message (no longer suggests switching to BTC URL format)
- [ ] Existing BTC address flows unchanged — verify `POST /api/outbox/bc1q...` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)