### PR TITLE
perf(hiro): logger telemetry + 3-state BNS/identity cache + refresh endpoint

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,32 @@
       "rules": {
         "no-restricted-syntax": "off"
       }
+    },
+    {
+      "files": ["lib/**/*.ts", "lib/**/*.tsx"],
+      "rules": {
+        "no-console": "error"
+      }
+    },
+    {
+      "files": [
+        "lib/logging.ts",
+        "lib/**/__tests__/**/*.ts",
+        "lib/**/__tests__/**/*.tsx",
+        "**/*.test.ts",
+        "**/*.test.tsx",
+        "lib/admin/auth.ts",
+        "lib/agent-lookup.ts",
+        "lib/bitcoin-verify.ts",
+        "lib/challenge.ts",
+        "lib/achievements/kv.ts",
+        "lib/heartbeat/kv-helpers.ts",
+        "lib/inbox/kv-helpers.ts",
+        "lib/vouch/kv-helpers.ts"
+      ],
+      "rules": {
+        "no-console": "off"
+      }
     }
   ]
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -337,10 +337,25 @@ Integration with ERC-8004 on-chain identity and reputation registries. Agents se
 - **Detection**: Platform queries on-chain state to find agent's NFT and agent-id
 - **Profile display**: Identity badge + reputation summary on agent profiles
 - **Guide page**: `/identity` provides step-by-step registration instructions
+- **Manual refresh**: `POST /api/identity/:address/refresh` busts cached BNS + identity state and re-runs both lookups. Wired to the profile-page "Not showing up correctly? Refresh" link for users who register BNS names or mint identity NFTs off-platform.
+
+### Cache Model for BNS + Identity Lookups
+
+Three-state cache in `lib/identity/kv-cache.ts`:
+
+| State | TTL | Helper |
+|-------|-----|--------|
+| Confirmed positive (Hiro returned a name/NFT) | 24h | `setCachedBnsName` / `setCachedIdentity` |
+| Confirmed negative (Hiro authoritatively said none) | 7d | `setCachedBnsNegative` / `setCachedIdentityNegative` |
+| Lookup failed (429/5xx/timeout/parse error) | 60s | `setCachedBnsLookupFailed` / `setCachedIdentityLookupFailed` |
+
+The 7d confirmed-negative TTL is safe because state transitions require an on-chain tx. Cache-bust hooks on write paths (backfill-identity, identity/[address] GET persist) keep the cache in sync when we discover new state; the refresh endpoint covers the off-platform case where a user registers a name or mints an NFT without us ever seeing it.
 
 **Related files:**
 - `lib/identity/` — Types, constants, detection, reputation fetching
-- `app/components/IdentityBadge.tsx` — On-chain identity status display
+- `lib/identity/kv-cache.ts` — Three-state cache + `invalidateBnsCache` / `invalidateIdentityCache`
+- `app/api/identity/[address]/refresh/route.ts` — Manual refresh endpoint (POST)
+- `app/components/IdentityBadge.tsx` — On-chain identity status display + refresh button
 - `app/components/ReputationSummary.tsx` — Reputation summary widget
 - `app/components/ReputationFeedbackList.tsx` — Paginated feedback list
 - `app/identity/page.tsx` — Identity & reputation guide

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -10,7 +10,12 @@ import { lookupBnsName } from "@/lib/bns";
 import { X_HANDLE } from "@/lib/constants";
 import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
-import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from "@/lib/identity/kv-cache";
+import {
+  getCachedIdentity,
+  setCachedIdentity,
+  setCachedIdentityNegative,
+  setCachedIdentityLookupFailed,
+} from "@/lib/identity/kv-cache";
 import type { AgentIdentity } from "@/lib/identity/types";
 import AgentProfile from "./AgentProfile";
 import Navbar from "../../components/Navbar";
@@ -118,11 +123,14 @@ async function resolveIdentity(
     const resp = await stacksApiFetch(
       url,
       { headers: buildHiroHeaders(hiroApiKey) },
-      2,
-      500,
-      1
+      { retries: 2, retries429: 1 }
     );
-    if (!resp.ok) return agent;
+    if (!resp.ok) {
+      // Transient upstream error — short-TTL lookup-failed cache so concurrent
+      // profile views don't all re-hit Hiro.
+      await setCachedIdentityLookupFailed(agent.stxAddress, kv);
+      return agent;
+    }
 
     const data = await resp.json() as {
       results?: Array<{ value: { repr: string } }>;
@@ -143,11 +151,13 @@ async function resolveIdentity(
         setCachedIdentity(agent.stxAddress, identity, kv),
       ]);
     } else {
-      // No identity found — write negative sentinel (5 min TTL)
+      // Confirmed no identity NFT for this address — 7d cache (bust on mint via refresh endpoint).
       await setCachedIdentityNegative(agent.stxAddress, kv);
     }
   } catch {
-    /* best-effort — transient Hiro errors should not break profile rendering */
+    // Best-effort — transient Hiro errors should not break profile rendering.
+    // Short-TTL lookup-failed cache so the hammer doesn't recur on every view.
+    await setCachedIdentityLookupFailed(agent.stxAddress, kv);
   }
 
   return agent;

--- a/app/api/achievements/verify/route.ts
+++ b/app/api/achievements/verify/route.ts
@@ -425,7 +425,11 @@ export async function POST(request: NextRequest) {
             // Fetch transaction from Stacks API with API key
             const txUrl = `${STACKS_API_BASE}/extended/v1/tx/${txid}`;
             const headers = buildHiroHeaders(hiroApiKey);
-            const txResp = await stacksApiFetch(txUrl, { headers });
+            const txResp = await stacksApiFetch(
+              txUrl,
+              { headers },
+              { logger }
+            );
 
             if (!txResp.ok) {
               // If the wrapper exhausted its 429 retry budget and still saw a rate

--- a/app/api/admin/backfill-identity/route.ts
+++ b/app/api/admin/backfill-identity/route.ts
@@ -4,6 +4,12 @@ import { requireAdmin } from "@/lib/admin/auth";
 import type { AgentRecord } from "@/lib/types";
 import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "@/lib/identity/constants";
 import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
+import { setCachedIdentity, setCachedIdentityNegative } from "@/lib/identity/kv-cache";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 /** Sleep helper for rate-spacing sequential Hiro API calls. */
 const sleep = (ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms));
@@ -33,9 +39,15 @@ export async function GET(request: NextRequest) {
   if (denied) return denied;
 
   try {
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const hiroApiKey = env.HIRO_API_KEY as string | undefined;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     const { searchParams } = new URL(request.url);
     const limitParam = parseInt(searchParams.get("limit") ?? "50", 10);
@@ -98,10 +110,17 @@ export async function GET(request: NextRequest) {
 
         try {
           const url = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${agent.stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
-          const resp = await stacksApiFetch(url, { headers: hiroHeaders });
+          const resp = await stacksApiFetch(
+            url,
+            { headers: hiroHeaders },
+            { logger }
+          );
 
           if (!resp.ok) {
-            console.warn(`[backfill-identity] Hiro error ${resp.status} for ${agent.stxAddress}`);
+            logger.warn("backfill.hiro_error", {
+              stxAddress: agent.stxAddress,
+              status: resp.status,
+            });
             errors++;
             // Still rate-space on error to avoid hammering a degraded endpoint
             await sleep(BACKFILL_INTER_CALL_DELAY_MS);
@@ -115,24 +134,41 @@ export async function GET(request: NextRequest) {
 
           if (!dryRun) {
             if (agentId != null) {
-              // Positive result — update both KV keys
+              // Positive result — update both KV keys AND the three-state
+              // identity cache so downstream SSR/profile paths see the fresh
+              // state instead of any stale confirmed-negative (7d TTL).
               const updatedRecord = JSON.stringify({ ...agent, erc8004AgentId: agentId });
               await Promise.all([
                 kv.put(`btc:${agent.btcAddress}`, updatedRecord),
                 kv.put(`stx:${agent.stxAddress}`, updatedRecord),
+                setCachedIdentity(
+                  agent.stxAddress,
+                  { agentId, owner: agent.stxAddress, uri: "" },
+                  kv,
+                  logger
+                ),
               ]);
               updated++;
               updatedAgents.push(`${agent.btcAddress} → agentId ${agentId}`);
             } else {
-              // Negative result — set sentinel to prevent re-checking (5-min TTL)
-              await kv.put(sentinelKey, "1", { expirationTtl: 300 });
+              // Negative result — set rate-limit sentinel to avoid re-checking
+              // from this admin route (5-min TTL) AND record confirmed-negative
+              // in the three-state identity cache (7d TTL) so other paths also
+              // skip the Hiro round-trip.
+              await Promise.all([
+                kv.put(sentinelKey, "1", { expirationTtl: 300 }),
+                setCachedIdentityNegative(agent.stxAddress, kv, logger),
+              ]);
             }
           } else if (agentId != null) {
             updated++;
             updatedAgents.push(`${agent.btcAddress} → agentId ${agentId} (dry run)`);
           }
         } catch (error) {
-          console.error(`[backfill-identity] Error for ${agent.stxAddress}:`, error);
+          logger.error("backfill.error", {
+            stxAddress: agent.stxAddress,
+            error: String(error),
+          });
           errors++;
           // Still rate-space on unexpected errors
           await sleep(BACKFILL_INTER_CALL_DELAY_MS);

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -12,6 +12,7 @@ import {
   createConsoleLogger,
   isLogsRPC,
 } from "@/lib/logging";
+import type { Logger } from "@/lib/logging";
 
 /**
  * Per-address rate-limit for manual refresh. Each refresh call:
@@ -60,6 +61,9 @@ export async function POST(
   { params }: { params: Promise<{ address: string }> }
 ) {
   const { address } = await params;
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const baseCtx = { rayId, path: request.nextUrl.pathname };
+  let logger: Logger = createConsoleLogger(baseCtx);
 
   if (!address || address.trim().length === 0) {
     return NextResponse.json(
@@ -72,11 +76,9 @@ export async function POST(
     const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
-    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
-    const baseCtx = { rayId, path: request.nextUrl.pathname };
-    const logger = isLogsRPC(env.LOGS)
+    logger = isLogsRPC(env.LOGS)
       ? createLogger(env.LOGS, ctx, baseCtx)
-      : createConsoleLogger(baseCtx);
+      : logger;
 
     const agent = await lookupAgent(kv, address);
     if (!agent) {
@@ -194,8 +196,12 @@ export async function POST(
       cachesCleared: ["cache:bns", "cache:identity", "identity-check"],
     });
   } catch (e) {
+    logger.error("identity.refresh_error", {
+      address,
+      error: String(e),
+    });
     return NextResponse.json(
-      { error: `Identity refresh failed: ${(e as Error).message}` },
+      { error: "Identity refresh failed" },
       { status: 500 }
     );
   }

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -1,0 +1,166 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import { lookupBnsName } from "@/lib/bns";
+import { detectAgentIdentity } from "@/lib/identity/detection";
+import {
+  invalidateBnsCache,
+  invalidateIdentityCache,
+} from "@/lib/identity/kv-cache";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
+
+/**
+ * POST /api/identity/:address/refresh — Bust cached BNS + identity state.
+ *
+ * The BNS/identity three-state cache uses a 7-day confirmed-negative TTL.
+ * That's correct for typical use (state changes require an on-chain tx) but
+ * leaves a long tail of users who register a BNS name or mint an ERC-8004
+ * identity NFT off-platform (e.g. via Xverse) after signing up with us. This
+ * endpoint is their manual escape hatch:
+ *
+ *   1. Delete `cache:bns:{stxAddress}` and `cache:identity:{stxAddress}`.
+ *   2. Re-run both lookups and return the fresh values.
+ *
+ * Rate-limit keys (`identity-check:{stxAddress}`) are also cleared so the
+ * next request from `/api/identity/:address` isn't suppressed by a stale
+ * sentinel.
+ *
+ * Accepts any registered agent address (BTC / STX / taproot) — resolves to
+ * the same AgentRecord and invalidates against its `stxAddress`.
+ *
+ * Response:
+ *   {
+ *     stxAddress: string,
+ *     bnsName: string | null,     // fresh value after re-lookup
+ *     agentId: number | null,     // fresh value after re-lookup
+ *     cachesCleared: ["cache:bns", "cache:identity", "identity-check"]
+ *   }
+ */
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ address: string }> }
+) {
+  const { address } = await params;
+
+  if (!address || address.trim().length === 0) {
+    return NextResponse.json(
+      { error: "Address parameter is required" },
+      { status: 400 }
+    );
+  }
+
+  try {
+    const { env, ctx } = await getCloudflareContext();
+    const kv = env.VERIFIED_AGENTS as KVNamespace;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
+
+    const agent = await lookupAgent(kv, address);
+    if (!agent) {
+      return NextResponse.json(
+        { error: "Agent not found", address },
+        { status: 404 }
+      );
+    }
+
+    const stxAddress = agent.stxAddress;
+
+    // 1. Bust caches. `identity-check:{stx}` is the rate-limit sentinel used
+    //    by /api/identity/:address GET — clearing it so the next lookup isn't
+    //    suppressed.
+    await Promise.all([
+      invalidateBnsCache(stxAddress, kv, logger),
+      invalidateIdentityCache(stxAddress, kv, logger),
+      kv.delete(`identity-check:${stxAddress}`),
+    ]);
+
+    logger.info("identity.refresh_requested", { stxAddress });
+
+    // 2. Re-run both lookups against fresh Hiro state.
+    const [bnsName, identity] = await Promise.all([
+      lookupBnsName(stxAddress, env.HIRO_API_KEY, kv, logger),
+      detectAgentIdentity(stxAddress, env.HIRO_API_KEY, kv, logger),
+    ]);
+
+    // 3. If either result differs from the stored agent record, persist the
+    //    update on both btc: and stx: keys so consumers that read the record
+    //    directly see the change immediately.
+    const bnsChanged = (agent.bnsName || null) !== (bnsName || null);
+    const idChanged =
+      (agent.erc8004AgentId ?? null) !== (identity?.agentId ?? null);
+
+    if (bnsChanged || idChanged) {
+      const updatedRecord = {
+        ...agent,
+        bnsName: bnsName ?? null,
+        erc8004AgentId: identity?.agentId ?? null,
+      };
+      const serialized = JSON.stringify(updatedRecord);
+      await Promise.all([
+        kv.put(`stx:${stxAddress}`, serialized),
+        kv.put(`btc:${agent.btcAddress}`, serialized),
+      ]);
+      logger.info("identity.refresh_persisted_update", {
+        stxAddress,
+        bnsChanged,
+        idChanged,
+      });
+    }
+
+    return NextResponse.json({
+      stxAddress,
+      btcAddress: agent.btcAddress,
+      bnsName: bnsName ?? null,
+      agentId: identity?.agentId ?? null,
+      cachesCleared: ["cache:bns", "cache:identity", "identity-check"],
+    });
+  } catch (e) {
+    return NextResponse.json(
+      { error: `Identity refresh failed: ${(e as Error).message}` },
+      { status: 500 }
+    );
+  }
+}
+
+/** GET returns self-documentation for the endpoint. */
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ address: string }> }
+) {
+  const { address } = await params;
+  return NextResponse.json(
+    {
+      endpoint: "POST /api/identity/:address/refresh",
+      description:
+        "Bust the cached BNS + identity state for an address and re-run both " +
+        "lookups. Use this after registering a BNS name or minting an ERC-8004 " +
+        "identity NFT off-platform (e.g. via Xverse) — the platform's 7-day " +
+        "confirmed-negative cache will otherwise serve stale state until it " +
+        "expires.",
+      method: "POST",
+      parameters: {
+        address:
+          "BTC, STX, or taproot address of a registered agent (same formats " +
+          "accepted by /api/agents/:address).",
+      },
+      response: {
+        stxAddress: "string — the agent's STX address",
+        btcAddress: "string — the agent's BTC address",
+        bnsName: "string | null — fresh BNS name after re-lookup",
+        agentId: "number | null — fresh ERC-8004 agent ID after re-lookup",
+        cachesCleared:
+          "string[] — cache key families that were invalidated",
+      },
+      example: `POST /api/identity/${address || "SP..."}/refresh`,
+    },
+    { status: 200 }
+  );
+}

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -76,9 +76,9 @@ export async function POST(
     const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
-    logger = isLogsRPC(env.LOGS)
-      ? createLogger(env.LOGS, ctx, baseCtx)
-      : logger;
+    if (isLogsRPC(env.LOGS)) {
+      logger = createLogger(env.LOGS, ctx, baseCtx);
+    }
 
     const agent = await lookupAgent(kv, address);
     if (!agent) {

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
-import { lookupBnsName } from "@/lib/bns";
-import { detectAgentIdentity } from "@/lib/identity/detection";
+import { lookupBnsNameWithOutcome } from "@/lib/bns";
+import { detectAgentIdentityWithOutcome } from "@/lib/identity/detection";
 import {
   invalidateBnsCache,
   invalidateIdentityCache,
@@ -12,6 +12,18 @@ import {
   createConsoleLogger,
   isLogsRPC,
 } from "@/lib/logging";
+
+/**
+ * Per-address rate-limit for manual refresh. Each refresh call:
+ *   - deletes two `cache:*` entries (bypassing the 7d confirmed-negative TTL),
+ *   - deletes the `identity-check:*` rate-limit sentinel,
+ *   - issues two fresh Hiro API calls (BNS + identity).
+ *
+ * Without this guard an unauthenticated caller could amplify upstream traffic
+ * by spamming POSTs. 60s is short enough to not block a user correcting a
+ * genuine state-change, long enough to neutralise abuse.
+ */
+const REFRESH_RATE_LIMIT_SECONDS = 60;
 
 /**
  * POST /api/identity/:address/refresh — Bust cached BNS + identity state.
@@ -31,6 +43,9 @@ import {
  *
  * Accepts any registered agent address (BTC / STX / taproot) — resolves to
  * the same AgentRecord and invalidates against its `stxAddress`.
+ *
+ * Rate-limited to one refresh per address per {@link REFRESH_RATE_LIMIT_SECONDS}
+ * seconds. Repeat calls within that window return 429 with `Retry-After`.
  *
  * Response:
  *   {
@@ -73,35 +88,78 @@ export async function POST(
 
     const stxAddress = agent.stxAddress;
 
-    // 1. Bust caches. `identity-check:{stx}` is the rate-limit sentinel used
-    //    by /api/identity/:address GET — clearing it so the next lookup isn't
-    //    suppressed.
-    await Promise.all([
+    // Rate limit: one manual refresh per address per REFRESH_RATE_LIMIT_SECONDS.
+    // Enforced BEFORE any cache invalidation or Hiro call so repeat POSTs
+    // don't keep busting the 7d confirmed-negative cache or amplifying traffic.
+    const refreshGateKey = `refresh-gate:${stxAddress}`;
+    const recentRefresh = await kv.get(refreshGateKey);
+    if (recentRefresh) {
+      return NextResponse.json(
+        {
+          error: `Refresh rate limit — try again in ${REFRESH_RATE_LIMIT_SECONDS} seconds`,
+          stxAddress,
+        },
+        {
+          status: 429,
+          headers: { "Retry-After": String(REFRESH_RATE_LIMIT_SECONDS) },
+        }
+      );
+    }
+    await kv.put(refreshGateKey, "1", {
+      expirationTtl: REFRESH_RATE_LIMIT_SECONDS,
+    });
+
+    // Invalidate caches. The `identity-check:{stx}` sentinel is deleted via
+    // best-effort try/catch — a KV hiccup on that key shouldn't fail the
+    // whole refresh (the typed cache invalidations are the load-bearing bust).
+    const invalidations: Promise<void>[] = [
       invalidateBnsCache(stxAddress, kv, logger),
       invalidateIdentityCache(stxAddress, kv, logger),
-      kv.delete(`identity-check:${stxAddress}`),
-    ]);
+      (async () => {
+        try {
+          await kv.delete(`identity-check:${stxAddress}`);
+        } catch (err) {
+          logger.warn("identity.refresh_identity_check_delete_failed", {
+            stxAddress,
+            error: String(err),
+          });
+        }
+      })(),
+    ];
+    await Promise.all(invalidations);
 
     logger.info("identity.refresh_requested", { stxAddress });
 
-    // 2. Re-run both lookups against fresh Hiro state.
-    const [bnsName, identity] = await Promise.all([
-      lookupBnsName(stxAddress, env.HIRO_API_KEY, kv, logger),
-      detectAgentIdentity(stxAddress, env.HIRO_API_KEY, kv, logger),
+    // Re-run both lookups against fresh Hiro state using the tri-state
+    // outcome helpers. We need the state so we can skip the AgentRecord
+    // write when the lookup was inconclusive (transient upstream error) —
+    // otherwise a Hiro incident during refresh would clobber a previously
+    // verified bnsName or erc8004AgentId with null.
+    const [bnsOutcome, idOutcome] = await Promise.all([
+      lookupBnsNameWithOutcome(stxAddress, env.HIRO_API_KEY, kv, logger),
+      detectAgentIdentityWithOutcome(stxAddress, env.HIRO_API_KEY, kv, logger),
     ]);
 
-    // 3. If either result differs from the stored agent record, persist the
-    //    update on both btc: and stx: keys so consumers that read the record
-    //    directly see the change immediately.
-    const bnsChanged = (agent.bnsName || null) !== (bnsName || null);
-    const idChanged =
-      (agent.erc8004AgentId ?? null) !== (identity?.agentId ?? null);
+    // Compute proposed next values. `"lookup-failed"` outcomes preserve the
+    // stored value; authoritative outcomes (positive or confirmed-negative)
+    // take effect.
+    const nextBnsName =
+      bnsOutcome.state === "lookup-failed"
+        ? agent.bnsName ?? null
+        : bnsOutcome.name;
+    const nextAgentId =
+      idOutcome.state === "lookup-failed"
+        ? agent.erc8004AgentId ?? null
+        : idOutcome.identity?.agentId ?? null;
+
+    const bnsChanged = (agent.bnsName ?? null) !== nextBnsName;
+    const idChanged = (agent.erc8004AgentId ?? null) !== nextAgentId;
 
     if (bnsChanged || idChanged) {
       const updatedRecord = {
         ...agent,
-        bnsName: bnsName ?? null,
-        erc8004AgentId: identity?.agentId ?? null,
+        bnsName: nextBnsName,
+        erc8004AgentId: nextAgentId,
       };
       const serialized = JSON.stringify(updatedRecord);
       await Promise.all([
@@ -112,14 +170,27 @@ export async function POST(
         stxAddress,
         bnsChanged,
         idChanged,
+        bnsOutcome: bnsOutcome.state,
+        idOutcome: idOutcome.state,
+      });
+    } else if (
+      bnsOutcome.state === "lookup-failed" ||
+      idOutcome.state === "lookup-failed"
+    ) {
+      logger.warn("identity.refresh_inconclusive", {
+        stxAddress,
+        bnsOutcome: bnsOutcome.state,
+        idOutcome: idOutcome.state,
       });
     }
 
     return NextResponse.json({
       stxAddress,
       btcAddress: agent.btcAddress,
-      bnsName: bnsName ?? null,
-      agentId: identity?.agentId ?? null,
+      bnsName: nextBnsName,
+      agentId: nextAgentId,
+      bnsOutcome: bnsOutcome.state,
+      idOutcome: idOutcome.state,
       cachesCleared: ["cache:bns", "cache:identity", "identity-check"],
     });
   } catch (e) {
@@ -146,6 +217,9 @@ export async function GET(
         "confirmed-negative cache will otherwise serve stale state until it " +
         "expires.",
       method: "POST",
+      rateLimit:
+        `One refresh per address per ${REFRESH_RATE_LIMIT_SECONDS} seconds. ` +
+        "Repeat calls return 429 with a Retry-After header.",
       parameters: {
         address:
           "BTC, STX, or taproot address of a registered agent (same formats " +
@@ -156,6 +230,10 @@ export async function GET(
         btcAddress: "string — the agent's BTC address",
         bnsName: "string | null — fresh BNS name after re-lookup",
         agentId: "number | null — fresh ERC-8004 agent ID after re-lookup",
+        bnsOutcome:
+          "\"positive\" | \"confirmed-negative\" | \"lookup-failed\" — whether the BNS lookup produced an authoritative result. On lookup-failed the stored bnsName is preserved rather than clobbered.",
+        idOutcome:
+          "\"positive\" | \"confirmed-negative\" | \"lookup-failed\" — same for identity.",
         cachesCleared:
           "string[] — cache key families that were invalidated",
       },

--- a/app/api/identity/[address]/route.ts
+++ b/app/api/identity/[address]/route.ts
@@ -4,6 +4,7 @@ import { lookupAgent } from "@/lib/agent-lookup";
 import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
 import {
+  getCachedIdentity,
   setCachedIdentity,
   setCachedIdentityNegative,
   setCachedIdentityLookupFailed,
@@ -76,6 +77,25 @@ export async function GET(
       return NextResponse.json(
         { agentId: agent.erc8004AgentId },
         { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=3600" } }
+      );
+    }
+
+    // Consult the typed identity cache before hitting Hiro. This covers both
+    // confirmed-negative (7d TTL) and lookup-failed (60s TTL) hits, so the
+    // concurrent-badge-render hammer is suppressed — not just by this route's
+    // own 5-min `identity-check:` sentinel but by failures recorded from
+    // other entry points (SSR, backfill, refresh endpoint).
+    const typedCached = await getCachedIdentity(agent.stxAddress, kv);
+    if (typedCached.hit) {
+      if (typedCached.value) {
+        return NextResponse.json(
+          { agentId: typedCached.value.agentId },
+          { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400, stale-while-revalidate=3600" } }
+        );
+      }
+      return NextResponse.json(
+        { agentId: null },
+        { headers: { "Cache-Control": "public, max-age=300, s-maxage=300" } }
       );
     }
 

--- a/app/api/identity/[address]/route.ts
+++ b/app/api/identity/[address]/route.ts
@@ -3,6 +3,16 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import { stacksApiFetch, buildHiroHeaders } from "@/lib/stacks-api-fetch";
 import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/constants";
+import {
+  setCachedIdentity,
+  setCachedIdentityNegative,
+  setCachedIdentityLookupFailed,
+} from "@/lib/identity/kv-cache";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "@/lib/logging";
 
 /**
  * GET /api/identity/:address — Detect on-chain ERC-8004 identity for an agent.
@@ -15,7 +25,7 @@ import { STACKS_API_BASE, IDENTITY_REGISTRY_CONTRACT } from "@/lib/identity/cons
  * Returns: { agentId: number | null }
  */
 export async function GET(
-  _request: NextRequest,
+  request: NextRequest,
   { params }: { params: Promise<{ address: string }> }
 ) {
   const { address } = await params;
@@ -42,8 +52,14 @@ export async function GET(
   }
 
   try {
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const baseCtx = { rayId, path: request.nextUrl.pathname };
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, baseCtx)
+      : createConsoleLogger(baseCtx);
 
     const agent = await lookupAgent(kv, address);
 
@@ -83,11 +99,12 @@ export async function GET(
     const resp = await stacksApiFetch(
       url,
       { headers: buildHiroHeaders(env.HIRO_API_KEY) },
-      2,
-      500,
-      1
+      { retries: 2, retries429: 1, logger }
     );
     if (!resp.ok) {
+      // Short-TTL lookup-failed cache so concurrent badge renders don't each
+      // re-hit Hiro while the upstream is degraded.
+      await setCachedIdentityLookupFailed(agent.stxAddress, kv, logger);
       return NextResponse.json(
         { error: `Hiro API error: ${resp.status}` },
         { status: 502 }
@@ -102,7 +119,9 @@ export async function GET(
     const match = repr?.match(/^u(\d+)$/);
     const agentId = match ? Number(match[1]) : null;
 
-    // Persist to KV if changed
+    // Persist to KV if changed, and keep the three-state identity cache in
+    // sync so other paths (SSR, backfill, refresh endpoint) don't serve a
+    // stale value.
     if (agentId !== agent.erc8004AgentId) {
       agent.erc8004AgentId = agentId;
       const updated = JSON.stringify(agent);
@@ -112,9 +131,21 @@ export async function GET(
       ]);
     }
 
-    // If still null, set rate limit so we don't hammer Hiro (5 min TTL)
-    if (agentId == null) {
-      await kv.put(rateLimitKey, "1", { expirationTtl: 300 });
+    if (agentId != null) {
+      await setCachedIdentity(
+        agent.stxAddress,
+        { agentId, owner: agent.stxAddress, uri: "" },
+        kv,
+        logger
+      );
+    } else {
+      // Confirmed no identity NFT for this address — 7d cache per three-state
+      // model. Also set the short rate-limit sentinel to avoid re-hitting
+      // Hiro from this endpoint specifically.
+      await Promise.all([
+        kv.put(rateLimitKey, "1", { expirationTtl: 300 }),
+        setCachedIdentityNegative(agent.stxAddress, kv, logger),
+      ]);
     }
 
     const cacheHeader = agentId != null

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2665,6 +2665,88 @@ export function GET() {
           },
         },
       },
+      "/api/identity/{address}/refresh": {
+        post: {
+          operationId: "refreshIdentity",
+          summary: "Bust cached BNS + identity state",
+          description:
+            "Delete cached BNS and identity entries for the agent, then re-run " +
+            "both lookups and return fresh values. Use after registering a BNS " +
+            "name or minting an ERC-8004 identity NFT off-platform — the 7-day " +
+            "confirmed-negative cache would otherwise serve stale state.",
+          parameters: [
+            {
+              name: "address",
+              in: "path",
+              required: true,
+              schema: { type: "string" },
+              description:
+                "BTC, STX, or taproot address of a registered agent",
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Refresh result with fresh BNS + identity values",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      stxAddress: { type: "string" },
+                      btcAddress: { type: "string" },
+                      bnsName: {
+                        oneOf: [{ type: "string" }, { type: "null" }],
+                        description: "BNS name after re-lookup, or null",
+                      },
+                      agentId: {
+                        oneOf: [{ type: "integer" }, { type: "null" }],
+                        description:
+                          "ERC-8004 agent ID after re-lookup, or null",
+                      },
+                      cachesCleared: {
+                        type: "array",
+                        items: { type: "string" },
+                        description: "Cache key families that were invalidated",
+                      },
+                    },
+                    required: [
+                      "stxAddress",
+                      "btcAddress",
+                      "bnsName",
+                      "agentId",
+                      "cachesCleared",
+                    ],
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Missing or empty address",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "Agent not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "500": {
+              description: "Refresh failed",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
       "/api/identity/{address}/reputation": {
         get: {
           operationId: "getReputation",

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2696,12 +2696,24 @@ export function GET() {
                       btcAddress: { type: "string" },
                       bnsName: {
                         oneOf: [{ type: "string" }, { type: "null" }],
-                        description: "BNS name after re-lookup, or null",
+                        description:
+                          "BNS name after re-lookup, or null. On `bnsOutcome=lookup-failed` the previously stored value is preserved (not clobbered with null).",
                       },
                       agentId: {
                         oneOf: [{ type: "integer" }, { type: "null" }],
                         description:
-                          "ERC-8004 agent ID after re-lookup, or null",
+                          "ERC-8004 agent ID after re-lookup, or null. Same preservation rule as bnsName on `idOutcome=lookup-failed`.",
+                      },
+                      bnsOutcome: {
+                        type: "string",
+                        enum: ["positive", "confirmed-negative", "lookup-failed"],
+                        description:
+                          "Tri-state outcome for the BNS lookup. `lookup-failed` = transient Hiro error; retry later.",
+                      },
+                      idOutcome: {
+                        type: "string",
+                        enum: ["positive", "confirmed-negative", "lookup-failed"],
+                        description: "Tri-state outcome for the identity lookup.",
                       },
                       cachesCleared: {
                         type: "array",
@@ -2714,6 +2726,8 @@ export function GET() {
                       "btcAddress",
                       "bnsName",
                       "agentId",
+                      "bnsOutcome",
+                      "idOutcome",
                       "cachesCleared",
                     ],
                   },
@@ -2730,6 +2744,21 @@ export function GET() {
             },
             "404": {
               description: "Agent not found",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "429": {
+              description:
+                "Rate limited — one refresh per address per 60 seconds",
+              headers: {
+                "Retry-After": {
+                  description: "Seconds until a retry is allowed",
+                  schema: { type: "integer" },
+                },
+              },
               content: {
                 "application/json": {
                   schema: { $ref: "#/components/schemas/ErrorResponse" },

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -28,6 +28,7 @@ import {
   createLogger,
   createConsoleLogger,
   isLogsRPC,
+  type Logger,
 } from "@/lib/logging";
 
 // ---------------------------------------------------------------------------
@@ -85,19 +86,24 @@ function detectIdentifierType(identifier: string): IdentifierType {
  */
 async function resolveAgentIdToStxAddress(
   agentId: number,
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  logger?: Logger
 ): Promise<string | null> {
   try {
     const result = await callReadOnly(
       IDENTITY_REGISTRY_CONTRACT,
       "get-owner",
       [uintCV(agentId)],
-      hiroApiKey
+      hiroApiKey,
+      logger
     );
-    const owner = parseClarityValue(result);
+    const owner = parseClarityValue(result, logger);
     return typeof owner === "string" ? owner : null;
   } catch (e) {
-    console.error(`Failed to resolve agent-id ${agentId} on-chain:`, e);
+    logger?.error("resolve.agent_id_onchain_failed", {
+      agentId,
+      error: String(e),
+    });
     return null;
   }
 }
@@ -269,7 +275,7 @@ export async function GET(
       }
 
       // Resolve agent-id to STX address via on-chain call
-      const stxAddress = await resolveAgentIdToStxAddress(agentId, hiroApiKey);
+      const stxAddress = await resolveAgentIdToStxAddress(agentId, hiroApiKey, logger);
       if (!stxAddress) {
         return NextResponse.json(
           {

--- a/app/components/IdentityBadge.tsx
+++ b/app/components/IdentityBadge.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect } from "react";
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 
 interface IdentityBadgeProps {
   agentId?: number;
@@ -14,6 +15,9 @@ export default function IdentityBadge({
 }: IdentityBadgeProps) {
   const [agentId, setAgentId] = useState(initialAgentId);
   const [loading, setLoading] = useState(initialAgentId === undefined);
+  const [refreshing, setRefreshing] = useState(false);
+  const [refreshError, setRefreshError] = useState<string | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     if (initialAgentId !== undefined) return;
@@ -30,8 +34,38 @@ export default function IdentityBadge({
       .finally(() => setLoading(false));
   }, [initialAgentId, stxAddress]);
 
+  async function handleRefresh() {
+    if (refreshing) return;
+    setRefreshing(true);
+    setRefreshError(null);
+    try {
+      const resp = await fetch(
+        `/api/identity/${encodeURIComponent(stxAddress)}/refresh`,
+        { method: "POST" }
+      );
+      if (!resp.ok) {
+        const body = (await resp.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error || `Refresh failed: ${resp.status}`);
+      }
+      const data = (await resp.json()) as {
+        agentId: number | null;
+        bnsName: string | null;
+      };
+      setAgentId(data.agentId ?? undefined);
+      // BNS (and any other server-rendered fields) live on the AgentRecord;
+      // reload the RSC payload to pick those up.
+      router.refresh();
+    } catch (e) {
+      setRefreshError((e as Error).message);
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  let body: React.ReactNode;
+
   if (loading) {
-    return (
+    body = (
       <div className="rounded-xl border border-white/[0.08] bg-[rgba(12,12,12,0.6)] backdrop-blur-sm p-4">
         <div className="flex items-center gap-3">
           <div className="size-8 rounded-full bg-white/[0.06] animate-pulse motion-reduce:animate-none" />
@@ -39,10 +73,8 @@ export default function IdentityBadge({
         </div>
       </div>
     );
-  }
-
-  if (agentId !== undefined) {
-    return (
+  } else if (agentId !== undefined) {
+    body = (
       <div className="rounded-xl border border-blue-500/15 bg-blue-500/[0.06] backdrop-blur-sm p-4">
         <div className="flex items-center gap-3">
           <div className="flex items-center justify-center size-8 rounded-full bg-blue-500/15">
@@ -57,27 +89,48 @@ export default function IdentityBadge({
         </div>
       </div>
     );
+  } else {
+    body = (
+      <Link
+        href="/identity"
+        className="block rounded-xl border border-white/[0.08] bg-[rgba(12,12,12,0.6)] backdrop-blur-sm p-4 transition-colors hover:border-white/[0.12]"
+      >
+        <div className="flex items-center gap-3">
+          <div className="flex items-center justify-center size-8 rounded-full bg-white/[0.06]">
+            <svg className="size-4 text-white/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
+            </svg>
+          </div>
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-white/70">Register Identity</div>
+            <div className="text-xs text-white/40">ERC-8004 on-chain verification</div>
+          </div>
+          <svg className="ml-auto size-4 text-white/30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+          </svg>
+        </div>
+      </Link>
+    );
   }
 
   return (
-    <Link
-      href="/identity"
-      className="block rounded-xl border border-white/[0.08] bg-[rgba(12,12,12,0.6)] backdrop-blur-sm p-4 transition-colors hover:border-white/[0.12]"
-    >
-      <div className="flex items-center gap-3">
-        <div className="flex items-center justify-center size-8 rounded-full bg-white/[0.06]">
-          <svg className="size-4 text-white/40" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m5.618-4.016A11.955 11.955 0 0112 2.944a11.955 11.955 0 01-8.618 3.04A12.02 12.02 0 003 9c0 5.591 3.824 10.29 9 11.622 5.176-1.332 9-6.03 9-11.622 0-1.042-.133-2.052-.382-3.016z" />
-          </svg>
-        </div>
-        <div className="min-w-0">
-          <div className="text-sm font-medium text-white/70">Register Identity</div>
-          <div className="text-xs text-white/40">ERC-8004 on-chain verification</div>
-        </div>
-        <svg className="ml-auto size-4 text-white/30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
-        </svg>
+    <div className="space-y-1.5">
+      {body}
+      <div className="flex items-center justify-end gap-2 px-1">
+        <button
+          type="button"
+          onClick={handleRefresh}
+          disabled={refreshing || loading}
+          className="text-[11px] text-white/40 hover:text-white/70 transition-colors underline underline-offset-2 decoration-white/20 hover:decoration-white/50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+        >
+          {refreshing ? "Refreshing…" : "Not showing up correctly? Refresh"}
+        </button>
       </div>
-    </Link>
+      {refreshError && (
+        <div className="px-1 text-[11px] text-red-400/80" role="alert">
+          {refreshError}
+        </div>
+      )}
+    </div>
   );
 }

--- a/app/components/IdentityBadge.tsx
+++ b/app/components/IdentityBadge.tsx
@@ -121,7 +121,7 @@ export default function IdentityBadge({
           type="button"
           onClick={handleRefresh}
           disabled={refreshing || loading}
-          className="text-[11px] text-white/40 hover:text-white/70 transition-colors underline underline-offset-2 decoration-white/20 hover:decoration-white/50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer"
+          className="text-[11px] text-white/40 hover:text-white/70 transition-colors underline underline-offset-2 decoration-white/20 hover:decoration-white/50 disabled:opacity-50 disabled:cursor-not-allowed cursor-pointer focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-white/40 rounded-sm"
         >
           {refreshing ? "Refreshing…" : "Not showing up correctly? Refresh"}
         </button>

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -753,14 +753,20 @@ Bust the cached BNS + identity state for an address and re-run both lookups. Use
 curl -X POST https://aibtc.com/api/identity/bc1q.../refresh
 # Returns: { "stxAddress": "SP...", "btcAddress": "bc1q...",
 #           "bnsName": "alice.btc", "agentId": 42,
+#           "bnsOutcome": "positive", "idOutcome": "positive",
 #           "cachesCleared": ["cache:bns", "cache:identity", "identity-check"] }
 \`\`\`
 
 **Parameters:** \`address\` — BTC, STX, or taproot address of a registered agent
 
+**Rate limit:** One refresh per address per 60 seconds. Repeat calls return 429 with a \`Retry-After\` header.
+
+**Outcome fields:** \`bnsOutcome\` and \`idOutcome\` report \`"positive"\` | \`"confirmed-negative"\` | \`"lookup-failed"\`. On \`"lookup-failed"\` (transient Hiro error) the stored record is preserved rather than clobbered with null — retry later.
+
 **Error responses:**
 - 400: Missing or empty address
 - 404: Agent not found
+- 429: Rate limited — retry in 60 seconds
 - 500: Refresh failed
 
 ### GET /api/identity/:address/reputation

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -745,6 +745,24 @@ curl https://aibtc.com/api/identity/bc1q...
 - 404: Agent not found
 - 500: Identity detection failed
 
+### POST /api/identity/:address/refresh
+
+Bust the cached BNS + identity state for an address and re-run both lookups. Use this after registering a BNS name or minting an ERC-8004 identity NFT off-platform (e.g. via Xverse) — the platform's 7-day confirmed-negative cache will otherwise serve stale state until it expires.
+
+\`\`\`bash
+curl -X POST https://aibtc.com/api/identity/bc1q.../refresh
+# Returns: { "stxAddress": "SP...", "btcAddress": "bc1q...",
+#           "bnsName": "alice.btc", "agentId": 42,
+#           "cachesCleared": ["cache:bns", "cache:identity", "identity-check"] }
+\`\`\`
+
+**Parameters:** \`address\` — BTC, STX, or taproot address of a registered agent
+
+**Error responses:**
+- 400: Missing or empty address
+- 404: Agent not found
+- 500: Refresh failed
+
 ### GET /api/identity/:address/reputation
 
 Fetch on-chain reputation data for an agent with ERC-8004 identity. Runs Stacks API calls server-side with caching.

--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -189,6 +189,124 @@ describe("lookupBnsName", () => {
     });
   });
 
+  describe("failure negative caching", () => {
+    /** Build an in-memory KV mock that records put() calls. */
+    function createMockKv() {
+      const store = new Map<string, { value: string; ttl?: number }>();
+      return {
+        get: vi.fn(async (key: string) => store.get(key)?.value ?? null),
+        put: vi.fn(
+          async (
+            key: string,
+            value: string,
+            options?: { expirationTtl?: number }
+          ) => {
+            store.set(key, { value, ttl: options?.expirationTtl });
+          }
+        ),
+        _store: store,
+      };
+    }
+
+    it("writes short-TTL negative cache on upstream !res.ok", async () => {
+      const kv = createMockKv();
+      // 500 is retried up to retries=2, so return 500 every time
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: mockHeaders(),
+      });
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(60);
+    });
+
+    it("writes short-TTL negative cache on !data.okay", async () => {
+      const kv = createMockKv();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: mockHeaders(),
+        json: async () => ({ okay: false, result: "some error" }),
+      });
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(60);
+    });
+
+    it("writes short-TTL negative cache on network error", async () => {
+      const kv = createMockKv();
+      mockFetch.mockRejectedValue(new Error("Network error"));
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(60);
+    });
+
+    it("does not re-hit Hiro after negative cache is warmed", async () => {
+      const kv = createMockKv();
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: mockHeaders(),
+      });
+
+      await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      const fetchCountAfterFirst = mockFetch.mock.calls.length;
+      mockFetch.mockClear();
+
+      // Second call — negative cache should suppress the Hiro request entirely
+      await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(fetchCountAfterFirst).toBeGreaterThan(0);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it("writes 7d confirmed-negative cache when V2 returns none", async () => {
+      const kv = createMockKv();
+      mockFetch.mockResolvedValue(mockV2None());
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      // 7d (604800s) TTL — confirmed "no name" per the three-state model.
+      // Busted on write paths (registration) and via the refresh endpoint.
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(7 * 24 * 60 * 60);
+    });
+  });
+
   describe("edge cases", () => {
     it("makes only one API call per invocation", async () => {
       mockFetch.mockResolvedValue(mockV2Response("test", "btc"));

--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { lookupBnsName } from "../bns";
+import { lookupBnsName, lookupBnsNameWithOutcome } from "../bns";
 
 // Mock fetch globally
 const mockFetch = vi.fn();
@@ -228,7 +228,7 @@ describe("lookupBnsName", () => {
       expect(kv._store.get(cacheKey)?.ttl).toBe(60);
     });
 
-    it("writes short-TTL negative cache on !data.okay", async () => {
+    it("writes 5-min contract-error cache on !data.okay", async () => {
       const kv = createMockKv();
       mockFetch.mockResolvedValue({
         ok: true,
@@ -245,7 +245,10 @@ describe("lookupBnsName", () => {
       expect(result).toBeNull();
       const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
       expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
-      expect(kv._store.get(cacheKey)?.ttl).toBe(60);
+      // Contract-reported errors use the 5-min TTL (BNS_CONTRACT_ERROR_CACHE_TTL),
+      // distinct from the 60s transient-upstream TTL — contract errors on valid
+      // input are effectively deterministic, so re-hitting Hiro every 60s is waste.
+      expect(kv._store.get(cacheKey)?.ttl).toBe(5 * 60);
     });
 
     it("writes short-TTL negative cache on network error", async () => {
@@ -304,6 +307,80 @@ describe("lookupBnsName", () => {
       // Busted on write paths (registration) and via the refresh endpoint.
       expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
       expect(kv._store.get(cacheKey)?.ttl).toBe(7 * 24 * 60 * 60);
+    });
+  });
+
+  describe("tri-state outcome (lookupBnsNameWithOutcome)", () => {
+    function createMockKv() {
+      const store = new Map<string, { value: string; ttl?: number }>();
+      return {
+        get: vi.fn(async (key: string) => store.get(key)?.value ?? null),
+        put: vi.fn(
+          async (
+            key: string,
+            value: string,
+            options?: { expirationTtl?: number }
+          ) => {
+            store.set(key, { value, ttl: options?.expirationTtl });
+          }
+        ),
+        _store: store,
+      };
+    }
+
+    it("returns positive outcome on successful lookup", async () => {
+      mockFetch.mockResolvedValue(mockV2Response("alice", "btc"));
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(outcome).toEqual({ state: "positive", name: "alice.btc" });
+    });
+
+    it("returns confirmed-negative outcome on (ok none)", async () => {
+      mockFetch.mockResolvedValue(mockV2None());
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(outcome).toEqual({ state: "confirmed-negative", name: null });
+    });
+
+    it("returns lookup-failed outcome on upstream error", async () => {
+      mockFetch.mockResolvedValue({
+        ok: false,
+        status: 500,
+        headers: mockHeaders(),
+      });
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(outcome).toEqual({ state: "lookup-failed", name: null });
+    });
+
+    it("returns lookup-failed outcome on !data.okay (contract error)", async () => {
+      const kv = createMockKv();
+      mockFetch.mockResolvedValue({
+        ok: true,
+        status: 200,
+        headers: mockHeaders(),
+        json: async () => ({ okay: false, result: "err" }),
+      });
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(outcome).toEqual({ state: "lookup-failed", name: null });
+      // Contract-error TTL should be the 5-min variant, not 60s.
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      expect(kv._store.get(cacheKey)?.ttl).toBe(5 * 60);
+    });
+
+    it("returns lookup-failed outcome on network error", async () => {
+      mockFetch.mockRejectedValue(new Error("Network error"));
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(outcome).toEqual({ state: "lookup-failed", name: null });
     });
   });
 

--- a/lib/__tests__/stacks-api-fetch.test.ts
+++ b/lib/__tests__/stacks-api-fetch.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  stacksApiFetch,
+  extractRateLimitInfo,
+  detect429,
+} from "../stacks-api-fetch";
+import type { Logger } from "../logging";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch as any;
+
+/** Build a minimal Headers that can report the rate-limit fields. */
+function mockHeaders(values: Record<string, string> = {}): Headers {
+  return {
+    get: (name: string) => values[name.toLowerCase()] ?? null,
+  } as unknown as Headers;
+}
+
+function createMockLogger(): Logger & {
+  _events: Array<{ level: string; message: string; context?: unknown }>;
+} {
+  const events: Array<{ level: string; message: string; context?: unknown }> = [];
+  const record = (level: string) => (msg: string, ctx?: unknown) => {
+    events.push({ level, message: msg, context: ctx });
+  };
+  return {
+    _events: events,
+    debug: record("debug"),
+    info: record("info"),
+    warn: record("warn"),
+    error: record("error"),
+  };
+}
+
+describe("stacksApiFetch logger telemetry", () => {
+  beforeEach(() => {
+    mockFetch.mockClear();
+  });
+
+  it("emits stacksApi.rate_limit_remaining on every parseable response", async () => {
+    const logger = createMockLogger();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.mainnet.hiro.so/v2/contracts/call-read/foo/bar/baz",
+      headers: mockHeaders({
+        "ratelimit-remaining": "123",
+        "ratelimit-limit": "500",
+        "ratelimit-reset": "42",
+      }),
+    });
+
+    await stacksApiFetch(
+      "https://api.mainnet.hiro.so/v2/contracts/call-read/foo/bar/baz",
+      {},
+      { logger }
+    );
+
+    const rlEvents = logger._events.filter(
+      (e) => e.message === "stacksApi.rate_limit_remaining"
+    );
+    expect(rlEvents).toHaveLength(1);
+    expect(rlEvents[0].context).toMatchObject({
+      path: "/v2/contracts/call-read/foo/bar/baz",
+      rlRemaining: 123,
+      rlLimit: 500,
+    });
+  });
+
+  it("emits stacksApi.approaching_rate_limit when remaining < 50", async () => {
+    const logger = createMockLogger();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      headers: mockHeaders({
+        "ratelimit-remaining": "10",
+        "ratelimit-limit": "500",
+      }),
+    });
+
+    await stacksApiFetch(
+      "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      {},
+      { logger }
+    );
+
+    const approaching = logger._events.filter(
+      (e) => e.message === "stacksApi.approaching_rate_limit"
+    );
+    expect(approaching).toHaveLength(1);
+    expect(approaching[0].level).toBe("warn");
+    expect(approaching[0].context).toMatchObject({
+      rlRemaining: 10,
+      threshold: 50,
+    });
+  });
+
+  it("does NOT emit approaching_rate_limit when remaining >= 50", async () => {
+    const logger = createMockLogger();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      headers: mockHeaders({ "ratelimit-remaining": "100" }),
+    });
+
+    await stacksApiFetch(
+      "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      {},
+      { logger }
+    );
+
+    const approaching = logger._events.filter(
+      (e) => e.message === "stacksApi.approaching_rate_limit"
+    );
+    expect(approaching).toHaveLength(0);
+  });
+
+  it("emits stacksApi.retry_budget_exhausted on sustained 429", async () => {
+    const logger = createMockLogger();
+    // Return 429 with Retry-After=0 every time to speed up test
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      url: "https://api.mainnet.hiro.so/extended/v1/tx/0x1",
+      headers: mockHeaders({
+        "ratelimit-remaining": "0",
+        "retry-after": "0",
+      }),
+    });
+
+    const response = await stacksApiFetch(
+      "https://api.mainnet.hiro.so/extended/v1/tx/0x1",
+      {},
+      { retries429: 2, logger } // retries429 = 2 for a short test
+    );
+
+    expect(response.status).toBe(429);
+    const exhausted = logger._events.filter(
+      (e) => e.message === "stacksApi.retry_budget_exhausted"
+    );
+    expect(exhausted).toHaveLength(1);
+    expect(exhausted[0].context).toMatchObject({
+      budget: "429",
+      status: 429,
+    });
+  });
+
+  it("is silent when no logger is provided", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      headers: mockHeaders({ "ratelimit-remaining": "5" }),
+    });
+
+    // Should not throw, and should complete without emitting telemetry
+    const response = await stacksApiFetch(
+      "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      {}
+    );
+    expect(response.status).toBe(200);
+  });
+
+  it("detect429 emits stacksApi.rate_limited via logger when status is 429", () => {
+    const logger = createMockLogger();
+    const response = {
+      status: 429,
+      url: "https://api.mainnet.hiro.so/x",
+      headers: mockHeaders({ "cf-ray": "abc123" }),
+    } as unknown as Response;
+
+    const result = detect429(response, logger);
+    expect(result.isRateLimited).toBe(true);
+    const rateLimited = logger._events.find(
+      (e) => e.message === "stacksApi.rate_limited"
+    );
+    expect(rateLimited).toBeDefined();
+    expect(rateLimited?.context).toMatchObject({ cfRay: "abc123" });
+  });
+
+  it("extractRateLimitInfo returns parsed fields even without logger", () => {
+    const response = {
+      url: "https://api.mainnet.hiro.so/x",
+      headers: mockHeaders({
+        "ratelimit-remaining": "42",
+        "ratelimit-limit": "500",
+      }),
+    } as unknown as Response;
+
+    const info = extractRateLimitInfo(response);
+    expect(info.remaining).toBe(42);
+    expect(info.limit).toBe(500);
+  });
+});

--- a/lib/achievements/verify.ts
+++ b/lib/achievements/verify.ts
@@ -156,10 +156,11 @@ export async function verifySbtcHolderAchievement(
         SBTC_CONTRACT,
         "get-balance",
         [standardPrincipalCV(stxAddress)],
-        hiroApiKey
+        hiroApiKey,
+        logger
       );
 
-      const parsed = parseClarityValue(response);
+      const parsed = parseClarityValue(response, logger);
       if (parsed === null) {
         // Transient API failure — don't cache a false "0", allow retry next time
         return false;
@@ -201,9 +202,11 @@ export async function verifyStackerAchievement(
 
     if (!stackingData) {
       const stackingUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/stacking`;
-      const stackingResp = await stacksApiFetch(stackingUrl, {
-        headers: buildHiroHeaders(hiroApiKey),
-      });
+      const stackingResp = await stacksApiFetch(
+        stackingUrl,
+        { headers: buildHiroHeaders(hiroApiKey) },
+        { logger }
+      );
 
       if (stackingResp.status === 404) {
         // 404 means no stacking data — not stacking
@@ -278,9 +281,11 @@ export async function verifyConnectorAchievement(
 
     if (!txs) {
       const txsUrl = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/transactions?limit=50`;
-      const resp = await stacksApiFetch(txsUrl, {
-        headers: buildHiroHeaders(hiroApiKey),
-      });
+      const resp = await stacksApiFetch(
+        txsUrl,
+        { headers: buildHiroHeaders(hiroApiKey) },
+        { logger }
+      );
 
       if (!resp.ok) {
         logger?.error("achievement.connector.fetch_failed", {

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -10,7 +10,9 @@ import {
   setCachedBnsName,
   setCachedBnsNegative,
   setCachedBnsLookupFailed,
+  setCachedBnsContractError,
   BNS_NONE_SENTINEL,
+  type LookupOutcomeState,
 } from "./identity/kv-cache";
 import { buildHiroHeaders } from "./identity/stacks-api";
 import { stacksApiFetch } from "./stacks-api-fetch";
@@ -21,27 +23,44 @@ const BNS_V2_CONTRACT = "SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF";
 const BNS_V2_NAME = "BNS-V2";
 
 /**
- * Look up the BNS name for a Stacks address using BNS-V2.
+ * Tri-state BNS lookup outcome.
  *
- * Calls the `get-primary` read-only function on the BNS-V2 contract,
- * which returns the primary name+namespace for an owner address.
+ * - `"positive"` — Hiro returned a name; `name` is set.
+ * - `"confirmed-negative"` — Hiro returned `(ok none)`. Authoritative "no name".
+ * - `"lookup-failed"` — transient upstream error (429/5xx/timeout/parse) or
+ *   contract-reported error. We don't know whether the address has a name.
  *
- * BNS V1 is deprecated — all names have been migrated to V2.
- *
- * @param stxAddress - Stacks address to lookup
- * @param hiroApiKey - Optional Hiro API key for authenticated requests
- * @param kv - Optional KV namespace for persistent caching
- * @param logger - Optional Logger for cache telemetry and error logging
+ * Callers that mirror lookup results into persistent storage (e.g. the
+ * refresh endpoint) should skip the write on `"lookup-failed"` — overwriting
+ * a verified `bnsName` with `null` during a Hiro incident would corrupt the
+ * AgentRecord.
  */
-export async function lookupBnsName(
+export type BnsLookupOutcome =
+  | { state: "positive"; name: string }
+  | { state: "confirmed-negative"; name: null }
+  | { state: "lookup-failed"; name: null };
+
+/**
+ * Internal: run the BNS-V2 `get-primary` lookup and return the tri-state
+ * outcome. Populates the KV cache with the appropriate TTL for each branch.
+ *
+ * Use {@link lookupBnsName} for callers that only need `string | null`.
+ */
+export async function lookupBnsNameWithOutcome(
   stxAddress: string,
   hiroApiKey?: string,
   kv?: KVNamespace,
   logger?: Logger
-): Promise<string | null> {
+): Promise<BnsLookupOutcome> {
   const cached = await getCachedBnsName(stxAddress, kv, logger);
-  if (cached === BNS_NONE_SENTINEL) return null;
-  if (cached) return cached;
+  if (cached === BNS_NONE_SENTINEL) {
+    // We can't tell from the cache alone whether this was confirmed-negative
+    // or lookup-failed (both write NONE_SENTINEL, only TTL differs). Treat
+    // any cached NONE_SENTINEL as confirmed-negative for return-type purposes
+    // — callers that care about the distinction should bust the cache first.
+    return { state: "confirmed-negative", name: null };
+  }
+  if (cached) return { state: "positive", name: cached };
 
   try {
     const principal = principalCV(stxAddress);
@@ -66,25 +85,25 @@ export async function lookupBnsName(
     );
 
     if (!res.ok) {
-      // Transient Hiro failure (429 / 5xx / exhausted retries). Short-TTL
-      // negative-cache so concurrent requests for the same address don't
-      // re-hit Hiro on every miss.
       logger?.warn("bns.lookup_upstream_error", {
         stxAddress,
         status: res.status,
       });
       await setCachedBnsLookupFailed(stxAddress, kv, logger);
-      return null;
+      return { state: "lookup-failed", name: null };
     }
 
     const data = (await res.json()) as { okay: boolean; result: string };
     if (!data.okay) {
-      // Contract-reported error. Treat as transient (short-TTL) rather than
-      // "confirmed no name" — the contract may have thrown for reasons
-      // unrelated to the address having a name.
+      // Contract-reported error. For BNS V2 `get-primary` against a valid
+      // principal this branch is practically unreachable — when it does fire
+      // it's usually deterministic (malformed principal), so use the 5-min
+      // contract-error TTL rather than the 60s lookup-failed TTL. Still
+      // classified as `lookup-failed` so callers that mirror to the
+      // AgentRecord skip the write.
       logger?.warn("bns.lookup_contract_error", { stxAddress });
-      await setCachedBnsLookupFailed(stxAddress, kv, logger);
-      return null;
+      await setCachedBnsContractError(stxAddress, kv, logger);
+      return { state: "lookup-failed", name: null };
     }
 
     const cv = deserializeCV(data.result);
@@ -94,20 +113,20 @@ export async function lookupBnsName(
     if (!json.success) {
       logger?.warn("bns.lookup_malformed_response", { stxAddress });
       await setCachedBnsLookupFailed(stxAddress, kv, logger);
-      return null;
+      return { state: "lookup-failed", name: null };
     }
 
     // Unwrap: response -> optional -> tuple
     const optional = json.value?.value;
     if (!optional) {
       await setCachedBnsNegative(stxAddress, kv, logger);
-      return null;
+      return { state: "confirmed-negative", name: null };
     }
 
     const tuple = optional.value;
     if (!tuple?.name?.value || !tuple?.namespace?.value) {
       await setCachedBnsNegative(stxAddress, kv, logger);
-      return null;
+      return { state: "confirmed-negative", name: null };
     }
 
     const name = bytesToUtf8(hexToBytes(tuple.name.value));
@@ -115,12 +134,46 @@ export async function lookupBnsName(
     const fullName = `${name}.${namespace}`;
 
     await setCachedBnsName(stxAddress, fullName, kv, logger);
-    return fullName;
+    return { state: "positive", name: fullName };
   } catch (e) {
-    // Network timeout / abort / parse error. Short-TTL negative-cache so the
-    // retry storm doesn't keep hammering Hiro for the same address.
     logger?.error("bns.lookup_failed", { stxAddress, error: String(e) });
     await setCachedBnsLookupFailed(stxAddress, kv, logger);
-    return null;
+    return { state: "lookup-failed", name: null };
   }
 }
+
+/**
+ * Look up the BNS name for a Stacks address using BNS-V2.
+ *
+ * Calls the `get-primary` read-only function on the BNS-V2 contract,
+ * which returns the primary name+namespace for an owner address.
+ *
+ * BNS V1 is deprecated — all names have been migrated to V2.
+ *
+ * Returns the BNS name or null (both confirmed-negative and lookup-failed
+ * collapse to null). Use {@link lookupBnsNameWithOutcome} if you need to
+ * distinguish those two cases (e.g. to avoid overwriting a stored value
+ * during a transient Hiro incident).
+ *
+ * @param stxAddress - Stacks address to lookup
+ * @param hiroApiKey - Optional Hiro API key for authenticated requests
+ * @param kv - Optional KV namespace for persistent caching
+ * @param logger - Optional Logger for cache telemetry and error logging
+ */
+export async function lookupBnsName(
+  stxAddress: string,
+  hiroApiKey?: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<string | null> {
+  const outcome = await lookupBnsNameWithOutcome(
+    stxAddress,
+    hiroApiKey,
+    kv,
+    logger
+  );
+  return outcome.name;
+}
+
+// Re-export for convenience so refresh-style callers can import once.
+export type { LookupOutcomeState };

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -5,7 +5,13 @@ import {
   cvToJSON,
 } from "@stacks/transactions";
 import { hexToBytes, bytesToUtf8 } from "@stacks/common";
-import { getCachedBnsName, setCachedBnsName, setCachedBnsNegative, BNS_NONE_SENTINEL } from "./identity/kv-cache";
+import {
+  getCachedBnsName,
+  setCachedBnsName,
+  setCachedBnsNegative,
+  setCachedBnsLookupFailed,
+  BNS_NONE_SENTINEL,
+} from "./identity/kv-cache";
 import { buildHiroHeaders } from "./identity/stacks-api";
 import { stacksApiFetch } from "./stacks-api-fetch";
 import { STACKS_API_BASE } from "./identity/constants";
@@ -56,21 +62,40 @@ export async function lookupBnsName(
           arguments: [`0x${serialized}`],
         }),
       },
-      2,
-      500,
-      1
+      { retries: 2, retries429: 1, logger }
     );
 
-    if (!res.ok) return null;
+    if (!res.ok) {
+      // Transient Hiro failure (429 / 5xx / exhausted retries). Short-TTL
+      // negative-cache so concurrent requests for the same address don't
+      // re-hit Hiro on every miss.
+      logger?.warn("bns.lookup_upstream_error", {
+        stxAddress,
+        status: res.status,
+      });
+      await setCachedBnsLookupFailed(stxAddress, kv, logger);
+      return null;
+    }
 
     const data = (await res.json()) as { okay: boolean; result: string };
-    if (!data.okay) return null;
+    if (!data.okay) {
+      // Contract-reported error. Treat as transient (short-TTL) rather than
+      // "confirmed no name" — the contract may have thrown for reasons
+      // unrelated to the address having a name.
+      logger?.warn("bns.lookup_contract_error", { stxAddress });
+      await setCachedBnsLookupFailed(stxAddress, kv, logger);
+      return null;
+    }
 
     const cv = deserializeCV(data.result);
     const json = cvToJSON(cv);
 
     // Response structure: (ok (some {name: buff, namespace: buff})) or (ok none)
-    if (!json.success) return null;
+    if (!json.success) {
+      logger?.warn("bns.lookup_malformed_response", { stxAddress });
+      await setCachedBnsLookupFailed(stxAddress, kv, logger);
+      return null;
+    }
 
     // Unwrap: response -> optional -> tuple
     const optional = json.value?.value;
@@ -92,7 +117,10 @@ export async function lookupBnsName(
     await setCachedBnsName(stxAddress, fullName, kv, logger);
     return fullName;
   } catch (e) {
+    // Network timeout / abort / parse error. Short-TTL negative-cache so the
+    // retry storm doesn't keep hammering Hiro for the same address.
     logger?.error("bns.lookup_failed", { stxAddress, error: String(e) });
+    await setCachedBnsLookupFailed(stxAddress, kv, logger);
     return null;
   }
 }

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -7,7 +7,12 @@ import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "./constants";
 import { callReadOnly, parseClarityValue, buildHiroHeaders } from "./stacks-api";
 import { stacksApiFetch } from "../stacks-api-fetch";
 import type { AgentIdentity } from "./types";
-import { getCachedIdentity, setCachedIdentity, setCachedIdentityNegative } from "./kv-cache";
+import {
+  getCachedIdentity,
+  setCachedIdentity,
+  setCachedIdentityNegative,
+  setCachedIdentityLookupFailed,
+} from "./kv-cache";
 import type { Logger } from "../logging";
 
 /**
@@ -42,7 +47,11 @@ export async function detectAgentIdentity(
     // Reduced retry budget for synchronous profile lookups: worst-case ~13s
     // instead of default ~71s. Primary NFT holdings call gets retries429=1 (1s max
     // 429 delay) and retries=2 (1.5s max 5xx delay).
-    const response = await stacksApiFetch(holdingsUrl, { headers }, 2, 500, 1);
+    const response = await stacksApiFetch(holdingsUrl, { headers }, {
+      retries: 2,
+      retries429: 1,
+      logger,
+    });
 
     if (!response.ok) {
       // Fallback to legacy scan if holdings API fails (e.g. 404, 500)
@@ -86,9 +95,10 @@ export async function detectAgentIdentity(
         IDENTITY_REGISTRY_CONTRACT,
         "get-token-uri",
         [uintCV(agentId)],
-        hiroApiKey
+        hiroApiKey,
+        logger
       );
-      uri = parseClarityValue(uriResult) || "";
+      uri = parseClarityValue(uriResult, logger) || "";
     } catch (error) {
       logger?.warn("identity.fetch_token_uri_failed", {
         agentId,
@@ -101,10 +111,13 @@ export async function detectAgentIdentity(
     await setCachedIdentity(stxAddress, identity, kv, logger);
     return identity;
   } catch (error) {
+    // Network timeout / abort / JSON parse failure. Short-TTL negative-cache
+    // so the retry storm doesn't keep hammering Hiro for the same address.
     logger?.error("identity.detect_error", {
       stxAddress,
       error: String(error),
     });
+    await setCachedIdentityLookupFailed(stxAddress, kv, logger);
     return null;
   }
 }
@@ -126,8 +139,8 @@ async function detectAgentIdentityLegacy(
   // we return null without caching so the next request will try again.
   const MAX_LEGACY_BATCHES = 1;
 
-  const lastIdResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-last-token-id", [], hiroApiKey);
-  const lastIdRaw = parseClarityValue(lastIdResult);
+  const lastIdResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-last-token-id", [], hiroApiKey, logger);
+  const lastIdRaw = parseClarityValue(lastIdResult, logger);
   const lastId = lastIdRaw !== null ? Number(lastIdRaw) : null;
 
   if (lastId === null || lastId < 0) return null;
@@ -145,16 +158,16 @@ async function detectAgentIdentityLegacy(
       batch.map(async (id) => {
         const ownerResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-owner", [
           uintCV(id),
-        ], hiroApiKey);
-        return { id, owner: parseClarityValue(ownerResult) };
+        ], hiroApiKey, logger);
+        return { id, owner: parseClarityValue(ownerResult, logger) };
       })
     );
     const match = results.find((r) => r.owner === stxAddress);
     if (match) {
       const uriResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-token-uri", [
         uintCV(match.id),
-      ], hiroApiKey);
-      const uri = parseClarityValue(uriResult);
+      ], hiroApiKey, logger);
+      const uri = parseClarityValue(uriResult, logger);
       const identity: AgentIdentity = { agentId: match.id, owner: match.owner!, uri: uri || "" };
       await setCachedIdentity(stxAddress, identity, kv, logger);
       return identity;
@@ -185,8 +198,8 @@ export async function hasIdentity(
   logger?: Logger
 ): Promise<boolean> {
   try {
-    const ownerResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-owner", [uintCV(agentId)], hiroApiKey);
-    const owner = parseClarityValue(ownerResult);
+    const ownerResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-owner", [uintCV(agentId)], hiroApiKey, logger);
+    const owner = parseClarityValue(ownerResult, logger);
     return owner !== null;
   } catch (error) {
     logger?.error("identity.has_identity_error", {

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -16,25 +16,46 @@ import {
 import type { Logger } from "../logging";
 
 /**
- * Detect if an agent has registered an on-chain identity.
+ * Tri-state identity lookup outcome.
  *
- * Uses the Hiro NFT holdings API to find identity NFTs owned by the
- * address in a single request, instead of scanning all token IDs.
+ * - `"positive"` — Hiro returned a matching NFT; `identity` is populated.
+ * - `"confirmed-negative"` — Hiro authoritatively returned no match.
+ * - `"lookup-failed"` — transient upstream error (429/5xx/timeout/parse) or
+ *   incomplete legacy scan. We don't know whether the address owns one.
  *
- * @param stxAddress - Stacks address to check
- * @param hiroApiKey - Optional Hiro API key for authenticated requests
- * @param kv - Optional KV namespace for persistent caching
- * @param logger - Optional Logger for cache telemetry and error logging
+ * Callers that mirror lookup results into persistent storage (e.g. the
+ * refresh endpoint) should skip the write on `"lookup-failed"` — overwriting
+ * a verified `erc8004AgentId` with `null` during a Hiro incident would
+ * corrupt the AgentRecord.
  */
-export async function detectAgentIdentity(
+export type IdentityLookupOutcome =
+  | { state: "positive"; identity: AgentIdentity }
+  | { state: "confirmed-negative"; identity: null }
+  | { state: "lookup-failed"; identity: null };
+
+/**
+ * Detect identity NFT ownership and return the tri-state outcome.
+ *
+ * Use {@link detectAgentIdentity} for callers that only need
+ * `AgentIdentity | null`.
+ */
+export async function detectAgentIdentityWithOutcome(
   stxAddress: string,
   hiroApiKey?: string,
   kv?: KVNamespace,
   logger?: Logger
-): Promise<AgentIdentity | null> {
+): Promise<IdentityLookupOutcome> {
   // Check KV cache first (distinguishes miss from cached negative result)
   const cached = await getCachedIdentity(stxAddress, kv, logger);
-  if (cached.hit) return cached.value;
+  if (cached.hit) {
+    if (cached.value) {
+      return { state: "positive", identity: cached.value };
+    }
+    // Cached NONE_SENTINEL. As with BNS, we can't distinguish
+    // confirmed-negative from lookup-failed from the cached value alone —
+    // callers that care should bust the cache first (see refresh endpoint).
+    return { state: "confirmed-negative", identity: null };
+  }
 
   try {
     // Query NFT holdings for this address filtered to the identity registry contract.
@@ -59,7 +80,12 @@ export async function detectAgentIdentity(
         stxAddress,
         status: response.status,
       });
-      return await detectAgentIdentityLegacy(stxAddress, hiroApiKey, kv, logger);
+      return await detectAgentIdentityLegacyWithOutcome(
+        stxAddress,
+        hiroApiKey,
+        kv,
+        logger
+      );
     }
 
     const data = await response.json() as {
@@ -74,7 +100,7 @@ export async function detectAgentIdentity(
     if (!data.results || data.results.length === 0) {
       // No identity NFT found for this address — cache negative to skip future Hiro API calls
       await setCachedIdentityNegative(stxAddress, kv, logger);
-      return null;
+      return { state: "confirmed-negative", identity: null };
     }
 
     // Extract the token ID from the value repr (format: "u42" for uint 42)
@@ -82,9 +108,10 @@ export async function detectAgentIdentity(
     const tokenIdMatch = nft.value.repr.match(/^u(\d+)$/);
     if (!tokenIdMatch) {
       // Parse/format failure does not prove the address has no identity NFT,
-      // so do not negative-cache this result.
+      // so do not negative-cache this result. Classify as lookup-failed so
+      // refresh-style callers don't clobber the stored agentId.
       logger?.warn("identity.parse_token_id_failed", { repr: nft.value.repr });
-      return null;
+      return { state: "lookup-failed", identity: null };
     }
     const agentId = Number(tokenIdMatch[1]);
 
@@ -107,9 +134,8 @@ export async function detectAgentIdentity(
     }
 
     const identity: AgentIdentity = { agentId, owner: stxAddress, uri };
-    // Cache the result
     await setCachedIdentity(stxAddress, identity, kv, logger);
-    return identity;
+    return { state: "positive", identity };
   } catch (error) {
     // Network timeout / abort / JSON parse failure. Short-TTL negative-cache
     // so the retry storm doesn't keep hammering Hiro for the same address.
@@ -118,32 +144,62 @@ export async function detectAgentIdentity(
       error: String(error),
     });
     await setCachedIdentityLookupFailed(stxAddress, kv, logger);
-    return null;
+    return { state: "lookup-failed", identity: null };
   }
+}
+
+/**
+ * Detect if an agent has registered an on-chain identity.
+ *
+ * Returns the identity or null (both confirmed-negative and lookup-failed
+ * collapse to null). Use {@link detectAgentIdentityWithOutcome} when you
+ * need to distinguish those two cases.
+ *
+ * @param stxAddress - Stacks address to check
+ * @param hiroApiKey - Optional Hiro API key for authenticated requests
+ * @param kv - Optional KV namespace for persistent caching
+ * @param logger - Optional Logger for cache telemetry and error logging
+ */
+export async function detectAgentIdentity(
+  stxAddress: string,
+  hiroApiKey?: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<AgentIdentity | null> {
+  const outcome = await detectAgentIdentityWithOutcome(
+    stxAddress,
+    hiroApiKey,
+    kv,
+    logger
+  );
+  return outcome.identity;
 }
 
 /**
  * Legacy O(N) scan — used only as fallback if the holdings API is unavailable.
  * Capped at MAX_LEGACY_BATCHES to prevent unbounded Hiro API consumption.
  */
-async function detectAgentIdentityLegacy(
+async function detectAgentIdentityLegacyWithOutcome(
   stxAddress: string,
   hiroApiKey?: string,
   kv?: KVNamespace,
   logger?: Logger
-): Promise<AgentIdentity | null> {
+): Promise<IdentityLookupOutcome> {
   logger?.warn("identity.legacy_scan_fallback", { stxAddress });
 
   // Cap at 1 batch (5 get-owner calls) to bound worst-case Hiro API consumption.
   // If the target agent's identity NFT was minted outside the most recent 5 IDs,
-  // we return null without caching so the next request will try again.
+  // we return lookup-failed without caching so the next request will try again.
   const MAX_LEGACY_BATCHES = 1;
 
   const lastIdResult = await callReadOnly(IDENTITY_REGISTRY_CONTRACT, "get-last-token-id", [], hiroApiKey, logger);
   const lastIdRaw = parseClarityValue(lastIdResult, logger);
   const lastId = lastIdRaw !== null ? Number(lastIdRaw) : null;
 
-  if (lastId === null || lastId < 0) return null;
+  if (lastId === null || lastId < 0) {
+    // Couldn't determine last token id — lookup is inconclusive.
+    return { state: "lookup-failed", identity: null };
+  }
 
   const BATCH_SIZE = 5;
   let batchCount = 0;
@@ -170,23 +226,23 @@ async function detectAgentIdentityLegacy(
       const uri = parseClarityValue(uriResult, logger);
       const identity: AgentIdentity = { agentId: match.id, owner: match.owner!, uri: uri || "" };
       await setCachedIdentity(stxAddress, identity, kv, logger);
-      return identity;
+      return { state: "positive", identity };
     }
     if (batchCount >= MAX_LEGACY_BATCHES) {
       // Scan is intentionally incomplete — don't negative-cache since the identity
-      // may exist beyond the batches we checked.
+      // may exist beyond the batches we checked. Classify as lookup-failed.
       logger?.warn("identity.legacy_scan_cap_hit", {
         stxAddress,
         batches: MAX_LEGACY_BATCHES,
         batchSize: BATCH_SIZE,
       });
-      return null;
+      return { state: "lookup-failed", identity: null };
     }
   }
 
-  // Exhausted all NFTs without finding a match — cache negative result
+  // Exhausted all NFTs without finding a match — cache confirmed-negative.
   await setCachedIdentityNegative(stxAddress, kv, logger);
-  return null;
+  return { state: "confirmed-negative", identity: null };
 }
 
 /**

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -1,10 +1,18 @@
 /**
  * KV-backed caching for stable data (BNS names, agent identities, reputation)
  *
- * Provides persistent caching across worker instances with appropriate TTLs:
- * - BNS names: 24 hours positive / 1 hour negative (very stable, rarely change)
- * - Agent identities: 24 hours (immutable once minted on-chain)
- * - Identity negative cache: 5 minutes (re-check frequently for newly registered agents)
+ * Three-state cache model for BNS/identity lookups:
+ *   1. **Confirmed positive** — Hiro returned a name/identity. Cached 24h.
+ *   2. **Confirmed negative** — Hiro authoritatively said "no name" / "no
+ *      identity NFT". State change requires an on-chain tx, so cached 7d.
+ *      Invalidated explicitly via {@link invalidateBnsCache} /
+ *      {@link invalidateIdentityCache} on write paths (registration, identity
+ *      NFT mint detection) and via the manual refresh endpoint.
+ *   3. **Lookup failed** — transient Hiro error (429/5xx/timeout/parse). We
+ *      don't know whether there's a name/identity. Cached 60s to stop a
+ *      request hammer without pinning the state for long.
+ *
+ * Other caches:
  * - Stacking status: 4 hours (changes only at PoX cycle boundaries ~2 weeks)
  * - Reputation data: 1 hour (changes slowly with new feedback)
  * - Address transactions: 30 minutes (grows over time but not hot path)
@@ -19,10 +27,30 @@ import type { AgentIdentity } from "./types";
 import type { Logger } from "../logging";
 
 // Cache TTLs in seconds
-const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours
-const BNS_NEGATIVE_CACHE_TTL = 60 * 60; // 1 hour for addresses with no BNS name
-const IDENTITY_CACHE_TTL = 24 * 60 * 60; // 24 hours (immutable NFT — raised from 6h)
-const IDENTITY_NEGATIVE_CACHE_TTL = 5 * 60; // 5 minutes for addresses with no identity
+const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours (confirmed positive)
+/**
+ * "Confirmed no name" — Hiro returned `(ok none)`. A state change requires
+ * an on-chain BNS registration tx; we bust this cache on registration/update
+ * write paths and via the explicit refresh endpoint.
+ */
+const BNS_CONFIRMED_NEGATIVE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
+/**
+ * "Lookup failed" — Hiro 429/5xx, malformed response, timeout. Short TTL so
+ * a transient upstream blip doesn't pin an address as name-less; long enough
+ * to stop a concurrent-request hammer.
+ */
+const BNS_LOOKUP_FAILED_CACHE_TTL = 60; // 60 seconds
+const IDENTITY_CACHE_TTL = 24 * 60 * 60; // 24 hours (immutable NFT once minted)
+/**
+ * "Confirmed no identity" — Hiro NFT holdings API authoritatively returned
+ * no matching NFT. State change requires an on-chain mint; we bust on write
+ * paths and via the refresh endpoint.
+ */
+const IDENTITY_CONFIRMED_NEGATIVE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
+/**
+ * "Lookup failed" for identity detection — same semantics as BNS failure TTL.
+ */
+const IDENTITY_LOOKUP_FAILED_CACHE_TTL = 60; // 60 seconds
 const STACKING_CACHE_TTL = 4 * 60 * 60; // 4 hours (PoX cycle is ~2 weeks)
 const REPUTATION_CACHE_TTL = 60 * 60; // 1 hour (raised from 5 minutes)
 const TX_CACHE_TTL = 30 * 60; // 30 minutes (raised from 5 minutes)
@@ -53,6 +81,25 @@ async function kvGet(
       error: String(error),
     });
     return null;
+  }
+}
+
+/** Safely delete a KV entry, logging errors. */
+async function kvDelete(
+  kv: KVNamespace | undefined,
+  key: string,
+  keyFamily: string,
+  logger?: Logger
+): Promise<void> {
+  if (!kv) return;
+  try {
+    await kv.delete(key);
+  } catch (error) {
+    logger?.error("cache.kv_delete_error", {
+      keyFamily,
+      key,
+      error: String(error),
+    });
   }
 }
 
@@ -187,6 +234,12 @@ export function setCachedBnsName(
   return kvPut(kv, `cache:bns:${address}`, name, BNS_CACHE_TTL, "bns", logger);
 }
 
+/**
+ * Cache a "confirmed no BNS name" response (Hiro returned `(ok none)`).
+ * Uses the long {@link BNS_CONFIRMED_NEGATIVE_CACHE_TTL} (7d) because state
+ * change requires an on-chain registration. Bust via
+ * {@link invalidateBnsCache} on write paths and via the refresh endpoint.
+ */
 export function setCachedBnsNegative(
   address: string,
   kv?: KVNamespace,
@@ -196,10 +249,48 @@ export function setCachedBnsNegative(
     kv,
     `cache:bns:${address}`,
     NONE_SENTINEL,
-    BNS_NEGATIVE_CACHE_TTL,
+    BNS_CONFIRMED_NEGATIVE_CACHE_TTL,
     "bns",
     logger
   );
+}
+
+/**
+ * Cache a BNS lookup failure (Hiro error, malformed response, timeout) for
+ * a short TTL ({@link BNS_LOOKUP_FAILED_CACHE_TTL} = 60s). Use this on paths
+ * that couldn't determine whether the address has a name — distinct from
+ * {@link setCachedBnsNegative} which records "confirmed no name" for 7d.
+ *
+ * Reuses the `NONE_SENTINEL` value so subsequent reads via
+ * {@link getCachedBnsName} treat the entry as "no name" until the short TTL
+ * expires and a fresh lookup is attempted.
+ */
+export function setCachedBnsLookupFailed(
+  address: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvPut(
+    kv,
+    `cache:bns:${address}`,
+    NONE_SENTINEL,
+    BNS_LOOKUP_FAILED_CACHE_TTL,
+    "bns",
+    logger
+  );
+}
+
+/**
+ * Delete the cached BNS entry for an address (both positive and negative).
+ * Use on write paths (registration completed, manual refresh) so the next
+ * lookup re-hits Hiro instead of serving a stale 7d confirmed-negative.
+ */
+export function invalidateBnsCache(
+  address: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvDelete(kv, `cache:bns:${address}`, "bns", logger);
 }
 
 export function getCachedIdentity(
@@ -232,6 +323,13 @@ export function setCachedIdentity(
   );
 }
 
+/**
+ * Cache a "confirmed no identity NFT" response (Hiro NFT holdings API
+ * authoritatively returned no match for the address). Uses the long
+ * {@link IDENTITY_CONFIRMED_NEGATIVE_CACHE_TTL} (7d) because state change
+ * requires an on-chain NFT mint. Bust via {@link invalidateIdentityCache}
+ * on write paths and via the refresh endpoint.
+ */
 export function setCachedIdentityNegative(
   address: string,
   kv?: KVNamespace,
@@ -241,10 +339,46 @@ export function setCachedIdentityNegative(
     kv,
     `cache:identity:${address}`,
     NONE_SENTINEL,
-    IDENTITY_NEGATIVE_CACHE_TTL,
+    IDENTITY_CONFIRMED_NEGATIVE_CACHE_TTL,
     "identity",
     logger
   );
+}
+
+/**
+ * Cache an identity lookup failure (Hiro error, malformed response, timeout)
+ * for a short TTL ({@link IDENTITY_LOOKUP_FAILED_CACHE_TTL} = 60s). Use this
+ * on paths that couldn't determine whether the address has an identity NFT —
+ * distinct from {@link setCachedIdentityNegative} which records "confirmed
+ * no identity" for 7d.
+ */
+export function setCachedIdentityLookupFailed(
+  address: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvPut(
+    kv,
+    `cache:identity:${address}`,
+    NONE_SENTINEL,
+    IDENTITY_LOOKUP_FAILED_CACHE_TTL,
+    "identity",
+    logger
+  );
+}
+
+/**
+ * Delete the cached identity entry for an address (both positive and
+ * negative). Use on write paths (identity detected and persisted, manual
+ * refresh) so the next lookup re-hits Hiro instead of serving a stale 7d
+ * confirmed-negative.
+ */
+export function invalidateIdentityCache(
+  address: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvDelete(kv, `cache:identity:${address}`, "identity", logger);
 }
 
 export function getCachedReputation<T>(

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -40,6 +40,17 @@ const BNS_CONFIRMED_NEGATIVE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
  * to stop a concurrent-request hammer.
  */
 const BNS_LOOKUP_FAILED_CACHE_TTL = 60; // 60 seconds
+/**
+ * "Contract-reported error" — Hiro returned `{okay: false}` from BNS V2
+ * `get-primary`. On a well-formed principal against a healthy contract this
+ * branch is practically unreachable; when it does fire it's usually a
+ * deterministic input issue (malformed address stored in our DB) rather than
+ * a transient upstream blip. 5 min avoids re-hitting Hiro every 60s for each
+ * affected address while still short enough to recover from any genuine
+ * one-off contract hiccup. Tracked follow-up: if sustained, investigate the
+ * underlying principal.
+ */
+const BNS_CONTRACT_ERROR_CACHE_TTL = 5 * 60; // 5 minutes
 const IDENTITY_CACHE_TTL = 24 * 60 * 60; // 24 hours (immutable NFT once minted)
 /**
  * "Confirmed no identity" — Hiro NFT holdings API authoritatively returned
@@ -57,6 +68,24 @@ const TX_CACHE_TTL = 30 * 60; // 30 minutes (raised from 5 minutes)
 
 /** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
 export type CacheResult<T> = { hit: true; value: T | null } | { hit: false };
+
+/**
+ * Tri-state outcome for authoritative BNS / identity lookups.
+ *
+ * Callers that mirror lookup results into the AgentRecord (e.g. the refresh
+ * endpoint) need to distinguish "confirmed absent" from "we don't know".
+ * The plain `lookupBnsName` / `detectAgentIdentity` helpers return
+ * `string | null` / `AgentIdentity | null`, which collapses confirmed-negative
+ * and lookup-failed into the same `null` — ambiguity that will clobber a
+ * verified field with null during a Hiro incident.
+ *
+ * The matching `WithOutcome` helpers (see `lib/bns.ts`, `lib/identity/detection.ts`)
+ * return this discriminant so callers can skip the write on `"lookup-failed"`.
+ */
+export type LookupOutcomeState =
+  | "positive"
+  | "confirmed-negative"
+  | "lookup-failed";
 
 /** Sentinel value for negative cache entries (address has no BNS name or on-chain identity). */
 export const NONE_SENTINEL = "__NONE__";
@@ -275,6 +304,28 @@ export function setCachedBnsLookupFailed(
     `cache:bns:${address}`,
     NONE_SENTINEL,
     BNS_LOOKUP_FAILED_CACHE_TTL,
+    "bns",
+    logger
+  );
+}
+
+/**
+ * Cache a BNS contract-reported error (Hiro returned `{okay: false}`) for a
+ * medium TTL ({@link BNS_CONTRACT_ERROR_CACHE_TTL} = 5min). Distinct from
+ * {@link setCachedBnsLookupFailed} (60s, transient upstream) because
+ * contract-level errors are typically deterministic — re-hitting Hiro every
+ * 60s is pure waste.
+ */
+export function setCachedBnsContractError(
+  address: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvPut(
+    kv,
+    `cache:bns:${address}`,
+    NONE_SENTINEL,
+    BNS_CONTRACT_ERROR_CACHE_TTL,
     "bns",
     logger
   );

--- a/lib/identity/reputation.ts
+++ b/lib/identity/reputation.ts
@@ -39,8 +39,8 @@ export async function getReputationSummary(
   if (cached.hit) return cached.value;
 
   try {
-    const result = await callReadOnly(REPUTATION_REGISTRY_CONTRACT, "get-summary", [uintCV(agentId)], hiroApiKey);
-    const summary = parseClarityValue(result);
+    const result = await callReadOnly(REPUTATION_REGISTRY_CONTRACT, "get-summary", [uintCV(agentId)], hiroApiKey, logger);
+    const summary = parseClarityValue(result, logger);
 
     if (!summary || Number(summary.count) === 0) {
       await setCachedReputation(cacheKey, null, kv, logger);
@@ -90,9 +90,9 @@ export async function getReputationFeedback(
       noneCV(), // opt-tag2
       falseCV(), // include-revoked
       cursorArg,
-    ], hiroApiKey);
+    ], hiroApiKey, logger);
 
-    const response = parseClarityValue(result);
+    const response = parseClarityValue(result, logger);
 
     if (!response || !response.items) {
       const empty: ReputationFeedbackResponse = { items: [], cursor: null };

--- a/lib/identity/stacks-api.ts
+++ b/lib/identity/stacks-api.ts
@@ -15,6 +15,7 @@ import {
 } from "@stacks/transactions";
 import { STACKS_API_BASE } from "./constants";
 import { stacksApiFetch, buildHiroHeaders, detect429 } from "../stacks-api-fetch";
+import type { Logger } from "../logging";
 
 // Re-export from shared location for backwards compatibility
 export { buildHiroHeaders, detect429 };
@@ -26,6 +27,7 @@ export { buildHiroHeaders, detect429 };
  * @param functionName - The read-only function to call
  * @param args - ClarityValue objects (will be serialized to hex for the API)
  * @param hiroApiKey - Optional Hiro API key for authenticated requests
+ * @param logger - Optional Logger for Hiro rate-limit + retry telemetry
  * @returns Parsed JSON representation of the Clarity return value from the Stacks API.
  * @throws Error if the Stacks API request fails (non-2xx HTTP response).
  */
@@ -33,7 +35,8 @@ export async function callReadOnly(
   contract: string,
   functionName: string,
   args: ClarityValue[],
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  logger?: Logger
 ): Promise<any> {
   const [contractAddress, contractName] = contract.split(".");
   const url = `${STACKS_API_BASE}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
@@ -56,13 +59,11 @@ export async function callReadOnly(
         arguments: hexArgs,
       }),
     },
-    2,
-    500,
-    2
+    { retries: 2, retries429: 2, logger }
   );
 
   // Log cf-ray for observability if the final response is still a 429 after retries
-  detect429(response);
+  detect429(response, logger);
 
   if (!response.ok) {
     throw new Error(
@@ -81,7 +82,7 @@ export async function callReadOnly(
  * hex-encoded Clarity value. We deserialize it and convert to a
  * JSON-friendly representation using cvToJSON from @stacks/transactions.
  */
-export function parseClarityValue(apiResponse: any): any {
+export function parseClarityValue(apiResponse: any, logger?: Logger): any {
   if (!apiResponse || apiResponse.okay !== true) {
     return null;
   }
@@ -91,7 +92,7 @@ export function parseClarityValue(apiResponse: any): any {
     const json = cvToJSON(cv);
     return unwrapCvJson(json);
   } catch (e) {
-    console.error("Failed to parse Clarity value from API response:", e);
+    logger?.error("stacksApi.parse_clarity_value_failed", { error: String(e) });
     return null;
   }
 }

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -845,10 +845,14 @@ export async function verifyTxidPayment(
 
     // 3. Fetch from API
     try {
-      const response = await stacksApiFetch(`${apiBase}/extended/v1/tx/${fullTxid}`, {
-        method: "GET",
-        headers: buildHiroHeaders(hiroApiKey),
-      });
+      const response = await stacksApiFetch(
+        `${apiBase}/extended/v1/tx/${fullTxid}`,
+        {
+          method: "GET",
+          headers: buildHiroHeaders(hiroApiKey),
+        },
+        { logger: log }
+      );
       if (!response.ok) {
         if (response.status === 404) {
           // Cache the negative result to prevent repeated lookups.

--- a/lib/stacks-api-fetch.ts
+++ b/lib/stacks-api-fetch.ts
@@ -11,7 +11,14 @@
  * - Respects Retry-After header on 429 (capped at 30s)
  * - Per-attempt timeout: 8 seconds
  * - Returns the final Response after all retries — callers check status
+ *
+ * Observability: callers may thread an optional {@link Logger}. When provided,
+ * rate-limit and retry events are emitted as structured `stacksApi.*` events
+ * (via worker-logs); otherwise the wrapper is silent (no console fallback —
+ * that would bypass the telemetry pipeline).
  */
+
+import type { Logger } from "./logging";
 
 /** Build headers for Hiro API requests, optionally including an API key. */
 export function buildHiroHeaders(hiroApiKey?: string): Record<string, string> {
@@ -23,20 +30,37 @@ export function buildHiroHeaders(hiroApiKey?: string): Record<string, string> {
 }
 
 /**
+ * Extract a stable pathname suffix from a URL for use as a log key.
+ * Falls back to the raw url if parsing fails (e.g. relative URL).
+ */
+function extractPath(url: string): string {
+  try {
+    return new URL(url).pathname;
+  } catch {
+    return url;
+  }
+}
+
+/**
  * Detect 429 rate limit responses and log cf-ray for observability.
  *
  * @returns Object with isRateLimited flag for caller branching
  */
-export function detect429(response: Response): {
+export function detect429(
+  response: Response,
+  logger?: Logger
+): {
   isRateLimited: boolean;
 } {
   const isRateLimited = response.status === 429;
 
   if (isRateLimited) {
     const cfRay = response.headers.get("cf-ray");
-    console.warn(
-      `Rate limit detected (429) on ${response.url}${cfRay ? ` [cf-ray: ${cfRay}]` : ""}`
-    );
+    logger?.warn("stacksApi.rate_limited", {
+      path: extractPath(response.url),
+      url: response.url,
+      ...(cfRay ? { cfRay } : {}),
+    });
   }
 
   return { isRateLimited };
@@ -65,15 +89,23 @@ export interface RateLimitInfo {
  * Reads ratelimit-remaining, ratelimit-limit, ratelimit-reset,
  * x-ratelimit-remaining-stacks-minute, and x-ratelimit-cost-stacks.
  *
- * Emits a warn-level log when the remaining budget drops below
- * RATE_LIMIT_WARN_THRESHOLD (50) to alert operators before key exhaustion.
+ * When a logger is provided, emits two structured events:
+ * - `stacksApi.rate_limit_remaining` on every parseable response (for tracking
+ *   how the remaining budget trends as cache hit rates rise).
+ * - `stacksApi.approaching_rate_limit` (warn level) when remaining drops below
+ *   RATE_LIMIT_WARN_THRESHOLD (50), so operators are alerted before key
+ *   exhaustion.
  *
  * @param response - The Response object from a Hiro API fetch
+ * @param logger - Optional Logger for emitting rate-limit telemetry
+ * @param path - Optional precomputed pathname (avoids re-parsing response.url)
  * @returns Parsed rate limit fields (null for any header that is absent or unparseable)
  */
-export function extractRateLimitInfo(response: Response): RateLimitInfo {
-  const tag = "[stacksApiFetch]";
-
+export function extractRateLimitInfo(
+  response: Response,
+  logger?: Logger,
+  path?: string
+): RateLimitInfo {
   function parseIntHeader(name: string): number | null {
     const val = response.headers.get(name);
     if (!val) return null;
@@ -87,11 +119,26 @@ export function extractRateLimitInfo(response: Response): RateLimitInfo {
   const remainingMinute = parseIntHeader("x-ratelimit-remaining-stacks-minute");
   const costStacks = parseIntHeader("x-ratelimit-cost-stacks");
 
-  if (remaining !== null && remaining < RATE_LIMIT_WARN_THRESHOLD) {
-    console.warn(
-      `${tag} Hiro API key approaching rate limit: ${remaining}/${limit ?? "?"} remaining` +
-        (reset !== null ? ` (resets in ${reset}s)` : "")
-    );
+  if (logger && remaining !== null) {
+    const resolvedPath = path ?? extractPath(response.url);
+    logger.info("stacksApi.rate_limit_remaining", {
+      path: resolvedPath,
+      rlRemaining: remaining,
+      ...(limit !== null ? { rlLimit: limit } : {}),
+      ...(reset !== null ? { rlReset: reset } : {}),
+      ...(remainingMinute !== null ? { rlRemainingMinute: remainingMinute } : {}),
+      ...(costStacks !== null ? { rlCostStacks: costStacks } : {}),
+    });
+
+    if (remaining < RATE_LIMIT_WARN_THRESHOLD) {
+      logger.warn("stacksApi.approaching_rate_limit", {
+        path: resolvedPath,
+        rlRemaining: remaining,
+        ...(limit !== null ? { rlLimit: limit } : {}),
+        ...(reset !== null ? { rlReset: reset } : {}),
+        threshold: RATE_LIMIT_WARN_THRESHOLD,
+      });
+    }
   }
 
   return { remaining, limit, reset, remainingMinute, costStacks };
@@ -134,16 +181,33 @@ function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/** Retry + observability configuration for {@link stacksApiFetch}. */
+export interface StacksApiFetchConfig {
+  /** Max attempts for 5xx errors (default: 3). */
+  retries?: number;
+  /** Base delay for 5xx exponential backoff in ms (default: 500). */
+  baseDelayMs?: number;
+  /** Max attempts for 429 rate-limit errors (default: {@link RATE_LIMIT_RETRIES} = 5). */
+  retries429?: number;
+  /**
+   * Optional Logger; when provided, emits `stacksApi.*` telemetry events
+   * (rate_limit_remaining, approaching_rate_limit, retry_budget_exhausted,
+   * retrying). Silent when omitted — we do not fall back to `console.*`,
+   * which would bypass the worker-logs pipeline.
+   */
+  logger?: Logger;
+}
+
 /**
  * Fetch a Stacks API URL with exponential backoff retry on 429/5xx responses.
  *
  * Each attempt uses an independent AbortSignal with a per-attempt timeout.
  *
- * 429 rate-limit responses use a separate retry budget (retries429, default 5)
+ * 429 rate-limit responses use a separate retry budget (`retries429`, default 5)
  * with a longer base delay (1s, 2s, 4s, 8s, 16s) to absorb burst rate limits.
  * The Retry-After header from Hiro takes precedence over computed backoff (capped at 30s).
  *
- * 5xx server errors use the standard retry budget (retries, default 3) with
+ * 5xx server errors use the standard retry budget (`retries`, default 3) with
  * 500ms base delay (500ms, 1s, 2s).
  *
  * On successful response (2xx or non-retryable 4xx), returns immediately.
@@ -152,20 +216,23 @@ function sleep(ms: number): Promise<void> {
  *
  * @param url - URL to fetch
  * @param options - Fetch options (method, headers, body). Signal is injected per-attempt.
- * @param retries - Max attempts for 5xx errors (default: 3)
- * @param baseDelayMs - Base delay for 5xx exponential backoff in ms (default: 500)
- * @param retries429 - Max attempts for 429 rate-limit errors (default: RATE_LIMIT_RETRIES = 5)
+ * @param config - Retry + observability config; pass just `{ logger }` when the
+ *                 defaults are fine, or override any retry field individually.
  * @returns The final Response object
  * @throws Only on network-level errors (DNS failure, connection refused) after all retries
  */
 export async function stacksApiFetch(
   url: string,
   options: RequestInit,
-  retries = 3,
-  baseDelayMs = 500,
-  retries429 = RATE_LIMIT_RETRIES
+  config: StacksApiFetchConfig = {}
 ): Promise<Response> {
-  const tag = "[stacksApiFetch]";
+  const {
+    retries = 3,
+    baseDelayMs = 500,
+    retries429 = RATE_LIMIT_RETRIES,
+    logger,
+  } = config;
+  const path = extractPath(url);
 
   // Separate retry budgets for 429 and 5xx
   let attempts429 = 0;
@@ -185,8 +252,9 @@ export async function stacksApiFetch(
     try {
       const response = await fetch(url, attemptOptions);
 
-      // Extract rate limit info on every response for observability (warns when low)
-      const rl = extractRateLimitInfo(response);
+      // Extract rate limit info on every response for observability (also emits
+      // stacksApi.rate_limit_remaining / approaching_rate_limit when logger present)
+      const rl = extractRateLimitInfo(response, logger, path);
 
       if (!isRetryableStatus(response.status)) {
         return response;
@@ -194,19 +262,19 @@ export async function stacksApiFetch(
 
       const is429 = response.status === 429;
 
-      // Build a compact rate limit suffix for retry log messages
-      const rlSuffix =
-        rl.remaining !== null
-          ? ` [rl: ${rl.remaining}/${rl.limit ?? "?"} remaining]`
-          : "";
-
       if (is429) {
         attempts429++;
         if (attempts429 >= retries429) {
           // Exhausted 429 retry budget — return final response to caller
-          console.warn(
-            `${tag} 429 retry budget exhausted (${retries429} attempts) for ${url}${rlSuffix}`
-          );
+          logger?.warn("stacksApi.retry_budget_exhausted", {
+            path,
+            url,
+            status: 429,
+            attempts: retries429,
+            budget: "429",
+            ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
+            ...(rl.limit !== null ? { rlLimit: rl.limit } : {}),
+          });
           return response;
         }
 
@@ -215,44 +283,72 @@ export async function stacksApiFetch(
           parseRetryAfterMs(response) ??
           RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempts429 - 1);
         const delayMs = Math.min(retryAfterMs, MAX_RETRY_AFTER_MS);
-        console.warn(
-          `${tag} 429 on ${url}, attempt ${attempts429}/${retries429}, retrying in ${delayMs}ms${rlSuffix}`
-        );
+        logger?.warn("stacksApi.retrying", {
+          path,
+          url,
+          status: 429,
+          attempt: attempts429,
+          maxAttempts: retries429,
+          delayMs,
+          ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
+        });
         await sleep(delayMs);
       } else {
         // 5xx error
         attempts5xx++;
         if (attempts5xx >= retries) {
-          console.warn(
-            `${tag} 5xx retry budget exhausted (${retries} attempts) for ${url} (status: ${response.status})${rlSuffix}`
-          );
+          logger?.warn("stacksApi.retry_budget_exhausted", {
+            path,
+            url,
+            status: response.status,
+            attempts: retries,
+            budget: "5xx",
+            ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
+            ...(rl.limit !== null ? { rlLimit: rl.limit } : {}),
+          });
           return response;
         }
 
         const delayMs = baseDelayMs * Math.pow(2, attempts5xx - 1);
-        console.warn(
-          `${tag} ${response.status} on ${url}, attempt ${attempts5xx}/${retries}, retrying in ${delayMs}ms${rlSuffix}`
-        );
+        logger?.warn("stacksApi.retrying", {
+          path,
+          url,
+          status: response.status,
+          attempt: attempts5xx,
+          maxAttempts: retries,
+          delayMs,
+          ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
+        });
         await sleep(delayMs);
       }
     } catch (error) {
       // Network-level error — counts against the 5xx budget
       attempts5xx++;
       if (attempts5xx >= retries) {
-        console.warn(
-          `${tag} Network error budget exhausted (${retries} attempts) for ${url} (${String(error)})`
-        );
+        logger?.warn("stacksApi.retry_budget_exhausted", {
+          path,
+          url,
+          attempts: retries,
+          budget: "network",
+          error: String(error),
+        });
         throw error;
       }
 
       const delayMs = baseDelayMs * Math.pow(2, attempts5xx - 1);
-      console.warn(
-        `${tag} Network error on ${url}, attempt ${attempts5xx}/${retries}, retrying in ${delayMs}ms`
-      );
+      logger?.warn("stacksApi.retrying", {
+        path,
+        url,
+        attempt: attempts5xx,
+        maxAttempts: retries,
+        delayMs,
+        error: String(error),
+        budget: "network",
+      });
       await sleep(delayMs);
     }
   }
 
   // Unreachable -- loop always returns or throws when a budget is exhausted
-  throw new Error(`${tag} Unexpected: retry loop exited without return`);
+  throw new Error(`[stacksApiFetch] Unexpected: retry loop exited without return`);
 }


### PR DESCRIPTION
Closes #609.

## Summary

Four linked observability + caching changes, all wired end-to-end:

- **Logger through `stacksApiFetch`** — refactored to an options-bag signature; emits structured `stacksApi.rate_limit_remaining` / `approaching_rate_limit` / `retry_budget_exhausted` events via worker-logs so #604's test-plan items become verifiable for the first time.
- **Three-state BNS/identity cache** — confirmed-positive (24h, unchanged) / confirmed-negative (7d, up from 1h BNS / 5min identity) / lookup-failed (60s, new). Fixes the 0/141 BNS hit rate captured in the 3h post-#606 triage window. Distinct constant names per state so intent is legible at call sites.
- **Cache-bust on write paths** — `/api/admin/backfill-identity` and `/api/identity/[address]` now keep the three-state cache in sync when new state is discovered. `POST /api/identity/:address/refresh` is the manual escape hatch for off-platform BNS/NFT registration; wired to a "Not showing up correctly? Refresh" link on the profile page's `IdentityBadge`.
- **ESLint guardrail** — `no-console: error` in `lib/**` with narrow exceptions for `lib/logging.ts` and files tracked by #551. Verified catches new `console.*` calls.

## Key changes

| File | Change |
|------|--------|
| `lib/stacks-api-fetch.ts` | `stacksApiFetch(url, opts, { retries?, baseDelayMs?, retries429?, logger? })`. Emits 5 structured events. Also exports `StacksApiFetchConfig`. |
| `lib/identity/kv-cache.ts` | New TTL constants + `setCachedBnsLookupFailed` / `setCachedIdentityLookupFailed` / `invalidateBnsCache` / `invalidateIdentityCache` helpers. |
| `lib/bns.ts` | All 4 failure paths (`!res.ok`, `!data.okay`, `!json.success`, `catch`) write lookup-failed sentinel. |
| `lib/identity/detection.ts` | Top-level catch writes lookup-failed. |
| `app/api/identity/[address]/refresh/route.ts` | **New**: POST clears `cache:bns:{stx}` + `cache:identity:{stx}` + `identity-check:{stx}`, re-runs both lookups, persists any state change. |
| `app/components/IdentityBadge.tsx` | Refresh button with loading/error states; calls `router.refresh()` after success to pick up BNS changes from the RSC payload. |
| `.eslintrc.json` | `no-console: error` on `lib/**` with narrow exceptions. |
| `CLAUDE.md`, `llms-full.txt`, `openapi.json` | Documentation for the refresh endpoint + cache model. |

## Test plan

- [x] `npm run lint` — clean (only pre-existing `<img>` warnings)
- [x] `npx tsc --noEmit` — clean
- [x] `npm test -- --run` — 471 tests passing (12 new: 7 logger telemetry + 5 three-state cache)
- [x] `npm run build` — clean; `/api/identity/[address]/refresh` visible in route table
- [ ] 24h post-merge log triage confirms checklist items from the issue:
  - `stacksApi.rate_limit_remaining` events visible, `rlRemaining` trending upward
  - `stacksApi.retry_budget_exhausted` ≈ 0/hr
  - `stacksApi.approaching_rate_limit` ≈ 0/hr
  - BNS `cache.hit` rate ≥ 20% on repeat-access keys (baseline: 0/141)
  - Identity `cache.hit` rate climbing similarly
  - No 503 spike on `/api/achievements/verify`
  - No `api.mainnet.hiro.so` in worker-logs outside wrapper-tagged events
  - Manual refresh endpoint exercised end-to-end from the profile page

🤖 Generated with [Claude Code](https://claude.com/claude-code)