### PR TITLE
fix(hero): remove genesis agents tag from hero agent total

### DIFF
--- a/app/components/HomeHeroStats.tsx
+++ b/app/components/HomeHeroStats.tsx
@@ -1,34 +1,21 @@
 import Link from "next/link";
 
-/** Maximum number of Genesis-tier agent spots in the network. */
-const GENESIS_CAP = 200;
-
 interface HomeHeroStatsProps {
   count: number;
-  genesisCount: number;
 }
 
 /**
- * Agent count + Genesis spots for the hero section.
+ * Agent count for the hero section.
  * Displayed inline next to the avatar stack on desktop,
  * stacked vertically below avatars on mobile.
  */
-export default function HomeHeroStats({ count, genesisCount }: HomeHeroStatsProps) {
-  const spotsRemaining = Math.max(GENESIS_CAP - genesisCount, 0);
-
+export default function HomeHeroStats({ count }: HomeHeroStatsProps) {
   return (
     <div className="flex items-center gap-3 max-md:flex-col max-md:items-start max-md:gap-1.5">
       <Link href="/agents" className="text-[14px] text-white/50 transition-colors hover:text-white/70 max-md:text-[13px]">
         <span className="font-semibold text-white tabular-nums">{count.toLocaleString()}</span>{" "}
         {count === 1 ? "agent" : "agents"} registered
       </Link>
-      {spotsRemaining > 0 && (
-        <span className="relative inline-flex items-center gap-1.5 rounded-full border border-[#F7931A]/20 bg-[#F7931A]/[0.06] px-3 py-1 text-[13px] max-md:text-[12px] whitespace-nowrap">
-          <span className="absolute inset-0 rounded-full bg-[#F7931A]/[0.08] blur-md" />
-          <span className="relative font-bold text-[#F7931A] tabular-nums">{spotsRemaining}</span>
-          <span className="relative text-white/60">Genesis open</span>
-        </span>
-      )}
     </div>
   );
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -122,17 +122,16 @@ async function fetchHomeData() {
     return {
       registeredCount: stats.total,
       topAgents,
-      genesisCount: stats.genesisCount,
       messageCount: stats.messageCount,
       activityData,
     };
   } catch {
-    return { registeredCount: 0, topAgents: [] as LeaderboardAgent[], genesisCount: 0, messageCount: 0, activityData: undefined };
+    return { registeredCount: 0, topAgents: [] as LeaderboardAgent[], messageCount: 0, activityData: undefined };
   }
 }
 
 export default async function Home() {
-  const { registeredCount, topAgents, genesisCount, messageCount, activityData } = await fetchHomeData();
+  const { registeredCount, topAgents, messageCount, activityData } = await fetchHomeData();
 
   return (
     <>
@@ -186,7 +185,7 @@ export default async function Home() {
                     ))}
                   </Link>
                 )}
-                <HomeHeroStats count={registeredCount} genesisCount={genesisCount} />
+                <HomeHeroStats count={registeredCount} />
               </div>
 
             </div>


### PR DESCRIPTION
## Summary

- Removes the "X Genesis open" badge from `HomeHeroStats` component
- Drops unused `genesisCount` prop from `HomeHeroStats` and its call site in `page.tsx`
- Agent total count still displays correctly on its own

The genesis agent count is a static label that no longer needs to be displayed alongside the dynamic agent total. Simplifies the hero section and avoids confusion as the agent count grows.

Closes #530

## Test plan

- [ ] Hero section shows agent count (e.g., "215 agents registered") without any genesis badge
- [ ] No TypeScript/build errors from removed prop
- [ ] Agent count link to `/agents` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)