### PR TITLE
Align inbox staging and delivery semantics

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -58,6 +58,20 @@ const SENDER_NONCE_ERRORS: Record<string, { error: string; retryAfter: number; n
   },
 };
 
+function buildMissingCanonicalIdentityBody(paymentResult: {
+  checkStatusUrl?: string;
+}) {
+  return {
+    error:
+      "Relay accepted the payment but did not return a canonical payment identity. Inbox delivery was not staged.",
+    code: "MISSING_CANONICAL_IDENTITY" as const,
+    retryable: false,
+    nextSteps:
+      "Do not assume delivery or invent a synthetic paymentId. Inspect relay or chain truth before deciding whether to retry.",
+    ...(paymentResult.checkStatusUrl && { checkStatusUrl: paymentResult.checkStatusUrl }),
+  };
+}
+
 /**
  * Verify optional Bitcoin sender signature over message content.
  * Supports both BIP-137 (address recovered from signature) and BIP-322
@@ -1173,6 +1187,30 @@ export async function POST(
       );
     }
 
+    if (errorCode === "PAYMENT_NOT_FOUND") {
+      return NextResponse.json(
+        {
+          error:
+            "The relay no longer recognizes this payment identity. Inbox delivery was not completed.",
+          code: errorCode,
+          retryable: false,
+          nextSteps:
+            "Do not assume delivery. Stop polling the old payment identity and restart the higher-level payment flow deliberately.",
+          ...(paymentResult.terminalReason && { terminalReason: paymentResult.terminalReason }),
+          ...(paymentResult.checkStatusUrl && { checkStatusUrl: paymentResult.checkStatusUrl }),
+          ...relayDiag,
+        },
+        { status: 409 }
+      );
+    }
+
+    if (errorCode === "MISSING_CANONICAL_IDENTITY") {
+      return NextResponse.json({
+        ...buildMissingCanonicalIdentityBody(paymentResult),
+        ...relayDiag,
+      }, { status: 502 });
+    }
+
     // RELAY_ERROR — relay 5xx, unexpected failure, or circuit breaker open.
     // Use the retryAfterSeconds from the verification result (circuit breaker returns 300s,
     // ordinary relay errors default to 10s).
@@ -1347,23 +1385,25 @@ export async function POST(
 
   if (paymentResult.paymentStatus === "pending") {
     if (!paymentResult.paymentId) {
-      logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+      logPaymentEvent(logger, "error", "payment.fallback_used", repoVersion, {
         route: request.nextUrl.pathname,
         paymentId: null,
         status: "pending",
-        action: "deliver_immediately_without_payment_id",
+        action: "reject_pending_without_canonical_identity",
         additionalContext: {
           messageId,
           fromAddress,
           toBtcAddress,
           receiptId: paymentResult.receiptId ?? null,
+          checkStatusUrl: paymentResult.checkStatusUrl ?? null,
         },
       });
-      logger.warn("Pending payment result missing paymentId; preserving fallback immediate delivery", {
+      logger.error("Pending payment result missing canonical paymentId; refusing delivery", {
         messageId,
         fromAddress,
         toBtcAddress,
       });
+      return NextResponse.json(buildMissingCanonicalIdentityBody(paymentResult), { status: 502 });
     } else {
       const checkStatusUrl =
         paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -60,6 +60,8 @@ const SENDER_NONCE_ERRORS: Record<string, { error: string; retryAfter: number; n
 
 function buildMissingCanonicalIdentityBody(paymentResult: {
   checkStatusUrl?: string;
+  relayCode?: string;
+  relayDetail?: string;
 }) {
   return {
     error:
@@ -69,6 +71,8 @@ function buildMissingCanonicalIdentityBody(paymentResult: {
     nextSteps:
       "Do not assume delivery or invent a synthetic paymentId. Inspect relay or chain truth before deciding whether to retry.",
     ...(paymentResult.checkStatusUrl && { checkStatusUrl: paymentResult.checkStatusUrl }),
+    ...(paymentResult.relayCode && { relayCode: paymentResult.relayCode }),
+    ...(paymentResult.relayDetail && { relayDetail: paymentResult.relayDetail }),
   };
 }
 
@@ -1205,10 +1209,7 @@ export async function POST(
     }
 
     if (errorCode === "MISSING_CANONICAL_IDENTITY") {
-      return NextResponse.json({
-        ...buildMissingCanonicalIdentityBody(paymentResult),
-        ...relayDiag,
-      }, { status: 502 });
+      return NextResponse.json(buildMissingCanonicalIdentityBody(paymentResult), { status: 502 });
     }
 
     // RELAY_ERROR — relay 5xx, unexpected failure, or circuit breaker open.

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -148,6 +148,8 @@ describe("inbox POST canonical staged-payment semantics", () => {
       success: true,
       payerStxAddress: SENDER_STX,
       paymentTxid: "a".repeat(64),
+      relayCode: "RELAY_CONTRACT_VIOLATION",
+      relayDetail: "accepted pending payment missing paymentId",
       settleResult: {
         success: true,
         transaction: "a".repeat(64),
@@ -224,10 +226,14 @@ describe("inbox POST canonical staged-payment semantics", () => {
       code: string;
       error: string;
       nextSteps: string;
+      relayCode?: string;
+      relayDetail?: string;
     };
     expect(body.code).toBe("MISSING_CANONICAL_IDENTITY");
     expect(body.error).toContain("did not return a canonical payment identity");
     expect(body.nextSteps).toContain("Do not assume delivery");
+    expect(body.relayCode).toBe("RELAY_CONTRACT_VIOLATION");
+    expect(body.relayDetail).toBe("accepted pending payment missing paymentId");
   });
 
   it("response headers omit X-Payment-Id", async () => {

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -1,12 +1,9 @@
 /**
- * Focused test for the pending-without-paymentId compat fallback in the inbox POST route.
+ * Focused tests for inbox POST canonical-identity handling around staged payments.
  *
- * When the relay accepts payment but returns paymentStatus: "pending" without a paymentId,
- * the route falls back to immediate 201 delivery instead of 202 staged. This test verifies:
- * - Response is 201 (not 202)
- * - No paymentId in response body
- * - No storeStagedInboxPayment call
- * - Warning logged about the compat fallback
+ * Phase 3 contract:
+ * - pending without relay-owned paymentId must fail closed
+ * - pending with relay-owned paymentId stays staged and must not claim delivery
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { NextRequest } from "next/server";
@@ -101,7 +98,7 @@ const RECIPIENT_STX = "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
 const SENDER_STX = "SP1SENDER0000000000000000000000000000TEST";
 const NETWORK = "mainnet";
 
-describe("inbox POST: pending-without-paymentId compat fallback", () => {
+describe("inbox POST canonical staged-payment semantics", () => {
   let kv: KVNamespace;
 
   beforeEach(() => {
@@ -146,7 +143,7 @@ describe("inbox POST: pending-without-paymentId compat fallback", () => {
       description: "test",
     });
 
-    // Relay returns pending WITHOUT paymentId — the compat fallback
+    // Relay returns pending WITHOUT paymentId — this must now fail closed.
     mocks.verifyInboxPayment.mockResolvedValue({
       success: true,
       payerStxAddress: SENDER_STX,
@@ -158,7 +155,7 @@ describe("inbox POST: pending-without-paymentId compat fallback", () => {
         network: networkToCAIP2(NETWORK),
       },
       paymentStatus: "pending",
-      // NOTE: no paymentId — this is the compat case
+      // NOTE: no paymentId — canonical identity is missing
     });
 
     mocks.checkSenderRateLimit.mockResolvedValue(null);
@@ -193,12 +190,12 @@ describe("inbox POST: pending-without-paymentId compat fallback", () => {
     });
   }
 
-  it("returns 201 (not 202) when relay reports pending without paymentId", async () => {
+  it("returns 502 when relay reports pending without paymentId", async () => {
     const response = await POST(buildRequest(), {
       params: Promise.resolve({ address: RECIPIENT_BTC }),
     });
 
-    expect(response.status).toBe(201);
+    expect(response.status).toBe(502);
   });
 
   it("does not create a staged payment record", async () => {
@@ -209,28 +206,28 @@ describe("inbox POST: pending-without-paymentId compat fallback", () => {
     expect(mocks.storeStagedInboxPayment).not.toHaveBeenCalled();
   });
 
-  it("stores the message for immediate delivery", async () => {
+  it("does not store the message for delivery when canonical identity is missing", async () => {
     await POST(buildRequest(), {
       params: Promise.resolve({ address: RECIPIENT_BTC }),
     });
 
-    expect(mocks.storeMessage).toHaveBeenCalledTimes(1);
-    expect(mocks.updateAgentInbox).toHaveBeenCalledTimes(1);
+    expect(mocks.storeMessage).not.toHaveBeenCalled();
+    expect(mocks.updateAgentInbox).not.toHaveBeenCalled();
   });
 
-  it("response body omits paymentId", async () => {
+  it("returns a fail-closed error body when canonical identity is missing", async () => {
     const response = await POST(buildRequest(), {
       params: Promise.resolve({ address: RECIPIENT_BTC }),
     });
 
     const body = (await response.json()) as {
-      success: boolean;
-      inbox: { paymentId?: string; paymentStatus?: string };
+      code: string;
+      error: string;
+      nextSteps: string;
     };
-    expect(body.success).toBe(true);
-    expect(body.inbox).toBeDefined();
-    expect(body.inbox.paymentId).toBeUndefined();
-    expect(body.inbox.paymentStatus).toBe("pending");
+    expect(body.code).toBe("MISSING_CANONICAL_IDENTITY");
+    expect(body.error).toContain("did not return a canonical payment identity");
+    expect(body.nextSteps).toContain("Do not assume delivery");
   });
 
   it("response headers omit X-Payment-Id", async () => {
@@ -242,21 +239,58 @@ describe("inbox POST: pending-without-paymentId compat fallback", () => {
     expect(response.headers.get("X-Payment-Check-Url")).toBeNull();
   });
 
-  it("logs the compat fallback warning", async () => {
+  it("logs the fail-closed missing-identity event", async () => {
     await POST(buildRequest(), {
       params: Promise.resolve({ address: RECIPIENT_BTC }),
     });
 
     expect(mocks.logPaymentEvent).toHaveBeenCalledWith(
       mocks.logger,
-      "warn",
+      "error",
       "payment.fallback_used",
       expect.any(String),
       expect.objectContaining({
         paymentId: null,
         status: "pending",
-        action: "deliver_immediately_without_payment_id",
+        action: "reject_pending_without_canonical_identity",
       })
     );
+  });
+
+  it("returns 202 staged wording and avoids delivery language when canonical paymentId is present", async () => {
+    mocks.verifyInboxPayment.mockResolvedValueOnce({
+      success: true,
+      payerStxAddress: SENDER_STX,
+      paymentTxid: "a".repeat(64),
+      settleResult: {
+        success: true,
+        transaction: "a".repeat(64),
+        payer: SENDER_STX,
+        network: networkToCAIP2(NETWORK),
+      },
+      paymentStatus: "pending",
+      paymentId: "pay_staged_case",
+      checkStatusUrl: "https://relay.example/check/pay_staged_case",
+    });
+
+    const response = await POST(buildRequest(), {
+      params: Promise.resolve({ address: RECIPIENT_BTC }),
+    });
+    const body = (await response.json()) as {
+      message: string;
+      inbox: { paymentStatus: string; paymentId?: string };
+      checkStatusUrl?: string;
+    };
+
+    expect(response.status).toBe(202);
+    expect(body.message).toBe(
+      "Payment accepted. Inbox delivery is staged until the relay reports confirmed."
+    );
+    expect(body.message).not.toContain("Message sent successfully");
+    expect(body.inbox.paymentStatus).toBe("pending");
+    expect(body.inbox.paymentId).toBe("pay_staged_case");
+    expect(body.checkStatusUrl).toBe("https://relay.example/check/pay_staged_case");
+    expect(mocks.storeStagedInboxPayment).toHaveBeenCalledTimes(1);
+    expect(mocks.storeMessage).not.toHaveBeenCalled();
   });
 });

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -482,6 +482,54 @@ describe("payment-status route", () => {
     );
   });
 
+  it("discards staged inbox records on canonical unknown_payment_identity not_found", async () => {
+    const kv = createMockKV();
+    await stagePendingPayment(kv, "pay_not_found_terminal_case", "msg_not_found_terminal_case");
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_not_found_terminal_case",
+            status: "not_found",
+            terminalReason: "unknown_payment_identity",
+            error: "Payment pay_not_found_terminal_case not found or expired",
+            checkStatusUrl: "https://relay.example/check/pay_not_found_terminal_case",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_not_found_terminal_case"),
+      { params: Promise.resolve({ paymentId: "pay_not_found_terminal_case" }) }
+    );
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_not_found_terminal_case",
+        status: "not_found",
+        terminalReason: "unknown_payment_identity",
+        checkStatusUrl: "https://relay.example/check/pay_not_found_terminal_case",
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_not_found_terminal_case")).toBeNull();
+    expect(await getMessage(kv, "msg_not_found_terminal_case")).toBeNull();
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.delivery_discarded",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_not_found_terminal_case",
+        paymentId: "pay_not_found_terminal_case",
+        status: "not_found",
+        terminalReason: "unknown_payment_identity",
+        action: "discard_staged_delivery",
+      })
+    );
+  });
+
   it("logs malformed relay poll payloads before schema parse failure", async () => {
     const kv = createMockKV();
     mocks.getCloudflareContext.mockResolvedValue({

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -337,6 +337,57 @@ describe("payment-status route", () => {
     );
   });
 
+  it("surfaces sender nonce gap terminal metadata from relay polling", async () => {
+    const kv = createMockKV();
+    await stagePendingPayment(kv, "pay_sender_gap_case", "msg_sender_gap_case");
+
+    mocks.getCloudflareContext.mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: kv,
+        X402_RELAY: {
+          checkPayment: vi.fn().mockResolvedValue({
+            paymentId: "pay_sender_gap_case",
+            status: "failed",
+            terminalReason: "sender_nonce_gap",
+            errorCode: "SENDER_NONCE_GAP",
+            error: "sender nonce gap detected",
+            checkStatusUrl: "https://relay.example/check/pay_sender_gap_case",
+          }),
+        },
+      },
+      ctx: {},
+    });
+
+    const response = await GET(
+      new NextRequest("https://aibtc.com/api/payment-status/pay_sender_gap_case"),
+      { params: Promise.resolve({ paymentId: "pay_sender_gap_case" }) }
+    );
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        paymentId: "pay_sender_gap_case",
+        status: "failed",
+        terminalReason: "sender_nonce_gap",
+        errorCode: "SENDER_NONCE_GAP",
+        error: "sender nonce gap detected",
+        checkStatusUrl: "https://relay.example/check/pay_sender_gap_case",
+      })
+    );
+    expect(await getStagedInboxPayment(kv, "pay_sender_gap_case")).toBeNull();
+    expect(await getMessage(kv, "msg_sender_gap_case")).toBeNull();
+    expect(mocks.logger.info).toHaveBeenCalledWith(
+      "payment.delivery_discarded",
+      expect.objectContaining({
+        route: "/api/payment-status/pay_sender_gap_case",
+        paymentId: "pay_sender_gap_case",
+        status: "failed",
+        terminalReason: "sender_nonce_gap",
+        action: "discard_staged_delivery",
+      })
+    );
+  });
+
   it("returns HTTP 404 on canonical not_found", async () => {
     const kv = createMockKV();
     mocks.getCloudflareContext.mockResolvedValue({

--- a/lib/inbox/__tests__/relay-rpc.test.ts
+++ b/lib/inbox/__tests__/relay-rpc.test.ts
@@ -226,6 +226,24 @@ describe("submitViaRPC", () => {
 
       expect(rpc.submitPayment).toHaveBeenCalledWith(baseTxHex, baseSettle);
     });
+
+    it("fails closed when submitPayment accepts but omits canonical paymentId", async () => {
+      const rpc: RelayRPC = {
+        submitPayment: vi.fn().mockResolvedValue({
+          accepted: true,
+          status: "queued",
+          checkStatusUrl: "https://relay.example/check/missing-id",
+        }),
+        checkPayment: vi.fn(),
+      };
+
+      const result = await submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("MISSING_CANONICAL_IDENTITY");
+      expect(result.checkStatusUrl).toBe("https://relay.example/check/missing-id");
+      expect(rpc.checkPayment).not.toHaveBeenCalled();
+    });
   });
 
   describe("successful settlement paths", () => {
@@ -433,6 +451,9 @@ describe("submitViaRPC", () => {
         checkPayment: vi.fn().mockResolvedValue({
           paymentId: "pay_notfound",
           status: "not_found",
+          terminalReason: "unknown_payment_identity",
+          checkStatusUrl: "https://relay.example/check/pay_notfound",
+          errorCode: "UNKNOWN_PAYMENT_IDENTITY",
           error: "Payment pay_notfound not found or expired",
         }),
       };
@@ -442,7 +463,40 @@ describe("submitViaRPC", () => {
       const result = await resultPromise;
 
       expect(result.success).toBe(false);
-      expect(result.errorCode).toBe("RELAY_ERROR");
+      expect(result.errorCode).toBe("PAYMENT_NOT_FOUND");
+      expect(result.terminalReason).toBe("unknown_payment_identity");
+      expect(result.checkStatusUrl).toBe("https://relay.example/check/pay_notfound");
+      expect(result.relayDetail).toBe("Payment pay_notfound not found or expired");
+    });
+
+    it("surfaces sender nonce gap terminal metadata from relay polling", async () => {
+      const rpc: RelayRPC = {
+        submitPayment: vi.fn().mockResolvedValue({
+          accepted: true,
+          paymentId: "pay_gap_terminal",
+          status: "queued",
+          checkStatusUrl: "https://relay.example/pay/pay_gap_terminal",
+        }),
+        checkPayment: vi.fn().mockResolvedValue({
+          paymentId: "pay_gap_terminal",
+          status: "failed",
+          terminalReason: "sender_nonce_gap",
+          errorCode: "SENDER_NONCE_GAP",
+          error: "sender nonce gap detected",
+          checkStatusUrl: "https://relay.example/check/pay_gap_terminal",
+        }),
+      };
+
+      const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+      await vi.runAllTimersAsync();
+      const result = await resultPromise;
+
+      expect(result.success).toBe(false);
+      expect(result.errorCode).toBe("SENDER_NONCE_GAP");
+      expect(result.terminalReason).toBe("sender_nonce_gap");
+      expect(result.checkStatusUrl).toBe("https://relay.example/check/pay_gap_terminal");
+      expect(result.relayCode).toBe("SENDER_NONCE_GAP");
+      expect(result.relayDetail).toBe("sender nonce gap detected");
     });
   });
 

--- a/lib/inbox/__tests__/relay-rpc.test.ts
+++ b/lib/inbox/__tests__/relay-rpc.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mapRPCErrorCode, submitViaRPC } from "../relay-rpc";
+import { __testUtils, mapRPCErrorCode, submitViaRPC } from "../relay-rpc";
 import type { RelayRPC, RelaySettleOptions } from "../relay-rpc";
 import type { Logger } from "@/lib/logging";
 
@@ -764,6 +764,27 @@ describe("submitViaRPC", () => {
         "RPC: poll exhausted after relay accepted — treating as pending success",
         expect.objectContaining({ paymentId: "pay_log_exhaust" })
       );
+    });
+  });
+});
+
+describe("relay-rpc parser compatibility", () => {
+  it("drops unknown relay errorCode values while preserving canonical not_found fields", () => {
+    const parsed = __testUtils.parseCheckPaymentResult({
+      paymentId: "pay_parse_not_found",
+      status: "not_found",
+      terminalReason: "unknown_payment_identity",
+      errorCode: "UNKNOWN_PAYMENT_IDENTITY",
+      error: "Payment pay_parse_not_found not found or expired",
+      checkStatusUrl: "https://relay.example/check/pay_parse_not_found",
+    });
+
+    expect(parsed).toEqual({
+      paymentId: "pay_parse_not_found",
+      status: "not_found",
+      terminalReason: "unknown_payment_identity",
+      error: "Payment pay_parse_not_found not found or expired",
+      checkStatusUrl: "https://relay.example/check/pay_parse_not_found",
     });
   });
 });

--- a/lib/inbox/__tests__/x402-verify-rpc.test.ts
+++ b/lib/inbox/__tests__/x402-verify-rpc.test.ts
@@ -4,6 +4,7 @@ import { verifyInboxPayment } from "../x402-verify";
 import type { RelayRPC } from "../relay-rpc";
 import { getSBTCAsset } from "../x402-config";
 import { networkToCAIP2 } from "x402-stacks";
+import { createMockKVWithOptions } from "./kv-mock";
 
 const mocks = vi.hoisted(() => ({
   submitViaRPC: vi.fn(),
@@ -74,5 +75,29 @@ describe("verifyInboxPayment RPC contract", () => {
       paymentId: "pay_rpc_hint_case",
       checkStatusUrl: "https://relay.example/check/pay_rpc_hint_case",
     });
+  });
+
+  it("counts missing canonical identity as a relay failure for breaker accounting", async () => {
+    const { kv, store } = createMockKVWithOptions();
+    mocks.submitViaRPC.mockResolvedValue({
+      success: false,
+      errorCode: "MISSING_CANONICAL_IDENTITY",
+      error: "Relay accepted payment but did not return a canonical payment identity",
+    });
+
+    const relayRPC = {} as RelayRPC;
+    const result = await verifyInboxPayment(
+      payload,
+      recipientStxAddress,
+      network,
+      "https://relay.example",
+      undefined,
+      kv,
+      relayRPC
+    );
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("MISSING_CANONICAL_IDENTITY");
+    expect(store.get("inbox:relay:circuit-breaker:count")).toBe("1");
   });
 });

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -147,6 +147,10 @@ function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
   return RpcCheckPaymentResultSchema.parse(collapsed);
 }
 
+export const __testUtils = {
+  parseCheckPaymentResult,
+};
+
 function mapTerminalOutcome(
   checkResult: RelayCheckResult
 ): InboxPaymentErrorCode {
@@ -286,7 +290,7 @@ export async function submitViaRPC(
         error:
           checkResult.error ||
           "Relay no longer recognizes this payment identity. Do not treat the message as delivered.",
-        errorCode: mapTerminalOutcome(checkResult),
+        errorCode: "PAYMENT_NOT_FOUND",
         paymentId,
         ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -6,6 +6,7 @@
  */
 
 import {
+  RpcErrorCodeSchema,
   RpcCheckPaymentResultSchema,
   RpcSenderNonceInfoSchema,
   RpcSettleOptionsSchema,
@@ -93,9 +94,28 @@ const TERMINAL_REASON_ERROR_CODE_MAP: Partial<Record<TerminalReason, InboxPaymen
   broadcast_failure: "BROADCAST_FAILED",
   chain_abort: "SETTLEMENT_FAILED",
   internal_error: "RELAY_ERROR",
+  expired: "PAYMENT_NOT_FOUND",
+  unknown_payment_identity: "PAYMENT_NOT_FOUND",
 };
 
 function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
+  if (
+    raw &&
+    typeof raw === "object" &&
+    "accepted" in raw &&
+    (raw as { accepted?: unknown }).accepted === true &&
+    typeof (raw as { paymentId?: unknown }).paymentId !== "string"
+  ) {
+    const rawRecord = raw as Record<string, unknown>;
+    return {
+      accepted: true,
+      status: "queued",
+      ...(typeof rawRecord.checkStatusUrl === "string" && {
+        checkStatusUrl: rawRecord.checkStatusUrl,
+      }),
+    } as RelaySubmitResult;
+  }
+
   if (
     raw &&
     typeof raw === "object" &&
@@ -113,7 +133,18 @@ function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
 }
 
 function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
-  return RpcCheckPaymentResultSchema.parse(collapseSubmittedStatus(raw));
+  const collapsed = collapseSubmittedStatus(raw);
+  if (
+    collapsed &&
+    typeof collapsed === "object" &&
+    "errorCode" in collapsed &&
+    !RpcErrorCodeSchema.safeParse((collapsed as { errorCode?: unknown }).errorCode).success
+  ) {
+    const { errorCode: _ignored, ...rest } = collapsed as Record<string, unknown>;
+    return RpcCheckPaymentResultSchema.parse(rest);
+  }
+
+  return RpcCheckPaymentResultSchema.parse(collapsed);
 }
 
 function mapTerminalOutcome(
@@ -170,8 +201,9 @@ export async function submitViaRPC(
     log.warn("RPC: submitPayment accepted but missing paymentId");
     return {
       success: false,
-      error: "Relay accepted payment but did not return a paymentId",
-      errorCode: "RELAY_ERROR",
+      error: "Relay accepted payment but did not return a canonical payment identity",
+      errorCode: "MISSING_CANONICAL_IDENTITY",
+      ...(submitResult.checkStatusUrl && { checkStatusUrl: submitResult.checkStatusUrl }),
     };
   }
   log.debug("RPC: payment queued", {
@@ -243,14 +275,23 @@ export async function submitViaRPC(
         checkResult.checkStatusUrl,
         submitCheckStatusUrl
       );
-      log.warn("RPC: payment not found", { paymentId });
+      log.warn("RPC: payment not found", {
+        paymentId,
+        terminalReason: checkResult.terminalReason,
+        errorCode: checkResult.errorCode,
+        error: checkResult.error,
+      });
       return {
         success: false,
-        error: "Payment not found in relay — it may have expired.",
-        errorCode: "RELAY_ERROR",
+        error:
+          checkResult.error ||
+          "Relay no longer recognizes this payment identity. Do not treat the message as delivered.",
+        errorCode: mapTerminalOutcome(checkResult),
         paymentId,
         ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
+        ...(checkResult.errorCode != null && { relayCode: checkResult.errorCode }),
+        ...(checkResult.error && { relayDetail: checkResult.error }),
       };
     }
 

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -88,6 +88,8 @@ interface StacksTxData {
  * - SETTLEMENT_TIMEOUT: relay gave up polling but tx was broadcast; recover via paymentTxid.
  * - INSUFFICIENT_FUNDS: sBTC balance too low.
  * - PAYMENT_REJECTED: relay or verifier rejected the payment (bad payload, wrong recipient, etc.).
+ * - PAYMENT_NOT_FOUND: relay reported the old canonical payment identity is gone.
+ * - MISSING_CANONICAL_IDENTITY: relay accepted the payment but failed to return a canonical public identity.
  * - RELAY_ERROR: relay 5xx or unexpected failure.
  * - INVALID_TRANSACTION_FORMAT: payload contains invalid data (e.g. raw hex instead of serialized Stacks tx).
  * - SENDER_NONCE_STALE: RPC path — submitted nonce is below the current account nonce (pre-enqueue rejection).
@@ -252,6 +254,10 @@ const RELAY_RETRYABLE_CODES = new Set([
   "CLIENT_BAD_NONCE",
   "TOO_MUCH_CHAINING",
 ]);
+
+function shouldCountRelayFailureForBreaker(errorCode: InboxPaymentErrorCode | TxidPaymentErrorCode | (string & {}) | undefined): boolean {
+  return errorCode === "RELAY_ERROR" || errorCode === "MISSING_CANONICAL_IDENTITY";
+}
 
 /** Parse a relay error response body into a structured object. */
 function parseRelayErrorBody(
@@ -503,7 +509,7 @@ export async function verifyInboxPayment(
 
         // RPC failure: record circuit breaker for RELAY_ERROR codes, cache for INSUFFICIENT_FUNDS, then return
         if (!rpcResult.success) {
-          if (kv && rpcResult.errorCode === "RELAY_ERROR") {
+          if (kv && shouldCountRelayFailureForBreaker(rpcResult.errorCode)) {
             await recordRelayFailure(
               kv,
               RELAY_CIRCUIT_BREAKER_KEY,
@@ -750,6 +756,7 @@ export async function verifyInboxPayment(
     paymentTxid,
     recipientStxAddress,
     paymentStatus: relayPaymentStatus,
+    // Observability-only: accepted settlement state, not a caller-facing field.
     paymentLifecycle:
       relayPaymentStatus === "pending" ? "accepted_and_staged" : "accepted_and_confirmed",
   });

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -101,6 +101,8 @@ export type InboxPaymentErrorCode =
   | "SETTLEMENT_TIMEOUT"
   | "INSUFFICIENT_FUNDS"
   | "PAYMENT_REJECTED"
+  | "PAYMENT_NOT_FOUND"
+  | "MISSING_CANONICAL_IDENTITY"
   | "RELAY_ERROR"
   | "INVALID_TRANSACTION_FORMAT"
   | "SENDER_NONCE_STALE"
@@ -748,11 +750,14 @@ export async function verifyInboxPayment(
     paymentTxid,
     recipientStxAddress,
     paymentStatus: relayPaymentStatus,
+    paymentLifecycle:
+      relayPaymentStatus === "pending" ? "accepted_and_staged" : "accepted_and_confirmed",
   });
   emitPaymentEvent("info", "payment.accepted", {
     paymentId: relayPaymentId ?? null,
     status: relayPaymentStatus ?? "confirmed",
-    action: relayPaymentStatus === "pending" ? "stage_delivery" : "deliver_immediately",
+    action:
+      relayPaymentStatus === "pending" ? "accept_payment_for_staging" : "accept_payment_for_delivery",
   });
 
   return {


### PR DESCRIPTION
## Summary
- fail closed when the relay accepts a pending payment without returning a canonical `paymentId`
- preserve canonical relay polling semantics for `not_found`, `terminalReason`, and `checkStatusUrl`
- keep staged inbox responses explicitly non-terminal and add coverage for staged, `not_found`, and sender nonce gap polling flows

## Verification
- `npm run typecheck`
- `npm run lint` (passes with pre-existing `no-img-element` warnings outside this diff)
- `npm test -- lib/inbox/__tests__/relay-rpc.test.ts lib/inbox/__tests__/payment-status-route.test.ts lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts`

## Notes
- Relay quest state updates for the Phase 3 checkpoint were recorded in `x402-sponsor-relay` and are not part of this repo PR.
- This addresses the landing-page portion of the boring payment state machine quest and reduces, but does not fully eliminate, the broader cross-repo `agent-news#435` failure shape.