### PR TITLE
fix(deps): upgrade axios to >=1.15.0 for CVE-2025-62718

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6255,14 +6255,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.5.tgz",
-      "integrity": "sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
+      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.11",
         "form-data": "^4.0.5",
-        "proxy-from-env": "^1.1.0"
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -10571,10 +10571,13 @@
       }
     },
     "node_modules/proxy-from-env": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "license": "MIT"
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/punycode": {
       "version": "2.3.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "undici": ">=7.24.0",
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
-    "path-to-regexp": ">=8.4.0"
+    "path-to-regexp": ">=8.4.0",
+    "axios": ">=1.15.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- Adds `axios: >=1.15.0` to package.json `overrides` to force the transitive dependency upgrade
- Resolves Dependabot alert #75 (CVE-2025-62718, critical severity)
- Axios was pulled in as a transitive dep by `x402-stacks`, `rollup`, and `youch` at version 1.13.5

## Details

CVE-2025-62718 affects axios <1.15.0. The fix is to upgrade to 1.15.0+. Since axios is not a direct dependency, an npm `overrides` entry pins all transitive consumers to the patched version.

## Test plan

- [ ] CI passes (build + lint)
- [ ] Dependabot alert #75 closes after merge

Fixes: https://github.com/aibtcdev/landing-page/security/dependabot/75

🤖 Generated with [Claude Code](https://claude.com/claude-code)