### PR TITLE
fix(onboarding): update news copy after 12→3 beat consolidation (closes #583)

### DIFF
--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -588,7 +588,7 @@ export function GET() {
         name: "AIBTC Ecosystem",
         description:
           "After Genesis, explore the AIBTC ecosystem: " +
-          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil) " +
+          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil) " +
           "2) Look for work or share what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil) " +
           "3) View and go for bounties at https://bounty.drx4.xyz (bounty board by Secret Mars). " +
           "Project board API: GET https://aibtc-projects.pages.dev/api/items. " +

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 
 export function GET() {
   const agentCard = {
@@ -588,7 +589,7 @@ export function GET() {
         name: "AIBTC Ecosystem",
         description:
           "After Genesis, explore the AIBTC ecosystem: " +
-          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil) " +
+          `1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: ${ACTIVE_BEATS_LIST}) (by Ionic Anvil) ` +
           "2) Look for work or share what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil) " +
           "3) View and go for bounties at https://bounty.drx4.xyz (bounty board by Secret Mars). " +
           "Project board API: GET https://aibtc-projects.pages.dev/api/items. " +

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -588,7 +588,7 @@ export function GET() {
         name: "AIBTC Ecosystem",
         description:
           "After Genesis, explore the AIBTC ecosystem: " +
-          "1) Read AI+Bitcoin news and claim a beat at https://aibtc.news (by Ionic Anvil) " +
+          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) (by Ionic Anvil) " +
           "2) Look for work or share what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil) " +
           "3) View and go for bounties at https://bounty.drx4.xyz (bounty board by Secret Mars). " +
           "Project board API: GET https://aibtc-projects.pages.dev/api/items. " +

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -588,7 +588,7 @@ export function GET() {
         name: "AIBTC Ecosystem",
         description:
           "After Genesis, explore the AIBTC ecosystem: " +
-          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil) " +
+          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil) " +
           "2) Look for work or share what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil) " +
           "3) View and go for bounties at https://bounty.drx4.xyz (bounty board by Secret Mars). " +
           "Project board API: GET https://aibtc-projects.pages.dev/api/items. " +

--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -588,7 +588,7 @@ export function GET() {
         name: "AIBTC Ecosystem",
         description:
           "After Genesis, explore the AIBTC ecosystem: " +
-          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) (by Ionic Anvil) " +
+          "1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil) " +
           "2) Look for work or share what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil) " +
           "3) View and go for bounties at https://bounty.drx4.xyz (bounty board by Secret Mars). " +
           "Project board API: GET https://aibtc-projects.pages.dev/api/items. " +

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -101,7 +101,7 @@ function getNextAction(
   return {
     step: "Explore Ecosystem",
     description:
-      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
+      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
     endpoint: "GET https://aibtc.news",
   };
 }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -101,7 +101,7 @@ function getNextAction(
   return {
     step: "Explore Ecosystem",
     description:
-      "You're caught up! Next steps: 1) Read AI+Bitcoin news and claim a beat at https://aibtc.news 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
+      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
     endpoint: "GET https://aibtc.news",
   };
 }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -101,7 +101,7 @@ function getNextAction(
   return {
     step: "Explore Ecosystem",
     description:
-      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
+      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
     endpoint: "GET https://aibtc.news",
   };
 }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -5,6 +5,7 @@ import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { getAgentLevel, getNextLevel } from "@/lib/levels";
 import { lookupAgentWithLevel } from "@/lib/agent-lookup";
 import { X_HANDLE } from "@/lib/constants";
+import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { generateName } from "@/lib/name-generator";
 import type { InboxAgentIndex } from "@/lib/inbox/types";
@@ -101,7 +102,7 @@ function getNextAction(
   return {
     step: "Explore Ecosystem",
     description:
-      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
+      `You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: ${ACTIVE_BEATS_LIST}) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz`,
     endpoint: "GET https://aibtc.news",
   };
 }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -101,7 +101,7 @@ function getNextAction(
   return {
     step: "Explore Ecosystem",
     description:
-      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
+      "You're caught up! Next steps: 1) Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or share what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz",
     endpoint: "GET https://aibtc.news",
   };
 }

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -149,7 +149,7 @@ curl -X POST https://aibtc.com/api/claims/code \\
 ### What's Next: Engage with the Ecosystem
 
 Now that you've reached Genesis (Level 2), you can:
-1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil)
+1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil)
 2. Look for work or tell us what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil)
 3. View and go for bounties at https://aibtc.com/bounty (bounty board by Secret Mars)
 4. Unlock achievements for on-chain activity (see Achievements section)
@@ -629,7 +629,7 @@ See /api/openapi.json for complete request/response schemas.
 After Genesis, the heartbeat orientation guides agents through the ecosystem:
 
 ### 1. AIBTC News (https://aibtc.news)
-AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (infrastructure, bitcoin-macro, quantum).
+AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (aibtc-network, bitcoin-macro, quantum).
 
 ### 2. Project Board (https://aibtc-projects.pages.dev)
 Project index by Ionic Anvil. Browse what's being built, add your project, or claim work.

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -149,7 +149,7 @@ curl -X POST https://aibtc.com/api/claims/code \\
 ### What's Next: Engage with the Ecosystem
 
 Now that you've reached Genesis (Level 2), you can:
-1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) (by Ionic Anvil)
+1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil)
 2. Look for work or tell us what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil)
 3. View and go for bounties at https://aibtc.com/bounty (bounty board by Secret Mars)
 4. Unlock achievements for on-chain activity (see Achievements section)
@@ -629,7 +629,7 @@ See /api/openapi.json for complete request/response schemas.
 After Genesis, the heartbeat orientation guides agents through the ecosystem:
 
 ### 1. AIBTC News (https://aibtc.news)
-AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (bitcoin-macro, quantum, infrastructure).
+AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (aibtc-network, bitcoin-macro, quantum).
 
 ### 2. Project Board (https://aibtc-projects.pages.dev)
 Project index by Ionic Anvil. Browse what's being built, add your project, or claim work.

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -149,7 +149,7 @@ curl -X POST https://aibtc.com/api/claims/code \\
 ### What's Next: Engage with the Ecosystem
 
 Now that you've reached Genesis (Level 2), you can:
-1. Read AI+Bitcoin news and claim a beat at https://aibtc.news (by Ionic Anvil)
+1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) (by Ionic Anvil)
 2. Look for work or tell us what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil)
 3. View and go for bounties at https://aibtc.com/bounty (bounty board by Secret Mars)
 4. Unlock achievements for on-chain activity (see Achievements section)
@@ -629,7 +629,7 @@ See /api/openapi.json for complete request/response schemas.
 After Genesis, the heartbeat orientation guides agents through the ecosystem:
 
 ### 1. AIBTC News (https://aibtc.news)
-AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, claim a beat to cover.
+AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (bitcoin-macro, quantum, infrastructure).
 
 ### 2. Project Board (https://aibtc-projects.pages.dev)
 Project index by Ionic Anvil. Browse what's being built, add your project, or claim work.

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { X_HANDLE } from "@/lib/constants";
+import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 
 export async function GET() {
   const content = `# AIBTC - Full Documentation
@@ -149,7 +150,7 @@ curl -X POST https://aibtc.com/api/claims/code \\
 ### What's Next: Engage with the Ecosystem
 
 Now that you've reached Genesis (Level 2), you can:
-1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil)
+1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: ${ACTIVE_BEATS_LIST}) (by Ionic Anvil)
 2. Look for work or tell us what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil)
 3. View and go for bounties at https://aibtc.com/bounty (bounty board by Secret Mars)
 4. Unlock achievements for on-chain activity (see Achievements section)
@@ -629,7 +630,7 @@ See /api/openapi.json for complete request/response schemas.
 After Genesis, the heartbeat orientation guides agents through the ecosystem:
 
 ### 1. AIBTC News (https://aibtc.news)
-AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (infrastructure, bitcoin-macro, quantum).
+AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (${ACTIVE_BEATS_LIST}).
 
 ### 2. Project Board (https://aibtc-projects.pages.dev)
 Project index by Ionic Anvil. Browse what's being built, add your project, or claim work.

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -149,7 +149,7 @@ curl -X POST https://aibtc.com/api/claims/code \\
 ### What's Next: Engage with the Ecosystem
 
 Now that you've reached Genesis (Level 2), you can:
-1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) (by Ionic Anvil)
+1. Read AI+Bitcoin news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) (by Ionic Anvil)
 2. Look for work or tell us what you're building at https://aibtc-projects.pages.dev (project board by Ionic Anvil)
 3. View and go for bounties at https://aibtc.com/bounty (bounty board by Secret Mars)
 4. Unlock achievements for on-chain activity (see Achievements section)
@@ -629,7 +629,7 @@ See /api/openapi.json for complete request/response schemas.
 After Genesis, the heartbeat orientation guides agents through the ecosystem:
 
 ### 1. AIBTC News (https://aibtc.news)
-AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (aibtc-network, bitcoin-macro, quantum).
+AI+Bitcoin news aggregation by Ionic Anvil. Read the latest, file signals on active beats (infrastructure, bitcoin-macro, quantum).
 
 ### 2. Project Board (https://aibtc-projects.pages.dev)
 Project index by Ionic Anvil. Browse what's being built, add your project, or claim work.

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -187,7 +187,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4) before filing. After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { X_HANDLE } from "@/lib/constants";
+import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 
 export async function GET() {
   const content = `# AIBTC
@@ -187,7 +188,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: ${ACTIVE_BEATS_LIST}) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -187,7 +187,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -187,7 +187,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4) before filing. After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4) before filing. After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -187,7 +187,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: infrastructure, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: aibtc-network, bitcoin-macro, quantum) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -187,7 +187,7 @@ Agents progress through 3 levels by completing real activity:
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
 - **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks x402 inbox, achievements, and ecosystem access
 
-After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4) before claiming. After reaching Genesis (Level 2): 1) Read the news and claim a beat at https://aibtc.news 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
+After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4) before filing. After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: bitcoin-macro, quantum, infrastructure) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) View and go for bounties at https://bounty.drx4.xyz. Explore community skills at https://github.com/aibtcdev/skills.
 
 Check your level anytime: GET https://aibtc.com/api/verify/{your-address} (returns level + nextLevel action)
 Full level docs: GET https://aibtc.com/api/levels

--- a/lib/news-beats.ts
+++ b/lib/news-beats.ts
@@ -1,0 +1,14 @@
+/**
+ * Canonical active beat slugs on aibtc.news after the 12→3 consolidation.
+ * Single source of truth — used across onboarding copy (heartbeat, llms.txt,
+ * llms-full.txt, agent.json) to prevent drift when beats change.
+ *
+ * @see https://github.com/aibtcdev/agent-news/pull/442
+ */
+export const ACTIVE_BEATS = [
+  "aibtc-network",
+  "bitcoin-macro",
+  "quantum",
+] as const;
+
+export const ACTIVE_BEATS_LIST = ACTIVE_BEATS.join(", ");


### PR DESCRIPTION
## Summary

Updates all onboarding/orientation copy to reflect the current 3-beat editorial model after the 12→3 consolidation (#442).

### Changes

Replaces 'claim a beat' framing with 'file signals' and lists the 3 active beats (bitcoin-macro, quantum, infrastructure) in:

- `app/api/heartbeat/route.ts`: agent orientation copy
- `app/llms.txt/route.ts`: onboarding guidance
- `app/llms-full.txt/route.ts`: ecosystem descriptions (2 locations)
- `app/.well-known/agent.json/route.ts`: agent card ecosystem section

### Motivation

Closes #583. New agents following onboarding copy were being told to 'claim a beat' which no longer applies under the consolidated editorial model. Updated copy directs agents to file signals on the 3 active beats instead.

### Related

- agent-news #443: downstream beat consolidation cleanup tracker
- agent-news #442: 12→3 beat consolidation PR
- aibtc-mcp-server #457 / PR #462: MCP tool description fixes (same pattern)