### PR TITLE
perf(hiro): cut Hiro API volume 5-10x via proxy, wrapper, caching, fan-out caps

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,3 +1,31 @@
 {
-  "extends": "next/core-web-vitals"
+  "extends": "next/core-web-vitals",
+  "rules": {
+    "no-restricted-syntax": [
+      "error",
+      {
+        "selector": "Literal[value=/api\\.hiro\\.so/]",
+        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE from lib/identity/constants.ts."
+      },
+      {
+        "selector": "TemplateLiteral > TemplateElement[value.raw=/api\\.hiro\\.so/]",
+        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE from lib/identity/constants.ts."
+      }
+    ]
+  },
+  "overrides": [
+    {
+      "files": [
+        "lib/stacks-api-fetch.ts",
+        "lib/identity/constants.ts",
+        "lib/**/__tests__/**/*.ts",
+        "lib/**/__tests__/**/*.tsx",
+        "**/*.test.ts",
+        "**/*.test.tsx"
+      ],
+      "rules": {
+        "no-restricted-syntax": "off"
+      }
+    }
+  ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,12 +4,12 @@
     "no-restricted-syntax": [
       "error",
       {
-        "selector": "Literal[value=/api\\.hiro\\.so/]",
-        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE from lib/identity/constants.ts."
+        "selector": "Literal[value=/api(?:\\.mainnet|\\.testnet)?\\.hiro\\.so/]",
+        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE / STACKS_API_TESTNET_BASE from lib/identity/constants.ts."
       },
       {
-        "selector": "TemplateLiteral > TemplateElement[value.raw=/api\\.hiro\\.so/]",
-        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE from lib/identity/constants.ts."
+        "selector": "TemplateLiteral > TemplateElement[value.raw=/api(?:\\.mainnet|\\.testnet)?\\.hiro\\.so/]",
+        "message": "Direct Hiro API URL not allowed. Use stacksApiFetch() from lib/stacks-api-fetch.ts with STACKS_API_BASE / STACKS_API_TESTNET_BASE from lib/identity/constants.ts."
       }
     ]
   },

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -8,6 +8,8 @@ import { getAgentLevel, computeLevel, LEVELS } from "@/lib/levels";
 import { generateName } from "@/lib/name-generator";
 import { lookupBnsName } from "@/lib/bns";
 import { X_HANDLE } from "@/lib/constants";
+import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
+import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
 import AgentProfile from "./AgentProfile";
 import Navbar from "../../components/Navbar";
 import AnimatedBackground from "../../components/AnimatedBackground";
@@ -97,14 +99,13 @@ async function resolveIdentity(
 
   // Fetch from Hiro
   try {
-    const contract = "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2";
-    const assetId = `${contract}::agent-identity`;
-    const url = `https://api.mainnet.hiro.so/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
+    const [contractAddress, contractName] = IDENTITY_REGISTRY_CONTRACT.split(".");
+    const assetId = `${contractAddress}.${contractName}::agent-identity`;
+    const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
-    const headers: Record<string, string> = {};
-    if (hiroApiKey) headers["X-Hiro-API-Key"] = hiroApiKey;
-
-    const resp = await fetch(url, { headers });
+    const resp = await stacksApiFetch(url, {
+      headers: buildHiroHeaders(hiroApiKey),
+    });
     if (!resp.ok) return agent;
 
     const data = await resp.json() as {

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -112,9 +112,16 @@ async function resolveIdentity(
     const assetId = `${contractAddress}.${contractName}::agent-identity`;
     const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
-    const resp = await stacksApiFetch(url, {
-      headers: buildHiroHeaders(hiroApiKey),
-    });
+    // SSR profile path — reduced retry budget so a throttled Hiro cannot
+    // block page rendering for tens of seconds. Falls back to the uncached
+    // agent record on failure.
+    const resp = await stacksApiFetch(
+      url,
+      { headers: buildHiroHeaders(hiroApiKey) },
+      2,
+      500,
+      1
+    );
     if (!resp.ok) return agent;
 
     const data = await resp.json() as {

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -10,6 +10,8 @@ import { lookupBnsName } from "@/lib/bns";
 import { X_HANDLE } from "@/lib/constants";
 import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
+import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from "@/lib/identity/kv-cache";
+import type { AgentIdentity } from "@/lib/identity/types";
 import AgentProfile from "./AgentProfile";
 import Navbar from "../../components/Navbar";
 import AnimatedBackground from "../../components/AnimatedBackground";
@@ -82,22 +84,29 @@ async function resolveAgent(
 
 /**
  * Detect and cache the on-chain ERC-8004 identity for an agent.
- * Reuses the same TTL-based caching logic as /api/identity/[address].
+ *
+ * Uses the typed identity KV cache (cache:identity: prefix) for both positive
+ * and negative results. Positive results are cached for 24h (immutable NFT).
+ * Negative results are cached for 5min so newly registered agents are detected.
  */
 async function resolveIdentity(
   kv: KVNamespace,
   agent: AgentRecord,
   hiroApiKey?: string
 ): Promise<AgentRecord> {
-  // Positive result — skip Hiro
+  // Positive result already on the agent record — skip cache + Hiro
   if (agent.erc8004AgentId != null) return agent;
 
-  // For null/undefined, rate-limit Hiro calls (5 min TTL key)
-  const rateLimitKey = `identity-check:${agent.stxAddress}`;
-  const recentlyChecked = await kv.get(rateLimitKey);
-  if (recentlyChecked) return agent;
+  // Check typed identity cache (covers both positive and negative sentinels)
+  const cached = await getCachedIdentity(agent.stxAddress, kv);
+  if (cached.hit) {
+    if (cached.value) {
+      agent.erc8004AgentId = cached.value.agentId;
+    }
+    return agent;
+  }
 
-  // Fetch from Hiro
+  // Cache miss — fetch from Hiro through the keyed wrapper
   try {
     const [contractAddress, contractName] = IDENTITY_REGISTRY_CONTRACT.split(".");
     const assetId = `${contractAddress}.${contractName}::agent-identity`;
@@ -116,20 +125,22 @@ async function resolveIdentity(
     const match = repr?.match(/^u(\d+)$/);
     const newAgentId = match ? Number(match[1]) : null;
 
-    if (newAgentId !== agent.erc8004AgentId) {
+    if (newAgentId != null) {
+      // Found identity — update agent record and write positive cache
       agent.erc8004AgentId = newAgentId;
       const updated = JSON.stringify(agent);
+      const identity: AgentIdentity = { agentId: newAgentId, owner: agent.stxAddress, uri: "" };
       await Promise.all([
         kv.put(`stx:${agent.stxAddress}`, updated),
         kv.put(`btc:${agent.btcAddress}`, updated),
+        setCachedIdentity(agent.stxAddress, identity, kv),
       ]);
-    }
-    // Rate-limit negative results (5 min TTL)
-    if (newAgentId == null) {
-      await kv.put(rateLimitKey, "1", { expirationTtl: 300 });
+    } else {
+      // No identity found — write negative sentinel (5 min TTL)
+      await setCachedIdentityNegative(agent.stxAddress, kv);
     }
   } catch {
-    /* best-effort */
+    /* best-effort — transient Hiro errors should not break profile rendering */
   }
 
   return agent;

--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -21,7 +21,7 @@ import {
   setCachedTransaction,
 } from "@/lib/identity/kv-cache";
 import { buildHiroHeaders, detect429 } from "@/lib/identity/stacks-api";
-import { stacksApiFetch } from "@/lib/stacks-api-fetch";
+import { stacksApiFetch, parseRetryAfterMs } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE } from "@/lib/identity/constants";
 
 const RATE_LIMIT_MS = ACHIEVEMENT_VERIFY_RATE_LIMIT_MS;
@@ -406,11 +406,31 @@ export async function POST(request: NextRequest) {
             const txResp = await stacksApiFetch(txUrl, { headers });
 
             if (!txResp.ok) {
+              // If the wrapper exhausted its 429 retry budget and still saw a rate
+              // limit from Hiro, surface that as 503 + Retry-After so callers can
+              // back off rather than treating it as a permanent client error.
+              if (txResp.status === 429) {
+                const retryAfterMs = parseRetryAfterMs(txResp);
+                const retryAfterSeconds = retryAfterMs != null
+                  ? Math.ceil(retryAfterMs / 1000)
+                  : 60;
+                return NextResponse.json(
+                  {
+                    error: `Upstream rate limit while fetching transaction ${txid}. Retry later.`,
+                  },
+                  {
+                    status: 503,
+                    headers: { "Retry-After": String(retryAfterSeconds) },
+                  }
+                );
+              }
+              const upstreamStatus =
+                txResp.status >= 500 && txResp.status < 600 ? 502 : 400;
               return NextResponse.json(
                 {
                   error: `Failed to fetch transaction ${txid}: ${txResp.status} ${txResp.statusText}`,
                 },
-                { status: 400 }
+                { status: upstreamStatus }
               );
             }
 

--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -21,6 +21,8 @@ import {
   setCachedTransaction,
 } from "@/lib/identity/kv-cache";
 import { buildHiroHeaders, detect429 } from "@/lib/identity/stacks-api";
+import { stacksApiFetch } from "@/lib/stacks-api-fetch";
+import { STACKS_API_BASE } from "@/lib/identity/constants";
 
 const RATE_LIMIT_MS = ACHIEVEMENT_VERIFY_RATE_LIMIT_MS;
 
@@ -132,8 +134,7 @@ export function GET() {
       },
       externalAPIs: {
         mempoolSpace: "https://mempool.space/api/address/{btcAddress}/txs",
-        stacksAPI:
-          "https://api.hiro.so/extended/v1/tx/{txid}",
+        stacksAPI: "Stacks Extended API /extended/v1/tx/{txid} (proxied through server)",
       },
       documentation: {
         achievements: "https://aibtc.com/api/achievements",
@@ -400,27 +401,9 @@ export async function POST(request: NextRequest) {
 
           if (!tx) {
             // Fetch transaction from Stacks API with API key
-            const txUrl = `https://api.hiro.so/extended/v1/tx/${txid}`;
+            const txUrl = `${STACKS_API_BASE}/extended/v1/tx/${txid}`;
             const headers = buildHiroHeaders(hiroApiKey);
-            const txResp = await fetch(txUrl, {
-              headers,
-              signal: AbortSignal.timeout(10000),
-            });
-
-            // Check for rate limiting
-            const rateLimitCheck = detect429(txResp);
-            if (rateLimitCheck.isRateLimited) {
-              return NextResponse.json(
-                {
-                  error: `Stacks API rate limited. Try again later.`,
-                  retryAfter: 60,
-                },
-                {
-                  status: 503,
-                  headers: { "Retry-After": "60" },
-                }
-              );
-            }
+            const txResp = await stacksApiFetch(txUrl, { headers });
 
             if (!txResp.ok) {
               return NextResponse.json(

--- a/app/api/admin/backfill-identity/route.ts
+++ b/app/api/admin/backfill-identity/route.ts
@@ -3,6 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
 import type { AgentRecord } from "@/lib/types";
 import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "@/lib/identity/constants";
+import { stacksApiFetch } from "@/lib/stacks-api-fetch";
 
 /**
  * GET /api/admin/backfill-identity
@@ -92,7 +93,7 @@ export async function GET(request: NextRequest) {
 
         try {
           const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
-          const resp = await fetch(url, { headers: hiroHeaders });
+          const resp = await stacksApiFetch(url, { headers: hiroHeaders });
 
           if (!resp.ok) {
             console.warn(`[backfill-identity] Hiro error ${resp.status} for ${agent.stxAddress}`);

--- a/app/api/admin/backfill-identity/route.ts
+++ b/app/api/admin/backfill-identity/route.ts
@@ -3,7 +3,13 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
 import type { AgentRecord } from "@/lib/types";
 import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "@/lib/identity/constants";
-import { stacksApiFetch } from "@/lib/stacks-api-fetch";
+import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
+
+/** Sleep helper for rate-spacing sequential Hiro API calls. */
+const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
+
+/** Minimum delay between Hiro API calls to stay within rate limits (200ms = 5 calls/sec). */
+const BACKFILL_INTER_CALL_DELAY_MS = 200;
 
 /**
  * GET /api/admin/backfill-identity
@@ -39,8 +45,7 @@ export async function GET(request: NextRequest) {
     const [contractAddress, contractName] = IDENTITY_REGISTRY_CONTRACT.split(".");
     const assetId = `${contractAddress}.${contractName}::agent-identity`;
 
-    const hiroHeaders: Record<string, string> = {};
-    if (hiroApiKey) hiroHeaders["X-Hiro-API-Key"] = hiroApiKey;
+    const hiroHeaders = buildHiroHeaders(hiroApiKey);
 
     let processed = 0;
     let updated = 0;
@@ -98,6 +103,8 @@ export async function GET(request: NextRequest) {
           if (!resp.ok) {
             console.warn(`[backfill-identity] Hiro error ${resp.status} for ${agent.stxAddress}`);
             errors++;
+            // Still rate-space on error to avoid hammering a degraded endpoint
+            await sleep(BACKFILL_INTER_CALL_DELAY_MS);
             continue;
           }
 
@@ -127,7 +134,13 @@ export async function GET(request: NextRequest) {
         } catch (error) {
           console.error(`[backfill-identity] Error for ${agent.stxAddress}:`, error);
           errors++;
+          // Still rate-space on unexpected errors
+          await sleep(BACKFILL_INTER_CALL_DELAY_MS);
+          continue;
         }
+
+        // Rate-space: wait between Hiro calls to stay within budget
+        await sleep(BACKFILL_INTER_CALL_DELAY_MS);
       }
 
       listComplete = listResult.list_complete;

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -1,7 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { LEVELS } from "@/lib/levels";
-import { lookupBnsName } from "@/lib/bns";
 import { getCachedAgentList } from "@/lib/cache";
 
 export async function GET(request: NextRequest) {
@@ -109,41 +108,6 @@ export async function GET(request: NextRequest) {
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     const { agents: cachedAgents } = await getCachedAgentList(kv);
-
-    // Lazy BNS refresh: for agents without bnsName but with stxAddress,
-    // attempt BNS lookup and persist if found. Capped to avoid excessive
-    // external API calls, and fire-and-forget so it doesn't block the response.
-    // Note: BNS updates write to source KV records but don't invalidate the
-    // agent list cache — updated names appear after natural TTL expiry (~2 min).
-    // This is intentional: BNS changes are rare and not time-critical.
-    const hiroApiKey = env.HIRO_API_KEY;
-    const MAX_BNS_REFRESH_PER_REQUEST = 10;
-    const agentsNeedingBns = cachedAgents.filter(
-      (agent) => !agent.bnsName && agent.stxAddress
-    );
-    if (agentsNeedingBns.length > 0) {
-      const batch = agentsNeedingBns.slice(0, MAX_BNS_REFRESH_PER_REQUEST);
-      void Promise.allSettled(
-        batch.map(async (agent) => {
-          const bnsName = await lookupBnsName(agent.stxAddress, hiroApiKey, kv);
-          if (bnsName) {
-            // Update the source records in KV (cache will pick up on next rebuild)
-            const agentRecord = await kv.get(`stx:${agent.stxAddress}`);
-            if (agentRecord) {
-              try {
-                const parsed = JSON.parse(agentRecord);
-                parsed.bnsName = bnsName;
-                const updated = JSON.stringify(parsed);
-                await Promise.all([
-                  kv.put(`stx:${agent.stxAddress}`, updated),
-                  kv.put(`btc:${agent.btcAddress}`, updated),
-                ]);
-              } catch { /* ignore parse errors */ }
-            }
-          }
-        })
-      );
-    }
 
     // Sort by most recently verified
     const sorted = [...cachedAgents].sort(

--- a/app/api/identity/[address]/route.ts
+++ b/app/api/identity/[address]/route.ts
@@ -78,9 +78,15 @@ export async function GET(
     const assetId = `${contractAddress}.${contractName}::agent-identity`;
     const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
-    const resp = await stacksApiFetch(url, {
-      headers: buildHiroHeaders(env.HIRO_API_KEY as string | undefined),
-    });
+    // Browser-facing endpoint — reduced retry budget so sustained Hiro 429s
+    // cannot block the identity badge render for tens of seconds.
+    const resp = await stacksApiFetch(
+      url,
+      { headers: buildHiroHeaders(env.HIRO_API_KEY) },
+      2,
+      500,
+      1
+    );
     if (!resp.ok) {
       return NextResponse.json(
         { error: `Hiro API error: ${resp.status}` },

--- a/app/api/identity/[address]/route.ts
+++ b/app/api/identity/[address]/route.ts
@@ -53,10 +53,11 @@ export async function GET(
     }
 
     // Positive result in KV — return immediately
+    // Identity NFTs are immutable once minted; cache aggressively at the CDN layer.
     if (agent.erc8004AgentId != null) {
       return NextResponse.json(
         { agentId: agent.erc8004AgentId },
-        { headers: { "Cache-Control": "public, max-age=300, s-maxage=600" } }
+        { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=3600" } }
       );
     }
 
@@ -66,7 +67,7 @@ export async function GET(
     if (recentlyChecked) {
       return NextResponse.json(
         { agentId: null },
-        { headers: { "Cache-Control": "public, max-age=60, s-maxage=120" } }
+        { headers: { "Cache-Control": "public, max-age=300, s-maxage=300" } }
       );
     }
 
@@ -110,8 +111,8 @@ export async function GET(
     }
 
     const cacheHeader = agentId != null
-      ? "public, max-age=300, s-maxage=600"
-      : "public, max-age=60, s-maxage=120";
+      ? "public, max-age=3600, s-maxage=86400, stale-while-revalidate=3600"
+      : "public, max-age=300, s-maxage=300";
 
     return NextResponse.json(
       { agentId },

--- a/app/api/identity/[address]/route.ts
+++ b/app/api/identity/[address]/route.ts
@@ -1,6 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
+import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
+import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
 
 /**
  * GET /api/identity/:address — Detect on-chain ERC-8004 identity for an agent.
@@ -72,14 +74,13 @@ export async function GET(
     }
 
     // Fetch from Hiro
-    const contract = "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2";
-    const assetId = `${contract}::agent-identity`;
-    const url = `https://api.mainnet.hiro.so/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
+    const [contractAddress, contractName] = IDENTITY_REGISTRY_CONTRACT.split(".");
+    const assetId = `${contractAddress}.${contractName}::agent-identity`;
+    const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
-    const headers: Record<string, string> = {};
-    if (env.HIRO_API_KEY) headers["X-Hiro-API-Key"] = env.HIRO_API_KEY;
-
-    const resp = await fetch(url, { headers });
+    const resp = await stacksApiFetch(url, {
+      headers: buildHiroHeaders(env.HIRO_API_KEY as string | undefined),
+    });
     if (!resp.ok) {
       return NextResponse.json(
         { error: `Hiro API error: ${resp.status}` },

--- a/app/components/IdentityBadge.tsx
+++ b/app/components/IdentityBadge.tsx
@@ -8,8 +8,6 @@ interface IdentityBadgeProps {
   stxAddress: string;
 }
 
-const CONTRACT = "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2";
-
 export default function IdentityBadge({
   agentId: initialAgentId,
   stxAddress,
@@ -20,15 +18,13 @@ export default function IdentityBadge({
   useEffect(() => {
     if (initialAgentId !== undefined) return;
 
-    const assetId = `${CONTRACT}::agent-identity`;
-    const url = `https://api.mainnet.hiro.so/extended/v1/tokens/nft/holdings?principal=${stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
-
-    fetch(url)
-      .then((r) => r.json())
-      .then((data: any) => {
-        const repr = data.results?.[0]?.value?.repr;
-        const match = repr?.match(/^u(\d+)$/);
-        if (match) setAgentId(Number(match[1]));
+    fetch(`/api/identity/${encodeURIComponent(stxAddress)}`)
+      .then((r) => {
+        if (!r.ok) return null;
+        return r.json() as Promise<{ agentId: number | null }>;
+      })
+      .then((data) => {
+        if (data?.agentId != null) setAgentId(data.agentId);
       })
       .catch(() => {})
       .finally(() => setLoading(false));

--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -5,6 +5,11 @@ import { lookupBnsName } from "../bns";
 const mockFetch = vi.fn();
 global.fetch = mockFetch as any;
 
+/** Minimal headers mock that satisfies stacksApiFetch's extractRateLimitInfo. */
+function mockHeaders(): Headers {
+  return { get: () => null } as unknown as Headers;
+}
+
 /**
  * Build a mock Hiro API response for BNS-V2 get-primary.
  * Constructs the actual Clarity hex that @stacks/transactions can deserialize.
@@ -32,6 +37,8 @@ function mockV2Response(name: string, namespace: string) {
 
   return {
     ok: true,
+    status: 200,
+    headers: mockHeaders(),
     json: async () => ({ okay: true, result }),
   };
 }
@@ -40,6 +47,8 @@ function mockV2None() {
   // (ok none) = 0x07 09
   return {
     ok: true,
+    status: 200,
+    headers: mockHeaders(),
     json: async () => ({ okay: true, result: "0x0709" }),
   };
 }
@@ -69,7 +78,7 @@ describe("lookupBnsName", () => {
       await lookupBnsName("SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7");
 
       expect(mockFetch).toHaveBeenCalledWith(
-        "https://api.hiro.so/v2/contracts/call-read/SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF/BNS-V2/get-primary",
+        "https://api.mainnet.hiro.so/v2/contracts/call-read/SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF/BNS-V2/get-primary",
         expect.objectContaining({
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -99,7 +108,7 @@ describe("lookupBnsName", () => {
     });
 
     it("returns null when API response is not ok", async () => {
-      mockFetch.mockResolvedValue({ ok: false, status: 404 });
+      mockFetch.mockResolvedValue({ ok: false, status: 404, headers: mockHeaders() });
 
       const result = await lookupBnsName(
         "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
@@ -108,7 +117,8 @@ describe("lookupBnsName", () => {
     });
 
     it("returns null when API response is 500", async () => {
-      mockFetch.mockResolvedValue({ ok: false, status: 500 });
+      // 500 is retried by stacksApiFetch (up to 3 attempts) — all return 500 here
+      mockFetch.mockResolvedValue({ ok: false, status: 500, headers: mockHeaders() });
 
       const result = await lookupBnsName(
         "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
@@ -119,6 +129,8 @@ describe("lookupBnsName", () => {
     it("returns null when okay is false", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
+        status: 200,
+        headers: mockHeaders(),
         json: async () => ({ okay: false, result: "some error" }),
       });
 
@@ -151,6 +163,8 @@ describe("lookupBnsName", () => {
     it("does not throw on JSON parse failure", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
+        status: 200,
+        headers: mockHeaders(),
         json: async () => {
           throw new Error("Invalid JSON");
         },
@@ -164,6 +178,8 @@ describe("lookupBnsName", () => {
     it("does not throw on invalid Clarity value", async () => {
       mockFetch.mockResolvedValue({
         ok: true,
+        status: 200,
+        headers: mockHeaders(),
         json: async () => ({ okay: true, result: "0xdeadbeef" }),
       });
 

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -213,7 +213,7 @@ export async function verifyStackerAchievement(
       await setCachedStacking(stxAddress, stackingData, kv);
     }
 
-    const locked = (stackingData as { locked: string }).locked ?? "0";
+    const locked = stackingData.locked ?? "0";
     return locked !== "0" && locked !== "";
   } catch (error) {
     console.error(`Failed to verify stacker achievement for ${stxAddress}:`, error);

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -14,6 +14,8 @@ import {
   callReadOnly,
   parseClarityValue,
 } from "@/lib/identity/stacks-api";
+import { stacksApiFetch } from "@/lib/stacks-api-fetch";
+import { STACKS_API_BASE } from "@/lib/identity/constants";
 import { standardPrincipalCV } from "@stacks/transactions";
 
 /** Rate limit window for achievement verification (5 minutes) */
@@ -189,10 +191,9 @@ export async function verifyStackerAchievement(
     let stackingData = await getCachedTransaction(cacheKey, kv);
 
     if (!stackingData) {
-      const stackingUrl = `https://api.hiro.so/extended/v1/address/${stxAddress}/stacking`;
-      const stackingResp = await fetch(stackingUrl, {
+      const stackingUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/stacking`;
+      const stackingResp = await stacksApiFetch(stackingUrl, {
         headers: buildHiroHeaders(hiroApiKey),
-        signal: AbortSignal.timeout(10000),
       });
 
       if (stackingResp.status === 404) {
@@ -262,10 +263,9 @@ export async function verifyConnectorAchievement(
     let txs = await getCachedTransaction(cacheKey, kv);
 
     if (!txs) {
-      const txsUrl = `https://api.hiro.so/extended/v1/address/${stxAddress}/transactions?limit=50`;
-      const resp = await fetch(txsUrl, {
+      const txsUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/transactions?limit=50`;
+      const resp = await stacksApiFetch(txsUrl, {
         headers: buildHiroHeaders(hiroApiKey),
-        signal: AbortSignal.timeout(10000),
       });
 
       if (!resp.ok) {

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -8,6 +8,8 @@
 import {
   getCachedTransaction,
   setCachedTransaction,
+  getCachedStacking,
+  setCachedStacking,
 } from "@/lib/identity/kv-cache";
 import {
   buildHiroHeaders,
@@ -187,8 +189,7 @@ export async function verifyStackerAchievement(
   hiroApiKey?: string
 ): Promise<boolean> {
   try {
-    const cacheKey = `stacking:${stxAddress}`;
-    let stackingData = await getCachedTransaction(cacheKey, kv);
+    let stackingData = await getCachedStacking(stxAddress, kv);
 
     if (!stackingData) {
       const stackingUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/stacking`;
@@ -209,7 +210,7 @@ export async function verifyStackerAchievement(
       }
 
       stackingData = (await stackingResp.json()) as { locked: string };
-      await setCachedTransaction(cacheKey, stackingData, kv);
+      await setCachedStacking(stxAddress, stackingData, kv);
     }
 
     const locked = (stackingData as { locked: string }).locked ?? "0";

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -41,6 +41,8 @@ export async function lookupBnsName(
     const headers = buildHiroHeaders(hiroApiKey);
     headers["Content-Type"] = "application/json";
 
+    // BNS lookup runs on request paths (register, verify, SSR). Use a reduced
+    // retry budget so a degraded Hiro cannot block requests for tens of seconds.
     const res = await stacksApiFetch(
       `${STACKS_API_BASE}/v2/contracts/call-read/${BNS_V2_CONTRACT}/${BNS_V2_NAME}/get-primary`,
       {
@@ -50,7 +52,10 @@ export async function lookupBnsName(
           sender: stxAddress,
           arguments: [`0x${serialized}`],
         }),
-      }
+      },
+      2,
+      500,
+      1
     );
 
     if (!res.ok) return null;

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -7,11 +7,11 @@ import {
 import { hexToBytes, bytesToUtf8 } from "@stacks/common";
 import { getCachedBnsName, setCachedBnsName, setCachedBnsNegative, BNS_NONE_SENTINEL } from "./identity/kv-cache";
 import { buildHiroHeaders } from "./identity/stacks-api";
+import { stacksApiFetch } from "./stacks-api-fetch";
+import { STACKS_API_BASE } from "./identity/constants";
 
 const BNS_V2_CONTRACT = "SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF";
 const BNS_V2_NAME = "BNS-V2";
-const HIRO_API = "https://api.hiro.so";
-const BNS_TIMEOUT_MS = 5000;
 
 /**
  * Look up the BNS name for a Stacks address using BNS-V2.
@@ -41,8 +41,8 @@ export async function lookupBnsName(
     const headers = buildHiroHeaders(hiroApiKey);
     headers["Content-Type"] = "application/json";
 
-    const res = await fetch(
-      `${HIRO_API}/v2/contracts/call-read/${BNS_V2_CONTRACT}/${BNS_V2_NAME}/get-primary`,
+    const res = await stacksApiFetch(
+      `${STACKS_API_BASE}/v2/contracts/call-read/${BNS_V2_CONTRACT}/${BNS_V2_NAME}/get-primary`,
       {
         method: "POST",
         headers,
@@ -50,7 +50,6 @@ export async function lookupBnsName(
           sender: stxAddress,
           arguments: [`0x${serialized}`],
         }),
-        signal: AbortSignal.timeout(BNS_TIMEOUT_MS),
       }
     );
 

--- a/lib/identity/constants.ts
+++ b/lib/identity/constants.ts
@@ -17,3 +17,9 @@ export const WAD_DECIMALS = 18;
  * Used by heartbeat and identity endpoints to prevent excessive on-chain queries
  */
 export const IDENTITY_CHECK_TTL_MS = 60 * 60 * 1000;
+
+/**
+ * Cache TTL for identity checks in seconds (1 hour)
+ * Used for KV expirationTtl (KV takes seconds, not milliseconds)
+ */
+export const IDENTITY_CHECK_TTL_SECONDS = 60 * 60;

--- a/lib/identity/constants.ts
+++ b/lib/identity/constants.ts
@@ -17,9 +17,3 @@ export const WAD_DECIMALS = 18;
  * Used by heartbeat and identity endpoints to prevent excessive on-chain queries
  */
 export const IDENTITY_CHECK_TTL_MS = 60 * 60 * 1000;
-
-/**
- * Cache TTL for identity checks in seconds (1 hour)
- * Used for KV expirationTtl (KV takes seconds, not milliseconds)
- */
-export const IDENTITY_CHECK_TTL_SECONDS = 60 * 60;

--- a/lib/identity/constants.ts
+++ b/lib/identity/constants.ts
@@ -10,6 +10,8 @@ export const REPUTATION_REGISTRY_CONTRACT =
 
 export const STACKS_API_BASE = "https://api.mainnet.hiro.so";
 
+export const STACKS_API_TESTNET_BASE = "https://api.testnet.hiro.so";
+
 export const WAD_DECIMALS = 18;
 
 /**

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -108,7 +108,10 @@ async function detectAgentIdentityLegacy(
 ): Promise<AgentIdentity | null> {
   console.warn(`[identity] falling back to legacy O(N) scan for ${stxAddress}`);
 
-  const MAX_LEGACY_BATCHES = 3;
+  // Cap at 1 batch (5 get-owner calls) to bound worst-case Hiro API consumption.
+  // If the target agent's identity NFT was minted outside the most recent 5 IDs,
+  // we return null without caching so the next request will try again.
+  const MAX_LEGACY_BATCHES = 1;
 
   const lastIdResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-last-token-id", [], hiroApiKey);
   const lastIdRaw = parseClarityValue(lastIdResult);
@@ -147,7 +150,7 @@ async function detectAgentIdentityLegacy(
       // Scan is intentionally incomplete — don't negative-cache since the identity
       // may exist beyond the batches we checked.
       console.warn(
-        `[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batches) for ${stxAddress}, returning incomplete result without negative cache`
+        `[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batch × ${BATCH_SIZE} IDs) for ${stxAddress}, returning null without negative cache`
       );
       return null;
     }

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -21,6 +21,15 @@ const STACKING_CACHE_TTL = 4 * 60 * 60; // 4 hours (PoX cycle is ~2 weeks)
 const REPUTATION_CACHE_TTL = 60 * 60; // 1 hour (raised from 5 minutes)
 const TX_CACHE_TTL = 30 * 60; // 30 minutes (raised from 5 minutes)
 
+/** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
+export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
+
+/** Sentinel value for negative cache entries (address has no BNS name or on-chain identity). */
+export const NONE_SENTINEL = "__NONE__";
+
+/** @deprecated Use NONE_SENTINEL instead. */
+export const BNS_NONE_SENTINEL = NONE_SENTINEL;
+
 /** Safely read a string value from KV, returning null on miss or error. */
 async function kvGet(
   kv: KVNamespace | undefined,
@@ -50,6 +59,79 @@ async function kvPut(
   }
 }
 
+/**
+ * Emit a structured cache-hit/miss telemetry event. Centralized so all cache
+ * readers log with a consistent shape (keyFamily + key, plus an optional
+ * `negative: true` flag for negative-cache hits).
+ */
+function logCacheEvent(
+  event: "cache_hit" | "cache_miss",
+  keyFamily: string,
+  key: string,
+  negative = false
+): void {
+  const payload: Record<string, unknown> = { event, keyFamily, key };
+  if (negative) payload.negative = true;
+  console.log(JSON.stringify(payload));
+}
+
+/**
+ * Read and JSON-parse a cached value, emitting telemetry on hit/miss.
+ * Returns the parsed value, or null on miss / parse failure. Used by caches
+ * that don't need to distinguish "missing" from "cached null" (e.g. the
+ * transaction and stacking caches).
+ */
+async function readJsonCache<T>(
+  kv: KVNamespace | undefined,
+  prefix: string,
+  keyFamily: string,
+  key: string
+): Promise<T | null> {
+  const raw = await kvGet(kv, `${prefix}${key}`);
+  if (!raw) {
+    logCacheEvent("cache_miss", keyFamily, key);
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw) as T;
+    logCacheEvent("cache_hit", keyFamily, key);
+    return parsed;
+  } catch (e) {
+    console.error(`Failed to parse cached ${keyFamily} for ${key}:`, e);
+    return null;
+  }
+}
+
+/**
+ * Read a cache entry that uses NONE_SENTINEL to distinguish negative hits
+ * from misses. Returns a CacheResult so callers can tell apart "never cached"
+ * from "cached as null".
+ */
+async function readSentinelCache<T>(
+  kv: KVNamespace | undefined,
+  prefix: string,
+  keyFamily: string,
+  key: string
+): Promise<CacheResult<T>> {
+  const raw = await kvGet(kv, `${prefix}${key}`);
+  if (raw === null) {
+    logCacheEvent("cache_miss", keyFamily, key);
+    return { hit: false };
+  }
+  if (raw === NONE_SENTINEL) {
+    logCacheEvent("cache_hit", keyFamily, key, true);
+    return { hit: true, value: null };
+  }
+  try {
+    const parsed = JSON.parse(raw) as T;
+    logCacheEvent("cache_hit", keyFamily, key);
+    return { hit: true, value: parsed };
+  } catch (e) {
+    console.error(`Failed to parse cached ${keyFamily} for ${key}:`, e);
+    return { hit: false };
+  }
+}
+
 export function getCachedBnsName(
   address: string,
   kv?: KVNamespace
@@ -65,16 +147,6 @@ export function setCachedBnsName(
   return kvPut(kv, `cache:bns:${address}`, name, BNS_CACHE_TTL);
 }
 
-/** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
-export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
-
-/** Sentinel value for negative cache entries (address has no BNS name or on-chain identity). */
-export const NONE_SENTINEL = "__NONE__";
-
-/** @deprecated Use NONE_SENTINEL instead. */
-export const BNS_NONE_SENTINEL = NONE_SENTINEL;
-
-
 export function setCachedBnsNegative(
   address: string,
   kv?: KVNamespace
@@ -82,26 +154,11 @@ export function setCachedBnsNegative(
   return kvPut(kv, `cache:bns:${address}`, NONE_SENTINEL, BNS_NEGATIVE_CACHE_TTL);
 }
 
-export async function getCachedIdentity(
+export function getCachedIdentity(
   address: string,
   kv?: KVNamespace
 ): Promise<CacheResult<AgentIdentity>> {
-  const raw = await kvGet(kv, `cache:identity:${address}`);
-  if (raw === null) {
-    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "identity", key: address }));
-    return { hit: false };
-  }
-  if (raw === NONE_SENTINEL) {
-    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "identity", key: address, negative: true }));
-    return { hit: true, value: null };
-  }
-  try {
-    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "identity", key: address }));
-    return { hit: true, value: JSON.parse(raw) as AgentIdentity };
-  } catch (e) {
-    console.error(`Failed to parse cached identity for ${address}:`, e);
-    return { hit: false };
-  }
+  return readSentinelCache<AgentIdentity>(kv, "cache:identity:", "identity", address);
 }
 
 export function setCachedIdentity(
@@ -119,22 +176,11 @@ export function setCachedIdentityNegative(
   return kvPut(kv, `cache:identity:${address}`, NONE_SENTINEL, IDENTITY_NEGATIVE_CACHE_TTL);
 }
 
-export async function getCachedReputation<T>(
+export function getCachedReputation<T>(
   key: string,
   kv?: KVNamespace
 ): Promise<CacheResult<T>> {
-  const raw = await kvGet(kv, `cache:reputation:${key}`);
-  if (raw === null) {
-    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "reputation", key }));
-    return { hit: false };
-  }
-  try {
-    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "reputation", key }));
-    return { hit: true, value: JSON.parse(raw) as T | null };
-  } catch (e) {
-    console.error(`Failed to parse cached reputation for key ${key}:`, e);
-    return { hit: false };
-  }
+  return readSentinelCache<T>(kv, "cache:reputation:", "reputation", key);
 }
 
 export function setCachedReputation(
@@ -145,22 +191,11 @@ export function setCachedReputation(
   return kvPut(kv, `cache:reputation:${key}`, JSON.stringify(data), REPUTATION_CACHE_TTL);
 }
 
-export async function getCachedTransaction(
+export function getCachedTransaction(
   txid: string,
   kv?: KVNamespace
 ): Promise<any | null> {
-  const raw = await kvGet(kv, `cache:tx:${txid}`);
-  if (!raw) {
-    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "tx", key: txid }));
-    return null;
-  }
-  try {
-    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "tx", key: txid }));
-    return JSON.parse(raw);
-  } catch (e) {
-    console.error(`Failed to parse cached transaction ${txid}:`, e);
-    return null;
-  }
+  return readJsonCache<any>(kv, "cache:tx:", "tx", txid);
 }
 
 export function setCachedTransaction(
@@ -171,22 +206,11 @@ export function setCachedTransaction(
   return kvPut(kv, `cache:tx:${txid}`, JSON.stringify(data), TX_CACHE_TTL);
 }
 
-export async function getCachedStacking(
+export function getCachedStacking(
   stxAddress: string,
   kv?: KVNamespace
 ): Promise<any | null> {
-  const raw = await kvGet(kv, `cache:stacking:${stxAddress}`);
-  if (!raw) {
-    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "stacking", key: stxAddress }));
-    return null;
-  }
-  try {
-    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "stacking", key: stxAddress }));
-    return JSON.parse(raw);
-  } catch (e) {
-    console.error(`Failed to parse cached stacking data for ${stxAddress}:`, e);
-    return null;
-  }
+  return readJsonCache<any>(kv, "cache:stacking:", "stacking", stxAddress);
 }
 
 export function setCachedStacking(

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -97,7 +97,10 @@ async function readJsonCache<T>(
     logCacheEvent("cache_hit", keyFamily, key);
     return parsed;
   } catch (e) {
-    console.error(`Failed to parse cached ${keyFamily} for ${key}:`, e);
+    // key is user-supplied (address/txid) — keep it out of the format string
+    // and pass it as a separate argument so it cannot be interpreted as a
+    // printf-style specifier (ref: CodeQL format-string advisory).
+    console.error("Failed to parse cached entry", { keyFamily, key }, e);
     return null;
   }
 }
@@ -127,7 +130,7 @@ async function readSentinelCache<T>(
     logCacheEvent("cache_hit", keyFamily, key);
     return { hit: true, value: parsed };
   } catch (e) {
-    console.error(`Failed to parse cached ${keyFamily} for ${key}:`, e);
+    console.error("Failed to parse cached entry", { keyFamily, key }, e);
     return { hit: false };
   }
 }
@@ -206,16 +209,21 @@ export function setCachedTransaction(
   return kvPut(kv, `cache:tx:${txid}`, JSON.stringify(data), TX_CACHE_TTL);
 }
 
+/** Minimal shape of a Hiro stacking response used by the stacker achievement. */
+export interface StackingCacheEntry {
+  locked: string;
+}
+
 export function getCachedStacking(
   stxAddress: string,
   kv?: KVNamespace
-): Promise<any | null> {
-  return readJsonCache<any>(kv, "cache:stacking:", "stacking", stxAddress);
+): Promise<StackingCacheEntry | null> {
+  return readJsonCache<StackingCacheEntry>(kv, "cache:stacking:", "stacking", stxAddress);
 }
 
 export function setCachedStacking(
   stxAddress: string,
-  data: any,
+  data: StackingCacheEntry,
   kv?: KVNamespace
 ): Promise<void> {
   return kvPut(kv, `cache:stacking:${stxAddress}`, JSON.stringify(data), STACKING_CACHE_TTL);

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -2,9 +2,12 @@
  * KV-backed caching for stable data (BNS names, agent identities, reputation)
  *
  * Provides persistent caching across worker instances with appropriate TTLs:
- * - BNS names: 24 hours (very stable, rarely change)
- * - Agent identities: 6 hours (semi-stable, can change if re-registered)
- * - Reputation data: 5 minutes (changes with new feedback)
+ * - BNS names: 24 hours positive / 1 hour negative (very stable, rarely change)
+ * - Agent identities: 24 hours (immutable once minted on-chain)
+ * - Identity negative cache: 5 minutes (re-check frequently for newly registered agents)
+ * - Stacking status: 4 hours (changes only at PoX cycle boundaries ~2 weeks)
+ * - Reputation data: 1 hour (changes slowly with new feedback)
+ * - Address transactions: 30 minutes (grows over time but not hot path)
  */
 
 import type { AgentIdentity } from "./types";
@@ -12,10 +15,11 @@ import type { AgentIdentity } from "./types";
 // Cache TTLs in seconds
 const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours
 const BNS_NEGATIVE_CACHE_TTL = 60 * 60; // 1 hour for addresses with no BNS name
-const IDENTITY_CACHE_TTL = 6 * 60 * 60; // 6 hours
+const IDENTITY_CACHE_TTL = 24 * 60 * 60; // 24 hours (immutable NFT — raised from 6h)
 const IDENTITY_NEGATIVE_CACHE_TTL = 5 * 60; // 5 minutes for addresses with no identity
-const REPUTATION_CACHE_TTL = 5 * 60; // 5 minutes
-const TX_CACHE_TTL = 5 * 60; // 5 minutes
+const STACKING_CACHE_TTL = 4 * 60 * 60; // 4 hours (PoX cycle is ~2 weeks)
+const REPUTATION_CACHE_TTL = 60 * 60; // 1 hour (raised from 5 minutes)
+const TX_CACHE_TTL = 30 * 60; // 30 minutes (raised from 5 minutes)
 
 /** Safely read a string value from KV, returning null on miss or error. */
 async function kvGet(
@@ -83,9 +87,16 @@ export async function getCachedIdentity(
   kv?: KVNamespace
 ): Promise<CacheResult<AgentIdentity>> {
   const raw = await kvGet(kv, `cache:identity:${address}`);
-  if (raw === null) return { hit: false };
-  if (raw === NONE_SENTINEL) return { hit: true, value: null };
+  if (raw === null) {
+    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "identity", key: address }));
+    return { hit: false };
+  }
+  if (raw === NONE_SENTINEL) {
+    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "identity", key: address, negative: true }));
+    return { hit: true, value: null };
+  }
   try {
+    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "identity", key: address }));
     return { hit: true, value: JSON.parse(raw) as AgentIdentity };
   } catch (e) {
     console.error(`Failed to parse cached identity for ${address}:`, e);
@@ -113,8 +124,12 @@ export async function getCachedReputation<T>(
   kv?: KVNamespace
 ): Promise<CacheResult<T>> {
   const raw = await kvGet(kv, `cache:reputation:${key}`);
-  if (raw === null) return { hit: false };
+  if (raw === null) {
+    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "reputation", key }));
+    return { hit: false };
+  }
   try {
+    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "reputation", key }));
     return { hit: true, value: JSON.parse(raw) as T | null };
   } catch (e) {
     console.error(`Failed to parse cached reputation for key ${key}:`, e);
@@ -135,8 +150,12 @@ export async function getCachedTransaction(
   kv?: KVNamespace
 ): Promise<any | null> {
   const raw = await kvGet(kv, `cache:tx:${txid}`);
-  if (!raw) return null;
+  if (!raw) {
+    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "tx", key: txid }));
+    return null;
+  }
   try {
+    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "tx", key: txid }));
     return JSON.parse(raw);
   } catch (e) {
     console.error(`Failed to parse cached transaction ${txid}:`, e);
@@ -150,4 +169,30 @@ export function setCachedTransaction(
   kv?: KVNamespace
 ): Promise<void> {
   return kvPut(kv, `cache:tx:${txid}`, JSON.stringify(data), TX_CACHE_TTL);
+}
+
+export async function getCachedStacking(
+  stxAddress: string,
+  kv?: KVNamespace
+): Promise<any | null> {
+  const raw = await kvGet(kv, `cache:stacking:${stxAddress}`);
+  if (!raw) {
+    console.log(JSON.stringify({ event: "cache_miss", keyFamily: "stacking", key: stxAddress }));
+    return null;
+  }
+  try {
+    console.log(JSON.stringify({ event: "cache_hit", keyFamily: "stacking", key: stxAddress }));
+    return JSON.parse(raw);
+  } catch (e) {
+    console.error(`Failed to parse cached stacking data for ${stxAddress}:`, e);
+    return null;
+  }
+}
+
+export function setCachedStacking(
+  stxAddress: string,
+  data: any,
+  kv?: KVNamespace
+): Promise<void> {
+  return kvPut(kv, `cache:stacking:${stxAddress}`, JSON.stringify(data), STACKING_CACHE_TTL);
 }

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -53,10 +53,8 @@ import { submitViaRPC } from "./relay-rpc";
 import type { Logger } from "../logging";
 import { stacksApiFetch, buildHiroHeaders, parseRetryAfterMs } from "../stacks-api-fetch";
 import { getCachedTransaction, setCachedTransaction } from "../identity/kv-cache";
-import { STACKS_API_BASE } from "../identity/constants";
+import { STACKS_API_BASE, STACKS_API_TESTNET_BASE } from "../identity/constants";
 import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
-
-const STACKS_API_TESTNET_BASE = "https://api.testnet.hiro.so";
 
 const NOOP_LOGGER: Logger = {
   debug: () => {},

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -53,6 +53,9 @@ import { submitViaRPC } from "./relay-rpc";
 import type { Logger } from "../logging";
 import { stacksApiFetch, buildHiroHeaders, parseRetryAfterMs } from "../stacks-api-fetch";
 import { getCachedTransaction, setCachedTransaction } from "../identity/kv-cache";
+import { STACKS_API_BASE } from "../identity/constants";
+
+const STACKS_API_TESTNET_BASE = "https://api.testnet.hiro.so";
 import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
 
 const NOOP_LOGGER: Logger = {
@@ -804,9 +807,7 @@ export async function verifyTxidPayment(
   const fullTxid = `0x${normalizedTxid}`;
 
   const apiBase =
-    network === "mainnet"
-      ? "https://api.hiro.so"
-      : "https://api.testnet.hiro.so";
+    network === "mainnet" ? STACKS_API_BASE : STACKS_API_TESTNET_BASE;
 
   log.info("Verifying txid payment recovery", {
     txid: fullTxid,

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -54,9 +54,9 @@ import type { Logger } from "../logging";
 import { stacksApiFetch, buildHiroHeaders, parseRetryAfterMs } from "../stacks-api-fetch";
 import { getCachedTransaction, setCachedTransaction } from "../identity/kv-cache";
 import { STACKS_API_BASE } from "../identity/constants";
+import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
 
 const STACKS_API_TESTNET_BASE = "https://api.testnet.hiro.so";
-import type { TerminalReason } from "@aibtc/tx-schemas/terminal-reasons";
 
 const NOOP_LOGGER: Logger = {
   debug: () => {},


### PR DESCRIPTION
## Summary

Fresh Hiro API keys were exhausting within hours. This branch addresses every leak identified in the audit (see `.planning/2026-04-16-hiro-rate-limit-reduction/QUEST.md`) in a single PR.

- **Stop browser-originated Hiro calls.** `IdentityBadge` now fetches `/api/identity/[stxAddress]` instead of `api.mainnet.hiro.so` directly. This was the dominant leak — it scaled with visitor traffic and had no API key.
- **Centralize + lint-enforce.** Every Hiro call now routes through `lib/stacks-api-fetch.ts` (key injection, retry, rate-limit observability). ESLint rule (`no-restricted-syntax`) fails the build if any file outside the wrapper, `lib/identity/constants.ts`, or tests references `api.hiro.so` / `api.mainnet.hiro.so` as a string or template literal.
- **Positive caching + right-sized TTLs.** SSR `resolveIdentity` now writes positive cache on hit (previously only a 5-min negative sentinel). TTLs raised to match data volatility: identity 6h → 24h, reputation 5min → 1h, tx scan 5min → 30min. Stacking gets a new 4h cache. Per-keyFamily cache-hit/miss telemetry emitted as structured JSON logs.
- **Cap fan-out and de-prioritize discretionary work.** Legacy `get-owner` fallback in `lib/identity/detection.ts` capped from 15 → 5. `backfill-identity` admin endpoint rate-spaced at 200ms between calls. BNS lazy refresh removed from the `/api/agents` user-request hot path.

Quest plan is under `.planning/2026-04-16-hiro-rate-limit-reduction/`.

## Commits

- `perf(identity)`: proxy IdentityBadge through keyed server route
- `perf(hiro)`: route bns and achievement verify through stacksApiFetch
- `perf(hiro)`: route all remaining app-layer Hiro calls through stacksApiFetch
- `perf(hiro)`: migrate remaining Hiro hostname literals to wrapper constants
- `chore(lint)`: ban direct Hiro API hostnames outside wrapper and constants
- `perf(cache)`: raise KV TTLs and add cache-hit/miss telemetry
- `perf(ssr)`: write positive identity cache in SSR resolveIdentity
- `perf(achievements)`: use dedicated stacking cache and keyed fetch wrapper
- `perf(identity)`: cap legacy get-owner fan-out to ≤5 calls
- `perf(admin)`: rate-space backfill-identity and migrate to stacksApiFetch
- `perf(agents)`: remove BNS lazy refresh from user-request hot path
- `refactor(kv-cache)`: extract shared telemetry and read helpers
- `refactor`: drop unused constant and fix interleaved import in x402-verify

## Test plan

- [x] `npm run lint` — no errors (pre-existing `no-img-element` warnings only)
- [x] `npm run build` — clean, 51 routes compiled
- [x] `npm test` — 459/459 passing
- [ ] DevTools network tab on `/agents/[address]` and `/inbox/[address]` — confirm zero requests to `api.mainnet.hiro.so`
- [ ] Post-deploy: worker-logs 24h window shows ≥5x reduction in Hiro `x-ratelimit-remaining` consumption rate
- [ ] Post-deploy: `cache_hit` / `cache_miss` structured logs visible per `keyFamily` (identity, reputation, tx, stacking)

## Follow-up

Phase 5 of the quest is post-deploy verification against worker-logs. Will be captured in the quest archive after a 24h observation window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)