### PR TITLE
feat(llms): update Notable Skills to skills-v0.28.0

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -874,7 +874,7 @@ npx skills add aibtcdev/skills/{skill-name}
 curl https://aibtc.com/skills
 \`\`\`
 
-### Notable Skills (skills-v0.26.0)
+### Notable Skills (skills-v0.28.0)
 
 | Skill | Description |
 |-------|-------------|
@@ -905,7 +905,7 @@ curl https://aibtc.com/skills
 | inbox | x402-gated inbox — pay-to-contact messaging with micropayment authorization *(v0.24.0)* |
 | openrouter | OpenRouter AI — route LLM calls across multiple model providers *(v0.24.0)* |
 | relay-diagnostic | Relay diagnostics — sponsor relay health checks and nonce recovery *(v0.24.0)* |
-| nostr | Nostr protocol — post notes, read feeds, derive keys, amplify signals |
+| nostr | Nostr protocol — post notes, read feeds, derive keys, amplify signals; NIP-06 key derivation default *(v0.28.0)* |
 | tokens | SIP-010 tokens — balances, transfers, metadata, top holders |
 | nft | SIP-009 NFTs — holdings, transfers, metadata, collection info |
 | query | Stacks network queries — account info, tx history, contract calls |
@@ -916,6 +916,8 @@ curl https://aibtc.com/skills
 | bounty-scanner | Autonomous bounty hunting — scan bounty.drx4.xyz, claim and submit bounties *(v0.27.0)* |
 | runes | L1 Runes — balances, transfers, inscription ops via Unisat API *(v0.27.0, migrated from Hiro)* |
 | aibtc-news | AIBTC news aggregation — front-page stories, status filters, disclosure field *(v0.27.0)* |
+| stacking-lottery | Bitcoin stacking lottery participation *(v0.28.0)* |
+| maximumsats-wot | Web of Trust trust scoring *(v0.28.0)* |
 
 Web directory: https://aibtc.com/skills
 Source: https://github.com/aibtcdev/skills

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -271,7 +271,7 @@ npx skills add aibtcdev/skills/{skill-name}
 curl https://aibtc.com/skills
 \`\`\`
 
-Notable skills: btc (L1 balances/transfers), stx (STX transfers), sbtc (sBTC bridging), defi (DEX swaps), tenero (Stacks market analytics — token info, top gainers/losers, whale trades, holder stats), x402 (paid messaging), wallet (BIP39 key management), erc8004 (on-chain agent identity), transfer (STX/token/NFT transfers), psbt (PSBT construction/signing), openrouter (OpenRouter AI integration), relay-diagnostic (sponsor relay health/nonce recovery), inbox (x402-gated inbox), bounty-scanner (autonomous bounty hunting — bounty.drx4.xyz), runes (L1 Runes balances/transfers, inscription ops via Unisat API), aibtc-news (AIBTC news aggregation with front-page, status filters, disclosure), and more.
+Notable skills: btc (L1 balances/transfers), stx (STX transfers), sbtc (sBTC bridging), defi (DEX swaps), tenero (Stacks market analytics — token info, top gainers/losers, whale trades, holder stats), x402 (paid messaging), wallet (BIP39 key management), erc8004 (on-chain agent identity), transfer (STX/token/NFT transfers), psbt (PSBT construction/signing), openrouter (OpenRouter AI integration), relay-diagnostic (sponsor relay health/nonce recovery), inbox (x402-gated inbox), bounty-scanner (autonomous bounty hunting — bounty.drx4.xyz), runes (L1 Runes balances/transfers, inscription ops via Unisat API), aibtc-news (AIBTC news aggregation with front-page, status filters, disclosure), nostr (Nostr notes, feeds, NIP-06 key derivation), stacking-lottery (Bitcoin stacking lottery participation), maximumsats-wot (Web of Trust trust scoring), and more.
 
 Web directory: https://aibtc.com/skills
 Source: https://github.com/aibtcdev/skills


### PR DESCRIPTION
## Summary

- Add `stacking-lottery` (Bitcoin stacking lottery participation) to notable skills in both `llms.txt` and `llms-full.txt`
- Add `maximumsats-wot` (Web of Trust trust scoring) to notable skills in both files
- Update `nostr` entry to note NIP-06 key derivation default (v0.28.0)
- Bump Notable Skills section heading from `skills-v0.26.0` → `skills-v0.28.0`

`jingswap` (v0.26.0) and `contract` (v0.25.0) were already present in the table.

## Test plan

- [ ] Check `https://aibtc.com/llms.txt` — stacking-lottery, maximumsats-wot, and nostr (NIP-06) appear in Notable skills inline list
- [ ] Check `https://aibtc.com/llms-full.txt` — Notable Skills table heading shows v0.28.0, stacking-lottery and maximumsats-wot rows added, nostr row updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)