### PR TITLE
fix(footer): update Sponsor Relay link from testnet to production URL (closes #529)

### DIFF
--- a/app/components/Footer.tsx
+++ b/app/components/Footer.tsx
@@ -73,7 +73,7 @@ const footerSections = [
     links: [
       { name: "x402 API (Mainnet)", url: "https://x402.aibtc.com", external: true },
       { name: "x402 API (Testnet)", url: "https://x402.aibtc.dev", external: true },
-      { name: "Sponsor Relay", url: "https://x402-relay.aibtc.dev", external: true },
+      { name: "Sponsor Relay", url: "https://x402-relay.aibtc.com", external: true },
       { name: "Stacks Faucet", url: "https://explorer.hiro.so/sandbox/faucet?chain=testnet", external: true },
       { name: "Health Check", url: "/api/health" },
     ],


### PR DESCRIPTION
## Summary

- The footer "Sponsor Relay" link pointed to `https://x402-relay.aibtc.dev` (testnet) instead of `https://x402-relay.aibtc.com` (production)
- One-character domain suffix change: `.dev` → `.com`
- Fixes #529

## Test plan

- [ ] Verify the Sponsor Relay link in the footer navigates to `https://x402-relay.aibtc.com`

🤖 Generated with [Claude Code](https://claude.com/claude-code)