### PR TITLE
fix(bns): map (err u131) ERR-NO-PRIMARY-NAME to confirmed-negative cache

### DIFF
--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -71,6 +71,11 @@ function mockV2ErrNoPrimary() {
 
 function mockV2ErrOther(code: number) {
   // Any other (err uN) — treated as a genuine malformed/unexpected response.
+  // `code` is encoded as a Clarity u128 (16 bytes / 32 hex chars), so any
+  // value in [0, 2^128 - 1] is representable. JS `number` safely covers up
+  // to 2^53 - 1, which is far more than any plausible contract error code;
+  // u131 (ERR-NO-PRIMARY-NAME) is the only code we currently special-case,
+  // so callers pass small example codes like 101 here.
   const hex = code.toString(16).padStart(32, "0");
   return {
     ok: true,

--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -44,12 +44,39 @@ function mockV2Response(name: string, namespace: string) {
 }
 
 function mockV2None() {
-  // (ok none) = 0x07 09
+  // Defense-in-depth path: (ok none) = 0x07 09. BNS-V2 doesn't actually
+  // return this today (see mockV2ErrNoPrimary) but the parser keeps the
+  // branch in case the contract signature ever changes.
   return {
     ok: true,
     status: 200,
     headers: mockHeaders(),
     json: async () => ({ okay: true, result: "0x0709" }),
+  };
+}
+
+function mockV2ErrNoPrimary() {
+  // Real BNS-V2 response for an address with no primary name:
+  // (err u131) ERR-NO-PRIMARY-NAME = 0x08 01 00...00 83
+  return {
+    ok: true,
+    status: 200,
+    headers: mockHeaders(),
+    json: async () => ({
+      okay: true,
+      result: "0x080100000000000000000000000000000083",
+    }),
+  };
+}
+
+function mockV2ErrOther(code: number) {
+  // Any other (err uN) — treated as a genuine malformed/unexpected response.
+  const hex = code.toString(16).padStart(32, "0");
+  return {
+    ok: true,
+    status: 200,
+    headers: mockHeaders(),
+    json: async () => ({ okay: true, result: "0x0801" + hex }),
   };
 }
 
@@ -98,7 +125,16 @@ describe("lookupBnsName", () => {
   });
 
   describe("fallback to null cases", () => {
-    it("returns null when V2 returns none (no primary name)", async () => {
+    it("returns null when V2 returns err u131 (no primary name)", async () => {
+      mockFetch.mockResolvedValue(mockV2ErrNoPrimary());
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(result).toBeNull();
+    });
+
+    it("returns null when V2 returns (ok none) [defense-in-depth]", async () => {
       mockFetch.mockResolvedValue(mockV2None());
 
       const result = await lookupBnsName(
@@ -292,7 +328,24 @@ describe("lookupBnsName", () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
-    it("writes 7d confirmed-negative cache when V2 returns none", async () => {
+    it("writes 7d confirmed-negative cache when V2 returns err u131", async () => {
+      const kv = createMockKv();
+      mockFetch.mockResolvedValue(mockV2ErrNoPrimary());
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      // 7d (604800s) TTL — confirmed "no primary name" per the three-state model.
+      // ERR-NO-PRIMARY-NAME is the real BNS-V2 response for nameless addresses.
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(7 * 24 * 60 * 60);
+    });
+
+    it("writes 7d confirmed-negative cache when V2 returns (ok none) [defense-in-depth]", async () => {
       const kv = createMockKv();
       mockFetch.mockResolvedValue(mockV2None());
 
@@ -303,10 +356,25 @@ describe("lookupBnsName", () => {
       );
       expect(result).toBeNull();
       const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
-      // 7d (604800s) TTL — confirmed "no name" per the three-state model.
-      // Busted on write paths (registration) and via the refresh endpoint.
       expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
       expect(kv._store.get(cacheKey)?.ttl).toBe(7 * 24 * 60 * 60);
+    });
+
+    it("writes 60s lookup-failed cache on unexpected err code (not u131)", async () => {
+      const kv = createMockKv();
+      // ERR-UNWRAP (u101) or any other non-u131 error is treated as a
+      // genuine malformed response — short-TTL defer rather than 7d pin.
+      mockFetch.mockResolvedValue(mockV2ErrOther(101));
+
+      const result = await lookupBnsName(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+        undefined,
+        kv as unknown as KVNamespace
+      );
+      expect(result).toBeNull();
+      const cacheKey = "cache:bns:SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+      expect(kv._store.get(cacheKey)?.value).toBe("__NONE__");
+      expect(kv._store.get(cacheKey)?.ttl).toBe(60);
     });
   });
 
@@ -336,7 +404,15 @@ describe("lookupBnsName", () => {
       expect(outcome).toEqual({ state: "positive", name: "alice.btc" });
     });
 
-    it("returns confirmed-negative outcome on (ok none)", async () => {
+    it("returns confirmed-negative outcome on err u131 (no primary name)", async () => {
+      mockFetch.mockResolvedValue(mockV2ErrNoPrimary());
+      const outcome = await lookupBnsNameWithOutcome(
+        "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
+      );
+      expect(outcome).toEqual({ state: "confirmed-negative", name: null });
+    });
+
+    it("returns confirmed-negative outcome on (ok none) [defense-in-depth]", async () => {
       mockFetch.mockResolvedValue(mockV2None());
       const outcome = await lookupBnsNameWithOutcome(
         "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -109,9 +109,19 @@ export async function lookupBnsNameWithOutcome(
     const cv = deserializeCV(data.result);
     const json = cvToJSON(cv);
 
-    // Response structure: (ok (some {name: buff, namespace: buff})) or (ok none)
+    // BNS-V2 `get-primary` response shape, per contract source:
+    //   (ok { name: (buff 48), namespace: (buff 20) }) — address has a primary name
+    //   (err u131) ERR-NO-PRIMARY-NAME                — address has no primary name
+    // The `(ok none)` branch below is defense-in-depth in case the contract
+    // signature ever changes to `(response (optional {...}) uint)`.
     if (!json.success) {
-      logger?.warn("bns.lookup_malformed_response", { stxAddress });
+      const errCode = json.value?.value;
+      if (errCode === "131") {
+        // Authoritative "no primary name" — cache as confirmed-negative (7d).
+        await setCachedBnsNegative(stxAddress, kv, logger);
+        return { state: "confirmed-negative", name: null };
+      }
+      logger?.warn("bns.lookup_malformed_response", { stxAddress, errCode });
       await setCachedBnsLookupFailed(stxAddress, kv, logger);
       return { state: "lookup-failed", name: null };
     }

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -22,6 +22,11 @@ import type { Logger } from "./logging";
 const BNS_V2_CONTRACT = "SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF";
 const BNS_V2_NAME = "BNS-V2";
 
+// BNS-V2 error code returned by `get-primary` when the address has no
+// primary name. Treated as an authoritative "no name" signal and cached
+// with the confirmed-negative (7d) TTL.
+const BNS_ERR_NO_PRIMARY_NAME = "131";
+
 /**
  * Tri-state BNS lookup outcome.
  *
@@ -110,13 +115,13 @@ export async function lookupBnsNameWithOutcome(
     const json = cvToJSON(cv);
 
     // BNS-V2 `get-primary` response shape, per contract source:
-    //   (ok { name: (buff 48), namespace: (buff 20) }) — address has a primary name
-    //   (err u131) ERR-NO-PRIMARY-NAME                — address has no primary name
+    //   (ok (some { name: (buff 48), namespace: (buff 20) })) — address has a primary name
+    //   (err u131) ERR-NO-PRIMARY-NAME                        — address has no primary name
     // The `(ok none)` branch below is defense-in-depth in case the contract
-    // signature ever changes to `(response (optional {...}) uint)`.
+    // ever emits an empty optional for "no primary name" instead of the err.
     if (!json.success) {
       const errCode = json.value?.value;
-      if (errCode === "131") {
+      if (errCode === BNS_ERR_NO_PRIMARY_NAME) {
         // Authoritative "no primary name" — cache as confirmed-negative (7d).
         await setCachedBnsNegative(stxAddress, kv, logger);
         return { state: "confirmed-negative", name: null };


### PR DESCRIPTION
## Summary

BNS-V2 `get-primary` returns `(err u131)` for addresses with no primary name, not `(ok none)`. The parser was routing every nameless agent through the 60s lookup-failed TTL, so each pageview re-hit Hiro about once a minute. Post-#610 triage traced the bulk of the remaining rate-limit pressure to this one path.

Verified directly against the deployed contract and source (`SP2QEZ06AGJ3RKJPBV14SY1V5BBFNAW33D96YPGZF.BNS-V2`):

```clarity
(define-constant ERR-NO-PRIMARY-NAME (err u131))
(define-read-only (get-primary (owner principal))
    (ok (get-bns-from-id
          (unwrap! (map-get? primary-name owner) ERR-NO-PRIMARY-NAME)))
)
```

Three distinct addresses from tonight's `bns.lookup_malformed_response` logs all return:

```
{ "okay": true, "result": "0x080100000000000000000000000000000083" }
// decodes to (err u131) — ERR-NO-PRIMARY-NAME
```

## Fix

In the `!json.success` branch of `lib/bns.ts`, check `json.value.value === "131"` and route to `setCachedBnsNegative` (7d confirmed-negative). Any other error code keeps the 60s lookup-failed semantics (truly unexpected, deserves re-lookup). The `(ok none)` branch is retained as defense-in-depth in case the contract signature ever changes.

## Evidence from production (post-#610, 25-min window)

| Signal | Before this fix | Expected after |
|---|---|---|
| `bns.lookup_malformed_response` | 59 events | near-zero (only for non-u131 errors) |
| `stacksApi.approaching_rate_limit` | ~360/hr | decays as BNS cache fills |
| BNS `cache.hit` rate | 11% | climbs toward reputation's 92% once nameless-agent cache fills |
| `SP1VQBRA…E2X6J`-class 18× hammer | present | eliminated on second lookup for 7d |

## Test plan

- [x] `npm test` — 480/480 pass (`lib/__tests__/bns.test.ts` now has 27 tests)
- [x] `npx tsc --noEmit` — clean
- [x] Direct contract call confirms `(err u131)` response shape for three randomly-sampled addresses from tonight's logs
- [ ] Post-deploy: `bns.lookup_malformed_response` volume drops to near-zero
- [ ] Post-deploy: BNS `cache.hit` rate climbs past 50% within 2h as nameless-agent cache fills
- [ ] Post-deploy: `stacksApi.approaching_rate_limit` decays toward zero

## Test coverage added

- `mockV2ErrNoPrimary()` — real BNS-V2 no-name response → confirmed-negative (7d TTL)
- `mockV2None()` — `(ok none)` defense-in-depth fallback → confirmed-negative (7d TTL)
- `mockV2ErrOther(code)` — any other err code (e.g. u101 ERR-UNWRAP) → lookup-failed (60s TTL)

## References

- #604 — initial Hiro rate-limit reduction (introduced the `!json.success` path with wrong assumption)
- #609 — observability + cache strategy (three-state TTL model)
- #610 — previous PR that resolved #609

🤖 Generated with [Claude Code](https://claude.com/claude-code)