### PR TITLE
fix(deps): override vite to >=7.3.2 for CVE-2026-39363

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "undici": ">=7.24.0",
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
-    "path-to-regexp": ">=8.4.0"
+    "path-to-regexp": ">=8.4.0",
+    "vite": ">=7.3.2"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- Adds `vite: ">=7.3.2"` to the `overrides` section in `package.json`
- Vite 7.3.1 is vulnerable to two high-severity issues (Dependabot alerts #72, #74):
  - **CVE-2026-39363**: Arbitrary file read via Vite Dev Server WebSocket
  - Vite `server.fs.deny` bypass with queries
- Vite is a transitive dependency of `vitest` — not a direct dep, so an override is needed
- Both issues are **dev server only** (no production exposure), but patching is best practice
- Fix version 7.3.2 is confirmed in the advisory's `first_patched_version`

## Test plan

- [ ] CI passes (build + lint)
- [ ] `package-lock.json` updated vite to 7.3.2+ after `npm install`
- [ ] Dependabot alerts #72, #74 auto-dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)