### PR TITLE
feat(inbox): accept STX address in inbox URL path and resolve to agent

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -517,8 +517,8 @@ export async function POST(
         error: "Malformed JSON body",
         parseError,
         expectedBody: {
-          toBtcAddress: "string — recipient's Bitcoin address (bc1...)",
-          toStxAddress: "string — recipient's Stacks address (SP...)",
+          toBtcAddress: "optional string — recipient's Bitcoin address (bc1...). Inferred from URL address if omitted.",
+          toStxAddress: "optional string — recipient's Stacks address (SP...). Inferred from URL address if omitted.",
           content: "string — message text (max 500 characters)",
           signature:
             "optional string — BIP-137/BIP-322 signature over 'Inbox Message | {content}'",
@@ -541,6 +541,14 @@ export async function POST(
   const paymentSigHeader =
     request.headers.get(X402_HEADERS.PAYMENT_SIGNATURE) ||
     request.headers.get("X-Payment-Signature"); // backwards compat
+
+  // Auto-populate recipient addresses from the resolved agent when the body omits them.
+  // This allows callers to use a STX address in the URL without knowing the BTC address.
+  if (body && typeof body === "object") {
+    const b = body as Record<string, unknown>;
+    if (!b.toBtcAddress) b.toBtcAddress = agent.btcAddress;
+    if (!b.toStxAddress) b.toStxAddress = agent.stxAddress;
+  }
 
   // Validate message body (paymentTxid/paymentSatoshis are optional for the initial 402 request)
   const validation = validateInboxMessage(body);


### PR DESCRIPTION
## Summary

- When agents call `POST /api/inbox/SP...` using a Stacks address in the URL, the handler now auto-populates `toBtcAddress` and `toStxAddress` in the request body from the resolved agent record before validation runs
- This makes `toBtcAddress` and `toStxAddress` optional in the request body when the URL address (BTC or STX) uniquely identifies the recipient
- Agents that discover peers via on-chain Stacks activity (where only the STX address is visible) no longer need a separate lookup to find the BTC address before sending inbox messages
- No changes to validation logic — the body fields still validate correctly when provided; they're only auto-filled when absent

## Root Cause

`lookupAgent()` already resolved both BTC and STX addresses from the URL parameter. The friction was at body validation: `toBtcAddress` and `toStxAddress` were required fields even when the URL already identified the recipient unambiguously.

## Test plan

- [x] `npm run build` passes (TypeScript clean)
- [x] `npm test` passes (332 tests, 0 failures)
- [ ] POST `/api/inbox/SP2GHQRCRMYY4S8PMBR49BEKX144VR437YT42SF3B` with body `{"content":"hello"}` (no BTC address) should return 402 Payment Required (not a validation error)
- [ ] POST with explicit `toBtcAddress` and `toStxAddress` still works as before
- [ ] GET `/api/inbox/SP...` still returns correct inbox

Closes #453

🤖 Generated with [Claude Code](https://claude.com/claude-code)