### PR TITLE
fix(circuit-breaker): raise threshold to 10, reduce TTL to 120s

### DIFF
--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -90,17 +90,20 @@ export const RELAY_CIRCUIT_BREAKER_KEY = "inbox:relay:circuit-breaker";
 /**
  * Number of consecutive relay failures that trip the circuit breaker.
  * Once tripped, relay calls are blocked until the TTL expires.
+ * Raised from 5 to 10 to avoid tripping on transient relay hiccups.
  */
-export const RELAY_CIRCUIT_BREAKER_THRESHOLD = 5;
+export const RELAY_CIRCUIT_BREAKER_THRESHOLD = 10;
 
 /**
- * Seconds the circuit breaker stays open after tripping (5 minutes).
+ * Seconds the circuit breaker stays open after tripping (2 minutes).
  * Also the rolling window for counting failures.
+ * Reduced from 300s to 120s so agents recover faster after a relay blip.
  */
-export const RELAY_CIRCUIT_BREAKER_TTL_SECONDS = 300;
+export const RELAY_CIRCUIT_BREAKER_TTL_SECONDS = 120;
 
 /**
  * Seconds clients should wait before retrying when circuit is open.
  * Matches RELAY_CIRCUIT_BREAKER_TTL_SECONDS.
+ * Reduced from 300s to 120s in line with the shorter TTL.
  */
-export const RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS = 300;
+export const RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS = 120;

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -471,7 +471,11 @@ export async function verifyInboxPayment(
     } catch (error) {
       const result = relayExceptionResult("Sponsor relay error", error);
       log.error("Sponsor relay exception", { error: result.error, relayCode: result.relayCode, errorCode: result.errorCode });
-      // Network-level exceptions (fetch failures, timeouts) count as relay failures.
+      // Network-level exceptions (fetch failures, timeouts) count as relay failures toward
+      // the circuit breaker. Note: timeouts are ambiguous — the tx may have been broadcast
+      // successfully before the timeout. Agents should check paymentTxid recovery if they
+      // see SETTLEMENT_TIMEOUT errors. A future improvement could count timeouts at reduced
+      // weight (e.g. 0.5) since they don't conclusively indicate relay unavailability.
       if (kv) {
         await recordRelayFailure(
           kv,
@@ -497,7 +501,10 @@ export async function verifyInboxPayment(
     } catch (error) {
       const result = relayExceptionResult("Payment settlement error", error);
       log.error("Relay settlement exception", { error: result.error, relayCode: result.relayCode, errorCode: result.errorCode });
-      // Network-level exceptions (fetch failures, timeouts) count as relay failures.
+      // Network-level exceptions (fetch failures, timeouts) count as relay failures toward
+      // the circuit breaker. Timeouts are ambiguous — the tx may have been broadcast before
+      // the timeout fired. See the sponsored path catch block for a note on potential
+      // reduced-weight counting for timeouts in a future improvement.
       if (kv) {
         await recordRelayFailure(
           kv,


### PR DESCRIPTION
## Summary

Fixes #513 — the inbox relay circuit breaker was too aggressive, blocking all agents for 5 minutes after just 5 failures in a 5-minute window. This caused mass message delivery failures during brief relay hiccups.

### Changes

| Constant | Old | New |
|----------|-----|-----|
| `RELAY_CIRCUIT_BREAKER_THRESHOLD` | 5 | 10 |
| `RELAY_CIRCUIT_BREAKER_TTL_SECONDS` | 300 | 120 |
| `RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS` | 300 | 120 |

Also adds clarifying comments in `x402-verify.ts` noting that timeout failures are ambiguous — the tx may have been broadcast successfully before the timeout fired. A future improvement could count timeouts at reduced weight (0.5) rather than the same as hard 5xx failures.

### Context

Relay-side fixes (#219, #222) have already merged. This tuning follows to bring client-side thresholds in line with the improved relay reliability.

## Test plan

- [ ] Confirm `RELAY_CIRCUIT_BREAKER_THRESHOLD` is 10 in `lib/inbox/constants.ts`
- [ ] Confirm `RELAY_CIRCUIT_BREAKER_TTL_SECONDS` is 120 in `lib/inbox/constants.ts`
- [ ] Confirm `RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS` is 120 in `lib/inbox/constants.ts`
- [ ] Verify existing tests in `lib/inbox/__tests__/` still pass
- [ ] Check that circuit breaker comments in `x402-verify.ts` accurately reflect the ambiguity of timeout failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)