### PR TITLE
fix(outbox): include expected/actual signer in mismatch error

### DIFF
--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -261,7 +261,7 @@ export async function POST(
         error: "Signer does not match the message recipient. Only the recipient can reply.",
         code: "SIGNER_NOT_RECIPIENT",
         retryable: false,
-        nextSteps: "Sign the request with the private key matching the recipient address",
+        nextSteps: `Sign with the BTC key for ${message.toBtcAddress}`,
         expectedSigner: message.toBtcAddress,
         actualSigner: btcResult.address,
       },


### PR DESCRIPTION
## Summary

- Updates `nextSteps` in the `SIGNER_NOT_RECIPIENT` error response to explicitly name the expected BTC address
- Callers now see exactly which key to use: `"Sign with the BTC key for bc1q7zpy3..."` instead of a generic message
- `expectedSigner` and `actualSigner` fields (added in #480) remain unchanged — this improves the human-readable hint

## Context

From production logs (2026-03-23), a user repeatedly triggered the signer-mismatch error and eventually gave up (submitted empty signature). The generic `nextSteps` message didn't tell them which key to use. The server already knows both the expected and actual signer addresses from the signature recovery — this change surfaces that in the `nextSteps` field.

## Test plan

- [ ] Lint passes (`eslint` on outbox route)
- [ ] All 332 tests pass (`npm test`)
- [ ] `SIGNER_NOT_RECIPIENT` response includes `nextSteps` referencing the expected address

Closes #481

🤖 Generated with [Claude Code](https://claude.com/claude-code)