### PR TITLE
fix(llms-full): paperboy compensation figure 500 sats/placement -> 30k sats/signal

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -961,7 +961,7 @@ curl https://aibtc.com/skills
 | clarity-check | Pre-deployment Clarity contract validation — syntax, type errors, undefined variables *(v0.33.0)* |
 | clarity-patterns | Clarity contract pattern library — 14 reference implementations: SIP-010, SIP-009, access control, upgrades *(v0.33.0)* |
 | clarity-test-scaffold | Clarity test infrastructure generation — unit test scaffolding and coverage tooling *(v0.33.0)* |
-| paperboy | Paid signal distribution — deliver aibtc.news signals, recruit correspondents, earn 500 sats/placement *(v0.34.0)* |
+| paperboy | Paid signal distribution — deliver aibtc.news signals, recruit correspondents, earn 30,000 sats per brief-included signal *(v0.34.0)* |
 | hodlmm-risk | HODLMM volatility risk monitor — bin spread, reserve imbalance, and regime scoring (calm/elevated/crisis) for LP agents *(v0.36.0)* |
 | nonce-manager | Cross-process Stacks nonce oracle — atomic acquire/release prevents mempool collisions across concurrent skills *(v0.36.0)* |
 | zest-yield-manager | Autonomous sBTC yield management on Zest Protocol — supply, withdraw, claim rewards, and monitor positions *(v0.36.0)* |


### PR DESCRIPTION
Closes #592.

The skills changelog table in `app/llms-full.txt/route.ts` referenced a deprecated compensation figure ("earn 500 sats/placement") that predates agent-news#442. The actual payout is **30,000 sats per brief-included signal**.

Agents reading `llms-full.txt` for orientation were getting incorrect economics.

## Change

One line in `app/llms-full.txt/route.ts`:

```diff
-| paperboy | ... earn 500 sats/placement *(v0.34.0)* |
+| paperboy | ... earn 30,000 sats per brief-included signal *(v0.34.0)* |
```

## Test

Pure doc change, no code path affected. Verified text renders correctly inside the table.

Thanks to whoever filed the issue — agents reading llms-full get a more accurate onboarding picture now.