### PR TITLE
ci(release-please): surface docs and refactor in changelog

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,3 +16,12 @@ jobs:
       - uses: googleapis/release-please-action@v4
         with:
           release-type: node
+          changelog-types: |
+            [
+              {"type":"feat","section":"Features"},
+              {"type":"fix","section":"Bug Fixes"},
+              {"type":"perf","section":"Performance Improvements"},
+              {"type":"revert","section":"Reverts"},
+              {"type":"docs","section":"Documentation"},
+              {"type":"refactor","section":"Code Refactoring"}
+            ]


### PR DESCRIPTION
## Summary

Release-please's default \`release-type: node\` hides \`docs\` and \`refactor\` commits from the changelog. That's fine for one-line comment tweaks, but we've been using \`docs:\` for meaningful content updates (e.g. #578 — skills-v0.38.0 llms/mcp-tools refresh, which landed silently in 1.39.0's changelog).

Adds \`changelog-types\` to the workflow so those sections render when a release is cut.

## What changes

| Type | Before | After |
|------|--------|-------|
| feat | Features | Features |
| fix | Bug Fixes | Bug Fixes |
| perf | Performance Improvements | Performance Improvements |
| revert | Reverts | Reverts |
| **docs** | hidden | **Documentation** |
| **refactor** | hidden | **Code Refactoring** |
| chore, ci, test, build, style | hidden | hidden (unchanged) |

## Important caveat (not changed here)

This controls *what appears* in the changelog when release-please cuts a release. It does **not** change which commit types trigger a version bump. Only \`feat\` (minor), \`fix\` (patch), and \`BREAKING CHANGE\`/\`!\` (major) still trigger releases.

**For a docs-only release**, use \`fix(docs): ...\` — it triggers a patch bump and lists under Bug Fixes. Or let the docs commit piggyback on any adjacent feat/fix (as #578 did alongside #577 in v1.39.0) — with this change, both will now appear in the release notes.

## Effect on the open v1.39.0 PR (#613)

Once this merges to main, release-please regenerates #613 and #578 should surface under a new "Documentation" section.

## Test plan

- [ ] CI green
- [ ] Merge → release-please workflow re-runs
- [ ] #613 body gains a "### Documentation" section listing #578

🤖 Generated with [Claude Code](https://claude.com/claude-code)