### PR TITLE
perf(api): fix Hiro API exhaustion and slow agent profiles

### DIFF
--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -1,13 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import type { AgentRecord, ClaimStatus } from "@/lib/types";
-import { getAgentLevel } from "@/lib/levels";
+import type { AgentRecord } from "@/lib/types";
+import { getAchievementDefinition } from "@/lib/achievements";
 import { lookupBnsName } from "@/lib/bns";
-import { getAgentAchievements, getAchievementDefinition } from "@/lib/achievements";
-import { getCheckInRecord } from "@/lib/heartbeat";
-import { detectAgentIdentity, getReputationSummary } from "@/lib/identity";
-import { getAgentInbox, getSentIndex } from "@/lib/inbox/kv-helpers";
-import { getCAIP19AgentId } from "@/lib/caip19";
+import { enrichAgentProfile } from "@/lib/agent-enrichment";
 
 /**
  * Determine the address type and KV prefix from the format.
@@ -268,112 +264,19 @@ export async function GET(
       }).catch(() => {});
     }
 
-    // Enrichment timeout: if Hiro API hangs, return agent record with null enrichment fields
-    const ENRICHMENT_TIMEOUT_MS = 10_000;
-    const enrichmentTimeout = new Promise<null>((resolve) =>
-      setTimeout(() => {
-        console.warn(
-          `[agents/${agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
-        );
-        resolve(null);
-      }, ENRICHMENT_TIMEOUT_MS)
+    const enrichment = await enrichAgentProfile(
+      agent,
+      kv,
+      hiroApiKey,
+      `agents/${agent.btcAddress}`
     );
 
-    // Look up claim, achievements, check-in, identity+reputation, inbox, and sent index in parallel.
-    // Identity and reputation are combined into a single slot so reputation starts immediately
-    // after identity resolves, without blocking the other parallel fetches.
-    const enrichmentResult = await Promise.race([
-      Promise.all([
-        kv.get(`claim:${agent.btcAddress}`),
-        getAgentAchievements(kv, agent.btcAddress),
-        getCheckInRecord(kv, agent.btcAddress),
-        // Combined identity + reputation slot
-        (async () => {
-          // Use cached identity if available; agent-id 0 is valid (falsy) so use != null
-          const identityResult =
-            agent.erc8004AgentId != null
-              ? { agentId: agent.erc8004AgentId, stxAddress: agent.stxAddress }
-              : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
-          if (!identityResult) return { identity: null, reputation: null };
-          let rep = null;
-          try {
-            rep = await getReputationSummary(identityResult.agentId, hiroApiKey, kv);
-          } catch (e) {
-            console.error(
-              `Failed to fetch reputation for agent ${agent.btcAddress}:`,
-              e
-            );
-          }
-          return { identity: identityResult, reputation: rep };
-        })(),
-        getAgentInbox(kv, agent.btcAddress),
-        getSentIndex(kv, agent.btcAddress),
-      ]),
-      enrichmentTimeout,
-    ]);
-
-    // Destructure enrichment result; fall back to empty values on timeout
-    const [
-      claimData,
-      achievements,
-      checkInRecord,
-      identityAndReputation,
-      inboxIndex,
-      sentIndex,
-    ] = enrichmentResult ?? [null, [], null, { identity: null, reputation: null }, null, null];
-
-    const identity = identityAndReputation?.identity ?? null;
-    const reputation = identityAndReputation?.reputation ?? null;
-
-    let claim: ClaimStatus | null = null;
-    if (claimData) {
-      try {
-        claim = JSON.parse(claimData) as ClaimStatus;
-      } catch (e) {
-        console.error(`Failed to parse claim for ${agent.btcAddress}:`, e);
-      }
-    }
-
-    const levelInfo = getAgentLevel(agent, claim);
-    const checkIn = checkInRecord
+    const checkIn = enrichment.checkIn
       ? {
-          lastCheckInAt: checkInRecord.lastCheckInAt,
-          checkInCount: checkInRecord.checkInCount,
+          lastCheckInAt: enrichment.checkIn.lastCheckInAt,
+          checkInCount: enrichment.checkIn.checkInCount,
         }
       : null;
-
-    // Compute trust metrics
-    const trust = {
-      level: levelInfo.level,
-      levelName: levelInfo.levelName,
-      onChainIdentity: !!identity,
-      reputationScore: reputation?.summaryValue ?? null,
-      reputationCount: reputation?.count ?? 0,
-    };
-
-    // Compute activity metrics
-    const activity = {
-      lastActiveAt: agent.lastActiveAt ?? null,
-      checkInCount: (checkInRecord?.checkInCount ?? agent.checkInCount) ?? 0,
-      hasCheckedIn: !!checkInRecord,
-      hasInboxMessages: !!inboxIndex,
-      unreadInboxCount: inboxIndex?.unreadCount ?? 0,
-      sentCount: sentIndex?.messageIds.length ?? 0,
-    };
-
-    // Compute capabilities (derived from level and registration state)
-    const capabilities: string[] = [];
-    if (levelInfo.level >= 1) {
-      capabilities.push("heartbeat");
-    }
-    // Inbox/x402 capability based on having an STX address (not inbox history)
-    if (agent.stxAddress) {
-      capabilities.push("inbox");
-      capabilities.push("x402");
-    }
-    if (identity) {
-      capabilities.push("reputation");
-    }
 
     return NextResponse.json(
       {
@@ -393,11 +296,11 @@ export async function GET(
           btcPublicKey: agent.btcPublicKey,
           lastActiveAt: agent.lastActiveAt,
           checkInCount: agent.checkInCount,
-          erc8004AgentId: identity?.agentId ?? agent.erc8004AgentId ?? null,
-          caip19: getCAIP19AgentId(identity?.agentId ?? agent.erc8004AgentId ?? null),
+          erc8004AgentId: enrichment.resolvedAgentId,
+          caip19: enrichment.caip19,
         },
-        ...levelInfo,
-        achievements: achievements.map((record) => {
+        ...enrichment.levelInfo,
+        achievements: enrichment.achievements.map((record) => {
           const def = getAchievementDefinition(record.achievementId);
           return {
             id: record.achievementId,
@@ -409,9 +312,9 @@ export async function GET(
           };
         }),
         checkIn,
-        trust,
-        activity,
-        capabilities,
+        trust: enrichment.trust,
+        activity: enrichment.activity,
+        capabilities: enrichment.capabilities,
       },
       {
         headers: {

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -268,19 +268,62 @@ export async function GET(
       }).catch(() => {});
     }
 
-    // Look up claim, achievements, check-in, identity, inbox, and sent index in parallel
-    const [claimData, achievements, checkInRecord, identity, inboxIndex, sentIndex] = await Promise.all([
-      kv.get(`claim:${agent.btcAddress}`),
-      getAgentAchievements(kv, agent.btcAddress),
-      getCheckInRecord(kv, agent.btcAddress),
-      // Use cached identity if available, otherwise detect
-      // Note: use != null (not truthiness) because agent-id 0 is valid but falsy
-      agent.erc8004AgentId != null
-        ? Promise.resolve({ agentId: agent.erc8004AgentId, stxAddress: agent.stxAddress })
-        : detectAgentIdentity(agent.stxAddress, hiroApiKey, kv),
-      getAgentInbox(kv, agent.btcAddress),
-      getSentIndex(kv, agent.btcAddress),
+    // Enrichment timeout: if Hiro API hangs, return agent record with null enrichment fields
+    const ENRICHMENT_TIMEOUT_MS = 10_000;
+    const enrichmentTimeout = new Promise<null>((resolve) =>
+      setTimeout(() => {
+        console.warn(
+          `[agents/${agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
+        );
+        resolve(null);
+      }, ENRICHMENT_TIMEOUT_MS)
+    );
+
+    // Look up claim, achievements, check-in, identity+reputation, inbox, and sent index in parallel.
+    // Identity and reputation are combined into a single slot so reputation starts immediately
+    // after identity resolves, without blocking the other parallel fetches.
+    const enrichmentResult = await Promise.race([
+      Promise.all([
+        kv.get(`claim:${agent.btcAddress}`),
+        getAgentAchievements(kv, agent.btcAddress),
+        getCheckInRecord(kv, agent.btcAddress),
+        // Combined identity + reputation slot
+        (async () => {
+          // Use cached identity if available; agent-id 0 is valid (falsy) so use != null
+          const identityResult =
+            agent.erc8004AgentId != null
+              ? { agentId: agent.erc8004AgentId, stxAddress: agent.stxAddress }
+              : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
+          if (!identityResult) return { identity: null, reputation: null };
+          let rep = null;
+          try {
+            rep = await getReputationSummary(identityResult.agentId, hiroApiKey, kv);
+          } catch (e) {
+            console.error(
+              `Failed to fetch reputation for agent ${agent.btcAddress}:`,
+              e
+            );
+          }
+          return { identity: identityResult, reputation: rep };
+        })(),
+        getAgentInbox(kv, agent.btcAddress),
+        getSentIndex(kv, agent.btcAddress),
+      ]),
+      enrichmentTimeout,
     ]);
+
+    // Destructure enrichment result; fall back to empty values on timeout
+    const [
+      claimData,
+      achievements,
+      checkInRecord,
+      identityAndReputation,
+      inboxIndex,
+      sentIndex,
+    ] = enrichmentResult ?? [null, [], null, { identity: null, reputation: null }, null, null];
+
+    const identity = identityAndReputation?.identity ?? null;
+    const reputation = identityAndReputation?.reputation ?? null;
 
     let claim: ClaimStatus | null = null;
     if (claimData) {
@@ -288,17 +331,6 @@ export async function GET(
         claim = JSON.parse(claimData) as ClaimStatus;
       } catch (e) {
         console.error(`Failed to parse claim for ${agent.btcAddress}:`, e);
-      }
-    }
-
-    // Fetch reputation summary if identity exists (non-critical, don't fail the whole response)
-    let reputation = null;
-    if (identity) {
-      try {
-        reputation = await getReputationSummary(identity.agentId, hiroApiKey, kv);
-      } catch (e) {
-        console.error(`Failed to fetch reputation for agent ${agent.btcAddress}:`, e);
-        // Reputation is optional metadata — continue without it
       }
     }
 

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -392,21 +392,68 @@ export async function GET(
     // Enrich agent data (parallel fetches — same pattern as /api/agents/[address])
     // -----------------------------------------------------------------------
 
-    const [claimData, achievements, checkInRecord, identity, inboxIndex] =
-      await Promise.all([
+    // Enrichment timeout: if Hiro API hangs, return agent record with null enrichment fields
+    const ENRICHMENT_TIMEOUT_MS = 10_000;
+    const enrichmentTimeout = new Promise<null>((resolve) =>
+      setTimeout(() => {
+        console.warn(
+          `[resolve/${agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
+        );
+        resolve(null);
+      }, ENRICHMENT_TIMEOUT_MS)
+    );
+
+    // Look up claim, achievements, check-in, identity+reputation, and inbox in parallel.
+    // Identity and reputation are combined into a single slot so reputation starts immediately
+    // after identity resolves, without blocking the other parallel fetches.
+    const enrichmentResult = await Promise.race([
+      Promise.all([
         kv.get(`claim:${agent.btcAddress}`),
         getAgentAchievements(kv, agent.btcAddress),
         getCheckInRecord(kv, agent.btcAddress),
-        // Use cached identity if available; erc8004AgentId 0 is valid (falsy but != null)
-        agent.erc8004AgentId != null
-          ? Promise.resolve({
-              agentId: agent.erc8004AgentId,
-              owner: agent.stxAddress,
-              uri: "",
-            })
-          : detectAgentIdentity(agent.stxAddress, hiroApiKey, kv),
+        // Combined identity + reputation slot
+        (async () => {
+          // Use cached identity if available; agent-id 0 is valid (falsy) so use != null
+          const identityResult =
+            agent.erc8004AgentId != null
+              ? {
+                  agentId: agent.erc8004AgentId,
+                  owner: agent.stxAddress,
+                  uri: "",
+                }
+              : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
+          if (!identityResult) return { identity: null, reputation: null };
+          let rep = null;
+          try {
+            rep = await getReputationSummary(
+              identityResult.agentId,
+              hiroApiKey,
+              kv
+            );
+          } catch (e) {
+            console.error(
+              `Failed to fetch reputation for agent ${agent.btcAddress}:`,
+              e
+            );
+          }
+          return { identity: identityResult, reputation: rep };
+        })(),
         getAgentInbox(kv, agent.btcAddress),
-      ]);
+      ]),
+      enrichmentTimeout,
+    ]);
+
+    // Destructure enrichment result; fall back to empty values on timeout
+    const [
+      claimData,
+      achievements,
+      checkInRecord,
+      identityAndReputation,
+      inboxIndex,
+    ] = enrichmentResult ?? [null, [], null, { identity: null, reputation: null }, null];
+
+    const identity = identityAndReputation?.identity ?? null;
+    const reputation = identityAndReputation?.reputation ?? null;
 
     let claim: ClaimStatus | null = null;
     if (claimData) {
@@ -414,21 +461,6 @@ export async function GET(
         claim = JSON.parse(claimData) as ClaimStatus;
       } catch (e) {
         console.error(`Failed to parse claim for ${agent.btcAddress}:`, e);
-      }
-    }
-
-    // Fetch reputation if on-chain identity exists (non-critical)
-    let reputation = null;
-    if (identity) {
-      try {
-        reputation = await getReputationSummary(
-          identity.agentId,
-          hiroApiKey,
-          kv
-        );
-      } catch (e) {
-        console.error(`Failed to fetch reputation for agent ${agent.btcAddress}:`, e);
-        // Reputation is optional — continue without it
       }
     }
 

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -17,18 +17,13 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { uintCV } from "@stacks/transactions";
-import type { AgentRecord, ClaimStatus } from "@/lib/types";
-import { getAgentLevel } from "@/lib/levels";
-import { getAgentAchievements } from "@/lib/achievements";
-import { getCheckInRecord } from "@/lib/heartbeat";
-import { detectAgentIdentity, getReputationSummary } from "@/lib/identity";
+import type { AgentRecord } from "@/lib/types";
 import {
   callReadOnly,
   parseClarityValue,
   IDENTITY_REGISTRY_CONTRACT,
 } from "@/lib/identity";
-import { getCAIP19AgentId } from "@/lib/caip19";
-import { getAgentInbox } from "@/lib/inbox/kv-helpers";
+import { enrichAgentProfile } from "@/lib/agent-enrichment";
 
 // ---------------------------------------------------------------------------
 // Identifier type detection
@@ -389,83 +384,15 @@ export async function GET(
     }
 
     // -----------------------------------------------------------------------
-    // Enrich agent data (parallel fetches — same pattern as /api/agents/[address])
+    // Enrich agent data (parallel fetches with timeout guard)
     // -----------------------------------------------------------------------
 
-    // Enrichment timeout: if Hiro API hangs, return agent record with null enrichment fields
-    const ENRICHMENT_TIMEOUT_MS = 10_000;
-    const enrichmentTimeout = new Promise<null>((resolve) =>
-      setTimeout(() => {
-        console.warn(
-          `[resolve/${agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
-        );
-        resolve(null);
-      }, ENRICHMENT_TIMEOUT_MS)
+    const enrichment = await enrichAgentProfile(
+      agent,
+      kv,
+      hiroApiKey,
+      `resolve/${agent.btcAddress}`
     );
-
-    // Look up claim, achievements, check-in, identity+reputation, and inbox in parallel.
-    // Identity and reputation are combined into a single slot so reputation starts immediately
-    // after identity resolves, without blocking the other parallel fetches.
-    const enrichmentResult = await Promise.race([
-      Promise.all([
-        kv.get(`claim:${agent.btcAddress}`),
-        getAgentAchievements(kv, agent.btcAddress),
-        getCheckInRecord(kv, agent.btcAddress),
-        // Combined identity + reputation slot
-        (async () => {
-          // Use cached identity if available; agent-id 0 is valid (falsy) so use != null
-          const identityResult =
-            agent.erc8004AgentId != null
-              ? {
-                  agentId: agent.erc8004AgentId,
-                  owner: agent.stxAddress,
-                  uri: "",
-                }
-              : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
-          if (!identityResult) return { identity: null, reputation: null };
-          let rep = null;
-          try {
-            rep = await getReputationSummary(
-              identityResult.agentId,
-              hiroApiKey,
-              kv
-            );
-          } catch (e) {
-            console.error(
-              `Failed to fetch reputation for agent ${agent.btcAddress}:`,
-              e
-            );
-          }
-          return { identity: identityResult, reputation: rep };
-        })(),
-        getAgentInbox(kv, agent.btcAddress),
-      ]),
-      enrichmentTimeout,
-    ]);
-
-    // Destructure enrichment result; fall back to empty values on timeout
-    const [
-      claimData,
-      achievements,
-      checkInRecord,
-      identityAndReputation,
-      inboxIndex,
-    ] = enrichmentResult ?? [null, [], null, { identity: null, reputation: null }, null];
-
-    const identity = identityAndReputation?.identity ?? null;
-    const reputation = identityAndReputation?.reputation ?? null;
-
-    let claim: ClaimStatus | null = null;
-    if (claimData) {
-      try {
-        claim = JSON.parse(claimData) as ClaimStatus;
-      } catch (e) {
-        console.error(`Failed to parse claim for ${agent.btcAddress}:`, e);
-      }
-    }
-
-    const levelInfo = getAgentLevel(agent, claim);
-    const resolvedAgentId = identity?.agentId ?? agent.erc8004AgentId ?? null;
 
     // -----------------------------------------------------------------------
     // Build response sections
@@ -477,38 +404,9 @@ export async function GET(
       taprootAddress: agent.taprootAddress ?? null,
       displayName: agent.displayName ?? null,
       bnsName: agent.bnsName ?? null,
-      agentId: resolvedAgentId,
-      caip19: getCAIP19AgentId(resolvedAgentId),
+      agentId: enrichment.resolvedAgentId,
+      caip19: enrichment.caip19,
     };
-
-    const trust = {
-      level: levelInfo.level,
-      levelName: levelInfo.levelName,
-      onChainIdentity: !!identity,
-      reputationScore: reputation?.summaryValue ?? null,
-      reputationCount: reputation?.count ?? 0,
-    };
-
-    const activity = {
-      lastActiveAt: agent.lastActiveAt ?? null,
-      checkInCount:
-        (checkInRecord?.checkInCount ?? agent.checkInCount) ?? 0,
-      hasInboxMessages: !!inboxIndex,
-      unreadInboxCount: inboxIndex?.unreadCount ?? 0,
-    };
-
-    // Capabilities derived from level and registration state
-    const capabilities: string[] = [];
-    if (levelInfo.level >= 1) {
-      capabilities.push("heartbeat");
-    }
-    if (agent.stxAddress) {
-      capabilities.push("inbox");
-      capabilities.push("x402");
-    }
-    if (identity) {
-      capabilities.push("reputation");
-    }
 
     return NextResponse.json(
       {
@@ -516,12 +414,17 @@ export async function GET(
         identifier,
         identifierType,
         identity: identitySection,
-        trust,
-        activity,
-        capabilities,
+        trust: enrichment.trust,
+        activity: {
+          lastActiveAt: enrichment.activity.lastActiveAt,
+          checkInCount: enrichment.activity.checkInCount,
+          hasInboxMessages: enrichment.activity.hasInboxMessages,
+          unreadInboxCount: enrichment.activity.unreadInboxCount,
+        },
+        capabilities: enrichment.capabilities,
         // Include level progression info for convenience
-        nextLevel: levelInfo.nextLevel,
-        achievementCount: achievements.length,
+        nextLevel: enrichment.levelInfo.nextLevel,
+        achievementCount: enrichment.achievements.length,
       },
       {
         headers: {

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -415,6 +415,8 @@ export async function GET(
         identifierType,
         identity: identitySection,
         trust: enrichment.trust,
+        // Intentional subset: resolve returns fewer activity fields than /api/agents/[address]
+        // (omits hasCheckedIn and sentCount to keep the lightweight resolution contract stable)
         activity: {
           lastActiveAt: enrichment.activity.lastActiveAt,
           checkInCount: enrichment.activity.checkInCount,

--- a/lib/agent-enrichment.ts
+++ b/lib/agent-enrichment.ts
@@ -74,14 +74,15 @@ export async function enrichAgentProfile(
   hiroApiKey?: string,
   logPrefix?: string
 ): Promise<EnrichmentResult> {
-  const enrichmentTimeout = new Promise<null>((resolve) =>
-    setTimeout(() => {
+  let timeoutId: ReturnType<typeof setTimeout> | undefined;
+  const enrichmentTimeout = new Promise<null>((resolve) => {
+    timeoutId = setTimeout(() => {
       console.warn(
         `[${logPrefix ?? agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
       );
       resolve(null);
-    }, ENRICHMENT_TIMEOUT_MS)
-  );
+    }, ENRICHMENT_TIMEOUT_MS);
+  });
 
   // Fetch claim, achievements, check-in, identity+reputation, inbox, and sent index in parallel.
   // Identity and reputation are combined into a single slot so reputation starts immediately
@@ -94,7 +95,7 @@ export async function enrichAgentProfile(
       fetchIdentityAndReputation(agent, hiroApiKey, kv),
       getAgentInbox(kv, agent.btcAddress),
       getSentIndex(kv, agent.btcAddress),
-    ]),
+    ]).finally(() => clearTimeout(timeoutId)),
     enrichmentTimeout,
   ]);
 
@@ -169,7 +170,9 @@ async function fetchIdentityAndReputation(
   hiroApiKey: string | undefined,
   kv: KVNamespace
 ): Promise<{ identity: AgentIdentity | null; reputation: ReputationSummary | null }> {
-  // Use cached agent-id if available; agent-id 0 is valid (falsy) so use != null
+  // Use cached agent-id if available; agent-id 0 is valid (falsy) so use != null.
+  // When using the cached shortcut, uri is "" because fetching it would require
+  // an additional on-chain call — the agentId is sufficient for reputation lookups.
   const identityResult: AgentIdentity | null =
     agent.erc8004AgentId != null
       ? { agentId: agent.erc8004AgentId, owner: agent.stxAddress, uri: "" }

--- a/lib/agent-enrichment.ts
+++ b/lib/agent-enrichment.ts
@@ -1,0 +1,224 @@
+/**
+ * Shared agent profile enrichment.
+ *
+ * Fetches identity, reputation, achievements, check-in data, claim status,
+ * and inbox metrics for an agent in parallel with a timeout guard.
+ *
+ * Used by /api/agents/[address] and /api/resolve/[identifier] to avoid
+ * duplicating the same enrichment logic in both route handlers.
+ */
+
+import type { AgentRecord, ClaimStatus } from "@/lib/types";
+import type { AgentIdentity, ReputationSummary } from "@/lib/identity/types";
+import type { AchievementRecord } from "@/lib/achievements";
+import { getAgentLevel, type AgentLevelInfo } from "@/lib/levels";
+import { getAgentAchievements } from "@/lib/achievements";
+import { getCheckInRecord, type CheckInRecord } from "@/lib/heartbeat";
+import { detectAgentIdentity, getReputationSummary } from "@/lib/identity";
+import { getAgentInbox, getSentIndex } from "@/lib/inbox/kv-helpers";
+import { getCAIP19AgentId } from "@/lib/caip19";
+
+/** Timeout for all enrichment fetches (identity, reputation, achievements, inbox). */
+const ENRICHMENT_TIMEOUT_MS = 10_000;
+
+/** Trust metrics derived from identity and reputation data. */
+export interface TrustMetrics {
+  level: number;
+  levelName: string;
+  onChainIdentity: boolean;
+  reputationScore: number | null;
+  reputationCount: number;
+}
+
+/** Activity metrics derived from check-in and inbox data. */
+export interface ActivityMetrics {
+  lastActiveAt: string | null;
+  checkInCount: number;
+  hasCheckedIn: boolean;
+  hasInboxMessages: boolean;
+  unreadInboxCount: number;
+  sentCount: number;
+}
+
+/** Full enrichment result returned by enrichAgentProfile(). */
+export interface EnrichmentResult {
+  levelInfo: AgentLevelInfo;
+  claim: ClaimStatus | null;
+  identity: AgentIdentity | null;
+  reputation: ReputationSummary | null;
+  achievements: AchievementRecord[];
+  checkIn: CheckInRecord | null;
+  trust: TrustMetrics;
+  activity: ActivityMetrics;
+  capabilities: string[];
+  /** Resolved agent ID (from identity detection or stored record). */
+  resolvedAgentId: number | null;
+  /** CAIP-19 identifier for the agent, or null if no on-chain identity. */
+  caip19: string | null;
+}
+
+/**
+ * Enrich an agent record with identity, reputation, achievements, check-in,
+ * claim status, and inbox data. All fetches run in parallel with a timeout
+ * guard so a slow Hiro API does not block the response.
+ *
+ * @param agent - The agent record to enrich
+ * @param kv - Cloudflare KV namespace
+ * @param hiroApiKey - Optional Hiro API key for authenticated Stacks API requests
+ * @param logPrefix - Prefix for timeout warning logs (e.g. "agents/bc1q...")
+ * @returns Enrichment result with all derived metrics
+ */
+export async function enrichAgentProfile(
+  agent: AgentRecord,
+  kv: KVNamespace,
+  hiroApiKey?: string,
+  logPrefix?: string
+): Promise<EnrichmentResult> {
+  const enrichmentTimeout = new Promise<null>((resolve) =>
+    setTimeout(() => {
+      console.warn(
+        `[${logPrefix ?? agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
+      );
+      resolve(null);
+    }, ENRICHMENT_TIMEOUT_MS)
+  );
+
+  // Fetch claim, achievements, check-in, identity+reputation, inbox, and sent index in parallel.
+  // Identity and reputation are combined into a single slot so reputation starts immediately
+  // after identity resolves, without blocking the other parallel fetches.
+  const enrichmentResult = await Promise.race([
+    Promise.all([
+      kv.get(`claim:${agent.btcAddress}`),
+      getAgentAchievements(kv, agent.btcAddress),
+      getCheckInRecord(kv, agent.btcAddress),
+      fetchIdentityAndReputation(agent, hiroApiKey, kv),
+      getAgentInbox(kv, agent.btcAddress),
+      getSentIndex(kv, agent.btcAddress),
+    ]),
+    enrichmentTimeout,
+  ]);
+
+  // Destructure enrichment result; fall back to empty values on timeout
+  const [
+    claimData,
+    achievements,
+    checkInRecord,
+    identityAndReputation,
+    inboxIndex,
+    sentIndex,
+  ] = enrichmentResult ?? [
+    null,
+    [],
+    null,
+    { identity: null, reputation: null },
+    null,
+    null,
+  ];
+
+  const identity = identityAndReputation?.identity ?? null;
+  const reputation = identityAndReputation?.reputation ?? null;
+
+  const claim = parseClaim(claimData, agent.btcAddress);
+  const levelInfo = getAgentLevel(agent, claim);
+  const resolvedAgentId = identity?.agentId ?? agent.erc8004AgentId ?? null;
+
+  const trust: TrustMetrics = {
+    level: levelInfo.level,
+    levelName: levelInfo.levelName,
+    onChainIdentity: !!identity,
+    reputationScore: reputation?.summaryValue ?? null,
+    reputationCount: reputation?.count ?? 0,
+  };
+
+  const activity: ActivityMetrics = {
+    lastActiveAt: agent.lastActiveAt ?? null,
+    checkInCount: (checkInRecord?.checkInCount ?? agent.checkInCount) ?? 0,
+    hasCheckedIn: !!checkInRecord,
+    hasInboxMessages: !!inboxIndex,
+    unreadInboxCount: inboxIndex?.unreadCount ?? 0,
+    sentCount: sentIndex?.messageIds.length ?? 0,
+  };
+
+  const capabilities = deriveCapabilities(levelInfo.level, agent, identity);
+
+  return {
+    levelInfo,
+    claim,
+    identity,
+    reputation,
+    achievements,
+    checkIn: checkInRecord,
+    trust,
+    activity,
+    capabilities,
+    resolvedAgentId,
+    caip19: getCAIP19AgentId(resolvedAgentId),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch identity and reputation in a single sequential chain.
+ * Reputation depends on identity (needs agentId), so they cannot be fully parallel.
+ */
+async function fetchIdentityAndReputation(
+  agent: AgentRecord,
+  hiroApiKey: string | undefined,
+  kv: KVNamespace
+): Promise<{ identity: AgentIdentity | null; reputation: ReputationSummary | null }> {
+  // Use cached agent-id if available; agent-id 0 is valid (falsy) so use != null
+  const identityResult: AgentIdentity | null =
+    agent.erc8004AgentId != null
+      ? { agentId: agent.erc8004AgentId, owner: agent.stxAddress, uri: "" }
+      : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
+
+  if (!identityResult) return { identity: null, reputation: null };
+
+  let reputation: ReputationSummary | null = null;
+  try {
+    reputation = await getReputationSummary(identityResult.agentId, hiroApiKey, kv);
+  } catch (e) {
+    console.error(
+      `Failed to fetch reputation for agent ${agent.btcAddress}:`,
+      e
+    );
+  }
+  return { identity: identityResult, reputation };
+}
+
+/** Parse a raw KV claim string into a ClaimStatus, or null on miss/error. */
+function parseClaim(
+  claimData: string | null,
+  btcAddress: string
+): ClaimStatus | null {
+  if (!claimData) return null;
+  try {
+    return JSON.parse(claimData) as ClaimStatus;
+  } catch (e) {
+    console.error(`Failed to parse claim for ${btcAddress}:`, e);
+    return null;
+  }
+}
+
+/** Derive capabilities from level, agent record, and identity. */
+function deriveCapabilities(
+  level: number,
+  agent: AgentRecord,
+  identity: AgentIdentity | null
+): string[] {
+  const capabilities: string[] = [];
+  if (level >= 1) {
+    capabilities.push("heartbeat");
+  }
+  if (agent.stxAddress) {
+    capabilities.push("inbox");
+    capabilities.push("x402");
+  }
+  if (identity) {
+    capabilities.push("reputation");
+  }
+  return capabilities;
+}

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -66,8 +66,9 @@ export async function detectAgentIdentity(
     const nft = data.results[0];
     const tokenIdMatch = nft.value.repr.match(/^u(\d+)$/);
     if (!tokenIdMatch) {
+      // Parse/format failure does not prove the address has no identity NFT,
+      // so do not negative-cache this result.
       console.warn("Could not parse NFT token ID from repr:", nft.value.repr);
-      await setCachedIdentityNegative(stxAddress, kv);
       return null;
     }
     const agentId = Number(tokenIdMatch[1]);
@@ -143,8 +144,11 @@ async function detectAgentIdentityLegacy(
       return identity;
     }
     if (batchCount >= MAX_LEGACY_BATCHES) {
-      console.warn(`[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batches) for ${stxAddress}, caching negative`);
-      await setCachedIdentityNegative(stxAddress, kv);
+      // Scan is intentionally incomplete — don't negative-cache since the identity
+      // may exist beyond the batches we checked.
+      console.warn(
+        `[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batches) for ${stxAddress}, returning incomplete result without negative cache`
+      );
       return null;
     }
   }

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -7,7 +7,7 @@ import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "./constants";
 import { callReadOnly, parseClarityValue, buildHiroHeaders } from "./stacks-api";
 import { stacksApiFetch } from "../stacks-api-fetch";
 import type { AgentIdentity } from "./types";
-import { getCachedIdentity, setCachedIdentity } from "./kv-cache";
+import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from "./kv-cache";
 
 /**
  * Detect if an agent has registered an on-chain identity.
@@ -24,9 +24,9 @@ export async function detectAgentIdentity(
   hiroApiKey?: string,
   kv?: KVNamespace
 ): Promise<AgentIdentity | null> {
-  // Check KV cache first
+  // Check KV cache first (distinguishes miss from cached negative result)
   const cached = await getCachedIdentity(stxAddress, kv);
-  if (cached) return cached;
+  if (cached.hit) return cached.value;
 
   try {
     // Query NFT holdings for this address filtered to the identity registry contract.
@@ -54,7 +54,8 @@ export async function detectAgentIdentity(
     };
 
     if (!data.results || data.results.length === 0) {
-      // No identity NFT found for this address
+      // No identity NFT found for this address — cache negative to skip future Hiro API calls
+      await setCachedIdentityNegative(stxAddress, kv);
       return null;
     }
 
@@ -63,6 +64,7 @@ export async function detectAgentIdentity(
     const tokenIdMatch = nft.value.repr.match(/^u(\d+)$/);
     if (!tokenIdMatch) {
       console.warn("Could not parse NFT token ID from repr:", nft.value.repr);
+      await setCachedIdentityNegative(stxAddress, kv);
       return null;
     }
     const agentId = Number(tokenIdMatch[1]);
@@ -93,12 +95,17 @@ export async function detectAgentIdentity(
 
 /**
  * Legacy O(N) scan — used only as fallback if the holdings API is unavailable.
+ * Capped at MAX_LEGACY_BATCHES to prevent unbounded Hiro API consumption.
  */
 async function detectAgentIdentityLegacy(
   stxAddress: string,
   hiroApiKey?: string,
   kv?: KVNamespace
 ): Promise<AgentIdentity | null> {
+  console.warn(`[identity] falling back to legacy O(N) scan for ${stxAddress}`);
+
+  const MAX_LEGACY_BATCHES = 3;
+
   const lastIdResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-last-token-id", [], hiroApiKey);
   const lastIdRaw = parseClarityValue(lastIdResult);
   const lastId = lastIdRaw !== null ? Number(lastIdRaw) : null;
@@ -106,7 +113,9 @@ async function detectAgentIdentityLegacy(
   if (lastId === null || lastId < 0) return null;
 
   const BATCH_SIZE = 5;
+  let batchCount = 0;
   for (let i = lastId; i >= 0; i -= BATCH_SIZE) {
+    batchCount++;
     const batchStart = Math.max(0, i - BATCH_SIZE + 1);
     const batch = Array.from(
       { length: i - batchStart + 1 },
@@ -130,8 +139,15 @@ async function detectAgentIdentityLegacy(
       await setCachedIdentity(stxAddress, identity, kv);
       return identity;
     }
+    if (batchCount >= MAX_LEGACY_BATCHES) {
+      console.warn(`[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batches) for ${stxAddress}, caching negative`);
+      await setCachedIdentityNegative(stxAddress, kv);
+      return null;
+    }
   }
 
+  // Exhausted all NFTs without finding a match — cache negative result
+  await setCachedIdentityNegative(stxAddress, kv);
   return null;
 }
 

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -36,7 +36,10 @@ export async function detectAgentIdentity(
     const holdingsUrl = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
     const headers = buildHiroHeaders(hiroApiKey);
-    const response = await stacksApiFetch(holdingsUrl, { headers });
+    // Reduced retry budget for synchronous profile lookups: worst-case ~13s
+    // instead of default ~71s. Primary NFT holdings call gets retries429=1 (1s max
+    // 429 delay) and retries=2 (1.5s max 5xx delay).
+    const response = await stacksApiFetch(holdingsUrl, { headers }, 2, 500, 1);
 
     if (!response.ok) {
       // Fallback to legacy scan if holdings API fails (e.g. 404, 500)

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -13,6 +13,7 @@ import type { AgentIdentity } from "./types";
 const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours
 const BNS_NEGATIVE_CACHE_TTL = 60 * 60; // 1 hour for addresses with no BNS name
 const IDENTITY_CACHE_TTL = 6 * 60 * 60; // 6 hours
+const IDENTITY_NEGATIVE_CACHE_TTL = 5 * 60; // 5 minutes for addresses with no identity
 const REPUTATION_CACHE_TTL = 5 * 60; // 5 minutes
 const TX_CACHE_TTL = 5 * 60; // 5 minutes
 
@@ -60,6 +61,9 @@ export function setCachedBnsName(
   return kvPut(kv, `cache:bns:${address}`, name, BNS_CACHE_TTL);
 }
 
+/** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
+export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
+
 /** Sentinel value for negative BNS cache (address has no name). */
 export const BNS_NONE_SENTINEL = "__NONE__";
 
@@ -70,17 +74,21 @@ export function setCachedBnsNegative(
   return kvPut(kv, `cache:bns:${address}`, BNS_NONE_SENTINEL, BNS_NEGATIVE_CACHE_TTL);
 }
 
+/** Sentinel value for negative identity cache (address has no on-chain identity). */
+export const IDENTITY_NONE_SENTINEL = "__NONE__";
+
 export async function getCachedIdentity(
   address: string,
   kv?: KVNamespace
-): Promise<AgentIdentity | null> {
+): Promise<CacheResult<AgentIdentity>> {
   const raw = await kvGet(kv, `cache:identity:${address}`);
-  if (!raw) return null;
+  if (raw === null) return { hit: false };
+  if (raw === IDENTITY_NONE_SENTINEL) return { hit: true, value: null };
   try {
-    return JSON.parse(raw) as AgentIdentity;
+    return { hit: true, value: JSON.parse(raw) as AgentIdentity };
   } catch (e) {
     console.error(`Failed to parse cached identity for ${address}:`, e);
-    return null;
+    return { hit: false };
   }
 }
 
@@ -92,8 +100,12 @@ export function setCachedIdentity(
   return kvPut(kv, `cache:identity:${address}`, JSON.stringify(identity), IDENTITY_CACHE_TTL);
 }
 
-/** Result from reputation cache: distinguishes miss from cached null. */
-export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
+export function setCachedIdentityNegative(
+  address: string,
+  kv?: KVNamespace
+): Promise<void> {
+  return kvPut(kv, `cache:identity:${address}`, IDENTITY_NONE_SENTINEL, IDENTITY_NEGATIVE_CACHE_TTL);
+}
 
 export async function getCachedReputation<T>(
   key: string,

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -64,18 +64,19 @@ export function setCachedBnsName(
 /** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
 export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
 
-/** Sentinel value for negative BNS cache (address has no name). */
-export const BNS_NONE_SENTINEL = "__NONE__";
+/** Sentinel value for negative cache entries (address has no BNS name or on-chain identity). */
+export const NONE_SENTINEL = "__NONE__";
+
+/** @deprecated Use NONE_SENTINEL instead. */
+export const BNS_NONE_SENTINEL = NONE_SENTINEL;
+
 
 export function setCachedBnsNegative(
   address: string,
   kv?: KVNamespace
 ): Promise<void> {
-  return kvPut(kv, `cache:bns:${address}`, BNS_NONE_SENTINEL, BNS_NEGATIVE_CACHE_TTL);
+  return kvPut(kv, `cache:bns:${address}`, NONE_SENTINEL, BNS_NEGATIVE_CACHE_TTL);
 }
-
-/** Sentinel value for negative identity cache (address has no on-chain identity). */
-export const IDENTITY_NONE_SENTINEL = "__NONE__";
 
 export async function getCachedIdentity(
   address: string,
@@ -83,7 +84,7 @@ export async function getCachedIdentity(
 ): Promise<CacheResult<AgentIdentity>> {
   const raw = await kvGet(kv, `cache:identity:${address}`);
   if (raw === null) return { hit: false };
-  if (raw === IDENTITY_NONE_SENTINEL) return { hit: true, value: null };
+  if (raw === NONE_SENTINEL) return { hit: true, value: null };
   try {
     return { hit: true, value: JSON.parse(raw) as AgentIdentity };
   } catch (e) {
@@ -104,7 +105,7 @@ export function setCachedIdentityNegative(
   address: string,
   kv?: KVNamespace
 ): Promise<void> {
-  return kvPut(kv, `cache:identity:${address}`, IDENTITY_NONE_SENTINEL, IDENTITY_NEGATIVE_CACHE_TTL);
+  return kvPut(kv, `cache:identity:${address}`, NONE_SENTINEL, IDENTITY_NEGATIVE_CACHE_TTL);
 }
 
 export async function getCachedReputation<T>(

--- a/lib/identity/stacks-api.ts
+++ b/lib/identity/stacks-api.ts
@@ -44,14 +44,22 @@ export async function callReadOnly(
   const headers = buildHiroHeaders(hiroApiKey);
   headers["Content-Type"] = "application/json";
 
-  const response = await stacksApiFetch(url, {
-    method: "POST",
-    headers,
-    body: JSON.stringify({
-      sender: contractAddress,
-      arguments: hexArgs,
-    }),
-  });
+  // Reduced retry budget for synchronous profile lookups: worst-case ~20s
+  // instead of default ~71s. retries=2 (5xx), baseDelayMs=500, retries429=2.
+  const response = await stacksApiFetch(
+    url,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        sender: contractAddress,
+        arguments: hexArgs,
+      }),
+    },
+    2,
+    500,
+    2
+  );
 
   // Log cf-ray for observability if the final response is still a 429 after retries
   detect429(response);

--- a/lib/stacks-api-fetch.ts
+++ b/lib/stacks-api-fetch.ts
@@ -42,6 +42,61 @@ export function detect429(response: Response): {
   return { isRateLimited };
 }
 
+/** Rate limit warning threshold — warn when remaining drops below this value. */
+const RATE_LIMIT_WARN_THRESHOLD = 50;
+
+/** Parsed Hiro API rate limit headers from a response. */
+export interface RateLimitInfo {
+  /** Remaining requests in the current window (ratelimit-remaining). */
+  remaining: number | null;
+  /** Total request budget for the current window (ratelimit-limit). */
+  limit: number | null;
+  /** Seconds until the current window resets (ratelimit-reset). */
+  reset: number | null;
+  /** Remaining per-minute request budget (x-ratelimit-remaining-stacks-minute). */
+  remainingMinute: number | null;
+  /** API cost units consumed by this request (x-ratelimit-cost-stacks). */
+  costStacks: number | null;
+}
+
+/**
+ * Extract Hiro API rate limit headers from a response.
+ *
+ * Reads ratelimit-remaining, ratelimit-limit, ratelimit-reset,
+ * x-ratelimit-remaining-stacks-minute, and x-ratelimit-cost-stacks.
+ *
+ * Emits a warn-level log when the remaining budget drops below
+ * RATE_LIMIT_WARN_THRESHOLD (50) to alert operators before key exhaustion.
+ *
+ * @param response - The Response object from a Hiro API fetch
+ * @returns Parsed rate limit fields (null for any header that is absent or unparseable)
+ */
+export function extractRateLimitInfo(response: Response): RateLimitInfo {
+  const tag = "[stacksApiFetch]";
+
+  function parseIntHeader(name: string): number | null {
+    const val = response.headers.get(name);
+    if (!val) return null;
+    const n = parseInt(val, 10);
+    return isNaN(n) ? null : n;
+  }
+
+  const remaining = parseIntHeader("ratelimit-remaining");
+  const limit = parseIntHeader("ratelimit-limit");
+  const reset = parseIntHeader("ratelimit-reset");
+  const remainingMinute = parseIntHeader("x-ratelimit-remaining-stacks-minute");
+  const costStacks = parseIntHeader("x-ratelimit-cost-stacks");
+
+  if (remaining !== null && remaining < RATE_LIMIT_WARN_THRESHOLD) {
+    console.warn(
+      `${tag} Hiro API key approaching rate limit: ${remaining}/${limit ?? "?"} remaining` +
+        (reset !== null ? ` (resets in ${reset}s)` : "")
+    );
+  }
+
+  return { remaining, limit, reset, remainingMinute, costStacks };
+}
+
 /** Per-attempt fetch timeout in milliseconds. */
 const PER_ATTEMPT_TIMEOUT_MS = 8_000;
 
@@ -130,18 +185,27 @@ export async function stacksApiFetch(
     try {
       const response = await fetch(url, attemptOptions);
 
+      // Extract rate limit info on every response for observability (warns when low)
+      const rl = extractRateLimitInfo(response);
+
       if (!isRetryableStatus(response.status)) {
         return response;
       }
 
       const is429 = response.status === 429;
 
+      // Build a compact rate limit suffix for retry log messages
+      const rlSuffix =
+        rl.remaining !== null
+          ? ` [rl: ${rl.remaining}/${rl.limit ?? "?"} remaining]`
+          : "";
+
       if (is429) {
         attempts429++;
         if (attempts429 >= retries429) {
           // Exhausted 429 retry budget — return final response to caller
           console.warn(
-            `${tag} 429 retry budget exhausted (${retries429} attempts) for ${url}`
+            `${tag} 429 retry budget exhausted (${retries429} attempts) for ${url}${rlSuffix}`
           );
           return response;
         }
@@ -152,7 +216,7 @@ export async function stacksApiFetch(
           RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempts429 - 1);
         const delayMs = Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
         console.warn(
-          `${tag} 429 on ${url}, attempt ${attempts429}/${retries429}, retrying in ${delayMs}ms`
+          `${tag} 429 on ${url}, attempt ${attempts429}/${retries429}, retrying in ${delayMs}ms${rlSuffix}`
         );
         await sleep(delayMs);
       } else {
@@ -160,14 +224,14 @@ export async function stacksApiFetch(
         attempts5xx++;
         if (attempts5xx >= retries) {
           console.warn(
-            `${tag} 5xx retry budget exhausted (${retries} attempts) for ${url} (status: ${response.status})`
+            `${tag} 5xx retry budget exhausted (${retries} attempts) for ${url} (status: ${response.status})${rlSuffix}`
           );
           return response;
         }
 
         const delayMs = baseDelayMs * Math.pow(2, attempts5xx - 1);
         console.warn(
-          `${tag} ${response.status} on ${url}, attempt ${attempts5xx}/${retries}, retrying in ${delayMs}ms`
+          `${tag} ${response.status} on ${url}, attempt ${attempts5xx}/${retries}, retrying in ${delayMs}ms${rlSuffix}`
         );
         await sleep(delayMs);
       }


### PR DESCRIPTION
## Summary

- **Negative identity cache**: Agents without on-chain identity now get a 5-min negative cache entry, eliminating the majority of unnecessary Hiro API calls (the root cause of key exhaustion)
- **Legacy fallback cap**: O(N) NFT scan capped at 3 batches (15 NFTs) to prevent unbounded API consumption
- **Parallel enrichment**: Reputation fetch runs inside the identity slot in `Promise.all` instead of sequentially after it
- **10s enrichment timeout**: `Promise.race` wraps all enrichment — degraded Hiro API no longer blocks responses forever
- **Rate limit observability**: `extractRateLimitInfo()` reads Hiro rate limit headers on every response; warns when remaining calls drop below 50 (10% of 500 RPM budget)
- **Reduced retry budgets**: Worst-case retry latency cut from ~71s to ~13-20s for synchronous profile lookups
- **Shared enrichment helper**: Deduplicated enrichment logic from agents and resolve routes into `lib/agent-enrichment.ts`; fixed a type-safety bug where agents route built an identity shortcut missing `owner`/`uri` fields

## Test plan

- [x] `npm run build` passes (7 files changed, no type errors)
- [x] `npm run lint` passes (only pre-existing `<img>` warning)
- [x] `npm run test` passes (455/455)
- [ ] After deploy: monitor worker-logs for `ratelimit-remaining` warnings
- [ ] After deploy: verify Hiro API key consumption drops (check `x-ratelimit-remaining-stacks-minute`)
- [ ] Spot-check: `curl /api/agents/{knownBtcAddress}` returns fast with all fields
- [ ] Spot-check: `curl /api/agents/{unknownBtcAddress}` returns 404 instantly (negative cache)

🤖 Generated with [Claude Code](https://claude.com/claude-code)