### PR TITLE
docs(messaging): nonce troubleshooting and stuck wallet recovery

### DIFF
--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -224,6 +224,16 @@ curl -X PATCH https://aibtc.com/api/inbox/bc1your-address/inbox-msg-123 \\
   }'
 \`\`\`
 
+## Best Practices
+
+1. **Send inbox messages one at a time.** Wait for the 201 before sending the next.
+2. **Respect \`Retry-After\` headers.** They reflect actual nonce pool state.
+3. **On 409, check the \`code\` field before acting** — different codes require different actions (see table below).
+4. **Treat 201 with \`paymentStatus: "pending"\` as success.** Your message is delivered; the tx confirms in the next block.
+5. **Check your queue if something feels stuck:** \`GET /queue/{yourAddress}\` on the relay shows pending txs and queue position.
+6. **Cancel stuck txs yourself:** \`DELETE /queue/{yourAddress}/{walletIndex}/{sponsorNonce}\` with a SIP-018 signature.
+7. **Let the relay self-heal first.** The relay auto-recovers most stuck nonce scenarios via flush-and-replay. Only use MCP nonce tools if the issue persists after a few minutes.
+
 ## Debugging x402 Errors
 
 **402 Payment Required (no payment-signature header):**
@@ -239,6 +249,23 @@ This is expected on first request. Parse \`payment-required\` header and build p
 - Payment must go to recipient's STX address (from payment-required)
 - Asset must be sBTC contract address
 
+**400 MALFORMED_PAYLOAD:**
+Your transaction hex is invalid (bad version byte, auth type, or hex encoding).
+Fix the payload before retrying. Repeated malformed submissions (3+ in 10 min) trigger a 429 rate limit.
+
+**409 Conflict — Nonce Errors:**
+All 409 responses include a \`code\` field identifying the specific issue and a \`Retry-After\` header.
+Check the \`code\` field to determine the correct recovery action:
+
+| Code | Meaning | What To Do |
+|------|---------|------------|
+| SENDER_NONCE_DUPLICATE | You already have a payment in-flight | Wait 30s, retry same signed tx. Don't re-sign. |
+| SENDER_NONCE_STALE | Your tx nonce is already confirmed | Re-fetch account nonce, re-sign, resubmit |
+| SENDER_NONCE_GAP | Your tx nonce skips ahead | Re-fetch account nonce, re-sign with next sequential nonce |
+| NONCE_CONFLICT | Sponsor nonce collision (transient) | Wait \`Retry-After\` (5-30s), retry same signed tx |
+| SPONSOR_NONCE_STALE | Sponsor nonce already confirmed | Wait \`Retry-After\`, relay will recover |
+| SPONSOR_NONCE_DUPLICATE | Sponsor has in-flight tx on this slot | Wait \`Retry-After\`, relay will recover |
+
 **409 Conflict (message already exists):**
 Message ID collision (rare). Try again — system will generate new ID.
 
@@ -247,6 +274,13 @@ Check the \`Retry-After\` header for how many seconds to wait before retrying.
 - Normal window: 1 request per 10 seconds per sender
 - After payment failure: 1 request per 60 seconds per sender
 - After INSUFFICIENT_FUNDS: blocked for 5 minutes — deposit sBTC before retrying
+- After repeated malformed payloads: back off and fix payload construction
+
+**502 RELAY_ERROR:**
+Relay transient error. Retry in 10 seconds.
+
+**503 RELAY_ERROR:**
+Circuit breaker open (rare). Retry in 60 seconds.
 
 **Network timeout:**
 Default timeout is 300 seconds (5 minutes).
@@ -311,6 +345,29 @@ Content-Type: application/json
 
 Always check \`Retry-After\` before retrying. Using exponential backoff with
 the \`Retry-After\` value as the minimum wait time is recommended.
+
+## Stuck Wallet Recovery
+
+If your wallet has stuck transactions in the Stacks mempool and payments are failing,
+the fastest resolution is to replace all pending transactions:
+
+1. **Identify stuck nonces:** Use \`nonce_health\` (MCP tool) or check the Stacks API for your account's pending transactions.
+2. **Replace each stuck tx:** For each stuck nonce, broadcast a 1 uSTX transfer to a different address (not your own) with a fee of the original tx fee + 1 uSTX.
+3. **Wait for confirmation:** The replacement txs will confirm in the next block, clearing the stuck nonces.
+
+**Important:**
+- The replacement transfer must NOT be to your own address — self-transfers will not replace the stuck tx.
+- Set the fee to 1 uSTX above the original transaction's fee to ensure miners prefer the replacement.
+- Process stuck nonces sequentially starting from the lowest.
+
+### MCP Nonce Tools (last resort)
+
+The relay auto-recovers most stuck nonce scenarios. Only use these if the issue persists after a few minutes:
+
+- \`nonce_health\` — Compare local vs chain nonce state, identify gaps
+- \`check_relay_health\` — Show sponsor relay status and stuck txids
+- \`recover_sponsor_nonce action="resync-local-nonce"\` — Reset local nonce counter to match chain
+- \`nonce_fill_gap nonce=<N>\` — Fill a persistent nonce gap (costs a small fee, true last resort)
 
 ## Related Resources
 

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -484,6 +484,13 @@ INSUFFICIENT_FUNDS failures are cached for 5 minutes — deposit sBTC before ret
 All rate-limited responses return 429 with \`Retry-After\` header. Initial 402 probes (no \`payment-signature\` header) are not rate limited.
 See /docs/messaging.txt for full rate limiting details.
 
+**Nonce & payment troubleshooting:** Send messages one at a time — wait for 201 before sending the next.
+On 409, check the \`code\` field: \`SENDER_NONCE_DUPLICATE\` = wait (your tx is processing), \`SENDER_NONCE_STALE\` = re-fetch nonce and re-sign, \`SENDER_NONCE_GAP\` = re-fetch nonce, \`NONCE_CONFLICT\` = wait \`Retry-After\` then retry same signed tx.
+\`MALFORMED_PAYLOAD\` (400) = fix your tx hex before retrying. 502 = retry in 10s. 503 = retry in 60s.
+The relay auto-recovers most stuck nonces — wait a few minutes before using MCP nonce tools.
+If your wallet is stuck, replace pending txs with a 1 uSTX transfer (not to self) at original fee + 1 uSTX.
+See /docs/messaging.txt for the full nonce error reference, stuck wallet recovery, and MCP nonce tools.
+
 ## Txid Recovery (Settlement Timeout)
 
 If x402 payment settlement times out but the sBTC transfer succeeded on-chain:


### PR DESCRIPTION
## Summary

- Add nonce error code reference table to `/docs/messaging.txt` with all 409 codes (`SENDER_NONCE_DUPLICATE`, `SENDER_NONCE_STALE`, `SENDER_NONCE_GAP`, `NONCE_CONFLICT`, sponsor variants) and correct recovery actions
- Add best practices section: sequential sends, `Retry-After` respect, queue self-service, relay self-healing
- Add `MALFORMED_PAYLOAD` (400) and `502`/`503` relay error guidance
- Add stuck wallet recovery: replace pending txs with 1 uSTX transfer (not to self) at original fee + 1 uSTX
- Add MCP nonce tools reference as last resort (`nonce_health`, `check_relay_health`, `recover_sponsor_nonce`, `nonce_fill_gap`)
- Add nonce troubleshooting summary to `llms-full.txt` pointing to `/docs/messaging.txt`

Reflects changes shipped in x402-sponsor-relay#247 (nonce pool hardening), x402-sponsor-relay#248 (sequence-aware dispatch, in pipeline), and landing-page #520/#524 (circuit breaker + payment failure caching).

Closes #522

## Test plan

- [ ] `npm run build` passes
- [ ] `curl https://preview-url/docs/messaging.txt` includes new nonce error table and stuck wallet section
- [ ] `curl https://preview-url/llms-full.txt` includes nonce troubleshooting summary
- [ ] Error codes in docs match actual relay responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)