### PR TITLE
fix(deps): bump picomatch to 4.0.4 (CVE-2026-33671 ReDoS)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,9 @@
         "typescript": "^5",
         "vitest": "^4.0.18",
         "wrangler": "^4.65.0"
+      },
+      "overrides": {
+        "picomatch": ">=4.0.4"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -10484,9 +10487,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "license": "MIT",
       "engines": {
         "node": ">=12"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
   },
   "overrides": {
     "undici": ">=7.24.0",
-    "flatted": ">=3.4.0"
+    "flatted": ">=3.4.0",
+    "picomatch": ">=4.0.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- Bumps `picomatch` from 4.0.3 → 4.0.4 to fix Dependabot alert #62
- Adds `"picomatch": ">=4.0.4"` to `overrides` in `package.json` to pin all transitive resolutions
- Updates `package-lock.json` accordingly

**CVE-2026-33671** (GHSA-c2c7-rcm5-vvqj, CVSS 7.5 HIGH): ReDoS via crafted extglob patterns — e.g. `+(a|aa)` compiles to a regex with catastrophic backtracking. Risk is low here since picomatch is used as a transitive build-tooling dep (via `@dotenvx/dotenvx`, `tinyglobby`, `vite`, `vitest`) and no user-supplied glob patterns are passed to it at runtime.

## Test plan

- [ ] CI lint passes
- [ ] CI tests pass
- [ ] CI build passes
- [ ] Dependabot alert #62 auto-closes after merge

Closes #62 (Dependabot security alert)

🤖 Generated with [Claude Code](https://claude.com/claude-code)