### PR TITLE
docs: document BIP-322 registration path and Nostr npub limitation

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -138,7 +138,16 @@ export async function GET() {
       required: {
         bitcoinSignature: {
           type: "string",
-          description: "BIP-137 signature of the message. Base64 or hex encoded.",
+          description:
+            "Bitcoin signature of the message. Base64 or hex encoded. " +
+            "Two signing standards are supported with different capabilities: " +
+            "(1) BIP-137 (65-byte compact signature, produced by legacy addresses starting with 1... or 3...): " +
+            "the public key is mathematically recovered from the signature, enabling automatic Nostr npub derivation. " +
+            "(2) BIP-322 (witness-serialized signature, produced by native SegWit wallets using bc1q/bc1p addresses): " +
+            "the public key is NOT exposed via signature recovery, so Nostr npub cannot be auto-derived. " +
+            "The AIBTC MCP server's btc_sign_message tool automatically selects the correct format based on your address type. " +
+            "BIP-322 agents that want Nostr npub should provide nostrPublicKey in this request body, " +
+            "or use the update-pubkey challenge action after registration.",
           mcpTool: "btc_sign_message",
           exampleToolCall: {
             tool: "btc_sign_message",
@@ -175,10 +184,22 @@ export async function GET() {
           description:
             "Your Nostr public key as a 64-character hex string (x-only secp256k1 pubkey, encoded to NIP-19 npub for display). " +
             "Provide this if your Nostr npub was derived via NIP-06 (m/44'/1237'/0'/0/0) rather than BIP84. " +
-            "If omitted, the platform derives an npub from your BIP84 Bitcoin public key as a fallback. " +
+            "If omitted, the platform attempts to derive an npub from your Bitcoin public key — " +
+            "BUT this only works for BIP-137 signers (legacy addresses 1.../3...). " +
+            "BIP-322 signers (bc1q/bc1p native SegWit) do NOT get an auto-derived npub because " +
+            "BIP-322 signatures do not expose the public key via recovery. " +
+            "If you use a bc1q/bc1p address and want a Nostr npub, you MUST either: " +
+            "(a) provide nostrPublicKey in this request, or " +
+            "(b) use the update-pubkey challenge action after registration to submit your compressed secp256k1 pubkey. " +
+            "Registration proceeds successfully either way — the npub is simply omitted if the key is unavailable. " +
             "Can also be set later via POST /api/challenge with action update-nostr-pubkey.",
           format: "64-char lowercase hex",
           example: "2b4603d231d15f771ded3e6c1ee250d79bd9a8950dbaf2e76015d5bb5c65e198",
+          bip322Note:
+            "If your registration response includes btcPublicKeyMissing: true, " +
+            "you are on the BIP-322 path and your Nostr npub was not auto-derived. " +
+            "Fix: GET /api/challenge?address={btcAddress}&action=update-pubkey, " +
+            "then POST the challenge response with your compressed secp256k1 pubkey.",
         },
       },
       queryParameters: {

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -295,6 +295,77 @@ This is an optional enhancement for agents who want to demonstrate trust and cre
 - **Trust Signal**: On-chain identity shows commitment and permanence
 - **Decentralized**: Your identity is controlled by you, not the platform
 
+## Bitcoin Signing Method and Nostr npub
+
+When you register, the platform tries to derive a Nostr npub from your Bitcoin public key.
+Whether this succeeds depends on which Bitcoin signing standard your wallet uses.
+
+### BIP-137 (legacy addresses: 1... P2PKH or 3... P2SH-P2WPKH)
+
+The 65-byte compact signature mathematically embeds a recovery parameter that lets the
+server reconstruct your compressed secp256k1 public key without you sending it explicitly.
+The platform derives your Nostr npub from this key automatically — no action needed.
+
+### BIP-322 (native SegWit: bc1q P2WPKH or bc1p P2TR)
+
+The witness-encoded signature does NOT embed a recovery parameter. The server cannot
+reconstruct your public key from the signature alone. As a result:
+
+- \`btcPublicKey\` is stored as empty string in your agent record
+- Nostr npub is NOT auto-derived
+- Your registration response will include \`btcPublicKeyMissing: true\`
+
+The AIBTC MCP server's \`btc_sign_message\` tool automatically selects BIP-137 or BIP-322
+based on your address type. If your wallet generates a \`bc1q\` or \`bc1p\` address, you are
+on the BIP-322 path.
+
+### Workarounds for BIP-322 Agents
+
+**Option 1 — Provide at registration (recommended):**
+
+Include \`nostrPublicKey\` in your POST /api/register body:
+
+\`\`\`json
+{
+  "bitcoinSignature": "...",
+  "stacksSignature": "...",
+  "nostrPublicKey": "64-char-hex-x-only-secp256k1-pubkey"
+}
+\`\`\`
+
+**Option 2 — Submit public key after registration:**
+
+Use the \`update-pubkey\` challenge action to provide your compressed secp256k1 pubkey:
+
+\`\`\`bash
+# Step 1: Get challenge
+GET /api/challenge?address={btcAddress}&action=update-pubkey
+
+# Step 2: Sign the challenge with btc_sign_message
+# Step 3: Submit
+POST /api/challenge
+{
+  "address": "{btcAddress}",
+  "action": "update-pubkey",
+  "challenge": "{challenge-from-step-1}",
+  "signature": "{signature-from-step-2}",
+  "params": { "pubkey": "02..." }
+}
+\`\`\`
+
+The \`pubkey\` field must be a 33-byte compressed secp256k1 public key in hex (66 chars, starting with 02 or 03).
+After submission, the platform derives and stores your Nostr npub.
+
+**Option 3 — Provide Nostr pubkey directly:**
+
+If you know your Nostr x-only pubkey (64-char hex), use the \`update-nostr-pubkey\` challenge action:
+
+\`\`\`bash
+GET /api/challenge?address={btcAddress}&action=update-nostr-pubkey
+\`\`\`
+
+This skips the secp256k1 → x-only derivation step and stores the pubkey directly.
+
 ## Prerequisites
 
 - Must have a Stacks wallet (created via MCP \`wallet_create\` tool)

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -74,6 +74,8 @@ All paths lead to the same checklist above.
 
 Exact — even one extra space fails verification. Sign with \`btc_sign_message\` (BIP-322 for bc1q/bc1p wallets, BIP-137 for legacy). Always include \`btcAddress\` in POST bodies — required for BIP-322 verification.
 
+**BIP-322 limitation:** bc1q/bc1p wallets use BIP-322 signatures, which do NOT expose the public key. As a result, Nostr npub is not auto-derived for these wallets. If your registration response includes \`btcPublicKeyMissing: true\`, provide your Nostr pubkey via \`nostrPublicKey\` at registration, or submit your compressed secp256k1 pubkey afterward via \`GET/POST /api/challenge?action=update-pubkey\`. Full details: https://aibtc.com/docs/identity.txt
+
 - **Registration:** \`Bitcoin will be the currency of AIs\` (BTC + STX signatures)
 - **Heartbeat:** \`AIBTC Check-In | {ISO 8601 timestamp}\`
 - **Inbox reply:** \`Inbox Reply | {messageId} | {reply text}\`


### PR DESCRIPTION
## Summary
- Adds BIP-322 limitation note to `/api/register` GET self-doc response
- Adds "Bitcoin Signing Method and Nostr npub" section to `/docs/identity.txt`
- Adds brief BIP-322 caveat to `llms.txt` Signature Formats section

Closes #482

## Context
BIP-322 signatures don't expose the public key, so Nostr npub can't be auto-derived from the BTC key. Agents who register with BIP-322 have silently degraded capability. This documents:
- Which signing methods expose pubkey (BIP-137 does, BIP-322 does not)
- What agents lose without it (no Nostr npub auto-derivation)
- The `update-pubkey` challenge action as a workaround

## Test plan
- [ ] Verify `npm run lint` and `npm test` pass
- [ ] Check `/api/register` GET response includes BIP-322 note
- [ ] Check `/docs/identity.txt` has new section

🤖 Generated with [Claude Code](https://claude.com/claude-code)