### PR TITLE
feat(inbox): store pending payment records in KV for background reconciliation (closes #537)

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -13,6 +13,7 @@ import {
   updateSentIndex,
   listInboxMessages,
   listSentMessages,
+  storePendingPayment,
   INBOX_PRICE_SATS,
   REDEEMED_TXID_TTL_SECONDS,
   RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS,
@@ -1282,6 +1283,11 @@ export async function POST(
 
   // Invalidate cached agent list (inbox message count changed)
   await invalidateAgentListCache(kv);
+
+  // Store pending payment for background reconciliation (#537)
+  if (paymentResult.paymentStatus === "pending" && paymentResult.paymentId) {
+    storePendingPayment(kv, paymentResult.paymentId, messageId, toBtcAddress);
+  }
 
   // Build payment-response header only when we have an actual transaction.
   // Pending payments (poll exhausted before confirmation) have no txid yet —

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1286,7 +1286,7 @@ export async function POST(
 
   // Store pending payment for background reconciliation (#537)
   if (paymentResult.paymentStatus === "pending" && paymentResult.paymentId) {
-    storePendingPayment(kv, paymentResult.paymentId, messageId, toBtcAddress);
+    await storePendingPayment(kv, paymentResult.paymentId, messageId, toBtcAddress);
   }
 
   // Build payment-response header only when we have an actual transaction.

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -140,6 +140,11 @@ export const PAYMENT_FAILURE_CACHE_TTL_SECONDS = 300;
  */
 export const CACHEABLE_PAYMENT_FAILURE_CODES = new Set(["INSUFFICIENT_FUNDS"]);
 
+/** KV prefix for pending payment reconciliation records. */
+export const PENDING_PAYMENT_PREFIX = "inbox:pending:";
+/** TTL for pending payment records — matches relay's 24h KV TTL. */
+export const PENDING_PAYMENT_TTL_SECONDS = 86400;
+
 // --- RPC service binding polling constants ---
 
 /** Interval between checkPayment() polls (ms). */

--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -89,7 +89,7 @@ export {
 } from "./x402-config";
 
 // KV Helpers
-export type { ListInboxOptions, ListInboxResult, ListSentResult } from "./kv-helpers";
+export type { ListInboxOptions, ListInboxResult, ListSentResult, PendingPaymentRecord } from "./kv-helpers";
 export {
   getMessage,
   storeMessage,
@@ -103,4 +103,6 @@ export {
   listInboxMessages,
   listSentMessages,
   decrementUnreadCount,
+  storePendingPayment,
+  clearPendingPayment,
 } from "./kv-helpers";

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -531,8 +531,9 @@ export async function storePendingPayment(
       JSON.stringify(record),
       { expirationTtl: PENDING_PAYMENT_TTL_SECONDS }
     );
-  } catch {
+  } catch (err) {
     // KV write failure is non-fatal — reconciliation degrades gracefully
+    console.warn("[storePendingPayment] KV write failed:", err);
   }
 }
 
@@ -545,7 +546,7 @@ export async function clearPendingPayment(
 ): Promise<void> {
   try {
     await kv.delete(`${PENDING_PAYMENT_PREFIX}${paymentId}`);
-  } catch {
-    // Non-fatal
+  } catch (err) {
+    console.warn("[clearPendingPayment] KV write failed:", err);
   }
 }

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -5,7 +5,7 @@
  * and agent inbox indices. Follows the pattern from lib/achievements/kv.ts.
  */
 
-import { KV_PREFIXES } from "./constants";
+import { KV_PREFIXES, PENDING_PAYMENT_PREFIX, PENDING_PAYMENT_TTL_SECONDS } from "./constants";
 import type {
   InboxMessage,
   OutboxReply,
@@ -499,4 +499,53 @@ export async function listSentMessages(
   }
 
   return { index, messages, replies };
+}
+
+export interface PendingPaymentRecord {
+  paymentId: string;
+  messageId: string;
+  toBtcAddress: string;
+  acceptedAt: string;
+}
+
+/**
+ * Store a pending payment record for background reconciliation.
+ * Called when the relay accepts a payment but settlement hasn't confirmed yet.
+ * Expires after 24h (matching relay KV TTL — anything pending that long is stale).
+ */
+export async function storePendingPayment(
+  kv: KVNamespace,
+  paymentId: string,
+  messageId: string,
+  toBtcAddress: string
+): Promise<void> {
+  try {
+    const record: PendingPaymentRecord = {
+      paymentId,
+      messageId,
+      toBtcAddress,
+      acceptedAt: new Date().toISOString(),
+    };
+    await kv.put(
+      `${PENDING_PAYMENT_PREFIX}${paymentId}`,
+      JSON.stringify(record),
+      { expirationTtl: PENDING_PAYMENT_TTL_SECONDS }
+    );
+  } catch {
+    // KV write failure is non-fatal — reconciliation degrades gracefully
+  }
+}
+
+/**
+ * Remove a pending payment record after it has been reconciled (confirmed or failed).
+ */
+export async function clearPendingPayment(
+  kv: KVNamespace,
+  paymentId: string
+): Promise<void> {
+  try {
+    await kv.delete(`${PENDING_PAYMENT_PREFIX}${paymentId}`);
+  } catch {
+    // Non-fatal
+  }
 }


### PR DESCRIPTION
## Summary

Implements Step 1 of #537 — the KV data layer for pending payment reconciliation.

### Changes

- `lib/inbox/constants.ts`: add `PENDING_PAYMENT_PREFIX` and `PENDING_PAYMENT_TTL_SECONDS` constants
- `lib/inbox/kv-helpers.ts`: add `storePendingPayment()` and `clearPendingPayment()` helpers
- `lib/inbox/index.ts`: re-export new helpers and `PendingPaymentRecord` type from barrel
- `app/api/inbox/[address]/route.ts`: call `storePendingPayment()` after message creation when `paymentStatus === "pending"`

### Behavior

When the relay accepts a payment but settlement hasn't confirmed yet (`paymentStatus: "pending"`), a record is written to KV:

```
Key: inbox:pending:{paymentId}
Value: { paymentId, messageId, toBtcAddress, acceptedAt }
TTL: 86400s (24h — matches relay KV TTL)
```

The KV write is fire-and-forget (non-fatal on failure) so it never blocks the 201 response.

### What's not in this PR

The background reconciliation loop (cron trigger or DO alarm calling `rpc.checkPayment()` for each pending entry) is scoped to a follow-up PR once the data layer is confirmed. This PR gives maintainers a clean checkpoint before adding the scheduling infra.

## Test plan
- [ ] Send a message that produces `paymentStatus: "pending"` (e.g., force a relay poll timeout in staging)
- [ ] Verify `inbox:pending:{paymentId}` key appears in KV with correct fields
- [ ] Verify key auto-expires after 24h
- [ ] Verify a non-pending payment (confirmed) does NOT create a pending KV entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)