### PR TITLE
fix(ci): use plain v* tag format in release-please

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
+  "include-component-in-tag": false,
   "packages": {
     ".": {
       "release-type": "node",


### PR DESCRIPTION
## Summary

Follow-up to #616. Manifest mode in release-please defaults to tags like \`aibtcdev-landing-page-v1.38.0\`, but our existing tags are plain \`v1.38.0\`. Without a matching baseline tag, release-please regenerated the entire project history into the release notes — the replacement PR #617 has a ~60KB body.

Adds \`\"include-component-in-tag\": false\` to the config so tags stay as \`v1.38.0\`, matching the existing history.

## Before vs after

| Setting | Tag format | Baseline lookup |
|---------|-----------|-----------------|
| Default (manifest mode) | \`aibtcdev-landing-page-v1.38.0\` | Not found → regenerates all history |
| \`include-component-in-tag: false\` | \`v1.38.0\` | Matches existing tag ✓ |

## Expected behavior after merge

- Release-please finds \`v1.38.0\` as the last release
- Regenerates release PR with commits since \`v1.38.0\` only (same as #613 had before)
- \"### Documentation\" section now present, listing #578

## Test plan

- [ ] CI green
- [ ] Merge → release-please re-runs
- [ ] Release PR body is back to ~6 KB scope (1.38.0 → 1.39.0) and includes docs
- [ ] Next release tag is plain \`v1.39.0\`, not \`aibtcdev-landing-page-v1.39.0\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)