### PR TITLE
fix(logging): route kv-cache telemetry through Logger instead of console

### DIFF
--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -23,6 +23,11 @@ import {
 import { buildHiroHeaders, detect429 } from "@/lib/identity/stacks-api";
 import { stacksApiFetch, parseRetryAfterMs } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE } from "@/lib/identity/constants";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 const RATE_LIMIT_MS = ACHIEVEMENT_VERIFY_RATE_LIMIT_MS;
 
@@ -190,10 +195,16 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY as string | undefined;
     const unisatApiKey = env.UNISAT_API_KEY as string | undefined;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     // Look up agent
     const agentData = await kv.get(`btc:${btcAddress}`);
@@ -287,7 +298,7 @@ export async function POST(request: NextRequest) {
 
       if (!hasSender) {
         try {
-          const hasOutgoingTx = await verifySenderAchievement(btcAddress, kv);
+          const hasOutgoingTx = await verifySenderAchievement(btcAddress, kv, logger);
 
           if (hasOutgoingTx) {
             const record = await grantAchievement(kv, btcAddress, "sender");
@@ -299,7 +310,10 @@ export async function POST(request: NextRequest) {
             });
           }
         } catch (e) {
-          console.error("Failed to check sender achievement:", e);
+          logger.error("achievement.sender.check_failed", {
+            btcAddress,
+            error: String(e),
+          });
         }
       } else {
         alreadyHad.push("sender");
@@ -318,7 +332,8 @@ export async function POST(request: NextRequest) {
           const isStacking = await verifyStackerAchievement(
             agent.stxAddress,
             kv,
-            hiroApiKey
+            hiroApiKey,
+            logger
           );
 
           if (isStacking) {
@@ -331,7 +346,10 @@ export async function POST(request: NextRequest) {
             });
           }
         } catch (e) {
-          console.error("Failed to check stacker achievement:", e);
+          logger.error("achievement.stacker.check_failed", {
+            btcAddress,
+            error: String(e),
+          });
         }
       } else {
         alreadyHad.push("stacker");
@@ -350,7 +368,8 @@ export async function POST(request: NextRequest) {
           const holdsSbtc = await verifySbtcHolderAchievement(
             agent.stxAddress,
             kv,
-            hiroApiKey
+            hiroApiKey,
+            logger
           );
 
           if (holdsSbtc) {
@@ -363,7 +382,10 @@ export async function POST(request: NextRequest) {
             });
           }
         } catch (e) {
-          console.error("Failed to check sbtc-holder achievement:", e);
+          logger.error("achievement.sbtc_holder.check_failed", {
+            btcAddress,
+            error: String(e),
+          });
         }
       } else {
         alreadyHad.push("sbtc-holder");
@@ -397,7 +419,7 @@ export async function POST(request: NextRequest) {
           };
 
           // Check cache first
-          let tx: StacksTransaction | null = await getCachedTransaction(txid, kv);
+          let tx: StacksTransaction | null = await getCachedTransaction(txid, kv, logger);
 
           if (!tx) {
             // Fetch transaction from Stacks API with API key
@@ -437,7 +459,7 @@ export async function POST(request: NextRequest) {
             tx = (await txResp.json()) as StacksTransaction;
 
             // Cache the transaction
-            await setCachedTransaction(txid, tx, kv);
+            await setCachedTransaction(txid, tx, kv, logger);
           }
 
           // Ensure we have a transaction
@@ -570,7 +592,11 @@ export async function POST(request: NextRequest) {
             unlockedAt: record.unlockedAt,
           });
         } catch (e) {
-          console.error("Failed to check connector achievement:", e);
+          logger.error("achievement.connector.check_failed", {
+            btcAddress,
+            txid,
+            error: String(e),
+          });
           return NextResponse.json(
             {
               error: `Connector verification failed: ${(e as Error).message}`,
@@ -596,7 +622,8 @@ export async function POST(request: NextRequest) {
             inscriptionId,
             btcAddress,
             kv,
-            unisatApiKey
+            unisatApiKey,
+            logger
           );
 
           if (isOwner) {
@@ -611,7 +638,11 @@ export async function POST(request: NextRequest) {
             });
           }
         } catch (e) {
-          console.error("Failed to check inscriber achievement:", e);
+          logger.error("achievement.inscriber.check_failed", {
+            btcAddress,
+            inscriptionId,
+            error: String(e),
+          });
         }
       } else {
         alreadyHad.push("inscriber");

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -4,6 +4,11 @@ import type { AgentRecord } from "@/lib/types";
 import { getAchievementDefinition } from "@/lib/achievements";
 import { lookupBnsName } from "@/lib/bns";
 import { enrichAgentProfile } from "@/lib/agent-enrichment";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 /**
  * Determine the address type and KV prefix from the format.
@@ -189,9 +194,15 @@ export async function GET(
       );
     }
 
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     // Look up agent by address type
     let agent: AgentRecord | null = null;
@@ -252,14 +263,20 @@ export async function GET(
     // Lazy BNS refresh: if bnsName is missing, try to look it up.
     // Fire-and-forget so it doesn't block the response.
     if (!agent.bnsName && agent.stxAddress) {
-      void lookupBnsName(agent.stxAddress, hiroApiKey, kv).then((bnsName) => {
+      void lookupBnsName(agent.stxAddress, hiroApiKey, kv, logger).then((bnsName) => {
         if (bnsName) {
           agent.bnsName = bnsName;
           const updated = JSON.stringify(agent);
           Promise.all([
             kv.put(`stx:${agent.stxAddress}`, updated),
             kv.put(`btc:${agent.btcAddress}`, updated),
-          ]).catch((err) => console.error("Failed to update agent cache:", err));
+          ]).catch((err) =>
+            logger.error("agents.update_agent_cache_failed", {
+              btcAddress: agent.btcAddress,
+              stxAddress: agent.stxAddress,
+              error: String(err),
+            })
+          );
         }
       }).catch(() => {});
     }
@@ -268,7 +285,8 @@ export async function GET(
       agent,
       kv,
       hiroApiKey,
-      `agents/${agent.btcAddress}`
+      `agents/${agent.btcAddress}`,
+      logger
     );
 
     const checkIn = enrichment.checkIn

--- a/app/api/identity/[address]/reputation/route.ts
+++ b/app/api/identity/[address]/reputation/route.ts
@@ -5,6 +5,12 @@ import {
   getReputationSummary,
   getReputationFeedback,
 } from "@/lib/identity/reputation";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+  type Logger,
+} from "@/lib/logging";
 
 /**
  * Look up an agent by BTC or STX address.
@@ -12,7 +18,8 @@ import {
  */
 async function lookupAgent(
   kv: KVNamespace,
-  address: string
+  address: string,
+  logger: Logger
 ): Promise<AgentRecord | null> {
   const [btcData, stxData] = await Promise.all([
     kv.get(`btc:${address}`),
@@ -25,7 +32,10 @@ async function lookupAgent(
   try {
     return JSON.parse(data) as AgentRecord;
   } catch (e) {
-    console.error(`Failed to parse agent record for address ${address}:`, e);
+    logger.error("reputation.parse_agent_failed", {
+      address,
+      error: String(e),
+    });
     return null;
   }
 }
@@ -78,12 +88,18 @@ export async function GET(
     );
   }
 
-  try {
-    const { env } = await getCloudflareContext();
-    const kv = env.VERIFIED_AGENTS as KVNamespace;
-    const hiroApiKey = env.HIRO_API_KEY;
+  const { env, ctx } = await getCloudflareContext();
+  const kv = env.VERIFIED_AGENTS as KVNamespace;
+  const hiroApiKey = env.HIRO_API_KEY;
 
-    const agent = await lookupAgent(kv, address);
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const baseCtx = { rayId, path: request.nextUrl.pathname };
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, baseCtx)
+    : createConsoleLogger(baseCtx);
+
+  try {
+    const agent = await lookupAgent(kv, address, logger);
 
     if (!agent) {
       return NextResponse.json(
@@ -105,7 +121,7 @@ export async function GET(
     const agentId = agent.erc8004AgentId;
 
     if (type === "summary") {
-      const summary = await getReputationSummary(agentId, hiroApiKey, kv);
+      const summary = await getReputationSummary(agentId, hiroApiKey, kv, logger);
       return NextResponse.json(
         { summary },
         {
@@ -129,14 +145,14 @@ export async function GET(
       }
       cursor = parsedCursor;
     }
-    const feedback = await getReputationFeedback(agentId, cursor, hiroApiKey, kv);
+    const feedback = await getReputationFeedback(agentId, cursor, hiroApiKey, kv, logger);
 
     // Resolve client STX addresses to agent display names
     const clientAddresses = [...new Set(feedback.items.map((item) => item.client))];
     const clientAgents = new Map<string, AgentRecord>();
     await Promise.all(
       clientAddresses.map(async (addr) => {
-        const clientAgent = await lookupAgent(kv, addr);
+        const clientAgent = await lookupAgent(kv, addr, logger);
         if (clientAgent) clientAgents.set(addr, clientAgent);
       })
     );
@@ -159,7 +175,7 @@ export async function GET(
       }
     );
   } catch (e) {
-    console.error("Reputation fetch error:", e);
+    logger.error("reputation.fetch_error", { address, error: String(e) });
     return NextResponse.json(
       { error: `Reputation fetch failed: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/identity/[address]/reputation/route.ts
+++ b/app/api/identity/[address]/reputation/route.ts
@@ -88,17 +88,21 @@ export async function GET(
     );
   }
 
-  const { env, ctx } = await getCloudflareContext();
-  const kv = env.VERIFIED_AGENTS as KVNamespace;
-  const hiroApiKey = env.HIRO_API_KEY;
-
   const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
   const baseCtx = { rayId, path: request.nextUrl.pathname };
-  const logger = isLogsRPC(env.LOGS)
-    ? createLogger(env.LOGS, ctx, baseCtx)
-    : createConsoleLogger(baseCtx);
+  // Start with a console-backed logger so errors during Cloudflare context
+  // resolution still emit structured output; upgrade to the RPC logger once
+  // the LOGS binding is available.
+  let logger: Logger = createConsoleLogger(baseCtx);
 
   try {
+    const { env, ctx } = await getCloudflareContext();
+    const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const hiroApiKey = env.HIRO_API_KEY;
+    if (isLogsRPC(env.LOGS)) {
+      logger = createLogger(env.LOGS, ctx, baseCtx);
+    }
+
     const agent = await lookupAgent(kv, address, logger);
 
     if (!agent) {

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -784,7 +784,7 @@ export async function POST(request: NextRequest) {
 
     const [sponsorResult, bnsName] = await Promise.all([
       provisionSponsorKey(btcResult.address, bitcoinSignature, EXPECTED_MESSAGE, relayUrl, log),
-      lookupBnsName(stxResult.address, env.HIRO_API_KEY, kv),
+      lookupBnsName(stxResult.address, env.HIRO_API_KEY, kv, log),
     ]);
 
     const sponsorApiKey = sponsorResult.success ? sponsorResult.apiKey : undefined;

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -24,6 +24,11 @@ import {
   IDENTITY_REGISTRY_CONTRACT,
 } from "@/lib/identity";
 import { enrichAgentProfile } from "@/lib/agent-enrichment";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 // ---------------------------------------------------------------------------
 // Identifier type detection
@@ -220,7 +225,7 @@ function buildUsageResponse() {
 // ---------------------------------------------------------------------------
 
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ identifier: string }> }
 ) {
   try {
@@ -233,9 +238,15 @@ export async function GET(
 
     const identifierType = detectIdentifierType(identifier);
 
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     // -----------------------------------------------------------------------
     // Resolve identifier to AgentRecord
@@ -391,7 +402,8 @@ export async function GET(
       agent,
       kv,
       hiroApiKey,
-      `resolve/${agent.btcAddress}`
+      `resolve/${agent.btcAddress}`,
+      logger
     );
 
     // -----------------------------------------------------------------------

--- a/app/api/verify/[address]/route.ts
+++ b/app/api/verify/[address]/route.ts
@@ -4,6 +4,11 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { getAgentLevel } from "@/lib/levels";
 import { lookupBnsName } from "@/lib/bns";
 import { getCAIP19AgentId } from "@/lib/caip19";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 /**
  * Determine the address type from the format.
@@ -41,7 +46,7 @@ function getKvPrefix(addressType: "stx" | "bc1q" | "bc1p"): "stx" | "btc" {
  * - If KV error: returns 500
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ address: string }> }
 ) {
   try {
@@ -67,9 +72,15 @@ export async function GET(
       );
     }
 
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     // Use KV prefix for lookup (bc1q and bc1p both stored under "btc:" for compatibility)
     const kvPrefix = getKvPrefix(addressType);
@@ -101,7 +112,7 @@ export async function GET(
     // Run BNS lookup and claim fetch in parallel (both independent)
     const [bnsName, claimData] = await Promise.all([
       !agent.bnsName && agent.stxAddress
-        ? lookupBnsName(agent.stxAddress, hiroApiKey, kv)
+        ? lookupBnsName(agent.stxAddress, hiroApiKey, kv, logger)
         : Promise.resolve(null),
       kv.get(`claim:${agent.btcAddress}`),
     ]);

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -19,6 +19,7 @@ import {
 import { stacksApiFetch } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE } from "@/lib/identity/constants";
 import { standardPrincipalCV } from "@stacks/transactions";
+import type { Logger } from "@/lib/logging";
 
 /** Rate limit window for achievement verification (5 minutes) */
 export const ACHIEVEMENT_VERIFY_RATE_LIMIT_MS = 5 * 60 * 1000;
@@ -80,11 +81,12 @@ export async function setRateLimit(
  */
 export async function verifySenderAchievement(
   btcAddress: string,
-  kv: KVNamespace
+  kv: KVNamespace,
+  logger?: Logger
 ): Promise<boolean> {
   try {
     const cacheKey = `mempool-addr:${btcAddress}`;
-    let txs = await getCachedTransaction(cacheKey, kv);
+    let txs = await getCachedTransaction(cacheKey, kv, logger);
 
     if (!txs) {
       const mempoolUrl = `https://mempool.space/api/address/${btcAddress}/txs`;
@@ -93,9 +95,10 @@ export async function verifySenderAchievement(
       });
 
       if (!mempoolResp.ok) {
-        console.error(
-          `Failed to fetch mempool data for ${btcAddress}: ${mempoolResp.status}`
-        );
+        logger?.error("achievement.sender.mempool_fetch_failed", {
+          btcAddress,
+          status: mempoolResp.status,
+        });
         return false;
       }
 
@@ -104,7 +107,7 @@ export async function verifySenderAchievement(
       }>;
 
       // Cache the result
-      await setCachedTransaction(cacheKey, txs, kv);
+      await setCachedTransaction(cacheKey, txs, kv, logger);
     }
 
     // Check if any transaction has this address as an input
@@ -116,7 +119,10 @@ export async function verifySenderAchievement(
 
     return hasOutgoingTx;
   } catch (error) {
-    console.error(`Failed to verify sender achievement for ${btcAddress}:`, error);
+    logger?.error("achievement.sender.verify_error", {
+      btcAddress,
+      error: String(error),
+    });
     return false;
   }
 }
@@ -138,11 +144,12 @@ const SBTC_CONTRACT = "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token";
 export async function verifySbtcHolderAchievement(
   stxAddress: string,
   kv: KVNamespace,
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  logger?: Logger
 ): Promise<boolean> {
   try {
     const cacheKey = `sbtc-balance:${stxAddress}`;
-    let balanceData = await getCachedTransaction(cacheKey, kv);
+    let balanceData = await getCachedTransaction(cacheKey, kv, logger);
 
     if (!balanceData) {
       const response = await callReadOnly(
@@ -158,16 +165,16 @@ export async function verifySbtcHolderAchievement(
         return false;
       }
       balanceData = { balance: parsed };
-      await setCachedTransaction(cacheKey, balanceData, kv);
+      await setCachedTransaction(cacheKey, balanceData, kv, logger);
     }
 
     const balance = (balanceData as { balance: string }).balance ?? "0";
     return balance !== "0" && balance !== "";
   } catch (error) {
-    console.error(
-      `Failed to verify sbtc-holder achievement for ${stxAddress}:`,
-      error
-    );
+    logger?.error("achievement.sbtc_holder.verify_error", {
+      stxAddress,
+      error: String(error),
+    });
     return false;
   }
 }
@@ -186,10 +193,11 @@ export async function verifySbtcHolderAchievement(
 export async function verifyStackerAchievement(
   stxAddress: string,
   kv: KVNamespace,
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  logger?: Logger
 ): Promise<boolean> {
   try {
-    let stackingData = await getCachedStacking(stxAddress, kv);
+    let stackingData = await getCachedStacking(stxAddress, kv, logger);
 
     if (!stackingData) {
       const stackingUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/stacking`;
@@ -203,20 +211,24 @@ export async function verifyStackerAchievement(
       }
 
       if (!stackingResp.ok) {
-        console.error(
-          `Failed to fetch stacking data for ${stxAddress}: ${stackingResp.status}`
-        );
+        logger?.error("achievement.stacker.fetch_failed", {
+          stxAddress,
+          status: stackingResp.status,
+        });
         return false;
       }
 
       stackingData = (await stackingResp.json()) as { locked: string };
-      await setCachedStacking(stxAddress, stackingData, kv);
+      await setCachedStacking(stxAddress, stackingData, kv, logger);
     }
 
     const locked = stackingData.locked ?? "0";
     return locked !== "0" && locked !== "";
   } catch (error) {
-    console.error(`Failed to verify stacker achievement for ${stxAddress}:`, error);
+    logger?.error("achievement.stacker.verify_error", {
+      stxAddress,
+      error: String(error),
+    });
     return false;
   }
 }
@@ -257,11 +269,12 @@ const SBTC_CONTRACT_ID =
 export async function verifyConnectorAchievement(
   stxAddress: string,
   kv: KVNamespace,
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  logger?: Logger
 ): Promise<{ txid: string; recipientAddress: string } | null> {
   try {
     const cacheKey = `stx-txs:${stxAddress}`;
-    let txs = await getCachedTransaction(cacheKey, kv);
+    let txs = await getCachedTransaction(cacheKey, kv, logger);
 
     if (!txs) {
       const txsUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/transactions?limit=50`;
@@ -270,9 +283,10 @@ export async function verifyConnectorAchievement(
       });
 
       if (!resp.ok) {
-        console.error(
-          `Failed to fetch transactions for ${stxAddress}: ${resp.status}`
-        );
+        logger?.error("achievement.connector.fetch_failed", {
+          stxAddress,
+          status: resp.status,
+        });
         return null;
       }
 
@@ -290,7 +304,7 @@ export async function verifyConnectorAchievement(
         }>;
       };
       txs = data.results;
-      await setCachedTransaction(cacheKey, txs, kv);
+      await setCachedTransaction(cacheKey, txs, kv, logger);
     }
 
     // Find a qualifying sBTC transfer
@@ -337,10 +351,10 @@ export async function verifyConnectorAchievement(
 
     return null;
   } catch (error) {
-    console.error(
-      `Failed to verify connector achievement for ${stxAddress}:`,
-      error
-    );
+    logger?.error("achievement.connector.verify_error", {
+      stxAddress,
+      error: String(error),
+    });
     return null;
   }
 }
@@ -351,16 +365,17 @@ export async function verifyInscriberAchievement(
   inscriptionId: string,
   btcAddress: string,
   kv: KVNamespace,
-  unisatApiKey?: string
+  unisatApiKey?: string,
+  logger?: Logger
 ): Promise<boolean> {
   try {
     if (!INSCRIPTION_ID_RE.test(inscriptionId)) {
-      console.error(`Invalid inscriptionId format: ${inscriptionId}`);
+      logger?.error("achievement.inscriber.invalid_id", { inscriptionId });
       return false;
     }
 
     const cacheKey = `unisat-inscription:${inscriptionId}`;
-    let inscriptionData = await getCachedTransaction(cacheKey, kv);
+    let inscriptionData = await getCachedTransaction(cacheKey, kv, logger);
 
     if (!inscriptionData) {
       const url = `https://open-api.unisat.io/v1/indexer/inscription/info/${inscriptionId}`;
@@ -377,9 +392,10 @@ export async function verifyInscriberAchievement(
       });
 
       if (!resp.ok) {
-        console.error(
-          `Failed to fetch inscription ${inscriptionId} from Unisat: ${resp.status}`
-        );
+        logger?.error("achievement.inscriber.fetch_failed", {
+          inscriptionId,
+          status: resp.status,
+        });
         return false;
       }
 
@@ -387,7 +403,7 @@ export async function verifyInscriberAchievement(
         code: number;
         data?: { address?: string };
       };
-      await setCachedTransaction(cacheKey, inscriptionData, kv);
+      await setCachedTransaction(cacheKey, inscriptionData, kv, logger);
     }
 
     if (inscriptionData.code !== 0 || !inscriptionData.data?.address) {
@@ -396,7 +412,10 @@ export async function verifyInscriberAchievement(
 
     return inscriptionData.data.address === btcAddress;
   } catch (error) {
-    console.error(`Failed to verify inscriber achievement for ${inscriptionId}:`, error);
+    logger?.error("achievement.inscriber.verify_error", {
+      inscriptionId,
+      error: String(error),
+    });
     return false;
   }
 }

--- a/lib/agent-enrichment.ts
+++ b/lib/agent-enrichment.ts
@@ -17,6 +17,7 @@ import { getCheckInRecord, type CheckInRecord } from "@/lib/heartbeat";
 import { detectAgentIdentity, getReputationSummary } from "@/lib/identity";
 import { getAgentInbox, getSentIndex } from "@/lib/inbox/kv-helpers";
 import { getCAIP19AgentId } from "@/lib/caip19";
+import type { Logger } from "@/lib/logging";
 
 /** Timeout for all enrichment fetches (identity, reputation, achievements, inbox). */
 const ENRICHMENT_TIMEOUT_MS = 10_000;
@@ -72,14 +73,16 @@ export async function enrichAgentProfile(
   agent: AgentRecord,
   kv: KVNamespace,
   hiroApiKey?: string,
-  logPrefix?: string
+  logPrefix?: string,
+  logger?: Logger
 ): Promise<EnrichmentResult> {
   let timeoutId: ReturnType<typeof setTimeout> | undefined;
   const enrichmentTimeout = new Promise<null>((resolve) => {
     timeoutId = setTimeout(() => {
-      console.warn(
-        `[${logPrefix ?? agent.btcAddress}] Enrichment timed out after ${ENRICHMENT_TIMEOUT_MS}ms — returning partial response`
-      );
+      logger?.warn("enrichment.timed_out", {
+        context: logPrefix ?? agent.btcAddress,
+        timeoutMs: ENRICHMENT_TIMEOUT_MS,
+      });
       resolve(null);
     }, ENRICHMENT_TIMEOUT_MS);
   });
@@ -92,7 +95,7 @@ export async function enrichAgentProfile(
       kv.get(`claim:${agent.btcAddress}`),
       getAgentAchievements(kv, agent.btcAddress),
       getCheckInRecord(kv, agent.btcAddress),
-      fetchIdentityAndReputation(agent, hiroApiKey, kv),
+      fetchIdentityAndReputation(agent, hiroApiKey, kv, logger),
       getAgentInbox(kv, agent.btcAddress),
       getSentIndex(kv, agent.btcAddress),
     ]).finally(() => clearTimeout(timeoutId)),
@@ -119,7 +122,7 @@ export async function enrichAgentProfile(
   const identity = identityAndReputation?.identity ?? null;
   const reputation = identityAndReputation?.reputation ?? null;
 
-  const claim = parseClaim(claimData, agent.btcAddress);
+  const claim = parseClaim(claimData, agent.btcAddress, logger);
   const levelInfo = getAgentLevel(agent, claim);
   const resolvedAgentId = identity?.agentId ?? agent.erc8004AgentId ?? null;
 
@@ -168,7 +171,8 @@ export async function enrichAgentProfile(
 async function fetchIdentityAndReputation(
   agent: AgentRecord,
   hiroApiKey: string | undefined,
-  kv: KVNamespace
+  kv: KVNamespace,
+  logger?: Logger
 ): Promise<{ identity: AgentIdentity | null; reputation: ReputationSummary | null }> {
   // Use cached agent-id if available; agent-id 0 is valid (falsy) so use != null.
   // When using the cached shortcut, uri is "" because fetching it would require
@@ -176,18 +180,18 @@ async function fetchIdentityAndReputation(
   const identityResult: AgentIdentity | null =
     agent.erc8004AgentId != null
       ? { agentId: agent.erc8004AgentId, owner: agent.stxAddress, uri: "" }
-      : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv);
+      : await detectAgentIdentity(agent.stxAddress, hiroApiKey, kv, logger);
 
   if (!identityResult) return { identity: null, reputation: null };
 
   let reputation: ReputationSummary | null = null;
   try {
-    reputation = await getReputationSummary(identityResult.agentId, hiroApiKey, kv);
+    reputation = await getReputationSummary(identityResult.agentId, hiroApiKey, kv, logger);
   } catch (e) {
-    console.error(
-      `Failed to fetch reputation for agent ${agent.btcAddress}:`,
-      e
-    );
+    logger?.error("enrichment.reputation_fetch_failed", {
+      btcAddress: agent.btcAddress,
+      error: String(e),
+    });
   }
   return { identity: identityResult, reputation };
 }
@@ -195,13 +199,17 @@ async function fetchIdentityAndReputation(
 /** Parse a raw KV claim string into a ClaimStatus, or null on miss/error. */
 function parseClaim(
   claimData: string | null,
-  btcAddress: string
+  btcAddress: string,
+  logger?: Logger
 ): ClaimStatus | null {
   if (!claimData) return null;
   try {
     return JSON.parse(claimData) as ClaimStatus;
   } catch (e) {
-    console.error(`Failed to parse claim for ${btcAddress}:`, e);
+    logger?.error("enrichment.parse_claim_failed", {
+      btcAddress,
+      error: String(e),
+    });
     return null;
   }
 }

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -9,6 +9,7 @@ import { getCachedBnsName, setCachedBnsName, setCachedBnsNegative, BNS_NONE_SENT
 import { buildHiroHeaders } from "./identity/stacks-api";
 import { stacksApiFetch } from "./stacks-api-fetch";
 import { STACKS_API_BASE } from "./identity/constants";
+import type { Logger } from "./logging";
 
 const BNS_V2_CONTRACT = "SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF";
 const BNS_V2_NAME = "BNS-V2";
@@ -24,13 +25,15 @@ const BNS_V2_NAME = "BNS-V2";
  * @param stxAddress - Stacks address to lookup
  * @param hiroApiKey - Optional Hiro API key for authenticated requests
  * @param kv - Optional KV namespace for persistent caching
+ * @param logger - Optional Logger for cache telemetry and error logging
  */
 export async function lookupBnsName(
   stxAddress: string,
   hiroApiKey?: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<string | null> {
-  const cached = await getCachedBnsName(stxAddress, kv);
+  const cached = await getCachedBnsName(stxAddress, kv, logger);
   if (cached === BNS_NONE_SENTINEL) return null;
   if (cached) return cached;
 
@@ -72,13 +75,13 @@ export async function lookupBnsName(
     // Unwrap: response -> optional -> tuple
     const optional = json.value?.value;
     if (!optional) {
-      await setCachedBnsNegative(stxAddress, kv);
+      await setCachedBnsNegative(stxAddress, kv, logger);
       return null;
     }
 
     const tuple = optional.value;
     if (!tuple?.name?.value || !tuple?.namespace?.value) {
-      await setCachedBnsNegative(stxAddress, kv);
+      await setCachedBnsNegative(stxAddress, kv, logger);
       return null;
     }
 
@@ -86,10 +89,10 @@ export async function lookupBnsName(
     const namespace = bytesToUtf8(hexToBytes(tuple.namespace.value));
     const fullName = `${name}.${namespace}`;
 
-    await setCachedBnsName(stxAddress, fullName, kv);
+    await setCachedBnsName(stxAddress, fullName, kv, logger);
     return fullName;
   } catch (e) {
-    console.error(`BNS lookup failed for ${stxAddress}:`, e);
+    logger?.error("bns.lookup_failed", { stxAddress, error: String(e) });
     return null;
   }
 }

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -8,6 +8,7 @@ import { callReadOnly, parseClarityValue, buildHiroHeaders } from "./stacks-api"
 import { stacksApiFetch } from "../stacks-api-fetch";
 import type { AgentIdentity } from "./types";
 import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from "./kv-cache";
+import type { Logger } from "../logging";
 
 /**
  * Detect if an agent has registered an on-chain identity.
@@ -18,14 +19,16 @@ import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from 
  * @param stxAddress - Stacks address to check
  * @param hiroApiKey - Optional Hiro API key for authenticated requests
  * @param kv - Optional KV namespace for persistent caching
+ * @param logger - Optional Logger for cache telemetry and error logging
  */
 export async function detectAgentIdentity(
   stxAddress: string,
   hiroApiKey?: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<AgentIdentity | null> {
   // Check KV cache first (distinguishes miss from cached negative result)
-  const cached = await getCachedIdentity(stxAddress, kv);
+  const cached = await getCachedIdentity(stxAddress, kv, logger);
   if (cached.hit) return cached.value;
 
   try {
@@ -43,8 +46,11 @@ export async function detectAgentIdentity(
 
     if (!response.ok) {
       // Fallback to legacy scan if holdings API fails (e.g. 404, 500)
-      console.warn(`NFT holdings API returned ${response.status}, falling back to legacy scan`);
-      return await detectAgentIdentityLegacy(stxAddress, hiroApiKey, kv);
+      logger?.warn("identity.holdings_api_failed_falling_back", {
+        stxAddress,
+        status: response.status,
+      });
+      return await detectAgentIdentityLegacy(stxAddress, hiroApiKey, kv, logger);
     }
 
     const data = await response.json() as {
@@ -58,7 +64,7 @@ export async function detectAgentIdentity(
 
     if (!data.results || data.results.length === 0) {
       // No identity NFT found for this address — cache negative to skip future Hiro API calls
-      await setCachedIdentityNegative(stxAddress, kv);
+      await setCachedIdentityNegative(stxAddress, kv, logger);
       return null;
     }
 
@@ -68,7 +74,7 @@ export async function detectAgentIdentity(
     if (!tokenIdMatch) {
       // Parse/format failure does not prove the address has no identity NFT,
       // so do not negative-cache this result.
-      console.warn("Could not parse NFT token ID from repr:", nft.value.repr);
+      logger?.warn("identity.parse_token_id_failed", { repr: nft.value.repr });
       return null;
     }
     const agentId = Number(tokenIdMatch[1]);
@@ -84,15 +90,21 @@ export async function detectAgentIdentity(
       );
       uri = parseClarityValue(uriResult) || "";
     } catch (error) {
-      console.warn("Failed to fetch token URI for agent", agentId, error);
+      logger?.warn("identity.fetch_token_uri_failed", {
+        agentId,
+        error: String(error),
+      });
     }
 
     const identity: AgentIdentity = { agentId, owner: stxAddress, uri };
     // Cache the result
-    await setCachedIdentity(stxAddress, identity, kv);
+    await setCachedIdentity(stxAddress, identity, kv, logger);
     return identity;
   } catch (error) {
-    console.error("Error detecting agent identity:", error);
+    logger?.error("identity.detect_error", {
+      stxAddress,
+      error: String(error),
+    });
     return null;
   }
 }
@@ -104,9 +116,10 @@ export async function detectAgentIdentity(
 async function detectAgentIdentityLegacy(
   stxAddress: string,
   hiroApiKey?: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<AgentIdentity | null> {
-  console.warn(`[identity] falling back to legacy O(N) scan for ${stxAddress}`);
+  logger?.warn("identity.legacy_scan_fallback", { stxAddress });
 
   // Cap at 1 batch (5 get-owner calls) to bound worst-case Hiro API consumption.
   // If the target agent's identity NFT was minted outside the most recent 5 IDs,
@@ -143,34 +156,43 @@ async function detectAgentIdentityLegacy(
       ], hiroApiKey);
       const uri = parseClarityValue(uriResult);
       const identity: AgentIdentity = { agentId: match.id, owner: match.owner!, uri: uri || "" };
-      await setCachedIdentity(stxAddress, identity, kv);
+      await setCachedIdentity(stxAddress, identity, kv, logger);
       return identity;
     }
     if (batchCount >= MAX_LEGACY_BATCHES) {
       // Scan is intentionally incomplete — don't negative-cache since the identity
       // may exist beyond the batches we checked.
-      console.warn(
-        `[identity] legacy scan cap hit (${MAX_LEGACY_BATCHES} batch × ${BATCH_SIZE} IDs) for ${stxAddress}, returning null without negative cache`
-      );
+      logger?.warn("identity.legacy_scan_cap_hit", {
+        stxAddress,
+        batches: MAX_LEGACY_BATCHES,
+        batchSize: BATCH_SIZE,
+      });
       return null;
     }
   }
 
   // Exhausted all NFTs without finding a match — cache negative result
-  await setCachedIdentityNegative(stxAddress, kv);
+  await setCachedIdentityNegative(stxAddress, kv, logger);
   return null;
 }
 
 /**
  * Check if an agent ID exists (has been minted)
  */
-export async function hasIdentity(agentId: number, hiroApiKey?: string): Promise<boolean> {
+export async function hasIdentity(
+  agentId: number,
+  hiroApiKey?: string,
+  logger?: Logger
+): Promise<boolean> {
   try {
     const ownerResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-owner", [uintCV(agentId)], hiroApiKey);
     const owner = parseClarityValue(ownerResult);
     return owner !== null;
   } catch (error) {
-    console.error("Error checking identity existence:", error);
+    logger?.error("identity.has_identity_error", {
+      agentId,
+      error: String(error),
+    });
     return false;
   }
 }

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -8,9 +8,15 @@
  * - Stacking status: 4 hours (changes only at PoX cycle boundaries ~2 weeks)
  * - Reputation data: 1 hour (changes slowly with new feedback)
  * - Address transactions: 30 minutes (grows over time but not hot path)
+ *
+ * All public functions accept an optional {@link Logger}. When provided, cache
+ * hit/miss telemetry and KV/parse errors are emitted through that logger (and
+ * on to worker-logs). When omitted, the helpers are silent — we do NOT fall
+ * back to `console.*`, which would bypass worker-logs.
  */
 
 import type { AgentIdentity } from "./types";
+import type { Logger } from "../logging";
 
 // Cache TTLs in seconds
 const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours
@@ -33,13 +39,19 @@ export const BNS_NONE_SENTINEL = NONE_SENTINEL;
 /** Safely read a string value from KV, returning null on miss or error. */
 async function kvGet(
   kv: KVNamespace | undefined,
-  key: string
+  key: string,
+  keyFamily: string,
+  logger?: Logger
 ): Promise<string | null> {
   if (!kv) return null;
   try {
     return await kv.get(key);
   } catch (error) {
-    console.error(`KV read error for ${key}:`, error);
+    logger?.error("cache.kv_read_error", {
+      keyFamily,
+      key,
+      error: String(error),
+    });
     return null;
   }
 }
@@ -49,30 +61,38 @@ async function kvPut(
   kv: KVNamespace | undefined,
   key: string,
   value: string,
-  ttl: number
+  ttl: number,
+  keyFamily: string,
+  logger?: Logger
 ): Promise<void> {
   if (!kv) return;
   try {
     await kv.put(key, value, { expirationTtl: ttl });
   } catch (error) {
-    console.error(`KV write error for ${key}:`, error);
+    logger?.error("cache.kv_write_error", {
+      keyFamily,
+      key,
+      error: String(error),
+    });
   }
 }
 
 /**
- * Emit a structured cache-hit/miss telemetry event. Centralized so all cache
- * readers log with a consistent shape (keyFamily + key, plus an optional
- * `negative: true` flag for negative-cache hits).
+ * Emit a structured cache-hit/miss telemetry event via the logger.
+ * No-op when logger is undefined (callers that don't thread a logger
+ * simply skip telemetry rather than falling back to console).
  */
 function logCacheEvent(
-  event: "cache_hit" | "cache_miss",
+  logger: Logger | undefined,
+  event: "cache.hit" | "cache.miss",
   keyFamily: string,
   key: string,
   negative = false
 ): void {
-  const payload: Record<string, unknown> = { event, keyFamily, key };
+  if (!logger) return;
+  const payload: Record<string, unknown> = { keyFamily, key };
   if (negative) payload.negative = true;
-  console.log(JSON.stringify(payload));
+  logger.info(event, payload);
 }
 
 /**
@@ -85,22 +105,24 @@ async function readJsonCache<T>(
   kv: KVNamespace | undefined,
   prefix: string,
   keyFamily: string,
-  key: string
+  key: string,
+  logger?: Logger
 ): Promise<T | null> {
-  const raw = await kvGet(kv, `${prefix}${key}`);
+  const raw = await kvGet(kv, `${prefix}${key}`, keyFamily, logger);
   if (!raw) {
-    logCacheEvent("cache_miss", keyFamily, key);
+    logCacheEvent(logger, "cache.miss", keyFamily, key);
     return null;
   }
   try {
     const parsed = JSON.parse(raw) as T;
-    logCacheEvent("cache_hit", keyFamily, key);
+    logCacheEvent(logger, "cache.hit", keyFamily, key);
     return parsed;
-  } catch (e) {
-    // key is user-supplied (address/txid) — keep it out of the format string
-    // and pass it as a separate argument so it cannot be interpreted as a
-    // printf-style specifier (ref: CodeQL format-string advisory).
-    console.error("Failed to parse cached entry", { keyFamily, key }, e);
+  } catch (error) {
+    logger?.error("cache.parse_error", {
+      keyFamily,
+      key,
+      error: String(error),
+    });
     return null;
   }
 }
@@ -114,99 +136,169 @@ async function readSentinelCache<T>(
   kv: KVNamespace | undefined,
   prefix: string,
   keyFamily: string,
-  key: string
+  key: string,
+  logger?: Logger
 ): Promise<CacheResult<T>> {
-  const raw = await kvGet(kv, `${prefix}${key}`);
+  const raw = await kvGet(kv, `${prefix}${key}`, keyFamily, logger);
   if (raw === null) {
-    logCacheEvent("cache_miss", keyFamily, key);
+    logCacheEvent(logger, "cache.miss", keyFamily, key);
     return { hit: false };
   }
   if (raw === NONE_SENTINEL) {
-    logCacheEvent("cache_hit", keyFamily, key, true);
+    logCacheEvent(logger, "cache.hit", keyFamily, key, true);
     return { hit: true, value: null };
   }
   try {
     const parsed = JSON.parse(raw) as T;
-    logCacheEvent("cache_hit", keyFamily, key);
+    logCacheEvent(logger, "cache.hit", keyFamily, key);
     return { hit: true, value: parsed };
-  } catch (e) {
-    console.error("Failed to parse cached entry", { keyFamily, key }, e);
+  } catch (error) {
+    logger?.error("cache.parse_error", {
+      keyFamily,
+      key,
+      error: String(error),
+    });
     return { hit: false };
   }
 }
 
-export function getCachedBnsName(
+export async function getCachedBnsName(
   address: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<string | null> {
-  return kvGet(kv, `cache:bns:${address}`);
+  // BNS uses a raw string (name) rather than JSON, so we call kvGet directly
+  // and emit telemetry here for parity with the other caches.
+  const raw = await kvGet(kv, `cache:bns:${address}`, "bns", logger);
+  if (raw === null) {
+    logCacheEvent(logger, "cache.miss", "bns", address);
+    return null;
+  }
+  logCacheEvent(logger, "cache.hit", "bns", address, raw === NONE_SENTINEL);
+  return raw;
 }
 
 export function setCachedBnsName(
   address: string,
   name: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:bns:${address}`, name, BNS_CACHE_TTL);
+  return kvPut(kv, `cache:bns:${address}`, name, BNS_CACHE_TTL, "bns", logger);
 }
 
 export function setCachedBnsNegative(
   address: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:bns:${address}`, NONE_SENTINEL, BNS_NEGATIVE_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:bns:${address}`,
+    NONE_SENTINEL,
+    BNS_NEGATIVE_CACHE_TTL,
+    "bns",
+    logger
+  );
 }
 
 export function getCachedIdentity(
   address: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<CacheResult<AgentIdentity>> {
-  return readSentinelCache<AgentIdentity>(kv, "cache:identity:", "identity", address);
+  return readSentinelCache<AgentIdentity>(
+    kv,
+    "cache:identity:",
+    "identity",
+    address,
+    logger
+  );
 }
 
 export function setCachedIdentity(
   address: string,
   identity: AgentIdentity,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:identity:${address}`, JSON.stringify(identity), IDENTITY_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:identity:${address}`,
+    JSON.stringify(identity),
+    IDENTITY_CACHE_TTL,
+    "identity",
+    logger
+  );
 }
 
 export function setCachedIdentityNegative(
   address: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:identity:${address}`, NONE_SENTINEL, IDENTITY_NEGATIVE_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:identity:${address}`,
+    NONE_SENTINEL,
+    IDENTITY_NEGATIVE_CACHE_TTL,
+    "identity",
+    logger
+  );
 }
 
 export function getCachedReputation<T>(
   key: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<CacheResult<T>> {
-  return readSentinelCache<T>(kv, "cache:reputation:", "reputation", key);
+  return readSentinelCache<T>(
+    kv,
+    "cache:reputation:",
+    "reputation",
+    key,
+    logger
+  );
 }
 
 export function setCachedReputation(
   key: string,
   data: unknown,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:reputation:${key}`, JSON.stringify(data), REPUTATION_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:reputation:${key}`,
+    JSON.stringify(data),
+    REPUTATION_CACHE_TTL,
+    "reputation",
+    logger
+  );
 }
 
 export function getCachedTransaction(
   txid: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<any | null> {
-  return readJsonCache<any>(kv, "cache:tx:", "tx", txid);
+  return readJsonCache<any>(kv, "cache:tx:", "tx", txid, logger);
 }
 
 export function setCachedTransaction(
   txid: string,
   data: any,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:tx:${txid}`, JSON.stringify(data), TX_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:tx:${txid}`,
+    JSON.stringify(data),
+    TX_CACHE_TTL,
+    "tx",
+    logger
+  );
 }
 
 /** Minimal shape of a Hiro stacking response used by the stacker achievement. */
@@ -216,15 +308,30 @@ export interface StackingCacheEntry {
 
 export function getCachedStacking(
   stxAddress: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<StackingCacheEntry | null> {
-  return readJsonCache<StackingCacheEntry>(kv, "cache:stacking:", "stacking", stxAddress);
+  return readJsonCache<StackingCacheEntry>(
+    kv,
+    "cache:stacking:",
+    "stacking",
+    stxAddress,
+    logger
+  );
 }
 
 export function setCachedStacking(
   stxAddress: string,
   data: StackingCacheEntry,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<void> {
-  return kvPut(kv, `cache:stacking:${stxAddress}`, JSON.stringify(data), STACKING_CACHE_TTL);
+  return kvPut(
+    kv,
+    `cache:stacking:${stxAddress}`,
+    JSON.stringify(data),
+    STACKING_CACHE_TTL,
+    "stacking",
+    logger
+  );
 }

--- a/lib/identity/reputation.ts
+++ b/lib/identity/reputation.ts
@@ -7,6 +7,7 @@ import { REPUTATION_REGISTRY_CONTRACT } from "./constants";
 import { callReadOnly, parseClarityValue } from "./stacks-api";
 import { getCachedReputation, setCachedReputation } from "./kv-cache";
 import type { ReputationSummary, ReputationFeedbackResponse, ReputationFeedback } from "./types";
+import type { Logger } from "../logging";
 
 /**
  * WAD divisor: 10^18 as a BigInt.
@@ -30,10 +31,11 @@ function wadToNumber(wadStr: string): number {
 export async function getReputationSummary(
   agentId: number,
   hiroApiKey?: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<ReputationSummary | null> {
   const cacheKey = `summary:${agentId}`;
-  const cached = await getCachedReputation<ReputationSummary>(cacheKey, kv);
+  const cached = await getCachedReputation<ReputationSummary>(cacheKey, kv, logger);
   if (cached.hit) return cached.value;
 
   try {
@@ -41,7 +43,7 @@ export async function getReputationSummary(
     const summary = parseClarityValue(result);
 
     if (!summary || Number(summary.count) === 0) {
-      await setCachedReputation(cacheKey, null, kv);
+      await setCachedReputation(cacheKey, null, kv, logger);
       return null;
     }
 
@@ -54,10 +56,13 @@ export async function getReputationSummary(
       summaryValueDecimals: Number(summary["summary-value-decimals"]),
     };
 
-    await setCachedReputation(cacheKey, reputationSummary, kv);
+    await setCachedReputation(cacheKey, reputationSummary, kv, logger);
     return reputationSummary;
   } catch (error) {
-    console.error("Error fetching reputation summary:", error);
+    logger?.error("reputation.summary_fetch_error", {
+      agentId,
+      error: String(error),
+    });
     throw error;
   }
 }
@@ -69,10 +74,11 @@ export async function getReputationFeedback(
   agentId: number,
   cursor?: number,
   hiroApiKey?: string,
-  kv?: KVNamespace
+  kv?: KVNamespace,
+  logger?: Logger
 ): Promise<ReputationFeedbackResponse> {
   const cacheKey = `feedback:${agentId}:${cursor || 0}`;
-  const cached = await getCachedReputation<ReputationFeedbackResponse>(cacheKey, kv);
+  const cached = await getCachedReputation<ReputationFeedbackResponse>(cacheKey, kv, logger);
   if (cached.hit) return cached.value ?? { items: [], cursor: null };
 
   try {
@@ -90,7 +96,7 @@ export async function getReputationFeedback(
 
     if (!response || !response.items) {
       const empty: ReputationFeedbackResponse = { items: [], cursor: null };
-      await setCachedReputation(cacheKey, empty, kv);
+      await setCachedReputation(cacheKey, empty, kv, logger);
       return empty;
     }
 
@@ -110,10 +116,14 @@ export async function getReputationFeedback(
       cursor: response.cursor !== null ? Number(response.cursor) : null,
     };
 
-    await setCachedReputation(cacheKey, feedbackResponse, kv);
+    await setCachedReputation(cacheKey, feedbackResponse, kv, logger);
     return feedbackResponse;
   } catch (error) {
-    console.error("Error fetching reputation feedback:", error);
+    logger?.error("reputation.feedback_fetch_error", {
+      agentId,
+      cursor: cursor ?? null,
+      error: String(error),
+    });
     throw error;
   }
 }

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -817,7 +817,7 @@ export async function verifyTxidPayment(
   let txData: StacksTxData;
 
   // 1. Confirmed transactions are immutable -- check positive cache first
-  const cachedTx = await getCachedTransaction(normalizedTxid, kv) as StacksTxData | null;
+  const cachedTx = await getCachedTransaction(normalizedTxid, kv, log) as StacksTxData | null;
   if (cachedTx) {
     log.info("Txid verification: cache hit", { txid: fullTxid });
     txData = cachedTx;
@@ -922,8 +922,11 @@ export async function verifyTxidPayment(
 
   // Fire-and-forget cache write for confirmed transactions
   if (!cachedTx) {
-    setCachedTransaction(normalizedTxid, txData, kv).catch((err) => {
-      console.warn("[verifyTxidPayment] KV cache write failed:", String(err));
+    setCachedTransaction(normalizedTxid, txData, kv, log).catch((err) => {
+      log.warn("verifyTxidPayment.kv_cache_write_failed", {
+        error: String(err),
+        txid: fullTxid,
+      });
     });
   }
 


### PR DESCRIPTION
## Summary

- PR #604 added cache hit/miss telemetry and error logging in `lib/identity/kv-cache.ts` via `console.log`/`console.error`, bypassing our worker-logs pipeline. This fixes the source and threads a `Logger` through every caller so telemetry lands in worker-logs with the usual `rayId` / `path` / `appId` context.
- When no `Logger` is supplied, cache helpers are now silent (no console fallback) — we prefer missing a telemetry event over polluting stdout with unstructured JSON.
- Library helpers (`bns`, `identity/detection`, `identity/reputation`, `achievements/verify`, `agent-enrichment`, `inbox/x402-verify`) now accept an optional `logger` and thread it into every cache read/write and error path. API routes (`/api/achievements/verify`, `/api/agents/[address]`, `/api/verify/[address]`, `/api/identity/[address]/reputation`, `/api/resolve/[identifier]`) create a request-scoped logger (or console fallback for local dev without `LOGS`) and pass it down. `/api/register` was already building `log` and just needed it passed to `lookupBnsName`.

## Scope (what's intentionally not included)

- `app/agents/[address]/page.tsx` (SSR) still uses the cache helpers without a logger. Wiring a logger through React `cache()`-wrapped functions is a bigger refactor and these paths were already silent on telemetry before PR #604. Follow-up ticket.
- A handful of pre-existing `console.*` calls (e.g. `lib/achievements/kv.ts`, `lib/identity/stacks-api.ts`) predate PR #604 and are out of scope here.

## Test plan

- [x] `npm run lint` — passes (only pre-existing `<img>` warnings)
- [x] `npx tsc --noEmit` — passes
- [x] `npm test` — 459/459 pass
- [x] `npm run deploy:dry-run` — succeeds; bindings unchanged
- [ ] Post-merge: spot-check worker-logs in production for `cache.hit` / `cache.miss` events on `/api/agents/[address]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)