### PR TITLE
fix(inbox): downgrade SENDER_NONCE_* from error to warn logging

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1025,11 +1025,22 @@ export async function POST(
   );
 
   if (!paymentResult.success) {
-    logger.error("Payment verification failed", {
-      error: paymentResult.error,
-      errorCode: paymentResult.errorCode,
-      retryAfterSeconds: paymentResult.retryAfterSeconds,
-    });
+    const isExpectedNonceFailure =
+      paymentResult.errorCode === "SENDER_NONCE_DUPLICATE" ||
+      paymentResult.errorCode === "SENDER_NONCE_STALE" ||
+      paymentResult.errorCode === "SENDER_NONCE_GAP";
+    if (isExpectedNonceFailure) {
+      logger.warn("Payment rejected: sender nonce state (expected)", {
+        errorCode: paymentResult.errorCode,
+        retryAfterSeconds: paymentResult.retryAfterSeconds,
+      });
+    } else {
+      logger.error("Payment verification failed", {
+        error: paymentResult.error,
+        errorCode: paymentResult.errorCode,
+        retryAfterSeconds: paymentResult.retryAfterSeconds,
+      });
+    }
 
     const errorCode = paymentResult.errorCode;
     const retryAfterSeconds = paymentResult.retryAfterSeconds ?? 5;


### PR DESCRIPTION
## Summary
- Downgrade `SENDER_NONCE_DUPLICATE`, `SENDER_NONCE_STALE`, `SENDER_NONCE_GAP` logging from `error` to `warn` in the inbox POST route
- These are expected sender-state failures, not application errors — logging them as ERROR creates noise in monitoring dashboards
- Structured response payloads, `Retry-After` headers, and HTTP 409 status codes remain unchanged
- Addresses Proposal 1 from #546 (proposals 2+3 are separate work)

## Test plan
- [ ] Confirm no TypeScript errors: `npm run build` or `tsc --noEmit`
- [ ] Confirm existing behavior preserved: NONCE_CONFLICT, BROADCAST_FAILED, INSUFFICIENT_FUNDS still log as ERROR
- [ ] Confirm SENDER_NONCE_DUPLICATE/STALE/GAP now log as WARN in monitoring

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)