### PR TITLE
fix: align relay payment polling contract with tx-schemas

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -505,7 +505,7 @@ export async function POST(
   const logger = isLogsRPC(env.LOGS)
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
     : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
-  const repoVersion = getPaymentRepoVersion(env as unknown as Record<string, unknown>);
+  const repoVersion = getPaymentRepoVersion(env);
 
   // Extract network config once (used by both 402 response and payment verification)
   const network = (env.X402_NETWORK as "mainnet" | "testnet") || "mainnet";
@@ -1338,7 +1338,7 @@ export async function POST(
     ...(senderBtcAddress && { senderBtcAddress }),
     ...(senderSignatureInput && { senderSignature: senderSignatureInput }),
     ...(replyTo && { replyTo }),
-    ...(paymentResult.paymentStatus && { paymentStatus: paymentResult.paymentStatus }),
+    paymentStatus: paymentResult.paymentStatus ?? "confirmed",
     ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
     ...(paymentResult.receiptId && { receiptId: paymentResult.receiptId }),
   };
@@ -1347,68 +1347,73 @@ export async function POST(
 
   if (paymentResult.paymentStatus === "pending") {
     if (!paymentResult.paymentId) {
-      logger.error("Pending payment result missing paymentId", {
+      logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+        route: request.nextUrl.pathname,
+        paymentId: null,
+        status: "pending",
+        action: "deliver_immediately_without_payment_id",
+        additionalContext: {
+          messageId,
+          fromAddress,
+          toBtcAddress,
+          receiptId: paymentResult.receiptId ?? null,
+        },
+      });
+      logger.warn("Pending payment result missing paymentId; preserving fallback immediate delivery", {
         messageId,
         fromAddress,
         toBtcAddress,
       });
-      return NextResponse.json(
-        {
-          error: "Relay accepted the payment but did not return a paymentId for polling",
-          code: "RELAY_ERROR",
-        },
-        { status: 502 }
-      );
-    }
+    } else {
+      const checkStatusUrl =
+        paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;
 
-    const checkStatusUrl =
-      paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;
+      await storeStagedInboxPayment(kv, {
+        paymentId: paymentResult.paymentId,
+        createdAt: now,
+        ...(senderAgent?.btcAddress && { senderSentIndexBtcAddress: senderAgent.btcAddress }),
+        message,
+      });
 
-    await storeStagedInboxPayment(kv, {
-      paymentId: paymentResult.paymentId,
-      createdAt: now,
-      ...(senderAgent?.btcAddress && { senderSentIndexBtcAddress: senderAgent.btcAddress }),
-      message,
-    });
+      responseHeaders["X-Payment-Status"] = "pending";
+      responseHeaders["X-Payment-Id"] = paymentResult.paymentId;
+      responseHeaders["X-Payment-Check-Url"] = checkStatusUrl;
 
-    responseHeaders["X-Payment-Status"] = "pending";
-    responseHeaders["X-Payment-Id"] = paymentResult.paymentId;
-    responseHeaders["X-Payment-Check-Url"] = checkStatusUrl;
-
-    logPaymentEvent(logger, "info", "payment.delivery_staged", repoVersion, {
-      route: request.nextUrl.pathname,
-      paymentId: paymentResult.paymentId,
-      status: "pending",
-      action: "stage_delivery",
-      checkStatusUrl,
-      additionalContext: {
-        messageId,
-        fromAddress,
-        toBtcAddress,
-        senderBtcAddress: senderAgent?.btcAddress ?? null,
-      },
-    });
-
-    return NextResponse.json(
-      {
-        success: true,
-        message: "Payment accepted. Inbox delivery is staged until the relay reports confirmed.",
-        inbox: {
+      logPaymentEvent(logger, "info", "payment.delivery_staged", repoVersion, {
+        route: request.nextUrl.pathname,
+        paymentId: paymentResult.paymentId,
+        status: "pending",
+        action: "stage_delivery",
+        checkStatusUrl,
+        additionalContext: {
+          messageId,
           fromAddress,
           toBtcAddress,
-          sentAt: now,
-          authenticated,
-          ...(senderBtcAddress && { senderBtcAddress }),
-          paymentStatus: "pending",
-          paymentId: paymentResult.paymentId,
+          senderBtcAddress: senderAgent?.btcAddress ?? null,
         },
-        checkStatusUrl,
-      },
-      {
-        status: 202,
-        headers: responseHeaders,
-      }
-    );
+      });
+
+      return NextResponse.json(
+        {
+          success: true,
+          message: "Payment accepted. Inbox delivery is staged until the relay reports confirmed.",
+          inbox: {
+            fromAddress,
+            toBtcAddress,
+            sentAt: now,
+            authenticated,
+            ...(senderBtcAddress && { senderBtcAddress }),
+            paymentStatus: "pending",
+            paymentId: paymentResult.paymentId,
+          },
+          checkStatusUrl,
+        },
+        {
+          status: 202,
+          headers: responseHeaders,
+        }
+      );
+    }
   }
 
   await Promise.all([
@@ -1436,11 +1441,20 @@ export async function POST(
     logger.warn("grantAchievement failed (non-fatal)", { err, toBtcAddress })
   );
 
+  const deliveredPaymentStatus = message.paymentStatus ?? "confirmed";
+  const deliveredCheckStatusUrl = paymentResult.paymentId
+    ? paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`
+    : undefined;
+
   logPaymentEvent(logger, "info", "payment.delivery_confirmed", repoVersion, {
     route: request.nextUrl.pathname,
     paymentId: paymentResult.paymentId ?? null,
-    status: "confirmed",
-    action: "deliver_immediately",
+    status: deliveredPaymentStatus,
+    action:
+      deliveredPaymentStatus === "pending"
+        ? "deliver_immediately_pending_fallback"
+        : "deliver_immediately",
+    checkStatusUrl: deliveredCheckStatusUrl,
     additionalContext: {
       messageId,
       fromAddress,
@@ -1461,6 +1475,12 @@ export async function POST(
     };
     responseHeaders[X402_HEADERS.PAYMENT_RESPONSE] = btoa(JSON.stringify(paymentResponseData));
   }
+  responseHeaders["X-Payment-Status"] = deliveredPaymentStatus;
+  if (paymentResult.paymentId) {
+    responseHeaders["X-Payment-Id"] = paymentResult.paymentId;
+    responseHeaders["X-Payment-Check-Url"] =
+      deliveredCheckStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;
+  }
 
   return NextResponse.json(
     {
@@ -1473,8 +1493,9 @@ export async function POST(
         sentAt: now,
         authenticated,
         ...(senderBtcAddress && { senderBtcAddress }),
-        paymentStatus: "confirmed",
+        paymentStatus: deliveredPaymentStatus,
         ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
+        ...(paymentResult.receiptId && { receiptId: paymentResult.receiptId }),
       },
     },
     {

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -9,6 +9,7 @@ import {
   verifyInboxPayment,
   verifyTxidPayment,
   storeMessage,
+  storeStagedInboxPayment,
   updateAgentInbox,
   updateSentIndex,
   listInboxMessages,
@@ -25,6 +26,10 @@ import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { hasAchievement, grantAchievement } from "@/lib/achievements";
 import { networkToCAIP2, X402_HEADERS } from "x402-stacks";
 import type { PaymentPayloadV2 } from "x402-stacks";
+import {
+  getPaymentRepoVersion,
+  logPaymentEvent,
+} from "@/lib/inbox/payment-logging";
 
 /** Maps nonce-related error codes to structured action strings for agents and operators. */
 const NONCE_ACTION_MAP: Record<string, string> = {
@@ -440,7 +445,7 @@ export async function GET(
         flow: [
           "POST without payment-signature header → 402 Payment Required",
           "Complete x402 sBTC payment to recipient's STX address",
-          "POST with payment-signature header (base64 PaymentPayloadV2) → message delivered",
+          "POST with payment-signature header (base64 PaymentPayloadV2) → 201 confirmed delivery or 202 staged pending confirmation",
         ],
         documentation: "https://aibtc.com/llms-full.txt",
       },
@@ -500,6 +505,7 @@ export async function POST(
   const logger = isLogsRPC(env.LOGS)
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
     : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+  const repoVersion = getPaymentRepoVersion(env as unknown as Record<string, unknown>);
 
   // Extract network config once (used by both 402 response and payment verification)
   const network = (env.X402_NETWORK as "mainnet" | "testnet") || "mainnet";
@@ -571,6 +577,18 @@ export async function POST(
   const paymentSigHeader =
     request.headers.get(X402_HEADERS.PAYMENT_SIGNATURE) ||
     request.headers.get("X-Payment-Signature"); // backwards compat
+  const compatHeaderUsed =
+    !request.headers.get(X402_HEADERS.PAYMENT_SIGNATURE) &&
+    !!request.headers.get("X-Payment-Signature");
+
+  if (compatHeaderUsed) {
+    logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+      route: request.nextUrl.pathname,
+      status: "compat",
+      action: "legacy_x_payment_signature_header",
+      compatShimUsed: true,
+    });
+  }
 
   // Auto-populate recipient addresses from the resolved agent when the body omits them.
   // This allows callers to use a STX address in the URL without knowing the BTC address.
@@ -665,9 +683,14 @@ export async function POST(
 
   if (!paymentSigHeader && !paymentTxid) {
     // No payment signature and no txid — return 402 with payment requirements
-    logger.info("Returning 402 Payment Required", {
-      recipientStx: agent.stxAddress,
-      minAmount: INBOX_PRICE_SATS,
+    logPaymentEvent(logger, "info", "payment.required", repoVersion, {
+      route: request.nextUrl.pathname,
+      status: "requires_payment",
+      action: "return_payment_requirements",
+      additionalContext: {
+        recipientStx: agent.stxAddress,
+        minAmount: INBOX_PRICE_SATS,
+      },
     });
 
     return NextResponse.json(paymentRequiredBody, {
@@ -1004,6 +1027,12 @@ export async function POST(
   } catch {
     try {
       paymentPayload = JSON.parse(paymentSigHeader) as PaymentPayloadV2;
+      logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+        route: request.nextUrl.pathname,
+        status: "compat",
+        action: "plain_json_payment_signature_header",
+        compatShimUsed: true,
+      });
     } catch {
       logger.error("Invalid payment signature format");
       return NextResponse.json(
@@ -1029,7 +1058,8 @@ export async function POST(
     relayUrl,
     logger,
     kv,
-    env.X402_RELAY
+    env.X402_RELAY,
+    { route: request.nextUrl.pathname, repoVersion, env: env as unknown as Record<string, unknown> }
   );
 
   if (!paymentResult.success) {
@@ -1060,13 +1090,18 @@ export async function POST(
     // NONCE_CONFLICT — retryable; same tx hex is idempotent within 5 min.
     if (errorCode === "NONCE_CONFLICT") {
       const nonceAction = NONCE_ACTION_MAP[errorCode];
-      logger.info("inbox_payment_rejected", {
-        errorCode,
-        relayCode: paymentResult.relayCode,
-        retryAfter: retryAfterSeconds,
-        nonceAction,
-        recipientBtcAddress: agent.btcAddress,
-        requestId: rayId,
+      logPaymentEvent(logger, "info", "payment.retry_decision", repoVersion, {
+        route: request.nextUrl.pathname,
+        paymentId: paymentResult.paymentId ?? null,
+        status: errorCode,
+        action: nonceAction,
+        terminalReason: paymentResult.terminalReason ?? null,
+        additionalContext: {
+          relayCode: paymentResult.relayCode ?? null,
+          retryAfter: retryAfterSeconds,
+          recipientBtcAddress: agent.btcAddress,
+          requestId: rayId,
+        },
       });
       return NextResponse.json(
         {
@@ -1209,13 +1244,18 @@ export async function POST(
     const nonceError = errorCode ? SENDER_NONCE_ERRORS[errorCode] : undefined;
     if (nonceError) {
       const nonceAction = errorCode ? NONCE_ACTION_MAP[errorCode] : undefined;
-      logger.info("inbox_payment_rejected", {
-        errorCode,
-        relayCode: paymentResult.relayCode,
-        retryAfter: nonceError.retryAfter,
-        nonceAction,
-        recipientBtcAddress: agent.btcAddress,
-        requestId: rayId,
+      logPaymentEvent(logger, "info", "payment.retry_decision", repoVersion, {
+        route: request.nextUrl.pathname,
+        paymentId: paymentResult.paymentId ?? null,
+        status: errorCode,
+        action: nonceAction,
+        terminalReason: paymentResult.terminalReason ?? null,
+        additionalContext: {
+          relayCode: paymentResult.relayCode ?? null,
+          retryAfter: nonceError.retryAfter,
+          recipientBtcAddress: agent.btcAddress,
+          requestId: rayId,
+        },
       });
       return NextResponse.json(
         {
@@ -1299,8 +1339,77 @@ export async function POST(
     ...(senderSignatureInput && { senderSignature: senderSignatureInput }),
     ...(replyTo && { replyTo }),
     ...(paymentResult.paymentStatus && { paymentStatus: paymentResult.paymentStatus }),
+    ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
     ...(paymentResult.receiptId && { receiptId: paymentResult.receiptId }),
   };
+
+  const responseHeaders: Record<string, string> = {};
+
+  if (paymentResult.paymentStatus === "pending") {
+    if (!paymentResult.paymentId) {
+      logger.error("Pending payment result missing paymentId", {
+        messageId,
+        fromAddress,
+        toBtcAddress,
+      });
+      return NextResponse.json(
+        {
+          error: "Relay accepted the payment but did not return a paymentId for polling",
+          code: "RELAY_ERROR",
+        },
+        { status: 502 }
+      );
+    }
+
+    const checkStatusUrl =
+      paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: paymentResult.paymentId,
+      createdAt: now,
+      ...(senderAgent?.btcAddress && { senderSentIndexBtcAddress: senderAgent.btcAddress }),
+      message,
+    });
+
+    responseHeaders["X-Payment-Status"] = "pending";
+    responseHeaders["X-Payment-Id"] = paymentResult.paymentId;
+    responseHeaders["X-Payment-Check-Url"] = checkStatusUrl;
+
+    logPaymentEvent(logger, "info", "payment.delivery_staged", repoVersion, {
+      route: request.nextUrl.pathname,
+      paymentId: paymentResult.paymentId,
+      status: "pending",
+      action: "stage_delivery",
+      checkStatusUrl,
+      additionalContext: {
+        messageId,
+        fromAddress,
+        toBtcAddress,
+        senderBtcAddress: senderAgent?.btcAddress ?? null,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        success: true,
+        message: "Payment accepted. Inbox delivery is staged until the relay reports confirmed.",
+        inbox: {
+          fromAddress,
+          toBtcAddress,
+          sentAt: now,
+          authenticated,
+          ...(senderBtcAddress && { senderBtcAddress }),
+          paymentStatus: "pending",
+          paymentId: paymentResult.paymentId,
+        },
+        checkStatusUrl,
+      },
+      {
+        status: 202,
+        headers: responseHeaders,
+      }
+    );
+  }
 
   await Promise.all([
     storeMessage(kv, message),
@@ -1310,7 +1419,6 @@ export async function POST(
       : []),
   ]);
 
-  // Grant "Receiver" achievement on first inbox message received (best-effort)
   try {
     const hasReceiverX402 = await hasAchievement(kv, toBtcAddress, "receiver");
     if (!hasReceiverX402) {
@@ -1324,26 +1432,26 @@ export async function POST(
     console.error("Failed to check receiver achievement during inbox store:", error);
   }
 
-  // Grant x402-earner achievement to recipient on first x402 payment received (idempotent)
   await grantAchievement(kv, toBtcAddress, "x402-earner", { messageId, paymentTxid: message.paymentTxid }).catch((err) =>
     logger.warn("grantAchievement failed (non-fatal)", { err, toBtcAddress })
   );
 
-  logger.info("Message stored", {
-    messageId,
-    fromAddress,
-    toBtcAddress,
-    senderBtcAddress: senderAgent?.btcAddress ?? null,
-    paymentTxid: message.paymentTxid,
+  logPaymentEvent(logger, "info", "payment.delivery_confirmed", repoVersion, {
+    route: request.nextUrl.pathname,
+    paymentId: paymentResult.paymentId ?? null,
+    status: "confirmed",
+    action: "deliver_immediately",
+    additionalContext: {
+      messageId,
+      fromAddress,
+      toBtcAddress,
+      senderBtcAddress: senderAgent?.btcAddress ?? null,
+      paymentTxid: message.paymentTxid ?? null,
+    },
   });
 
-  // Invalidate cached agent list (inbox message count changed)
   await invalidateAgentListCache(kv);
 
-  // Build payment-response header only when we have an actual transaction.
-  // Pending payments (poll exhausted before confirmation) have no txid yet —
-  // omit the header to avoid emitting an empty `transaction` field.
-  const responseHeaders: Record<string, string> = {};
   if (message.paymentTxid) {
     const paymentResponseData = {
       success: true,
@@ -1352,15 +1460,6 @@ export async function POST(
       network: networkCAIP2,
     };
     responseHeaders[X402_HEADERS.PAYMENT_RESPONSE] = btoa(JSON.stringify(paymentResponseData));
-  }
-
-  // Surface pending payment settlement as headers so callers can't miss it.
-  // A 201 with X-Payment-Status: pending means the message IS delivered —
-  // callers must poll X-Payment-Check-Url instead of signing a new payment.
-  if (paymentResult.paymentStatus === "pending" && paymentResult.paymentId) {
-    responseHeaders["X-Payment-Status"] = "pending";
-    responseHeaders["X-Payment-Id"] = paymentResult.paymentId;
-    responseHeaders["X-Payment-Check-Url"] = `/api/payment-status/${paymentResult.paymentId}`;
   }
 
   return NextResponse.json(
@@ -1374,7 +1473,7 @@ export async function POST(
         sentAt: now,
         authenticated,
         ...(senderBtcAddress && { senderBtcAddress }),
-        ...(paymentResult.paymentStatus && { paymentStatus: paymentResult.paymentStatus }),
+        paymentStatus: "confirmed",
         ...(paymentResult.paymentId && { paymentId: paymentResult.paymentId }),
       },
     },

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -845,7 +845,7 @@ export function GET() {
           ],
           responses: {
             "200": {
-              description: "Payment status from the relay",
+              description: "Payment status from the relay for pending and non-not_found terminal states",
               content: {
                 "application/json": {
                   schema: {
@@ -865,6 +865,38 @@ export function GET() {
                           "replaced",
                           "not_found",
                         ],
+                      },
+                      txid: { type: "string", description: "On-chain transaction ID (if available)" },
+                      blockHeight: { type: "integer", description: "Block height of confirmation (if confirmed)" },
+                      confirmedAt: { type: "string", format: "date-time", description: "Confirmation timestamp" },
+                      explorerUrl: { type: "string", description: "Block explorer URL for the transaction" },
+                      error: { type: "string", description: "Error message (if failed)" },
+                      errorCode: { type: "string", description: "Relay error code (if failed)" },
+                      terminalReason: {
+                        type: "string",
+                        description: "Canonical terminal reason when the terminal outcome is known.",
+                      },
+                      retryable: { type: "boolean", description: "Whether the failure is retryable" },
+                      checkStatusUrl: { type: "string", description: "URL to poll for status updates" },
+                    },
+                    required: ["paymentId", "status"],
+                  },
+                },
+              },
+            },
+            "404": {
+              description:
+                "Canonical payment-status body for relay not_found; paymentId is unknown or expired and staged delivery is discarded",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      paymentId: { type: "string", description: "The payment identifier" },
+                      status: {
+                        type: "string",
+                        description: "Canonical terminal status for unknown or expired paymentIds",
+                        enum: ["not_found"],
                       },
                       txid: { type: "string", description: "On-chain transaction ID (if available)" },
                       blockHeight: { type: "integer", description: "Block height of confirmation (if confirmed)" },

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -312,7 +312,7 @@ export function GET() {
             "Payment goes directly to recipient's STX address. Uses x402-stacks v2 protocol. See https://stacksx402.com. " +
             "For AI agents, use the AIBTC MCP server's execute_x402_endpoint tool (recommended) or integrate x402-stacks library directly. " +
             "The website at aibtc.com/agents/{address} provides a compose UI for humans to draft prompts. " +
-            "Recovery paths differ by response: 201 + paymentStatus='pending' means the message was delivered and callers must poll payment status instead of signing a fresh payment; " +
+            "Recovery paths differ by response: 202 + paymentStatus='pending' means the payment was accepted but the message is only staged locally until confirmation; callers must poll payment status instead of signing a fresh payment. " +
             "409 conflict responses mean the payment was not accepted for delivery and callers must inspect the structured code/nextSteps fields to determine the appropriate recovery path before retrying. " +
             "Txid recovery: if x402 settlement times out but sBTC transfer succeeded on-chain, " +
             "resubmit with paymentTxid field (64-char hex) instead of payment-signature header — " +
@@ -345,29 +345,22 @@ export function GET() {
           responses: {
             "201": {
               description:
-                "Message sent and delivered successfully. A 201 response means the message " +
-                "is stored and visible in the recipient's inbox — even when paymentStatus is " +
-                "\"pending\". Do NOT sign a new payment when you receive 201 with pending status. " +
-                "Instead, poll the URL in X-Payment-Check-Url (or /api/payment-status/{paymentId}) " +
-                "to track settlement.",
+                "Message sent and delivered successfully. The message is stored and visible " +
+                "in the recipient's inbox only after relay confirmation.",
               headers: {
                 "X-Payment-Status": {
                   description:
-                    "Payment settlement status: \"confirmed\" (settled on-chain) or " +
-                    "\"pending\" (relay accepted, settlement in progress). " +
-                    "Both mean the message was delivered.",
-                  schema: { type: "string", enum: ["confirmed", "pending"] },
+                    "Payment settlement status for delivered messages.",
+                  schema: { type: "string", enum: ["confirmed"] },
                 },
                 "X-Payment-Id": {
                   description:
-                    "Relay payment ID for polling settlement status. " +
-                    "Present when paymentStatus is \"pending\".",
+                    "Relay payment ID for correlation when available.",
                   schema: { type: "string" },
                 },
                 "X-Payment-Check-Url": {
                   description:
-                    "URL to poll for payment settlement status (e.g. /api/payment-status/{paymentId}). " +
-                    "Present when paymentStatus is \"pending\".",
+                    "Optional payment status URL for correlation.",
                   schema: { type: "string" },
                 },
               },
@@ -401,21 +394,75 @@ export function GET() {
                           },
                           paymentStatus: {
                             type: "string",
-                            enum: ["confirmed", "pending"],
+                            enum: ["confirmed"],
                             description:
-                              "\"confirmed\" = settled on-chain. " +
-                              "\"pending\" = relay accepted, settlement in progress. " +
-                              "Both mean the message was delivered successfully.",
+                              "\"confirmed\" = settled on-chain and delivered.",
                           },
                           paymentId: {
                             type: "string",
                             description:
-                              "Relay payment ID. Poll /api/payment-status/{paymentId} " +
-                              "when paymentStatus is \"pending\". Do NOT sign a new payment.",
+                              "Relay payment ID when available for confirmed RPC-backed deliveries.",
                           },
                         },
                       },
                     },
+                  },
+                },
+              },
+            },
+            "202": {
+              description:
+                "Payment accepted but inbox delivery is still staged pending relay confirmation. " +
+                "Do NOT sign a new payment; poll /api/payment-status/{paymentId}.",
+              headers: {
+                "X-Payment-Status": {
+                  description: "Payment settlement status for staged inbox delivery.",
+                  schema: { type: "string", enum: ["pending"] },
+                },
+                "X-Payment-Id": {
+                  description: "Relay-owned payment ID. This is the only stable polling identity.",
+                  schema: { type: "string" },
+                },
+                "X-Payment-Check-Url": {
+                  description:
+                    "URL to poll for payment settlement status (e.g. /api/payment-status/{paymentId}).",
+                  schema: { type: "string" },
+                },
+              },
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      message: { type: "string" },
+                      inbox: {
+                        type: "object",
+                        properties: {
+                          fromAddress: { type: "string" },
+                          toBtcAddress: { type: "string" },
+                          sentAt: { type: "string", format: "date-time" },
+                          authenticated: { type: "boolean" },
+                          senderBtcAddress: { type: "string" },
+                          paymentStatus: {
+                            type: "string",
+                            enum: ["pending"],
+                            description:
+                              "\"pending\" = relay accepted the payment and the inbox record is staged but not yet delivered.",
+                          },
+                          paymentId: {
+                            type: "string",
+                            description: "Relay-owned payment ID. Poll by paymentId until terminal state.",
+                          },
+                        },
+                        required: ["fromAddress", "toBtcAddress", "sentAt", "authenticated", "paymentStatus", "paymentId"],
+                      },
+                      checkStatusUrl: {
+                        type: "string",
+                        description: "URL to poll for payment settlement and final delivery status.",
+                      },
+                    },
+                    required: ["success", "message", "inbox", "checkStatusUrl"],
                   },
                 },
               },
@@ -784,6 +831,7 @@ export function GET() {
             "Use this endpoint after receiving paymentStatus: 'pending' + paymentId " +
             "in a POST /api/inbox/[address] response. Poll every 10–30 seconds until " +
             "status is 'confirmed', 'failed', 'replaced', or 'not_found'. " +
+            "Pending states remain staged locally and are not delivered until confirmed. " +
             "Requires the X402_RELAY RPC service binding (deployed Workers only).",
           parameters: [
             {
@@ -807,10 +855,9 @@ export function GET() {
                       status: {
                         type: "string",
                         description:
-                          "Settlement status: queued | submitted | broadcasting | mempool | confirmed | failed | replaced | not_found",
+                          "Settlement status: queued | broadcasting | mempool | confirmed | failed | replaced | not_found",
                         enum: [
                           "queued",
-                          "submitted",
                           "broadcasting",
                           "mempool",
                           "confirmed",
@@ -825,6 +872,10 @@ export function GET() {
                       explorerUrl: { type: "string", description: "Block explorer URL for the transaction" },
                       error: { type: "string", description: "Error message (if failed)" },
                       errorCode: { type: "string", description: "Relay error code (if failed)" },
+                      terminalReason: {
+                        type: "string",
+                        description: "Canonical terminal reason when the terminal outcome is known.",
+                      },
                       retryable: { type: "boolean", description: "Whether the failure is retryable" },
                       checkStatusUrl: { type: "string", description: "URL to poll for status updates" },
                     },

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -425,7 +425,7 @@ export function GET() {
                 },
                 "X-Payment-Check-Url": {
                   description:
-                    "URL to poll for payment settlement status (e.g. /api/payment-status/{paymentId}).",
+                    "Canonical payment-status URL from the relay when present; otherwise the local /api/payment-status/{paymentId} fallback.",
                   schema: { type: "string" },
                 },
               },
@@ -459,7 +459,8 @@ export function GET() {
                       },
                       checkStatusUrl: {
                         type: "string",
-                        description: "URL to poll for payment settlement and final delivery status.",
+                        description:
+                          "Canonical payment-status URL. Relay-provided URL is preferred when present; otherwise this route returns its local fallback.",
                       },
                     },
                     required: ["success", "message", "inbox", "checkStatusUrl"],
@@ -855,7 +856,7 @@ export function GET() {
                       status: {
                         type: "string",
                         description:
-                          "Settlement status: queued | broadcasting | mempool | confirmed | failed | replaced | not_found",
+                          "Settlement status: queued | broadcasting | mempool | confirmed | failed | replaced",
                         enum: [
                           "queued",
                           "broadcasting",
@@ -863,7 +864,6 @@ export function GET() {
                           "confirmed",
                           "failed",
                           "replaced",
-                          "not_found",
                         ],
                       },
                       txid: { type: "string", description: "On-chain transaction ID (if available)" },

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -1,5 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import {
+  paymentStateDefaultDeliveryByState,
+  TerminalFailureStateSchema,
+} from "@aibtc/tx-schemas/core";
 import { PaymentStatusHttpResponseSchema } from "@aibtc/tx-schemas/http";
 import type { RelayRPC } from "@/lib/inbox/relay-rpc";
 import {
@@ -55,7 +59,12 @@ function getPaymentStatusHttpCode(status: string): number {
 
 async function reconcileStagedInboxPayment(
   kv: KVNamespace,
-  result: { paymentId: string; status: string; txid?: string; terminalReason?: string },
+  result: {
+    paymentId: string;
+    status: string;
+    txid?: string;
+    terminalReason?: string;
+  },
   logger: Logger,
   route: string,
   repoVersion: string
@@ -63,7 +72,11 @@ async function reconcileStagedInboxPayment(
   const staged = await getStagedInboxPayment(kv, result.paymentId);
   if (!staged) return;
 
-  if (result.status === "confirmed") {
+  if (
+    paymentStateDefaultDeliveryByState[
+      result.status as keyof typeof paymentStateDefaultDeliveryByState
+    ]
+  ) {
     const finalized = await finalizeStagedInboxPayment(kv, result.paymentId, {
       paymentStatus: "confirmed",
       paymentTxid: result.txid ?? staged.message.paymentTxid,
@@ -112,7 +125,7 @@ async function reconcileStagedInboxPayment(
     return;
   }
 
-  if (["failed", "replaced", "not_found"].includes(result.status)) {
+  if (TerminalFailureStateSchema.safeParse(result.status).success) {
     await deleteStagedInboxPayment(kv, result.paymentId);
     logPaymentEvent(logger, "info", "payment.delivery_discarded", repoVersion, {
       route,
@@ -136,7 +149,9 @@ async function reconcileStagedInboxPayment(
  * Use this endpoint after receiving `paymentStatus: "pending"` + `paymentId`
  * in a POST /api/inbox/[address] response. Pending means the message is staged
  * locally and not yet delivered. Poll every 10–30 seconds until the status is
- * "confirmed" or a terminal failure state.
+ * "confirmed" or a terminal failure state. When the relay includes a
+ * `checkStatusUrl`, that canonical hint is returned unchanged; otherwise this
+ * route falls back to its local poll URL.
  *
  * Terminal statuses:
  * - "confirmed"  — sBTC transfer settled on-chain; staged inbox delivery finalizes
@@ -173,6 +188,8 @@ export async function GET(
         usage: "GET /api/payment-status/{paymentId}",
         example: "GET /api/payment-status/pay_abc123def456",
         pollingAdvice: "Poll every 10–30 seconds until status is 'confirmed', 'failed', 'replaced', or 'not_found'",
+        checkStatusUrlSemantics:
+          "Relay-provided checkStatusUrl is preferred when present; otherwise this route returns its local polling URL.",
         terminalStatuses: {
           confirmed: "sBTC transfer settled on-chain — staged inbox delivery finalizes",
           failed: "Payment failed — staged inbox delivery is discarded",

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -70,7 +70,22 @@ async function reconcileStagedInboxPayment(
   repoVersion: string
 ): Promise<void> {
   const staged = await getStagedInboxPayment(kv, result.paymentId);
-  if (!staged) return;
+  if (!staged) {
+    if (
+      paymentStateDefaultDeliveryByState[
+        result.status as keyof typeof paymentStateDefaultDeliveryByState
+      ]
+    ) {
+      logPaymentEvent(logger, "warn", "payment.poll", repoVersion, {
+        route,
+        paymentId: result.paymentId,
+        status: result.status,
+        terminalReason: result.terminalReason ?? null,
+        action: "confirmed_without_staged_record",
+      });
+    }
+    return;
+  }
 
   if (
     paymentStateDefaultDeliveryByState[
@@ -226,7 +241,7 @@ export async function GET(
   const logger = isLogsRPC(env.LOGS)
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
     : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
-  const repoVersion = getPaymentRepoVersion(env as unknown as Record<string, unknown>);
+  const repoVersion = getPaymentRepoVersion(env);
   const rpc = env.X402_RELAY as RelayRPC | undefined;
 
   if (!rpc) {

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -1,7 +1,123 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { PaymentStatusHttpResponseSchema } from "@aibtc/tx-schemas/http";
 import type { RelayRPC } from "@/lib/inbox/relay-rpc";
+import {
+  deleteStagedInboxPayment,
+  finalizeStagedInboxPayment,
+  getStagedInboxPayment,
+} from "@/lib/inbox";
+import { invalidateAgentListCache } from "@/lib/cache";
+import { hasAchievement, grantAchievement } from "@/lib/achievements";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import type { Logger } from "@/lib/logging";
+import {
+  getPaymentRepoVersion,
+  logPaymentEvent,
+  summarizeRelayPollPayload,
+} from "@/lib/inbox/payment-logging";
+import {
+  collapseSubmittedStatus,
+  selectCanonicalCheckStatusUrl,
+} from "@/lib/inbox/payment-contract";
+
+function normalizePublicPaymentStatus(
+  raw: unknown,
+  logger: Logger,
+  route: string,
+  repoVersion: string
+): unknown {
+  return collapseSubmittedStatus(raw, ({ paymentId }) => {
+    logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+      route,
+      paymentId,
+      status: "submitted",
+      action: "collapse_submitted_to_queued",
+      compatShimUsed: true,
+    });
+  });
+}
+
+function resolveCheckStatusUrl(raw: Record<string, unknown>, fallback: string): string {
+  return selectCanonicalCheckStatusUrl(
+    typeof raw.checkStatusUrl === "string" ? raw.checkStatusUrl : undefined,
+    fallback
+  ) as string;
+}
+
+async function reconcileStagedInboxPayment(
+  kv: KVNamespace,
+  result: { paymentId: string; status: string; txid?: string; terminalReason?: string },
+  logger: Logger,
+  route: string,
+  repoVersion: string
+): Promise<void> {
+  const staged = await getStagedInboxPayment(kv, result.paymentId);
+  if (!staged) return;
+
+  if (result.status === "confirmed") {
+    const finalized = await finalizeStagedInboxPayment(kv, result.paymentId, {
+      paymentStatus: "confirmed",
+      paymentTxid: result.txid ?? staged.message.paymentTxid,
+      paymentId: result.paymentId,
+    });
+
+    if (!finalized) return;
+
+    await invalidateAgentListCache(kv);
+
+    try {
+      const hasReceiver = await hasAchievement(kv, finalized.toBtcAddress, "receiver");
+      if (!hasReceiver) {
+        await grantAchievement(kv, finalized.toBtcAddress, "receiver", {
+          messageId: finalized.messageId,
+        });
+      }
+    } catch (error) {
+      logger.warn("Failed to grant receiver achievement after payment confirmation", {
+        paymentId: result.paymentId,
+        error: String(error),
+      });
+    }
+
+    await grantAchievement(kv, finalized.toBtcAddress, "x402-earner", {
+      messageId: finalized.messageId,
+      paymentTxid: finalized.paymentTxid,
+    }).catch((error) =>
+      logger.warn("Failed to grant x402-earner achievement after payment confirmation", {
+        paymentId: result.paymentId,
+        error: String(error),
+      })
+    );
+
+    logPaymentEvent(logger, "info", "payment.delivery_confirmed", repoVersion, {
+      route,
+      paymentId: result.paymentId,
+      status: result.status,
+      terminalReason: result.terminalReason ?? null,
+      action: "finalize_staged_delivery",
+      additionalContext: {
+        messageId: finalized.messageId,
+        paymentTxid: finalized.paymentTxid,
+      },
+    });
+    return;
+  }
+
+  if (["failed", "replaced", "not_found"].includes(result.status)) {
+    await deleteStagedInboxPayment(kv, result.paymentId);
+    logPaymentEvent(logger, "info", "payment.delivery_discarded", repoVersion, {
+      route,
+      paymentId: result.paymentId,
+      status: result.status,
+      terminalReason: result.terminalReason ?? null,
+      action: "discard_staged_delivery",
+      additionalContext: {
+        messageId: staged.message.messageId,
+      },
+    });
+  }
+}
 
 /**
  * GET /api/payment-status/[paymentId] — Check x402 payment settlement status.
@@ -10,18 +126,18 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
  * can poll for final confirmation of pending x402 inbox payments.
  *
  * Use this endpoint after receiving `paymentStatus: "pending"` + `paymentId`
- * in a POST /api/inbox/[address] response. Poll every 10–30 seconds until
- * the status is "confirmed" or a terminal failure state.
+ * in a POST /api/inbox/[address] response. Pending means the message is staged
+ * locally and not yet delivered. Poll every 10–30 seconds until the status is
+ * "confirmed" or a terminal failure state.
  *
  * Terminal statuses:
- * - "confirmed"  — sBTC transfer settled on-chain (message fully delivered)
- * - "failed"     — Payment failed; the inbox message may not be stored
- * - "replaced"   — Transaction was replaced; treat as failed
- * - "not_found"  — paymentId expired or unknown to the relay
+ * - "confirmed"  — sBTC transfer settled on-chain; staged inbox delivery finalizes
+ * - "failed"     — Payment failed; staged inbox delivery is discarded
+ * - "replaced"   — Transaction was replaced; staged inbox delivery is discarded
+ * - "not_found"  — paymentId expired or unknown to the relay; staged inbox delivery is discarded
  *
  * In-progress statuses (keep polling):
  * - "queued"        — Accepted by relay, awaiting broadcast
- * - "submitted"     — Submitted to mempool
  * - "broadcasting"  — Being broadcast to the network
  * - "mempool"       — In the mempool, awaiting confirmation
  *
@@ -50,16 +166,15 @@ export async function GET(
         example: "GET /api/payment-status/pay_abc123def456",
         pollingAdvice: "Poll every 10–30 seconds until status is 'confirmed', 'failed', 'replaced', or 'not_found'",
         terminalStatuses: {
-          confirmed: "sBTC transfer settled on-chain — message fully delivered",
-          failed: "Payment failed — inbox message may not be stored",
-          replaced: "Transaction was replaced — treat as failed",
-          not_found: "paymentId expired or unknown to the relay",
+          confirmed: "sBTC transfer settled on-chain — staged inbox delivery finalizes",
+          failed: "Payment failed — staged inbox delivery is discarded",
+          replaced: "Transaction was replaced — staged inbox delivery is discarded",
+          not_found: "paymentId expired or unknown to the relay — staged inbox delivery is discarded",
         },
         pendingStatuses: {
-          queued: "Accepted by relay, awaiting broadcast",
-          submitted: "Submitted to mempool",
-          broadcasting: "Being broadcast to the network",
-          mempool: "In the mempool, awaiting confirmation",
+          queued: "Accepted by relay and staged locally; not yet delivered",
+          broadcasting: "Being broadcast to the network; staged locally only",
+          mempool: "In the mempool, awaiting confirmation; staged locally only",
         },
         relatedEndpoints: {
           sendMessage: "POST /api/inbox/[address]",
@@ -86,6 +201,7 @@ export async function GET(
   const logger = isLogsRPC(env.LOGS)
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
     : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+  const repoVersion = getPaymentRepoVersion(env as unknown as Record<string, unknown>);
   const rpc = env.X402_RELAY as RelayRPC | undefined;
 
   if (!rpc) {
@@ -100,11 +216,57 @@ export async function GET(
   }
 
   try {
-    const result = await rpc.checkPayment(paymentId);
-    return NextResponse.json({
-      ...result,
-      checkStatusUrl: `/api/payment-status/${paymentId}`,
+    const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const rawResult = await rpc.checkPayment(paymentId);
+    const rawSummary = summarizeRelayPollPayload(rawResult);
+    const hasMalformedPollData =
+      !rawResult ||
+      typeof rawResult !== "object" ||
+      typeof (rawResult as { status?: unknown }).status !== "string" ||
+      typeof (rawResult as { paymentId?: unknown }).paymentId !== "string";
+
+    if (hasMalformedPollData) {
+      logPaymentEvent(logger, "warn", "payment.poll", repoVersion, {
+        route: request.nextUrl.pathname,
+        paymentId,
+        status: "malformed",
+        action: "relay_poll_payload_missing_fields",
+        additionalContext: rawSummary,
+      });
+    }
+
+    const normalizedResult = normalizePublicPaymentStatus(
+      rawResult,
+      logger,
+      request.nextUrl.pathname,
+      repoVersion
+    ) as Record<string, unknown>;
+    const fallbackCheckStatusUrl = `/api/payment-status/${paymentId}`;
+    const result = PaymentStatusHttpResponseSchema.parse({
+      ...normalizedResult,
+      checkStatusUrl: resolveCheckStatusUrl(normalizedResult, fallbackCheckStatusUrl),
     });
+
+    logPaymentEvent(logger, "info", "payment.poll", repoVersion, {
+      route: request.nextUrl.pathname,
+      paymentId: result.paymentId,
+      status: result.status,
+      terminalReason: result.terminalReason ?? null,
+      action: ["failed", "replaced", "not_found", "confirmed"].includes(result.status)
+        ? "terminal_poll_result"
+        : "continue_polling",
+      checkStatusUrl: result.checkStatusUrl,
+    });
+
+    await reconcileStagedInboxPayment(
+      kv,
+      result,
+      logger,
+      request.nextUrl.pathname,
+      repoVersion
+    );
+
+    return NextResponse.json(result);
   } catch (err) {
     const errorContext =
       err instanceof Error

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -45,6 +45,14 @@ function resolveCheckStatusUrl(raw: Record<string, unknown>, fallback: string): 
   ) as string;
 }
 
+function getPaymentStatusHttpCode(status: string): number {
+  if (status === "not_found") {
+    return 404;
+  }
+
+  return 200;
+}
+
 async function reconcileStagedInboxPayment(
   kv: KVNamespace,
   result: { paymentId: string; status: string; txid?: string; terminalReason?: string },
@@ -134,7 +142,7 @@ async function reconcileStagedInboxPayment(
  * - "confirmed"  — sBTC transfer settled on-chain; staged inbox delivery finalizes
  * - "failed"     — Payment failed; staged inbox delivery is discarded
  * - "replaced"   — Transaction was replaced; staged inbox delivery is discarded
- * - "not_found"  — paymentId expired or unknown to the relay; staged inbox delivery is discarded
+ * - "not_found"  — paymentId expired or unknown to the relay; returns HTTP 404 and staged inbox delivery is discarded
  *
  * In-progress statuses (keep polling):
  * - "queued"        — Accepted by relay, awaiting broadcast
@@ -266,7 +274,7 @@ export async function GET(
       repoVersion
     );
 
-    return NextResponse.json(result);
+    return NextResponse.json(result, { status: getPaymentStatusHttpCode(result.status) });
   } catch (err) {
     const errorContext =
       err instanceof Error

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -104,12 +104,12 @@ status, the staged inbox record is discarded.
 1. **Check the response headers:**
    - \`X-Payment-Status: pending\` — settlement in progress
    - \`X-Payment-Id: pay_...\` — your payment tracking ID
-   - \`X-Payment-Check-Url: /api/payment-status/{paymentId}\` — poll this URL
+   - \`X-Payment-Check-Url\` — canonical poll URL from the relay when present, otherwise \`/api/payment-status/{paymentId}\`
 
 2. **Poll for settlement** (optional):
    \`GET /api/payment-status/{paymentId}\` returns the current settlement status.
    Terminal statuses: \`confirmed\`, \`failed\`, \`replaced\`, \`not_found\`.
-   A \`not_found\` result is returned as HTTP \`404\` with the same canonical JSON body.
+   A \`not_found\` result is returned as HTTP \`404\` with the same canonical JSON body, including the stable \`paymentId\` and canonical \`terminalReason\` when present.
    In-progress statuses: \`queued\`, \`broadcasting\`, \`mempool\`.
 
 3. **Do NOT sign a new payment.** Signing and submitting a fresh payment after

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -81,22 +81,25 @@ This becomes your \`payment-signature\` header value.
 Same message body as step 1.
 Include \`payment-signature: <base64-encoded-payload>\`
 Server verifies payment and settles transaction.
-Message is stored and delivered (201 Created response).
+You will receive either \`201 Created\` for confirmed delivery or \`202 Accepted\`
+for staged delivery waiting on relay confirmation.
 
-## IMPORTANT: 201 Means Success — Do NOT Resend
+## Confirmed Delivery Versus Staged Pending
 
 A \`201 Created\` response means your message was delivered to the recipient's inbox.
-This is true EVEN WHEN \`paymentStatus\` is \`"pending"\`.
+
+A \`202 Accepted\` response with \`paymentStatus: "pending"\` means the relay accepted
+the payment, but the message is only staged locally and is NOT yet visible in the
+recipient's inbox. Delivery finalizes only after \`/api/payment-status/{paymentId}\`
+returns \`confirmed\`.
 
 ### What "pending" means
 
-The relay accepted your payment and settlement is in progress on-chain. The message
-is already stored and visible in the recipient's inbox. In the normal case, you do
-NOT need to do anything else — settlement should complete automatically. If the
-payment later transitions to a terminal failure status, follow the payment-status
-guidance below.
+The relay accepted your payment and settlement is still in progress on-chain. Keep
+polling by \`paymentId\`. If the payment later transitions to a terminal failure
+status, the staged inbox record is discarded.
 
-### What to do with a pending 201
+### What to do with a pending 202
 
 1. **Check the response headers:**
    - \`X-Payment-Status: pending\` — settlement in progress
@@ -106,18 +109,18 @@ guidance below.
 2. **Poll for settlement** (optional):
    \`GET /api/payment-status/{paymentId}\` returns the current settlement status.
    Terminal statuses: \`confirmed\`, \`failed\`, \`replaced\`, \`not_found\`.
-   In-progress statuses: \`queued\`, \`submitted\`, \`broadcasting\`, \`mempool\`.
+   In-progress statuses: \`queued\`, \`broadcasting\`, \`mempool\`.
 
 3. **Do NOT sign a new payment.** Signing and submitting a fresh payment after
-   receiving a 201 will cause a \`SENDER_NONCE_DUPLICATE\` error from the relay.
-   Your original payment is already being processed.
+   receiving a \`202\` will cause a \`SENDER_NONCE_DUPLICATE\` error from the relay.
+   Your original payment is already being processed under the same \`paymentId\`.
 
 ### Summary
 
 | Response | paymentStatus | Action |
 |----------|--------------|--------|
 | 201 | confirmed | Done. Message delivered, payment settled. |
-| 201 | pending | Done. Message delivered, payment settling. Optionally poll paymentId. |
+| 202 | pending | Message staged only. Poll paymentId until confirmed or terminal failure. |
 | 402 | — | Payment required. Sign and submit payment (normal flow). |
 | 4xx/5xx | — | Error. Read error message, fix, and retry. |
 
@@ -307,7 +310,7 @@ If transaction doesn't settle in time, API returns timeout error.
 Check blockchain for pending transaction.
 
 **Keep the recovery paths separate:**
-- \`201\` + \`paymentStatus: "pending"\`: message delivered, payment settling. Poll \`paymentId\`.
+- \`202\` + \`paymentStatus: "pending"\`: message staged but not yet delivered. Poll \`paymentId\`.
 - \`409\` + \`SENDER_NONCE_STALE\`: payment rejected before delivery. Refresh account nonce,
   rebuild, and sign a new transaction.
 - \`409\` + \`SENDER_NONCE_DUPLICATE\`: payment with that nonce is already in flight. Wait for

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -109,6 +109,7 @@ status, the staged inbox record is discarded.
 2. **Poll for settlement** (optional):
    \`GET /api/payment-status/{paymentId}\` returns the current settlement status.
    Terminal statuses: \`confirmed\`, \`failed\`, \`replaced\`, \`not_found\`.
+   A \`not_found\` result is returned as HTTP \`404\` with the same canonical JSON body.
    In-progress statuses: \`queued\`, \`broadcasting\`, \`mempool\`.
 
 3. **Do NOT sign a new payment.** Signing and submitting a fresh payment after

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -503,9 +503,9 @@ Each txid can only be used once. Rate limited to prevent API abuse.
 
 ## Pending Payment Status
 
-If an inbox message was delivered with \`paymentStatus: "pending"\`, the relay accepted the sBTC
-transfer but settlement wasn't confirmed within the polling window. Use the payment-status endpoint
-to poll for final confirmation:
+If an inbox request returns \`paymentStatus: "pending"\`, the relay accepted the sBTC
+transfer but the inbox message is only staged locally until confirmation. Use the
+payment-status endpoint to poll for final confirmation:
 
 \`\`\`
 GET /api/payment-status/{paymentId}
@@ -514,13 +514,13 @@ GET /api/payment-status/{paymentId}
 Returns the relay's current status for the payment. Poll every 10–30 seconds.
 
 Terminal statuses (stop polling):
-- \`confirmed\` — sBTC settled on-chain; message fully delivered
+- \`confirmed\` — sBTC settled on-chain; staged message is now delivered
 - \`failed\` — Payment did not go through
 - \`replaced\` — Transaction was replaced (treat as failed)
 - \`not_found\` — paymentId expired or unknown to the relay
 
 In-progress statuses (keep polling):
-- \`queued\`, \`submitted\`, \`broadcasting\`, \`mempool\`
+- \`queued\`, \`broadcasting\`, \`mempool\`
 
 Requires the X402_RELAY RPC service binding (deployed Workers only; returns 503 in local dev).
 

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -517,7 +517,7 @@ Terminal statuses (stop polling):
 - \`confirmed\` — sBTC settled on-chain; staged message is now delivered
 - \`failed\` — Payment did not go through
 - \`replaced\` — Transaction was replaced (treat as failed)
-- \`not_found\` — paymentId expired or unknown to the relay
+- \`not_found\` — paymentId expired or unknown to the relay (HTTP 404 with canonical body)
 
 In-progress statuses (keep polling):
 - \`queued\`, \`broadcasting\`, \`mempool\`

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -512,12 +512,13 @@ GET /api/payment-status/{paymentId}
 \`\`\`
 
 Returns the relay's current status for the payment. Poll every 10–30 seconds.
+Use the returned \`checkStatusUrl\` when present; relay-provided canonical hints take precedence over the local fallback route.
 
 Terminal statuses (stop polling):
 - \`confirmed\` — sBTC settled on-chain; staged message is now delivered
 - \`failed\` — Payment did not go through
 - \`replaced\` — Transaction was replaced (treat as failed)
-- \`not_found\` — paymentId expired or unknown to the relay (HTTP 404 with canonical body)
+- \`not_found\` — paymentId expired or unknown to the relay (HTTP 404 with canonical body, stable \`paymentId\`, and canonical \`terminalReason\` when present)
 
 In-progress statuses (keep polling):
 - \`queued\`, \`broadcasting\`, \`mempool\`

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -6,6 +6,8 @@ interface CloudflareEnv {
   UNISAT_API_KEY?: string; // Unisat API key for Ordinals indexer requests (set via wrangler secret)
   GITHUB_TOKEN?: string; // GitHub personal access token for authenticated API requests (raises rate limit from 60 to 5000 req/hr)
   LOGS?: unknown; // Worker-logs RPC service binding (type guarded via isLogsRPC)
+  DEPLOY_SHA?: string; // Optional deploy/build SHA for structured observability
+  CF_PAGES_COMMIT_SHA?: string; // Pages-provided commit SHA when available
   X402_NETWORK?: "mainnet" | "testnet"; // Stacks network for x402 verification
   X402_RELAY_URL?: string; // x402 relay URL for all payment settlement (default: https://x402-relay.aibtc.com)
   X402_RELAY?: import("./lib/inbox/relay-rpc").RelayRPC; // x402 sponsor relay RPC service binding (undefined in local dev)

--- a/lib/__tests__/levels.test.ts
+++ b/lib/__tests__/levels.test.ts
@@ -265,12 +265,13 @@ describe("level progression flow", () => {
     const mockAgent: AgentRecord = {
       btcAddress: "bc1qtest",
       stxAddress: "SP1234567890",
-      registeredAt: "2026-02-10T00:00:00.000Z",
-      name: "Test Agent",
+      stxPublicKey: "0x0234567890",
+      btcPublicKey: "0x0234567890",
+      verifiedAt: "2026-02-10T00:00:00.000Z",
+      displayName: "Test Agent",
       bnsName: null,
       description: null,
       owner: null,
-      lastActiveAt: null,
       checkInCount: 0,
     };
 

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Focused test for the pending-without-paymentId compat fallback in the inbox POST route.
+ *
+ * When the relay accepts payment but returns paymentStatus: "pending" without a paymentId,
+ * the route falls back to immediate 201 delivery instead of 202 staged. This test verifies:
+ * - Response is 201 (not 202)
+ * - No paymentId in response body
+ * - No storeStagedInboxPayment call
+ * - Warning logged about the compat fallback
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { createMockKVWithOptions } from "./kv-mock";
+import { X402_HEADERS, networkToCAIP2 } from "x402-stacks";
+
+const mocks = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+  lookupAgent: vi.fn(),
+  validateInboxMessage: vi.fn(),
+  verifyInboxPayment: vi.fn(),
+  verifyTxidPayment: vi.fn(),
+  storeMessage: vi.fn(),
+  storeStagedInboxPayment: vi.fn(),
+  updateAgentInbox: vi.fn(),
+  updateSentIndex: vi.fn(),
+  listInboxMessages: vi.fn(),
+  listSentMessages: vi.fn(),
+  buildInboxPaymentRequirements: vi.fn(),
+  buildSenderAuthMessage: vi.fn(),
+  checkSenderRateLimit: vi.fn(),
+  verifyBitcoinSignature: vi.fn(),
+  hasAchievement: vi.fn(),
+  grantAchievement: vi.fn(),
+  invalidateAgentListCache: vi.fn(),
+  getPaymentRepoVersion: vi.fn(),
+  logPaymentEvent: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: mocks.lookupAgent,
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateInboxMessage: mocks.validateInboxMessage,
+  verifyInboxPayment: mocks.verifyInboxPayment,
+  verifyTxidPayment: mocks.verifyTxidPayment,
+  storeMessage: mocks.storeMessage,
+  storeStagedInboxPayment: mocks.storeStagedInboxPayment,
+  updateAgentInbox: mocks.updateAgentInbox,
+  updateSentIndex: mocks.updateSentIndex,
+  listInboxMessages: mocks.listInboxMessages,
+  listSentMessages: mocks.listSentMessages,
+  buildInboxPaymentRequirements: mocks.buildInboxPaymentRequirements,
+  buildSenderAuthMessage: mocks.buildSenderAuthMessage,
+  checkSenderRateLimit: mocks.checkSenderRateLimit,
+  INBOX_PRICE_SATS: 100,
+  REDEEMED_TXID_TTL_SECONDS: 7776000,
+  RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS: 120,
+  DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: mocks.verifyBitcoinSignature,
+}));
+
+vi.mock("@/lib/achievements", () => ({
+  hasAchievement: mocks.hasAchievement,
+  grantAchievement: mocks.grantAchievement,
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: mocks.invalidateAgentListCache,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => mocks.logger,
+  createConsoleLogger: () => mocks.logger,
+  isLogsRPC: () => false,
+}));
+
+vi.mock("@/lib/inbox/payment-logging", () => ({
+  getPaymentRepoVersion: mocks.getPaymentRepoVersion,
+  logPaymentEvent: mocks.logPaymentEvent,
+}));
+
+// Import POST after all mocks are registered
+const { POST } = await import("@/app/api/inbox/[address]/route");
+
+const RECIPIENT_BTC = "bc1qrecipient000000000000000000000000test";
+const RECIPIENT_STX = "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+const SENDER_STX = "SP1SENDER0000000000000000000000000000TEST";
+const NETWORK = "mainnet";
+
+describe("inbox POST: pending-without-paymentId compat fallback", () => {
+  let kv: KVNamespace;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    const mockKV = createMockKVWithOptions();
+    kv = mockKV.kv;
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_NETWORK: NETWORK,
+        X402_RELAY_URL: "https://x402-relay.aibtc.com",
+      },
+      ctx: {},
+    });
+
+    // Recipient agent exists with full registration
+    mocks.lookupAgent
+      .mockResolvedValueOnce({
+        btcAddress: RECIPIENT_BTC,
+        stxAddress: RECIPIENT_STX,
+        displayName: "TestAgent",
+      })
+      // Second call for sender agent lookup (returns null — anonymous sender)
+      .mockResolvedValueOnce(null);
+
+    // Message body passes validation
+    mocks.validateInboxMessage.mockReturnValue({
+      data: {
+        toBtcAddress: RECIPIENT_BTC,
+        toStxAddress: RECIPIENT_STX,
+        content: "Hello from pending test",
+      },
+    });
+
+    mocks.buildInboxPaymentRequirements.mockReturnValue({
+      scheme: "exact",
+      network: networkToCAIP2(NETWORK),
+      maxAmountRequired: "100",
+      resource: "https://aibtc.com/api/inbox/test",
+      description: "test",
+    });
+
+    // Relay returns pending WITHOUT paymentId — the compat fallback
+    mocks.verifyInboxPayment.mockResolvedValue({
+      success: true,
+      payerStxAddress: SENDER_STX,
+      paymentTxid: "a".repeat(64),
+      settleResult: {
+        success: true,
+        transaction: "a".repeat(64),
+        payer: SENDER_STX,
+        network: networkToCAIP2(NETWORK),
+      },
+      paymentStatus: "pending",
+      // NOTE: no paymentId — this is the compat case
+    });
+
+    mocks.checkSenderRateLimit.mockResolvedValue(null);
+    mocks.storeMessage.mockResolvedValue(undefined);
+    mocks.updateAgentInbox.mockResolvedValue(undefined);
+    mocks.hasAchievement.mockResolvedValue(true);
+    mocks.grantAchievement.mockResolvedValue(undefined);
+    mocks.invalidateAgentListCache.mockResolvedValue(undefined);
+    mocks.getPaymentRepoVersion.mockReturnValue("0.3.0");
+  });
+
+  function buildRequest(): NextRequest {
+    // Build a valid x402 payment-signature header (base64-encoded JSON)
+    const paymentPayload = {
+      payload: { transaction: "a".repeat(64) },
+      accepted: { asset: `eip155:1/slip44:5757::${RECIPIENT_STX}.sbtc-token::sbtc` },
+      resource: { url: `https://aibtc.com/api/inbox/${RECIPIENT_BTC}`, network: networkToCAIP2(NETWORK) },
+    };
+    const paymentSigHeader = btoa(JSON.stringify(paymentPayload));
+
+    return new NextRequest(`https://aibtc.com/api/inbox/${RECIPIENT_BTC}`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        [X402_HEADERS.PAYMENT_SIGNATURE]: paymentSigHeader,
+      },
+      body: JSON.stringify({
+        toBtcAddress: RECIPIENT_BTC,
+        toStxAddress: RECIPIENT_STX,
+        content: "Hello from pending test",
+      }),
+    });
+  }
+
+  it("returns 201 (not 202) when relay reports pending without paymentId", async () => {
+    const response = await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    expect(response.status).toBe(201);
+  });
+
+  it("does not create a staged payment record", async () => {
+    await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    expect(mocks.storeStagedInboxPayment).not.toHaveBeenCalled();
+  });
+
+  it("stores the message for immediate delivery", async () => {
+    await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    expect(mocks.storeMessage).toHaveBeenCalledTimes(1);
+    expect(mocks.updateAgentInbox).toHaveBeenCalledTimes(1);
+  });
+
+  it("response body omits paymentId", async () => {
+    const response = await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    const body = (await response.json()) as {
+      success: boolean;
+      inbox: { paymentId?: string; paymentStatus?: string };
+    };
+    expect(body.success).toBe(true);
+    expect(body.inbox).toBeDefined();
+    expect(body.inbox.paymentId).toBeUndefined();
+    expect(body.inbox.paymentStatus).toBe("pending");
+  });
+
+  it("response headers omit X-Payment-Id", async () => {
+    const response = await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    expect(response.headers.get("X-Payment-Id")).toBeNull();
+    expect(response.headers.get("X-Payment-Check-Url")).toBeNull();
+  });
+
+  it("logs the compat fallback warning", async () => {
+    await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+
+    expect(mocks.logPaymentEvent).toHaveBeenCalledWith(
+      mocks.logger,
+      "warn",
+      "payment.fallback_used",
+      expect.any(String),
+      expect.objectContaining({
+        paymentId: null,
+        status: "pending",
+        action: "deliver_immediately_without_payment_id",
+      })
+    );
+  });
+});

--- a/lib/inbox/__tests__/kv-helpers.test.ts
+++ b/lib/inbox/__tests__/kv-helpers.test.ts
@@ -1,13 +1,18 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
+  deleteStagedInboxPayment,
   decrementUnreadCount,
+  finalizeStagedInboxPayment,
   getAgentInbox,
   updateAgentInbox,
+  getStagedInboxPayment,
   storeMessage,
+  storeStagedInboxPayment,
   getMessage,
+  getSentIndex,
 } from "../kv-helpers";
 import type { InboxAgentIndex, InboxMessage } from "../types";
-import { createMockKV } from "./kv-mock";
+import { createMockKV, createMockKVWithOptions } from "./kv-mock";
 
 describe("decrementUnreadCount", () => {
   let kv: KVNamespace;
@@ -162,5 +167,111 @@ describe("reply flow integration test", () => {
     // Assert: unreadCount is now 0
     inbox = await getAgentInbox(kv, recipientBtc);
     expect(inbox?.unreadCount).toBe(0);
+  });
+});
+
+describe("staged inbox payment helpers", () => {
+  it("stores staged inbox payments keyed by paymentId with a TTL", async () => {
+    const { kv, putCalls } = createMockKVWithOptions();
+    const staged = {
+      paymentId: "pay_stage_ttl",
+      createdAt: new Date().toISOString(),
+      message: {
+        messageId: "msg_stage_ttl",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt: new Date().toISOString(),
+        paymentStatus: "pending" as const,
+        paymentId: "pay_stage_ttl",
+      },
+    };
+
+    await storeStagedInboxPayment(kv, staged);
+
+    expect(await getStagedInboxPayment(kv, "pay_stage_ttl")).toEqual(staged);
+    expect(putCalls).toContainEqual(
+      expect.objectContaining({
+        key: "inbox:staged-payment:pay_stage_ttl",
+        options: expect.objectContaining({ expirationTtl: 86400 }),
+      })
+    );
+  });
+
+  it("finalizes a staged inbox payment exactly once on confirmed", async () => {
+    const kv = createMockKV();
+    const now = new Date().toISOString();
+    const stagedMessage: InboxMessage = {
+      messageId: "msg_stage_confirmed",
+      fromAddress: "SP123",
+      toBtcAddress: "bc1recipient",
+      toStxAddress: "SP456",
+      content: "hello",
+      paymentSatoshis: 100,
+      sentAt: now,
+      paymentStatus: "pending",
+      paymentId: "pay_stage_confirmed",
+    };
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_stage_confirmed",
+      createdAt: now,
+      senderSentIndexBtcAddress: "bc1sender",
+      message: stagedMessage,
+    });
+
+    const finalized = await finalizeStagedInboxPayment(kv, "pay_stage_confirmed", {
+      paymentStatus: "confirmed",
+      paymentTxid: "a".repeat(64),
+    });
+
+    expect(finalized?.paymentStatus).toBe("confirmed");
+    expect(finalized?.paymentTxid).toBe("a".repeat(64));
+    expect(await getStagedInboxPayment(kv, "pay_stage_confirmed")).toBeNull();
+    expect(await getMessage(kv, "msg_stage_confirmed")).toEqual(
+      expect.objectContaining({
+        messageId: "msg_stage_confirmed",
+        paymentStatus: "confirmed",
+        paymentTxid: "a".repeat(64),
+      })
+    );
+    expect(await getAgentInbox(kv, "bc1recipient")).toEqual(
+      expect.objectContaining({ messageIds: ["msg_stage_confirmed"], unreadCount: 1 })
+    );
+    expect(await getSentIndex(kv, "bc1sender")).toEqual(
+      expect.objectContaining({ messageIds: ["msg_stage_confirmed"] })
+    );
+
+    const secondFinalize = await finalizeStagedInboxPayment(kv, "pay_stage_confirmed", {
+      paymentStatus: "confirmed",
+    });
+    expect(secondFinalize).toBeNull();
+    expect((await getAgentInbox(kv, "bc1recipient"))?.messageIds).toEqual(["msg_stage_confirmed"]);
+  });
+
+  it("discards staged inbox payments on terminal non-success", async () => {
+    const kv = createMockKV();
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_stage_discard",
+      createdAt: new Date().toISOString(),
+      message: {
+        messageId: "msg_stage_discard",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt: new Date().toISOString(),
+        paymentStatus: "pending",
+        paymentId: "pay_stage_discard",
+      },
+    });
+
+    await deleteStagedInboxPayment(kv, "pay_stage_discard");
+
+    expect(await getStagedInboxPayment(kv, "pay_stage_discard")).toBeNull();
+    expect(await getMessage(kv, "msg_stage_discard")).toBeNull();
   });
 });

--- a/lib/inbox/__tests__/kv-helpers.test.ts
+++ b/lib/inbox/__tests__/kv-helpers.test.ts
@@ -251,6 +251,54 @@ describe("staged inbox payment helpers", () => {
     expect((await getAgentInbox(kv, "bc1recipient"))?.messageIds).toEqual(["msg_stage_confirmed"]);
   });
 
+  it("repairs inbox and sent indexes when the message already exists before staged cleanup", async () => {
+    const kv = createMockKV();
+    const now = new Date().toISOString();
+    const stagedMessage: InboxMessage = {
+      messageId: "msg_stage_repair",
+      fromAddress: "SP123",
+      toBtcAddress: "bc1recipient",
+      toStxAddress: "SP456",
+      content: "hello",
+      paymentSatoshis: 100,
+      sentAt: now,
+      paymentStatus: "pending",
+      paymentId: "pay_stage_repair",
+    };
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_stage_repair",
+      createdAt: now,
+      senderSentIndexBtcAddress: "bc1sender",
+      message: stagedMessage,
+    });
+    await storeMessage(kv, {
+      ...stagedMessage,
+      paymentStatus: "confirmed",
+      paymentTxid: "b".repeat(64),
+    });
+
+    const finalized = await finalizeStagedInboxPayment(kv, "pay_stage_repair", {
+      paymentStatus: "confirmed",
+      paymentTxid: "b".repeat(64),
+    });
+
+    expect(finalized).toEqual(
+      expect.objectContaining({
+        messageId: "msg_stage_repair",
+        paymentStatus: "confirmed",
+        paymentTxid: "b".repeat(64),
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_stage_repair")).toBeNull();
+    expect(await getAgentInbox(kv, "bc1recipient")).toEqual(
+      expect.objectContaining({ messageIds: ["msg_stage_repair"], unreadCount: 1 })
+    );
+    expect(await getSentIndex(kv, "bc1sender")).toEqual(
+      expect.objectContaining({ messageIds: ["msg_stage_repair"] })
+    );
+  });
+
   it("discards staged inbox payments on terminal non-success", async () => {
     const kv = createMockKV();
     await storeStagedInboxPayment(kv, {

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -1,0 +1,374 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+import { getMessage, getStagedInboxPayment, storeStagedInboxPayment } from "@/lib/inbox";
+import { createMockKV } from "./kv-mock";
+import { GET } from "@/app/api/payment-status/[paymentId]/route";
+
+const mocks = vi.hoisted(() => ({
+  getCloudflareContext: vi.fn(),
+  invalidateAgentListCache: vi.fn(),
+  hasAchievement: vi.fn(),
+  grantAchievement: vi.fn(),
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: mocks.getCloudflareContext,
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: mocks.invalidateAgentListCache,
+}));
+
+vi.mock("@/lib/achievements", () => ({
+  hasAchievement: mocks.hasAchievement,
+  grantAchievement: mocks.grantAchievement,
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => mocks.logger,
+  createConsoleLogger: () => mocks.logger,
+  isLogsRPC: () => false,
+}));
+
+describe("payment-status route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasAchievement.mockResolvedValue(true);
+    mocks.grantAchievement.mockResolvedValue(undefined);
+    mocks.invalidateAgentListCache.mockResolvedValue(undefined);
+  });
+
+  it("normalizes submitted to queued in caller-facing payloads", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_submitted_case",
+            status: "submitted",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_submitted_case"),
+      { params: Promise.resolve({ paymentId: "pay_submitted_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_submitted_case",
+        status: "queued",
+      })
+    );
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "payment.fallback_used",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_submitted_case",
+        paymentId: "pay_submitted_case",
+        status: "submitted",
+        action: "collapse_submitted_to_queued",
+        compat_shim_used: true,
+      })
+    );
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.poll",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_submitted_case",
+        paymentId: "pay_submitted_case",
+        status: "queued",
+        action: "continue_polling",
+        checkStatusUrl_present: true,
+      })
+    );
+  });
+
+  it("prefers relay-provided checkStatusUrl when the shared contract includes it", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_hint_case",
+            status: "queued",
+            checkStatusUrl: "https://relay.example/check/pay_hint_case",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_hint_case"),
+      { params: Promise.resolve({ paymentId: "pay_hint_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_hint_case",
+        status: "queued",
+        checkStatusUrl: "https://relay.example/check/pay_hint_case",
+      })
+    );
+  });
+
+  it("falls back to the local payment-status route when relay omits checkStatusUrl", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_local_fallback_case",
+            status: "queued",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_local_fallback_case"),
+      { params: Promise.resolve({ paymentId: "pay_local_fallback_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_local_fallback_case",
+        status: "queued",
+        checkStatusUrl: "/api/payment-status/pay_local_fallback_case",
+      })
+    );
+  });
+
+  it("finalizes staged inbox records on confirmed", async () => {
+    const kv = createMockKV();
+    const sentAt = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_finalize_case",
+      createdAt: sentAt,
+      senderSentIndexBtcAddress: "bc1sender",
+      message: {
+        messageId: "msg_finalize_case",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId: "pay_finalize_case",
+      },
+    });
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_finalize_case",
+            status: "confirmed",
+            txid: "a".repeat(64),
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_finalize_case"),
+      { params: Promise.resolve({ paymentId: "pay_finalize_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_finalize_case",
+        status: "confirmed",
+        txid: "a".repeat(64),
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_finalize_case")).toBeNull();
+    expect(await getMessage(kv, "msg_finalize_case")).toEqual(
+      expect.objectContaining({
+        messageId: "msg_finalize_case",
+        paymentStatus: "confirmed",
+        paymentTxid: "a".repeat(64),
+      })
+    );
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.delivery_confirmed",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_finalize_case",
+        paymentId: "pay_finalize_case",
+        status: "confirmed",
+        action: "finalize_staged_delivery",
+      })
+    );
+  });
+
+  it("discards staged inbox records on terminal non-success states", async () => {
+    const kv = createMockKV();
+    const sentAt = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_discard_case",
+      createdAt: sentAt,
+      message: {
+        messageId: "msg_discard_case",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId: "pay_discard_case",
+      },
+    });
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_discard_case",
+            status: "failed",
+            terminalReason: "sender_nonce_stale",
+            errorCode: "SENDER_NONCE_STALE",
+            error: "stale nonce",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_discard_case"),
+      { params: Promise.resolve({ paymentId: "pay_discard_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_discard_case",
+        status: "failed",
+        terminalReason: "sender_nonce_stale",
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_discard_case")).toBeNull();
+    expect(await getMessage(kv, "msg_discard_case")).toBeNull();
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.delivery_discarded",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_discard_case",
+        paymentId: "pay_discard_case",
+        status: "failed",
+        terminalReason: "sender_nonce_stale",
+        action: "discard_staged_delivery",
+      })
+    );
+  });
+
+  it("logs malformed relay poll payloads before schema parse failure", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_malformed_case",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_malformed_case"),
+      { params: Promise.resolve({ paymentId: "pay_malformed_case" }) }
+    );
+
+    expect(response.status).toBe(500);
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "payment.poll",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_malformed_case",
+        paymentId: "pay_malformed_case",
+        status: "malformed",
+        action: "relay_poll_payload_missing_fields",
+      })
+    );
+  });
+
+  it("finalizes a confirmed staged payment exactly once across repeated polls", async () => {
+    const kv = createMockKV();
+    const sentAt = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_once_case",
+      createdAt: sentAt,
+      senderSentIndexBtcAddress: "bc1sender",
+      message: {
+        messageId: "msg_once_case",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId: "pay_once_case",
+      },
+    });
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_once_case",
+            status: "confirmed",
+            txid: "b".repeat(64),
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_once_case"),
+      { params: Promise.resolve({ paymentId: "pay_once_case" }) }
+    );
+    await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_once_case"),
+      { params: Promise.resolve({ paymentId: "pay_once_case" }) }
+    );
+
+    expect(await getStagedInboxPayment(kv, "pay_once_case")).toBeNull();
+    expect(await getMessage(kv, "msg_once_case")).toEqual(
+      expect.objectContaining({
+        messageId: "msg_once_case",
+        paymentStatus: "confirmed",
+        paymentTxid: "b".repeat(64),
+      })
+    );
+    expect(
+      mocks.logger.info.mock.calls.filter(([message]) => message === "payment.delivery_confirmed")
+    ).toHaveLength(1);
+  });
+});

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -44,6 +44,26 @@ describe("payment-status route", () => {
     mocks.invalidateAgentListCache.mockResolvedValue(undefined);
   });
 
+  async function stagePendingPayment(kv: KVNamespace, paymentId: string, messageId: string) {
+    const sentAt = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId,
+      createdAt: sentAt,
+      message: {
+        messageId,
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId,
+      },
+    });
+  }
+
   it("normalizes submitted to queued in caller-facing payloads", async () => {
     const kv = createMockKV();
     mocks.getCloudflareContext.mockResolvedValue({
@@ -120,6 +140,39 @@ describe("payment-status route", () => {
         paymentId: "pay_hint_case",
         status: "queued",
         checkStatusUrl: "https://relay.example/check/pay_hint_case",
+      })
+    );
+  });
+
+  it("prefers relay-provided checkStatusUrl for canonical not_found responses", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_not_found_hint_case",
+            status: "not_found",
+            terminalReason: "unknown_payment_identity",
+            checkStatusUrl: "https://relay.example/check/pay_not_found_hint_case",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_not_found_hint_case"),
+      { params: Promise.resolve({ paymentId: "pay_not_found_hint_case" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_not_found_hint_case",
+        status: "not_found",
+        terminalReason: "unknown_payment_identity",
+        checkStatusUrl: "https://relay.example/check/pay_not_found_hint_case",
       })
     );
   });
@@ -284,25 +337,64 @@ describe("payment-status route", () => {
     );
   });
 
-  it("returns 404 with the canonical body and discards staged records on not_found", async () => {
+  it("returns HTTP 404 on canonical not_found", async () => {
     const kv = createMockKV();
-    const sentAt = new Date().toISOString();
-
-    await storeStagedInboxPayment(kv, {
-      paymentId: "pay_not_found_case",
-      createdAt: sentAt,
-      message: {
-        messageId: "msg_not_found_case",
-        fromAddress: "SP123",
-        toBtcAddress: "bc1recipient",
-        toStxAddress: "SP456",
-        content: "hello",
-        paymentSatoshis: 100,
-        sentAt,
-        paymentStatus: "pending",
-        paymentId: "pay_not_found_case",
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_not_found_status_case",
+            status: "not_found",
+            terminalReason: "expired",
+          }),
+        },
       },
+      ctx: {},
     });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_not_found_status_case"),
+      { params: Promise.resolve({ paymentId: "pay_not_found_status_case" }) }
+    );
+
+    expect(response.status).toBe(404);
+  });
+
+  it("returns canonical body fields on not_found", async () => {
+    const kv = createMockKV();
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_not_found_body_case",
+            status: "not_found",
+            terminalReason: "expired",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_not_found_body_case"),
+      { params: Promise.resolve({ paymentId: "pay_not_found_body_case" }) }
+    );
+
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_not_found_body_case",
+        status: "not_found",
+        terminalReason: "expired",
+        checkStatusUrl: "/api/payment-status/pay_not_found_body_case",
+      })
+    );
+  });
+
+  it("discards staged inbox records on not_found", async () => {
+    const kv = createMockKV();
+    await stagePendingPayment(kv, "pay_not_found_case", "msg_not_found_case");
 
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
@@ -325,14 +417,6 @@ describe("payment-status route", () => {
     );
 
     expect(response.status).toBe(404);
-    await expect(response.json()).resolves.toEqual(
-      expect.objectContaining({
-        paymentId: "pay_not_found_case",
-        status: "not_found",
-        terminalReason: "expired",
-        checkStatusUrl: "/api/payment-status/pay_not_found_case",
-      })
-    );
     expect(await getStagedInboxPayment(kv, "pay_not_found_case")).toBeNull();
     expect(await getMessage(kv, "msg_not_found_case")).toBeNull();
     expect(mocks.logger.info).toHaveBeenCalledWith(

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -284,6 +284,69 @@ describe("payment-status route", () => {
     );
   });
 
+  it("returns 404 with the canonical body and discards staged records on not_found", async () => {
+    const kv = createMockKV();
+    const sentAt = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_not_found_case",
+      createdAt: sentAt,
+      message: {
+        messageId: "msg_not_found_case",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId: "pay_not_found_case",
+      },
+    });
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_not_found_case",
+            status: "not_found",
+            terminalReason: "expired",
+            error: "Payment pay_not_found_case not found or expired",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_not_found_case"),
+      { params: Promise.resolve({ paymentId: "pay_not_found_case" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_not_found_case",
+        status: "not_found",
+        terminalReason: "expired",
+        checkStatusUrl: "/api/payment-status/pay_not_found_case",
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_not_found_case")).toBeNull();
+    expect(await getMessage(kv, "msg_not_found_case")).toBeNull();
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.delivery_discarded",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_not_found_case",
+        paymentId: "pay_not_found_case",
+        status: "not_found",
+        terminalReason: "expired",
+        action: "discard_staged_delivery",
+      })
+    );
+  });
+
   it("logs malformed relay poll payloads before schema parse failure", async () => {
     const kv = createMockKV();
     mocks.getCloudflareContext.mockResolvedValue({

--- a/lib/inbox/__tests__/relay-rpc.test.ts
+++ b/lib/inbox/__tests__/relay-rpc.test.ts
@@ -210,13 +210,13 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-args-check",
+          paymentId: "pay_args_check",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-args-check",
+          paymentId: "pay_args_check",
           status: "confirmed",
-          txid: "args-txid",
+          txid: "a".repeat(64),
         }),
       };
 
@@ -233,13 +233,13 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-001",
+          paymentId: "pay_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-001",
+          paymentId: "pay_001",
           status: "confirmed",
-          txid: "abc123txid",
+          txid: "a".repeat(64),
           blockHeight: 12345,
         }),
       };
@@ -249,23 +249,23 @@ describe("submitViaRPC", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      expect(result.paymentTxid).toBe("abc123txid");
+      expect(result.paymentTxid).toBe("a".repeat(64));
       expect(result.paymentStatus).toBe("confirmed");
-      expect(result.paymentId).toBe("pay-001");
-      expect(rpc.checkPayment).toHaveBeenCalledWith("pay-001");
+      expect(result.paymentId).toBe("pay_001");
+      expect(rpc.checkPayment).toHaveBeenCalledWith("pay_001");
     });
 
     it("includes paymentId in success result", async () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-002",
+          paymentId: "pay_002",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-002",
+          paymentId: "pay_002",
           status: "confirmed",
-          txid: "txid002",
+          txid: "b".repeat(64),
         }),
       };
 
@@ -274,14 +274,38 @@ describe("submitViaRPC", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      expect(result.paymentId).toBe("pay-002");
+      expect(result.paymentId).toBe("pay_002");
+    });
+
+    it("prefers checkPayment checkStatusUrl over submitPayment hint", async () => {
+      const rpc: RelayRPC = {
+        submitPayment: vi.fn().mockResolvedValue({
+          accepted: true,
+          paymentId: "pay_hint_preferred",
+          status: "queued",
+          checkStatusUrl: "https://relay.example/pay/pay_hint_preferred",
+        }),
+        checkPayment: vi.fn().mockResolvedValue({
+          paymentId: "pay_hint_preferred",
+          status: "confirmed",
+          txid: "1".repeat(64),
+          checkStatusUrl: "https://relay.example/check/pay_hint_preferred",
+        }),
+      };
+
+      const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.checkStatusUrl).toBe("https://relay.example/check/pay_hint_preferred");
     });
 
     it("handles nonce gap warning (accepted=true with warning)", async () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-gap",
+          paymentId: "pay_gap",
           status: "queued_with_warning",
           warning: {
             code: "SENDER_NONCE_GAP",
@@ -292,9 +316,9 @@ describe("submitViaRPC", () => {
           },
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-gap",
+          paymentId: "pay_gap",
           status: "confirmed",
-          txid: "gap-txid",
+          txid: "c".repeat(64),
         }),
       };
 
@@ -304,7 +328,7 @@ describe("submitViaRPC", () => {
 
       // Nonce gap is accepted — should proceed to polling and succeed
       expect(result.success).toBe(true);
-      expect(result.paymentTxid).toBe("gap-txid");
+      expect(result.paymentTxid).toBe("c".repeat(64));
     });
   });
 
@@ -313,11 +337,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-fail-001",
+          paymentId: "pay_fail_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-fail-001",
+          paymentId: "pay_fail_001",
           status: "failed",
           errorCode: "BROADCAST_FAILED",
           error: "tx rejected by mempool",
@@ -338,11 +362,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-fail-002",
+          paymentId: "pay_fail_002",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-fail-002",
+          paymentId: "pay_fail_002",
           status: "failed",
           error: "internal relay error",
         }),
@@ -360,11 +384,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-fail-003",
+          paymentId: "pay_fail_003",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-fail-003",
+          paymentId: "pay_fail_003",
           status: "failed",
         }),
       };
@@ -381,11 +405,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-replaced",
+          paymentId: "pay_replaced",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-replaced",
+          paymentId: "pay_replaced",
           status: "replaced",
           error: "sponsor replaced transaction",
         }),
@@ -403,13 +427,13 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-notfound",
+          paymentId: "pay_notfound",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-notfound",
+          paymentId: "pay_notfound",
           status: "not_found",
-          error: "Payment pay-notfound not found or expired",
+          error: "Payment pay_notfound not found or expired",
         }),
       };
 
@@ -429,11 +453,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-exhaust-001",
+          paymentId: "pay_exhaust_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-exhaust-001",
+          paymentId: "pay_exhaust_001",
           status: "queued",
         }),
       };
@@ -444,8 +468,31 @@ describe("submitViaRPC", () => {
 
       expect(result.success).toBe(true);
       expect(result.paymentStatus).toBe("pending");
-      expect(result.paymentId).toBe("pay-exhaust-001");
+      expect(result.paymentId).toBe("pay_exhaust_001");
       expect(rpc.checkPayment).toHaveBeenCalledTimes(2);
+    });
+
+    it("falls back to submitPayment checkStatusUrl when polling result omits it", async () => {
+      const rpc: RelayRPC = {
+        submitPayment: vi.fn().mockResolvedValue({
+          accepted: true,
+          paymentId: "pay_submit_hint_only",
+          status: "queued",
+          checkStatusUrl: "https://relay.example/pay/pay_submit_hint_only",
+        }),
+        checkPayment: vi.fn().mockResolvedValue({
+          paymentId: "pay_submit_hint_only",
+          status: "queued",
+        }),
+      };
+
+      const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result.success).toBe(true);
+      expect(result.paymentStatus).toBe("pending");
+      expect(result.checkStatusUrl).toBe("https://relay.example/pay/pay_submit_hint_only");
     });
 
     it("returns pending success when all poll attempts return broadcasting", async () => {
@@ -453,11 +500,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-exhaust-002",
+          paymentId: "pay_exhaust_002",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-exhaust-002",
+          paymentId: "pay_exhaust_002",
           status: "broadcasting",
         }),
       };
@@ -477,13 +524,13 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-exhaust-txid",
+          paymentId: "pay_exhaust_txid",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-exhaust-txid",
+          paymentId: "pay_exhaust_txid",
           status: "mempool",
-          txid: "broadcast-but-not-confirmed",
+          txid: "d".repeat(64),
         }),
       };
 
@@ -492,9 +539,9 @@ describe("submitViaRPC", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      expect(result.paymentTxid).toBe("broadcast-but-not-confirmed");
+      expect(result.paymentTxid).toBe("d".repeat(64));
       expect(result.paymentStatus).toBe("pending");
-      expect(result.paymentId).toBe("pay-exhaust-txid");
+      expect(result.paymentId).toBe("pay_exhaust_txid");
     });
 
     it("returns pending success when mempool status has no txid", async () => {
@@ -503,11 +550,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-no-txid",
+          paymentId: "pay_no_txid",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-no-txid",
+          paymentId: "pay_no_txid",
           status: "mempool",
           // no txid yet
         }),
@@ -519,7 +566,7 @@ describe("submitViaRPC", () => {
 
       expect(result.success).toBe(true);
       expect(result.paymentStatus).toBe("pending");
-      expect(result.paymentId).toBe("pay-no-txid");
+      expect(result.paymentId).toBe("pay_no_txid");
       expect(result.paymentTxid).toBeUndefined();
     });
   });
@@ -531,16 +578,16 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-multi-001",
+          paymentId: "pay_multi_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockImplementation(async () => {
           callCount++;
-          if (callCount === 1) return { paymentId: "pay-multi-001", status: "queued" };
+          if (callCount === 1) return { paymentId: "pay_multi_001", status: "queued" };
           return {
-            paymentId: "pay-multi-001",
+            paymentId: "pay_multi_001",
             status: "confirmed",
-            txid: "multi-poll-txid",
+            txid: "e".repeat(64),
             blockHeight: 99999,
           };
         }),
@@ -551,7 +598,7 @@ describe("submitViaRPC", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(true);
-      expect(result.paymentTxid).toBe("multi-poll-txid");
+      expect(result.paymentTxid).toBe("e".repeat(64));
       expect(rpc.checkPayment).toHaveBeenCalledTimes(2);
     });
   });
@@ -574,7 +621,7 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-throw-001",
+          paymentId: "pay_throw_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockRejectedValue(new Error("RPC stream closed")),
@@ -593,13 +640,13 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-log-001",
+          paymentId: "pay_log_001",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-log-001",
+          paymentId: "pay_log_001",
           status: "confirmed",
-          txid: "log-txid",
+          txid: "f".repeat(64),
         }),
       };
 
@@ -613,11 +660,11 @@ describe("submitViaRPC", () => {
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         "RPC: payment queued",
-        expect.objectContaining({ paymentId: "pay-log-001" })
+        expect.objectContaining({ paymentId: "pay_log_001" })
       );
       expect(mockLogger.debug).toHaveBeenCalledWith(
         "RPC: checkPayment",
-        expect.objectContaining({ attempt: 0, paymentId: "pay-log-001", status: "confirmed" })
+        expect.objectContaining({ attempt: 0, paymentId: "pay_log_001", status: "confirmed" })
       );
     });
 
@@ -646,11 +693,11 @@ describe("submitViaRPC", () => {
       const rpc: RelayRPC = {
         submitPayment: vi.fn().mockResolvedValue({
           accepted: true,
-          paymentId: "pay-log-exhaust",
+          paymentId: "pay_log_exhaust",
           status: "queued",
         }),
         checkPayment: vi.fn().mockResolvedValue({
-          paymentId: "pay-log-exhaust",
+          paymentId: "pay_log_exhaust",
           status: "queued",
         }),
       };
@@ -661,7 +708,7 @@ describe("submitViaRPC", () => {
 
       expect(mockLogger.info).toHaveBeenCalledWith(
         "RPC: poll exhausted after relay accepted — treating as pending success",
-        expect.objectContaining({ paymentId: "pay-log-exhaust" })
+        expect.objectContaining({ paymentId: "pay_log_exhaust" })
       );
     });
   });

--- a/lib/inbox/__tests__/x402-verify-rpc.test.ts
+++ b/lib/inbox/__tests__/x402-verify-rpc.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PaymentPayloadV2 } from "x402-stacks";
+import { verifyInboxPayment } from "../x402-verify";
+import type { RelayRPC } from "../relay-rpc";
+import { getSBTCAsset } from "../x402-config";
+import { networkToCAIP2 } from "x402-stacks";
+
+const mocks = vi.hoisted(() => ({
+  submitViaRPC: vi.fn(),
+}));
+
+vi.mock("../relay-rpc", async () => {
+  const actual = await vi.importActual<typeof import("../relay-rpc")>("../relay-rpc");
+  return {
+    ...actual,
+    submitViaRPC: mocks.submitViaRPC,
+  };
+});
+
+vi.mock("@stacks/transactions", () => ({
+  AuthType: { Sponsored: 1 },
+  StacksWireType: { Address: "address" },
+  deserializeTransaction: vi.fn(() => ({
+    auth: {
+      authType: 1,
+      spendingCondition: {
+        hashMode: 0,
+        signer: "00".repeat(20),
+      },
+    },
+  })),
+  addressHashModeToVersion: vi.fn(() => 22),
+  addressToString: vi.fn(() => "SP2SENDERTESTADDRESS"),
+}));
+
+describe("verifyInboxPayment RPC contract", () => {
+  const recipientStxAddress = "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+  const network = "mainnet";
+  const payload = {
+    payload: { transaction: "00" },
+    accepted: { asset: getSBTCAsset(network) },
+    resource: {
+      url: "https://aibtc.com/api/inbox/bc1recipient",
+      network: networkToCAIP2(network),
+    },
+  } as unknown as PaymentPayloadV2;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("preserves relay-owned paymentId and canonical checkStatusUrl from the RPC path", async () => {
+    mocks.submitViaRPC.mockResolvedValue({
+      success: true,
+      paymentStatus: "pending",
+      paymentId: "pay_rpc_hint_case",
+      checkStatusUrl: "https://relay.example/check/pay_rpc_hint_case",
+    });
+
+    const relayRPC = {} as RelayRPC;
+    const result = await verifyInboxPayment(
+      payload,
+      recipientStxAddress,
+      network,
+      "https://relay.example",
+      undefined,
+      undefined,
+      relayRPC
+    );
+
+    expect(result).toMatchObject({
+      success: true,
+      paymentStatus: "pending",
+      paymentId: "pay_rpc_hint_case",
+      checkStatusUrl: "https://relay.example/check/pay_rpc_hint_case",
+    });
+  });
+});

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -91,7 +91,11 @@ export const KV_PREFIXES = {
   REPLY: "inbox:reply:",           // inbox:reply:{messageId} -> OutboxReply
   AGENT_INDEX: "inbox:agent:",     // inbox:agent:{btcAddress} -> InboxAgentIndex
   SENT_INDEX: "inbox:sent:",       // inbox:sent:{btcAddress} -> SentMessageIndex
+  STAGED_PAYMENT: "inbox:staged-payment:", // inbox:staged-payment:{paymentId} -> StagedInboxMessage
 } as const;
+
+/** TTL for staged inbox payment records (24 hours). */
+export const STAGED_PAYMENT_TTL_SECONDS = 24 * 60 * 60;
 
 // --- Circuit breaker constants ---
 

--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -12,6 +12,7 @@ export type {
   InboxAgentIndex,
   SentMessageIndex,
   RelayPaymentStatus,
+  StagedInboxMessage,
   PaymentFailureCache,
 } from "./types";
 
@@ -35,6 +36,7 @@ export {
   RPC_TOTAL_TIMEOUT_MS,
   PAYMENT_FAILURE_CACHE_PREFIX,
   PAYMENT_FAILURE_CACHE_TTL_SECONDS,
+  STAGED_PAYMENT_TTL_SECONDS,
   CACHEABLE_PAYMENT_FAILURE_CODES,
   INBOX_SENDER_RATE_LIMIT_PREFIX,
   INBOX_SENDER_RATE_LIMIT_NORMAL_TTL_SECONDS,
@@ -100,6 +102,10 @@ export {
   updateAgentInbox,
   getSentIndex,
   updateSentIndex,
+  getStagedInboxPayment,
+  storeStagedInboxPayment,
+  deleteStagedInboxPayment,
+  finalizeStagedInboxPayment,
   listInboxMessages,
   listSentMessages,
   decrementUnreadCount,

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -5,12 +5,13 @@
  * and agent inbox indices. Follows the pattern from lib/achievements/kv.ts.
  */
 
-import { KV_PREFIXES } from "./constants";
+import { KV_PREFIXES, STAGED_PAYMENT_TTL_SECONDS } from "./constants";
 import type {
   InboxMessage,
   OutboxReply,
   InboxAgentIndex,
   SentMessageIndex,
+  StagedInboxMessage,
 } from "./types";
 
 /**
@@ -51,6 +52,10 @@ function buildAgentIndexKey(btcAddress: string): string {
  */
 function buildSentIndexKey(btcAddress: string): string {
   return `${KV_PREFIXES.SENT_INDEX}${btcAddress}`;
+}
+
+function buildStagedPaymentKey(paymentId: string): string {
+  return `${KV_PREFIXES.STAGED_PAYMENT}${paymentId}`;
 }
 
 /**
@@ -318,6 +323,70 @@ export async function updateSentIndex(
   }
 
   await kv.put(key, JSON.stringify(index));
+}
+
+export async function getStagedInboxPayment(
+  kv: KVNamespace,
+  paymentId: string
+): Promise<StagedInboxMessage | null> {
+  const data = await kv.get(buildStagedPaymentKey(paymentId));
+  if (!data) return null;
+
+  try {
+    return JSON.parse(data) as StagedInboxMessage;
+  } catch (e) {
+    console.error(`Failed to parse staged inbox payment ${paymentId}:`, e);
+    return null;
+  }
+}
+
+export async function storeStagedInboxPayment(
+  kv: KVNamespace,
+  staged: StagedInboxMessage
+): Promise<void> {
+  await kv.put(buildStagedPaymentKey(staged.paymentId), JSON.stringify(staged), {
+    expirationTtl: STAGED_PAYMENT_TTL_SECONDS,
+  });
+}
+
+export async function deleteStagedInboxPayment(
+  kv: KVNamespace,
+  paymentId: string
+): Promise<void> {
+  await kv.delete(buildStagedPaymentKey(paymentId));
+}
+
+export async function finalizeStagedInboxPayment(
+  kv: KVNamespace,
+  paymentId: string,
+  updates: Partial<InboxMessage> = {}
+): Promise<InboxMessage | null> {
+  const staged = await getStagedInboxPayment(kv, paymentId);
+  if (!staged) return null;
+
+  const existingMessage = await getMessage(kv, staged.message.messageId);
+  if (existingMessage) {
+    await deleteStagedInboxPayment(kv, paymentId);
+    return existingMessage;
+  }
+
+  const finalizedMessage: InboxMessage = {
+    ...staged.message,
+    ...updates,
+    paymentStatus: "confirmed",
+    paymentId,
+  };
+
+  await Promise.all([
+    storeMessage(kv, finalizedMessage),
+    updateAgentInbox(kv, finalizedMessage.toBtcAddress, finalizedMessage.messageId, finalizedMessage.sentAt),
+    ...(staged.senderSentIndexBtcAddress
+      ? [updateSentIndex(kv, staged.senderSentIndexBtcAddress, finalizedMessage.messageId, finalizedMessage.sentAt)]
+      : []),
+  ]);
+
+  await deleteStagedInboxPayment(kv, paymentId);
+  return finalizedMessage;
 }
 
 /**

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -366,10 +366,25 @@ export async function finalizeStagedInboxPayment(
 
   const existingMessage = await getMessage(kv, staged.message.messageId);
   if (existingMessage) {
+    // KV doesn't give us cross-key transactions here. If a prior finalize stored the
+    // message but crashed before repairing indexes, rebuild them idempotently now.
+    await Promise.all([
+      updateAgentInbox(
+        kv,
+        existingMessage.toBtcAddress,
+        existingMessage.messageId,
+        existingMessage.sentAt
+      ),
+      ...(staged.senderSentIndexBtcAddress
+        ? [updateSentIndex(kv, staged.senderSentIndexBtcAddress, existingMessage.messageId, existingMessage.sentAt)]
+        : []),
+    ]);
     await deleteStagedInboxPayment(kv, paymentId);
     return existingMessage;
   }
 
+  // This remains best-effort under concurrent polls because Workers KV cannot atomically
+  // read/write the staged record, message body, and both indexes in one transaction.
   const finalizedMessage: InboxMessage = {
     ...staged.message,
     ...updates,

--- a/lib/inbox/payment-contract.ts
+++ b/lib/inbox/payment-contract.ts
@@ -1,3 +1,5 @@
+import { TrackedPaymentStateSchema } from "@aibtc/tx-schemas/core";
+
 export interface SubmittedStatusRecord {
   paymentId: string | null;
   status: "submitted";
@@ -7,6 +9,15 @@ export function collapseSubmittedStatus(
   raw: unknown,
   onSubmitted?: (record: SubmittedStatusRecord) => void
 ): unknown {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "status" in raw &&
+    TrackedPaymentStateSchema.safeParse((raw as { status?: unknown }).status).success
+  ) {
+    return raw;
+  }
+
   if (
     raw &&
     typeof raw === "object" &&

--- a/lib/inbox/payment-contract.ts
+++ b/lib/inbox/payment-contract.ts
@@ -1,0 +1,37 @@
+export interface SubmittedStatusRecord {
+  paymentId: string | null;
+  status: "submitted";
+}
+
+export function collapseSubmittedStatus(
+  raw: unknown,
+  onSubmitted?: (record: SubmittedStatusRecord) => void
+): unknown {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "status" in raw &&
+    (raw as { status?: unknown }).status === "submitted"
+  ) {
+    const rawRecord = raw as Record<string, unknown>;
+    onSubmitted?.({
+      paymentId:
+        typeof rawRecord.paymentId === "string" ? rawRecord.paymentId : null,
+      status: "submitted",
+    });
+    return {
+      ...raw,
+      status: "queued",
+    };
+  }
+
+  return raw;
+}
+
+export function selectCanonicalCheckStatusUrl(
+  ...candidates: Array<string | undefined>
+): string | undefined {
+  return candidates.find(
+    (candidate) => typeof candidate === "string" && candidate.length > 0
+  );
+}

--- a/lib/inbox/payment-logging.ts
+++ b/lib/inbox/payment-logging.ts
@@ -1,0 +1,82 @@
+import packageJson from "../../package.json";
+import type { Logger } from "@/lib/logging";
+
+export type PaymentEventName =
+  | "payment.required"
+  | "payment.accepted"
+  | "payment.poll"
+  | "payment.delivery_staged"
+  | "payment.delivery_confirmed"
+  | "payment.delivery_discarded"
+  | "payment.retry_decision"
+  | "payment.fallback_used";
+
+export type PaymentLogLevel = "debug" | "info" | "warn" | "error";
+
+export interface PaymentLogMetadata {
+  route: string;
+  paymentId?: string | null;
+  status?: string | null;
+  terminalReason?: string | null;
+  action?: string | null;
+  checkStatusUrl?: string | null;
+  compatShimUsed?: boolean;
+  additionalContext?: Record<string, unknown>;
+}
+
+export function getPaymentRepoVersion(env?: Record<string, unknown>): string {
+  const deploySha =
+    typeof env?.DEPLOY_SHA === "string" && env.DEPLOY_SHA.length > 0
+      ? env.DEPLOY_SHA
+      : typeof env?.CF_PAGES_COMMIT_SHA === "string" && env.CF_PAGES_COMMIT_SHA.length > 0
+        ? env.CF_PAGES_COMMIT_SHA
+        : undefined;
+
+  return deploySha ?? packageJson.version;
+}
+
+export function buildPaymentLogContext(
+  repoVersion: string,
+  metadata: PaymentLogMetadata
+): Record<string, unknown> {
+  return {
+    service: "landing-page",
+    route: metadata.route,
+    paymentId: metadata.paymentId ?? null,
+    status: metadata.status ?? null,
+    terminalReason: metadata.terminalReason ?? null,
+    action: metadata.action ?? null,
+    checkStatusUrl_present: Boolean(metadata.checkStatusUrl),
+    compat_shim_used: metadata.compatShimUsed ?? false,
+    repo_version: repoVersion,
+    ...metadata.additionalContext,
+  };
+}
+
+export function logPaymentEvent(
+  logger: Logger,
+  level: PaymentLogLevel,
+  event: PaymentEventName,
+  repoVersion: string,
+  metadata: PaymentLogMetadata
+): void {
+  logger[level](event, buildPaymentLogContext(repoVersion, metadata));
+}
+
+export function summarizeRelayPollPayload(raw: unknown): Record<string, unknown> {
+  if (!raw || typeof raw !== "object") {
+    return {
+      rawType: raw === null ? "null" : typeof raw,
+    };
+  }
+
+  const record = raw as Record<string, unknown>;
+  return {
+    rawType: "object",
+    rawKeys: Object.keys(record).sort(),
+    rawStatus:
+      typeof record.status === "string" ? record.status : null,
+    rawPaymentId:
+      typeof record.paymentId === "string" ? record.paymentId : null,
+  };
+}

--- a/lib/inbox/payment-logging.ts
+++ b/lib/inbox/payment-logging.ts
@@ -24,7 +24,12 @@ export interface PaymentLogMetadata {
   additionalContext?: Record<string, unknown>;
 }
 
-export function getPaymentRepoVersion(env?: Record<string, unknown>): string {
+export interface PaymentRepoVersionEnv {
+  DEPLOY_SHA?: string;
+  CF_PAGES_COMMIT_SHA?: string;
+}
+
+export function getPaymentRepoVersion(env?: PaymentRepoVersionEnv): string {
   const deploySha =
     typeof env?.DEPLOY_SHA === "string" && env.DEPLOY_SHA.length > 0
       ? env.DEPLOY_SHA

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -36,8 +36,8 @@ export type RelayCheckResult = z.infer<typeof RpcCheckPaymentResultSchema>;
  * Must match the actual relay WorkerEntrypoint method signatures.
  */
 export interface RelayRPC {
-  submitPayment(txHex: string, settle?: RelaySettleOptions): Promise<unknown>;
-  checkPayment(paymentId: string): Promise<unknown>;
+  submitPayment(txHex: string, settle?: RelaySettleOptions): Promise<RelaySubmitResult>;
+  checkPayment(paymentId: string): Promise<RelayCheckResult>;
   getSponsorStatus?(): Promise<SponsorStatusResult>;
 }
 
@@ -143,6 +143,7 @@ export async function submitViaRPC(
   log: Logger
 ): Promise<InboxPaymentVerification> {
   const deadline = Date.now() + RPC_TOTAL_TIMEOUT_MS;
+  let submitCheckStatusUrl: string | undefined;
 
   // Step 1: Submit the payment to the relay queue
   log.debug("RPC: submitting payment", { transaction: txHex.slice(0, 16) + "..." });
@@ -178,6 +179,7 @@ export async function submitViaRPC(
     status: submitResult.status,
     ...(submitResult.warning && { warning: submitResult.warning.code }),
   });
+  submitCheckStatusUrl = submitResult.checkStatusUrl;
 
   // Step 2: Poll for settlement result (bounded by both attempt count and total deadline)
   let lastCheckResult: RelayCheckResult | undefined;
@@ -196,22 +198,25 @@ export async function submitViaRPC(
     log.debug("RPC: checkPayment", { attempt, paymentId, status: checkResult.status });
 
     if (checkResult.status === "confirmed") {
+      const checkStatusUrl = selectCanonicalCheckStatusUrl(
+        checkResult.checkStatusUrl,
+        submitCheckStatusUrl
+      );
       return {
         success: true,
         paymentTxid: checkResult.txid || "",
         paymentStatus: "confirmed",
         paymentId,
-        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
-          checkStatusUrl: selectCanonicalCheckStatusUrl(
-            checkResult.checkStatusUrl,
-            submitResult.checkStatusUrl
-          ),
-        }),
+        ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
       };
     }
 
     if (checkResult.status === "failed" || checkResult.status === "replaced") {
+      const checkStatusUrl = selectCanonicalCheckStatusUrl(
+        checkResult.checkStatusUrl,
+        submitCheckStatusUrl
+      );
       const errorCode = mapTerminalOutcome(checkResult);
       log.warn("RPC: payment failed", {
         paymentId,
@@ -225,12 +230,7 @@ export async function submitViaRPC(
         error: checkResult.error || `Payment ${checkResult.status}`,
         errorCode,
         paymentId,
-        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
-          checkStatusUrl: selectCanonicalCheckStatusUrl(
-            checkResult.checkStatusUrl,
-            submitResult.checkStatusUrl
-          ),
-        }),
+        ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
         ...(checkResult.txid && { paymentTxid: checkResult.txid }),
         ...(checkResult.errorCode != null && { relayCode: checkResult.errorCode }),
@@ -239,18 +239,17 @@ export async function submitViaRPC(
     }
 
     if (checkResult.status === "not_found") {
+      const checkStatusUrl = selectCanonicalCheckStatusUrl(
+        checkResult.checkStatusUrl,
+        submitCheckStatusUrl
+      );
       log.warn("RPC: payment not found", { paymentId });
       return {
         success: false,
         error: "Payment not found in relay — it may have expired.",
         errorCode: "RELAY_ERROR",
         paymentId,
-        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
-          checkStatusUrl: selectCanonicalCheckStatusUrl(
-            checkResult.checkStatusUrl,
-            submitResult.checkStatusUrl
-          ),
-        }),
+        ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
       };
     }
@@ -267,6 +266,10 @@ export async function submitViaRPC(
   // return pending success — the relay has it and will eventually settle.
   const lastStatus = lastCheckResult?.status;
   if (!lastStatus || PENDING_STATUSES.has(lastStatus)) {
+    const checkStatusUrl = selectCanonicalCheckStatusUrl(
+      lastCheckResult?.checkStatusUrl,
+      submitCheckStatusUrl
+    );
     log.info("RPC: poll exhausted after relay accepted — treating as pending success", {
       paymentId,
       lastStatus: lastStatus ?? "none",
@@ -276,12 +279,7 @@ export async function submitViaRPC(
       success: true,
       paymentStatus: "pending",
       paymentId,
-      ...(selectCanonicalCheckStatusUrl(lastCheckResult?.checkStatusUrl, submitResult.checkStatusUrl) && {
-        checkStatusUrl: selectCanonicalCheckStatusUrl(
-          lastCheckResult?.checkStatusUrl,
-          submitResult.checkStatusUrl
-        ),
-      }),
+      ...(checkStatusUrl && { checkStatusUrl }),
       ...(lastCheckResult?.txid && { paymentTxid: lastCheckResult.txid }),
     };
   }
@@ -292,17 +290,16 @@ export async function submitViaRPC(
     lastStatus,
     attempts: RPC_POLL_MAX_ATTEMPTS,
   });
+  const checkStatusUrl = selectCanonicalCheckStatusUrl(
+    lastCheckResult?.checkStatusUrl,
+    submitCheckStatusUrl
+  );
   return {
     success: false,
     error: "RPC poll timed out waiting for settlement. Recover via paymentTxid.",
     errorCode: "SETTLEMENT_TIMEOUT",
     paymentId,
-    ...(selectCanonicalCheckStatusUrl(lastCheckResult?.checkStatusUrl, submitResult.checkStatusUrl) && {
-      checkStatusUrl: selectCanonicalCheckStatusUrl(
-        lastCheckResult?.checkStatusUrl,
-        submitResult.checkStatusUrl
-      ),
-    }),
+    ...(checkStatusUrl && { checkStatusUrl }),
     ...(lastCheckResult?.txid && { paymentTxid: lastCheckResult.txid }),
   };
 }

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -1,87 +1,43 @@
 /**
- * RPC type definitions and helpers for the X402_RELAY service binding.
+ * RPC helpers for the X402_RELAY service binding.
  *
- * These interfaces match the RelayRPC WorkerEntrypoint exposed by the
- * x402-sponsor-relay worker (x402Stacks/x402-sponsor-relay).
- * Source of truth: x402-sponsor-relay/src/rpc.ts
- *
- * submitViaRPC() replaces the HTTP fetch path in verifyInboxPayment()
- * when a service binding is available, using submitPayment() + polling
- * checkPayment() to eliminate nonce contention from synchronous relay calls.
+ * Caller-facing relay contracts come from `@aibtc/tx-schemas`; this file
+ * only adapts them into the inbox route's legacy success/error envelope.
  */
 
+import {
+  RpcCheckPaymentResultSchema,
+  RpcSenderNonceInfoSchema,
+  RpcSettleOptionsSchema,
+  RpcSubmitPaymentResultSchema,
+} from "@aibtc/tx-schemas/rpc";
+import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
+import type { z } from "zod";
 import type { Logger } from "../logging";
 import type { SponsorStatusResult } from "../sponsor/types";
 import type { InboxPaymentErrorCode, InboxPaymentVerification } from "./x402-verify";
+import {
+  collapseSubmittedStatus,
+  selectCanonicalCheckStatusUrl,
+} from "./payment-contract";
 import {
   RPC_POLL_INTERVAL_MS,
   RPC_POLL_MAX_ATTEMPTS,
   RPC_TOTAL_TIMEOUT_MS,
 } from "./constants";
 
-// ---------------------------------------------------------------------------
-// Types matching x402-sponsor-relay/src/rpc.ts SubmitPaymentResult
-// ---------------------------------------------------------------------------
-
-/** Settlement options passed to submitPayment (mirrors relay SettleOptions). */
-export interface RelaySettleOptions {
-  expectedRecipient: string;
-  minAmount: string;
-  tokenType?: string;
-  expectedSender?: string;
-  maxTimeoutSeconds?: number;
-}
-
-/** Sender nonce health info returned by the relay. */
-export interface RelaySenderNonceInfo {
-  provided: number;
-  expected: number;
-  healthy: boolean;
-  warning?: string;
-}
-
-/** Response from RelayRPC.submitPayment(). Mirrors SubmitPaymentResult. */
-export interface RelaySubmitResult {
-  accepted: boolean;
-  paymentId?: string;
-  status?: string;
-  senderNonce?: RelaySenderNonceInfo;
-  warning?: {
-    code: string;
-    detail: string;
-    senderNonce: { provided: number; expected: number; lastSeen: number };
-    help: string;
-    action: string;
-  };
-  error?: string;
-  code?: string;
-  retryable?: boolean;
-  help?: string;
-  action?: string;
-  checkStatusUrl?: string;
-}
-
-/** Response from RelayRPC.checkPayment(). Mirrors CheckPaymentResult. */
-export interface RelayCheckResult {
-  paymentId: string;
-  status: string;
-  txid?: string;
-  blockHeight?: number;
-  confirmedAt?: string;
-  explorerUrl?: string;
-  error?: string;
-  errorCode?: string;
-  retryable?: boolean;
-  senderNonceInfo?: RelaySenderNonceInfo;
-}
+export type RelaySettleOptions = z.infer<typeof RpcSettleOptionsSchema>;
+export type RelaySenderNonceInfo = z.infer<typeof RpcSenderNonceInfoSchema>;
+export type RelaySubmitResult = z.infer<typeof RpcSubmitPaymentResultSchema>;
+export type RelayCheckResult = z.infer<typeof RpcCheckPaymentResultSchema>;
 
 /**
  * Typed interface for the X402_RELAY service binding RPC methods.
  * Must match the actual relay WorkerEntrypoint method signatures.
  */
 export interface RelayRPC {
-  submitPayment(txHex: string, settle?: RelaySettleOptions): Promise<RelaySubmitResult>;
-  checkPayment(paymentId: string): Promise<RelayCheckResult>;
+  submitPayment(txHex: string, settle?: RelaySettleOptions): Promise<unknown>;
+  checkPayment(paymentId: string): Promise<unknown>;
   getSponsorStatus?(): Promise<SponsorStatusResult>;
 }
 
@@ -124,7 +80,51 @@ export function mapRPCErrorCode(
 }
 
 /** In-progress statuses where we keep polling. */
-const PENDING_STATUSES = new Set(["queued", "submitted", "broadcasting", "mempool"]);
+const PENDING_STATUSES = new Set(["queued", "broadcasting", "mempool"]);
+
+const TERMINAL_REASON_ERROR_CODE_MAP: Partial<Record<TerminalReason, InboxPaymentErrorCode>> = {
+  invalid_transaction: "PAYMENT_REJECTED",
+  not_sponsored: "PAYMENT_REJECTED",
+  sender_nonce_stale: "SENDER_NONCE_STALE",
+  sender_nonce_gap: "SENDER_NONCE_GAP",
+  sender_nonce_duplicate: "SENDER_NONCE_DUPLICATE",
+  queue_unavailable: "RELAY_ERROR",
+  sponsor_failure: "RELAY_ERROR",
+  broadcast_failure: "BROADCAST_FAILED",
+  chain_abort: "SETTLEMENT_FAILED",
+  internal_error: "RELAY_ERROR",
+};
+
+function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "accepted" in raw &&
+    (raw as { accepted?: unknown }).accepted === false &&
+    !("error" in raw)
+  ) {
+    return RpcSubmitPaymentResultSchema.parse({
+      ...raw,
+      error: "Payment submission rejected by relay",
+    });
+  }
+
+  return RpcSubmitPaymentResultSchema.parse(raw);
+}
+
+function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
+  return RpcCheckPaymentResultSchema.parse(collapseSubmittedStatus(raw));
+}
+
+function mapTerminalOutcome(
+  checkResult: RelayCheckResult
+): InboxPaymentErrorCode {
+  if (checkResult.terminalReason) {
+    return TERMINAL_REASON_ERROR_CODE_MAP[checkResult.terminalReason] ?? "RELAY_ERROR";
+  }
+
+  return mapRPCErrorCode(checkResult.errorCode);
+}
 
 /**
  * Submit a sponsored payment via RPC service binding and poll for settlement.
@@ -146,7 +146,7 @@ export async function submitViaRPC(
 
   // Step 1: Submit the payment to the relay queue
   log.debug("RPC: submitting payment", { transaction: txHex.slice(0, 16) + "..." });
-  const submitResult = await rpc.submitPayment(txHex, settle);
+  const submitResult = parseSubmitPaymentResult(await rpc.submitPayment(txHex, settle));
 
   if (!submitResult.accepted) {
     const errorCode = mapRPCErrorCode(submitResult.code);
@@ -191,7 +191,7 @@ export async function submitViaRPC(
       await new Promise<void>((resolve) => setTimeout(resolve, RPC_POLL_INTERVAL_MS));
     }
 
-    const checkResult = await rpc.checkPayment(paymentId);
+    const checkResult = parseCheckPaymentResult(await rpc.checkPayment(paymentId));
     lastCheckResult = checkResult;
     log.debug("RPC: checkPayment", { attempt, paymentId, status: checkResult.status });
 
@@ -201,14 +201,22 @@ export async function submitViaRPC(
         paymentTxid: checkResult.txid || "",
         paymentStatus: "confirmed",
         paymentId,
+        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
+          checkStatusUrl: selectCanonicalCheckStatusUrl(
+            checkResult.checkStatusUrl,
+            submitResult.checkStatusUrl
+          ),
+        }),
+        ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
       };
     }
 
     if (checkResult.status === "failed" || checkResult.status === "replaced") {
-      const errorCode = mapRPCErrorCode(checkResult.errorCode);
+      const errorCode = mapTerminalOutcome(checkResult);
       log.warn("RPC: payment failed", {
         paymentId,
         status: checkResult.status,
+        terminalReason: checkResult.terminalReason,
         errorCode: checkResult.errorCode,
         error: checkResult.error,
       });
@@ -217,6 +225,13 @@ export async function submitViaRPC(
         error: checkResult.error || `Payment ${checkResult.status}`,
         errorCode,
         paymentId,
+        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
+          checkStatusUrl: selectCanonicalCheckStatusUrl(
+            checkResult.checkStatusUrl,
+            submitResult.checkStatusUrl
+          ),
+        }),
+        ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
         ...(checkResult.txid && { paymentTxid: checkResult.txid }),
         ...(checkResult.errorCode != null && { relayCode: checkResult.errorCode }),
         ...(checkResult.error && { relayDetail: checkResult.error }),
@@ -230,10 +245,17 @@ export async function submitViaRPC(
         error: "Payment not found in relay — it may have expired.",
         errorCode: "RELAY_ERROR",
         paymentId,
+        ...(selectCanonicalCheckStatusUrl(checkResult.checkStatusUrl, submitResult.checkStatusUrl) && {
+          checkStatusUrl: selectCanonicalCheckStatusUrl(
+            checkResult.checkStatusUrl,
+            submitResult.checkStatusUrl
+          ),
+        }),
+        ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
       };
     }
 
-    // status is "queued", "submitted", "broadcasting", "mempool" — keep polling
+    // status is "queued", "broadcasting", or "mempool" — keep polling
     if (!PENDING_STATUSES.has(checkResult.status)) {
       log.warn("RPC: unexpected status", { paymentId, status: checkResult.status });
     }
@@ -254,6 +276,12 @@ export async function submitViaRPC(
       success: true,
       paymentStatus: "pending",
       paymentId,
+      ...(selectCanonicalCheckStatusUrl(lastCheckResult?.checkStatusUrl, submitResult.checkStatusUrl) && {
+        checkStatusUrl: selectCanonicalCheckStatusUrl(
+          lastCheckResult?.checkStatusUrl,
+          submitResult.checkStatusUrl
+        ),
+      }),
       ...(lastCheckResult?.txid && { paymentTxid: lastCheckResult.txid }),
     };
   }
@@ -269,6 +297,12 @@ export async function submitViaRPC(
     error: "RPC poll timed out waiting for settlement. Recover via paymentTxid.",
     errorCode: "SETTLEMENT_TIMEOUT",
     paymentId,
+    ...(selectCanonicalCheckStatusUrl(lastCheckResult?.checkStatusUrl, submitResult.checkStatusUrl) && {
+      checkStatusUrl: selectCanonicalCheckStatusUrl(
+        lastCheckResult?.checkStatusUrl,
+        submitResult.checkStatusUrl
+      ),
+    }),
     ...(lastCheckResult?.txid && { paymentTxid: lastCheckResult.txid }),
   };
 }

--- a/lib/inbox/types.ts
+++ b/lib/inbox/types.ts
@@ -19,7 +19,7 @@ export interface InboxMessage {
   toBtcAddress: string;
   toStxAddress: string;
   content: string;
-  /** On-chain transaction ID. Absent when paymentStatus is "pending" (poll exhausted before confirmation). */
+  /** On-chain transaction ID. Absent while a relay-accepted payment is still staged pending confirmation. */
   paymentTxid?: string;
   paymentSatoshis: number;
   sentAt: string;
@@ -53,10 +53,12 @@ export interface InboxMessage {
   /**
    * Payment settlement status from the x402 relay.
    * "confirmed" = relay confirmed the transaction on-chain.
-   * "pending" = relay timed out but the transaction was broadcast (will eventually confirm).
+   * "pending" = relay accepted the payment and the message is still staged locally.
    * Absent for messages delivered via txid recovery path.
    */
   paymentStatus?: RelayPaymentStatus;
+  /** Relay-owned payment identity for staged or confirmed RPC-backed deliveries. */
+  paymentId?: string;
   /**
    * Relay receipt ID for polling final confirmation when paymentStatus is "pending".
    * Can be used with the relay's /verify/:receiptId endpoint.
@@ -67,9 +69,19 @@ export interface InboxMessage {
 /**
  * Settlement status reported by the x402 relay.
  * - "confirmed": relay confirmed the transaction on-chain.
- * - "pending": relay timed out but the transaction was broadcast (will eventually confirm).
+ * - "pending": relay accepted the payment but the app has not delivered it yet.
  */
 export type RelayPaymentStatus = "confirmed" | "pending";
+
+/**
+ * Provisional inbox record staged locally until the relay reaches `confirmed`.
+ */
+export interface StagedInboxMessage {
+  paymentId: string;
+  message: InboxMessage;
+  senderSentIndexBtcAddress?: string;
+  createdAt: string;
+}
 
 /**
  * An outbox reply record stored at `inbox:reply:{messageId}`.

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -726,7 +726,7 @@ export async function verifyInboxPayment(
 
   // Extract payer address and transaction ID
   const payerStxAddress = settleResult.payer;
-  const paymentTxid = settleResult.transaction;
+  const paymentTxid = settleResult.transaction || undefined;
 
   if (!payerStxAddress) {
     log.error("Settlement succeeded but no payer address");

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -27,6 +27,10 @@ import {
   DEFAULT_RELAY_URL,
 } from "./x402-config";
 import {
+  getPaymentRepoVersion,
+  logPaymentEvent,
+} from "./payment-logging";
+import {
   INBOX_PRICE_SATS,
   RELAY_SETTLE_TIMEOUT_MS,
   SBTC_CONTRACTS,
@@ -49,6 +53,7 @@ import { submitViaRPC } from "./relay-rpc";
 import type { Logger } from "../logging";
 import { stacksApiFetch, buildHiroHeaders, parseRetryAfterMs } from "../stacks-api-fetch";
 import { getCachedTransaction, setCachedTransaction } from "../identity/kv-cache";
+import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
 
 const NOOP_LOGGER: Logger = {
   debug: () => {},
@@ -132,10 +137,14 @@ export interface InboxPaymentVerification {
   relayCode?: string;
   /** Raw error detail or message from the relay, for agent diagnostics. */
   relayDetail?: string;
+  /** Canonical terminal reason from the relay when the terminal outcome is known. */
+  terminalReason?: TerminalReason;
+  /** Canonical polling hint from the relay when it exposes one. */
+  checkStatusUrl?: string;
   settleResult?: SettlementResponseV2;
-  /** Settlement status from relay: "confirmed" when tx is final, "pending" when relay timed out but tx was broadcast. */
+  /** Compatibility status for inbox callers: confirmed is deliverable, pending means staged only. */
   paymentStatus?: RelayPaymentStatus;
-  /** Relay receipt ID for polling final confirmation when paymentStatus is "pending". */
+  /** Legacy relay receipt identifier from the HTTP fallback path. */
   receiptId?: string;
   /** Seconds to wait before retrying (only set for retryable errors like NONCE_CONFLICT). */
   retryAfterSeconds?: number;
@@ -311,9 +320,27 @@ export async function verifyInboxPayment(
   relayUrl: string = DEFAULT_RELAY_URL,
   logger?: Logger,
   kv?: KVNamespace,
-  relayRPC?: RelayRPC
+  relayRPC?: RelayRPC,
+  observability?: { route: string; repoVersion?: string; env?: Record<string, unknown> }
 ): Promise<InboxPaymentVerification> {
   const log = logger || NOOP_LOGGER;
+  const repoVersion =
+    observability?.repoVersion ?? getPaymentRepoVersion(observability?.env);
+
+  const emitPaymentEvent = (
+    level: "debug" | "info" | "warn" | "error",
+    event:
+      | "payment.accepted"
+      | "payment.retry_decision"
+      | "payment.fallback_used",
+    metadata: Omit<Parameters<typeof logPaymentEvent>[4], "route">
+  ) => {
+    if (!observability) return;
+    logPaymentEvent(log, level, event, repoVersion, {
+      route: observability.route,
+      ...metadata,
+    });
+  };
 
   // Helper: cache a payment failure before returning the result.
   // Consolidates the cache-write logic that was previously scattered across
@@ -452,6 +479,8 @@ export async function verifyInboxPayment(
   let relayPaymentStatus: RelayPaymentStatus | undefined;
   let relayReceiptId: string | undefined;
   let relayPaymentId: string | undefined;
+  let relayCheckStatusUrl: string | undefined;
+  let relayTerminalReason: TerminalReason | undefined;
 
   if (isSponsored) {
     log.debug("Routing sponsored transaction to relay", {
@@ -495,11 +524,17 @@ export async function verifyInboxPayment(
         };
         relayPaymentStatus = rpcResult.paymentStatus;
         relayPaymentId = rpcResult.paymentId;
+        relayCheckStatusUrl = rpcResult.checkStatusUrl;
+        relayTerminalReason = rpcResult.terminalReason;
       } catch (error) {
         return handleRelayException("RPC relay", error, log, kv);
       }
     } else {
       // --- HTTP fallback path: original fetch() logic ---
+      emitPaymentEvent("warn", "payment.fallback_used", {
+        action: "http_relay_fallback",
+        status: "fallback",
+      });
 
       const relayBody = JSON.stringify({
         transaction: paymentPayload.payload.transaction,
@@ -538,12 +573,28 @@ export async function verifyInboxPayment(
           if (relayError.retryable && RELAY_RETRYABLE_CODES.has(relayError.code ?? "")) {
             const waitMs = Math.min((relayError.retryAfter ?? 0) * 1000, 15_000);
             if (waitMs >= 15_000) {
+              emitPaymentEvent("warn", "payment.retry_decision", {
+                status: relayError.code ?? null,
+                action: "skip_retry_due_to_backoff_budget",
+                additionalContext: {
+                  retryAfterSeconds: relayError.retryAfter ?? null,
+                  waitMs,
+                },
+              });
               log.warn("Relay retryAfter >= 15s — skipping retry to avoid timeout", {
                 code: relayError.code,
                 retryAfter: relayError.retryAfter,
               });
               // Fall through to the non-ok handler below with the original errorBody
             } else {
+              emitPaymentEvent("info", "payment.retry_decision", {
+                status: relayError.code ?? null,
+                action: waitMs > 0 ? "retry_after_backoff" : "retry_immediately",
+                additionalContext: {
+                  retryAfterSeconds: relayError.retryAfter ?? null,
+                  waitMs,
+                },
+              });
               if (waitMs > 0) {
                 log.warn("Relay returned retryable nonce error, waiting before retry", {
                   code: relayError.code,
@@ -595,6 +646,7 @@ export async function verifyInboxPayment(
           txid?: string;
           receiptId?: string;
           code?: string;
+          terminalReason?: TerminalReason;
           error?: string;
           retryAfter?: number;
           details?: string;
@@ -615,6 +667,7 @@ export async function verifyInboxPayment(
             success: false,
             error: relayData.error || "Relay settlement failed",
             errorCode: mappedCode,
+            ...(relayData.terminalReason && { terminalReason: relayData.terminalReason }),
             relayCode: relayData.code,
             ...((relayData.details || relayData.error) && { relayDetail: relayData.details || relayData.error }),
             ...(relayData.retryAfter != null && { retryAfterSeconds: relayData.retryAfter }),
@@ -696,6 +749,11 @@ export async function verifyInboxPayment(
     recipientStxAddress,
     paymentStatus: relayPaymentStatus,
   });
+  emitPaymentEvent("info", "payment.accepted", {
+    paymentId: relayPaymentId ?? null,
+    status: relayPaymentStatus ?? "confirmed",
+    action: relayPaymentStatus === "pending" ? "stage_delivery" : "deliver_immediately",
+  });
 
   return {
     success: true,
@@ -703,6 +761,8 @@ export async function verifyInboxPayment(
     paymentTxid,
     settleResult,
     ...(relayPaymentStatus && { paymentStatus: relayPaymentStatus }),
+    ...(relayTerminalReason && { terminalReason: relayTerminalReason }),
+    ...(relayCheckStatusUrl && { checkStatusUrl: relayCheckStatusUrl }),
     ...(relayReceiptId && { receiptId: relayReceiptId }),
     ...(relayPaymentId && { paymentId: relayPaymentId }),
   };

--- a/lib/levels.ts
+++ b/lib/levels.ts
@@ -10,6 +10,7 @@
  */
 
 import type { AgentRecord, ClaimStatus } from "./types";
+export type { ClaimStatus } from "./types";
 
 export interface LevelDefinition {
   level: number;

--- a/lib/sponsor/__tests__/status.test.ts
+++ b/lib/sponsor/__tests__/status.test.ts
@@ -63,19 +63,12 @@ describe("getRelaySponsorStatusFromBinding", () => {
   });
 
   it("returns null when the binding does not expose sponsor status yet", async () => {
-    await expect(
-      getRelaySponsorStatusFromBinding({
-        submitPayment: async () => ({ accepted: true }),
-        checkPayment: async () => ({ paymentId: "p", status: "queued" }),
-      })
-    ).resolves.toBeNull();
+    await expect(getRelaySponsorStatusFromBinding({})).resolves.toBeNull();
   });
 
   it("returns normalized sponsor status from the relay binding", async () => {
     await expect(
       getRelaySponsorStatusFromBinding({
-        submitPayment: async () => ({ accepted: true }),
-        checkPayment: async () => ({ paymentId: "p", status: "queued" }),
         getSponsorStatus: async () => baseStatus,
       })
     ).resolves.toEqual(baseStatus);

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.37.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@aibtc/tx-schemas": "^0.2.2",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@opennextjs/cloudflare": "^1.17.1",
@@ -37,6 +38,15 @@
         "typescript": "^5",
         "vitest": "^4.0.18",
         "wrangler": "^4.65.0"
+      }
+    },
+    "node_modules/@aibtc/tx-schemas": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.2.2.tgz",
+      "integrity": "sha512-a6Mly35vvuxqXFVM3lSH/6ewe1io33eMXfY9rFSZz+790TbOebYIrd1gEQI+JTvd1NmntbXEibBXg5Mnif8sjw==",
+      "license": "MIT",
+      "dependencies": {
+        "zod": "^4.3.6"
       }
     },
     "node_modules/@alloc/quick-lru": {
@@ -13568,6 +13578,15 @@
       "dependencies": {
         "@poppinss/exception": "^1.2.2",
         "error-stack-parser-es": "^1.0.5"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.3.6.tgz",
+      "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.37.0",
       "hasInstallScript": true,
       "dependencies": {
-        "@aibtc/tx-schemas": "^0.2.2",
+        "@aibtc/tx-schemas": "^0.3.0",
         "@noble/curves": "^2.0.1",
         "@noble/hashes": "^2.0.1",
         "@opennextjs/cloudflare": "^1.17.1",
@@ -41,9 +41,9 @@
       }
     },
     "node_modules/@aibtc/tx-schemas": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.2.2.tgz",
-      "integrity": "sha512-a6Mly35vvuxqXFVM3lSH/6ewe1io33eMXfY9rFSZz+790TbOebYIrd1gEQI+JTvd1NmntbXEibBXg5Mnif8sjw==",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@aibtc/tx-schemas/-/tx-schemas-0.3.0.tgz",
+      "integrity": "sha512-pXzW9TnmFR3uJMfajbUdAYiPKRkNlzWWL2WGZ554NAeVIPq9vWyL6x8nrYtaDohuHlZRmMj1tSVeFap9AA+adw==",
       "license": "MIT",
       "dependencies": {
         "zod": "^4.3.6"

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "postinstall": "patch-package"
   },
   "dependencies": {
-    "@aibtc/tx-schemas": "^0.2.2",
+    "@aibtc/tx-schemas": "^0.3.0",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@opennextjs/cloudflare": "^1.17.1",

--- a/package.json
+++ b/package.json
@@ -14,9 +14,11 @@
     "cf-typegen": "npm run wrangler -- types --env-interface CloudflareEnv cloudflare-env.d.ts",
     "test": "vitest run",
     "test:watch": "vitest",
+    "typecheck": "tsc --noEmit",
     "postinstall": "patch-package"
   },
   "dependencies": {
+    "@aibtc/tx-schemas": "^0.2.2",
     "@noble/curves": "^2.0.1",
     "@noble/hashes": "^2.0.1",
     "@opennextjs/cloudflare": "^1.17.1",
@@ -40,13 +42,13 @@
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",
-    "patch-package": "^8.0.1",
     "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^15.1.3",
+    "patch-package": "^8.0.1",
     "tailwindcss": "^4.1.18",
     "typescript": "^5",
     "vitest": "^4.0.18",


### PR DESCRIPTION
## Summary
- align the inbox payment flow with the updated `@aibtc/tx-schemas` contract so RPC-backed polling preserves relay-owned `paymentId`, surfaces canonical `checkStatusUrl` when known, and normalizes caller-facing `submitted` to `queued`
- switch pending inbox delivery to an explicit staged `202 Accepted` flow and finalize or discard staged records through `GET /api/payment-status/{paymentId}` using the shared HTTP schema, including `terminalReason`
- update OpenAPI, docs, and LLM text so the public surface matches runtime: confirmed-only default delivery, `terminalReason`, `checkStatusUrl`, and staged pending semantics

## Simplifications
- replace local relay result interfaces with `@aibtc/tx-schemas` RPC schemas in `lib/inbox/relay-rpc.ts`
- remove duplicated `submitted -> queued` normalization and check-status URL selection into a shared inbox payment-contract helper
- tighten sponsor status coverage and add focused payment-status / RPC propagation tests instead of relying on noisier overlapping assertions

## Compatibility / Rollout Notes
- the `submitted -> queued` collapse remains intentionally as a compatibility shim for older relay payloads; caller-facing responses still exclude `submitted`
- HTTP relay settlement remains fallback-only when the `X402_RELAY` binding is unavailable; canonical-first polling stays primary in RPC-backed environments
- rollout still depends on the relay side consistently returning the updated tx-schemas contract, especially `checkStatusUrl` when known
- when relay reports `pending` without `paymentId`, the inbox route falls back to immediate 201 delivery (compat path for older relays that don't yet return payment IDs); this path is logged and tested

## Verification
- `npm test -- lib/inbox/__tests__/relay-rpc.test.ts lib/inbox/__tests__/payment-status-route.test.ts lib/inbox/__tests__/kv-helpers.test.ts lib/inbox/__tests__/x402-verify-rpc.test.ts lib/inbox/__tests__/x402-verify.test.ts lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts lib/sponsor/__tests__/status.test.ts`
- `npm run typecheck`
- `npm test`

## Residual Risk / Follow-up
- if an older relay deployment still emits legacy poll payloads, the compatibility collapse/logging path will be used until that rollout completes
- HTTP fallback does not provide the same canonical poll hint richness as the RPC binding, so parity still depends on environments using `X402_RELAY`