### PR TITLE
feat(inbox): add structured nonce diagnostics to 409 responses (closes #549)

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -26,6 +26,14 @@ import { hasAchievement, grantAchievement } from "@/lib/achievements";
 import { networkToCAIP2, X402_HEADERS } from "x402-stacks";
 import type { PaymentPayloadV2 } from "x402-stacks";
 
+/** Maps nonce-related error codes to structured action strings for agents and operators. */
+const NONCE_ACTION_MAP: Record<string, string> = {
+  SENDER_NONCE_STALE: "refetch_nonce_and_resign",
+  SENDER_NONCE_DUPLICATE: "wait_for_queued_tx",
+  SENDER_NONCE_GAP: "increment_nonce_and_resign",
+  NONCE_CONFLICT: "retry_same_payment",
+};
+
 /** Static lookup for SENDER_NONCE_* error responses (RPC path). */
 const SENDER_NONCE_ERRORS: Record<string, { error: string; retryAfter: number; nextSteps: string }> = {
   SENDER_NONCE_STALE: {
@@ -1051,6 +1059,15 @@ export async function POST(
 
     // NONCE_CONFLICT — retryable; same tx hex is idempotent within 5 min.
     if (errorCode === "NONCE_CONFLICT") {
+      const nonceAction = NONCE_ACTION_MAP[errorCode];
+      logger.info("inbox_payment_rejected", {
+        errorCode,
+        relayCode: paymentResult.relayCode,
+        retryAfter: retryAfterSeconds,
+        nonceAction,
+        recipientBtcAddress: agent.btcAddress,
+        requestId: rayId,
+      });
       return NextResponse.json(
         {
           error: `Nonce conflict: another transaction from your wallet is pending. Retry after ${retryAfterSeconds}s.`,
@@ -1059,6 +1076,16 @@ export async function POST(
           retryAfter: retryAfterSeconds,
           nextSteps: "Retry the payment — the relay had a transient nonce collision",
           ...relayDiag,
+          action: nonceAction,
+          ...(paymentResult.payerStxAddress && {
+            sender: { stxAddress: paymentResult.payerStxAddress },
+          }),
+          diagnostics: {
+            ...(paymentResult.relayCode && { relayCode: paymentResult.relayCode }),
+            ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
+            requestId: rayId,
+          },
+          docs: "https://github.com/aibtcdev/x402-sponsor-relay/tree/main/docs",
         },
         {
           status: 409,
@@ -1181,6 +1208,15 @@ export async function POST(
     // SENDER_NONCE_* — RPC path nonce rejections. All return HTTP 409 with retry guidance.
     const nonceError = errorCode ? SENDER_NONCE_ERRORS[errorCode] : undefined;
     if (nonceError) {
+      const nonceAction = errorCode ? NONCE_ACTION_MAP[errorCode] : undefined;
+      logger.info("inbox_payment_rejected", {
+        errorCode,
+        relayCode: paymentResult.relayCode,
+        retryAfter: nonceError.retryAfter,
+        nonceAction,
+        recipientBtcAddress: agent.btcAddress,
+        requestId: rayId,
+      });
       return NextResponse.json(
         {
           error: nonceError.error,
@@ -1189,6 +1225,16 @@ export async function POST(
           retryAfter: nonceError.retryAfter,
           nextSteps: nonceError.nextSteps,
           ...relayDiag,
+          action: nonceAction,
+          ...(paymentResult.payerStxAddress && {
+            sender: { stxAddress: paymentResult.payerStxAddress },
+          }),
+          diagnostics: {
+            ...(paymentResult.relayCode && { relayCode: paymentResult.relayCode }),
+            ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
+            requestId: rayId,
+          },
+          docs: "https://github.com/aibtcdev/x402-sponsor-relay/tree/main/docs",
         },
         {
           status: 409,


### PR DESCRIPTION
## Summary

- Adds `NONCE_ACTION_MAP` constant mapping nonce error codes to structured action strings (`refetch_nonce_and_resign`, `wait_for_queued_tx`, `increment_nonce_and_resign`, `retry_same_payment`)
- Enriches `NONCE_CONFLICT` and `SENDER_NONCE_*` 409 responses with: `action`, `sender` (when `payerStxAddress` available), `diagnostics` (`relayCode`, `paymentId`, `requestId`), and `docs` link
- Adds a structured `logger.info("inbox_payment_rejected", {...})` event after existing warn/error log calls in both nonce error branches, including `errorCode`, `relayCode`, `retryAfter`, `nonceAction`, `recipientBtcAddress`, and `requestId`

All existing response fields are preserved. No BNS resolution (follow-up per issue). No new dependencies.

## Test plan

- [ ] Trigger a `SENDER_NONCE_STALE` error by submitting a payment with a stale nonce — verify response includes `action: "refetch_nonce_and_resign"`, `diagnostics.requestId`, and `docs` URL
- [ ] Trigger a `NONCE_CONFLICT` error — verify `action: "retry_same_payment"` is present alongside existing fields
- [ ] Confirm `sender.stxAddress` is omitted when `payerStxAddress` is not available on the result
- [ ] Check worker logs for `inbox_payment_rejected` structured event with correct fields
- [ ] Verify no regression on successful payment path (no new fields added to 201 response)

🤖 Generated with [Claude Code](https://claude.com/claude-code)