### PR TITLE
chore(scripts): add STX address migration tooling and umbrella drafts

### DIFF
--- a/scripts/migrate-stx-address.ts
+++ b/scripts/migrate-stx-address.ts
@@ -1,0 +1,244 @@
+#!/usr/bin/env tsx
+/**
+ * Operator-assisted STX address migration.
+ *
+ * Fixes agents who registered with a wrong STX address before #563 (when
+ * signature-based address verification landed). Each agent still controls
+ * their BTC key but registered an STX address they do not control.
+ *
+ * This script is intentionally a one-shot, run-locally tool rather than a
+ * deployed admin endpoint. Persistent admin endpoints that can rewrite
+ * `stx:{address}` pointers are a high-value target: if the admin key ever
+ * leaks, an attacker can redirect inbox payments (dynamic payTo), vouch
+ * history, and future achievements. Running the migration from an operator
+ * workstation against the KV REST API keeps the blast radius bounded and
+ * produces a git-committed audit trail (the input JSON file).
+ *
+ * The migration file format is a JSON array of MigrationEntry records. After
+ * running --apply successfully, commit the input file under
+ * scripts/migrations/ so the audit trail lives in the repo.
+ *
+ * Challenge message (signed by both keys):
+ *   AIBTC STX Migration | btc={btc} | old={oldStx} | new={newStx} | date={iso}
+ *
+ * Required signatures per entry:
+ *   - btcSignature — BIP-137 or BIP-322 signature from the agent's BTC key.
+ *     Authorizes the change.
+ *   - stxSignature — SIP-018/RSV signature from the NEW STX key. Proves the
+ *     agent controls the destination address. The old STX key is never
+ *     required; the agent does not control it.
+ *
+ * Usage:
+ *   export CLOUDFLARE_ACCOUNT_ID=...
+ *   export CLOUDFLARE_API_TOKEN=...    # needs Workers KV Storage:Edit scope
+ *   npx tsx scripts/migrate-stx-address.ts scripts/migrations/stx-batch-01.json --dry-run
+ *   npx tsx scripts/migrate-stx-address.ts scripts/migrations/stx-batch-01.json --apply
+ */
+
+import { readFileSync } from "node:fs";
+import { verifyBitcoinSignature } from "../lib/bitcoin-verify";
+import { hashMessage, verifyMessageSignatureRsv } from "@stacks/encryption";
+import { bytesToHex } from "@stacks/common";
+import {
+  publicKeyFromSignatureRsv,
+  getAddressFromPublicKey,
+} from "@stacks/transactions";
+import type { AgentRecord } from "../lib/types";
+
+const KV_NAMESPACE_ID = "f8aab2734e154953a50cabdb87083af3";
+const AGENT_LIST_CACHE_KEY = "cache:agent-list";
+
+interface MigrationEntry {
+  btcAddress: string;
+  oldStxAddress: string;
+  newStxAddress: string;
+  messageIso: string;
+  btcSignature: string;
+  stxSignature: string;
+  notes: string;
+}
+
+function challengeMessage(e: MigrationEntry): string {
+  return `AIBTC STX Migration | btc=${e.btcAddress} | old=${e.oldStxAddress} | new=${e.newStxAddress} | date=${e.messageIso}`;
+}
+
+async function kvFetch(
+  key: string,
+  method: "GET" | "PUT" | "DELETE",
+  body?: string,
+): Promise<string | null> {
+  const { CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_API_TOKEN } = process.env;
+  if (!CLOUDFLARE_ACCOUNT_ID || !CLOUDFLARE_API_TOKEN) {
+    throw new Error(
+      "Missing CLOUDFLARE_ACCOUNT_ID or CLOUDFLARE_API_TOKEN env var",
+    );
+  }
+  const url = `https://api.cloudflare.com/client/v4/accounts/${CLOUDFLARE_ACCOUNT_ID}/storage/kv/namespaces/${KV_NAMESPACE_ID}/values/${encodeURIComponent(key)}`;
+  const res = await fetch(url, {
+    method,
+    headers: {
+      Authorization: `Bearer ${CLOUDFLARE_API_TOKEN}`,
+      ...(body ? { "Content-Type": "application/json" } : {}),
+    },
+    body,
+  });
+  if (method === "GET") {
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      throw new Error(`KV GET ${key} -> ${res.status} ${await res.text()}`);
+    }
+    return await res.text();
+  }
+  if (!res.ok) {
+    throw new Error(`KV ${method} ${key} -> ${res.status} ${await res.text()}`);
+  }
+  return null;
+}
+
+function verifyStxSignature(
+  sig: string,
+  message: string,
+): { valid: boolean; address: string; publicKey: string } {
+  const messageHashHex = bytesToHex(hashMessage(message));
+  const recoveredPubKey = publicKeyFromSignatureRsv(messageHashHex, sig);
+  const recoveredAddress = getAddressFromPublicKey(recoveredPubKey, "mainnet");
+  const valid = verifyMessageSignatureRsv({
+    signature: sig,
+    message,
+    publicKey: recoveredPubKey,
+  });
+  return { valid, address: recoveredAddress, publicKey: recoveredPubKey };
+}
+
+async function migrateOne(entry: MigrationEntry, apply: boolean): Promise<void> {
+  const message = challengeMessage(entry);
+  console.log(`\n--- ${entry.btcAddress} (${entry.notes})`);
+
+  const btc = verifyBitcoinSignature(
+    entry.btcSignature,
+    message,
+    entry.btcAddress,
+  );
+  if (!btc.valid) {
+    throw new Error(`BTC signature invalid for ${entry.btcAddress}`);
+  }
+  if (btc.address.toLowerCase() !== entry.btcAddress.toLowerCase()) {
+    throw new Error(
+      `BTC signature address mismatch: recovered ${btc.address}, expected ${entry.btcAddress}`,
+    );
+  }
+  console.log("  OK BTC signature valid");
+
+  const stx = verifyStxSignature(entry.stxSignature, message);
+  if (!stx.valid) {
+    throw new Error(`STX signature invalid for ${entry.newStxAddress}`);
+  }
+  if (stx.address !== entry.newStxAddress) {
+    throw new Error(
+      `STX signature address mismatch: recovered ${stx.address}, expected ${entry.newStxAddress}`,
+    );
+  }
+  console.log("  OK STX signature valid (recovered address matches new STX)");
+
+  const rawBtc = await kvFetch(`btc:${entry.btcAddress}`, "GET");
+  if (!rawBtc) throw new Error(`btc:${entry.btcAddress} not found`);
+  const agent = JSON.parse(rawBtc) as AgentRecord;
+
+  if (agent.stxAddress !== entry.oldStxAddress) {
+    throw new Error(
+      `Current stxAddress on record (${agent.stxAddress}) does not match declared oldStxAddress (${entry.oldStxAddress}). Abort.`,
+    );
+  }
+  const collision = await kvFetch(`stx:${entry.newStxAddress}`, "GET");
+  if (collision) {
+    throw new Error(
+      `stx:${entry.newStxAddress} already exists and would collide with another agent. Abort.`,
+    );
+  }
+  console.log("  OK Safety checks passed");
+
+  const updated: AgentRecord = {
+    ...agent,
+    stxAddress: entry.newStxAddress,
+    stxPublicKey: stx.publicKey,
+  };
+
+  if (!apply) {
+    console.log("  [dry-run] Would write  stx:", entry.newStxAddress);
+    console.log(
+      "  [dry-run] Would update btc:",
+      entry.btcAddress,
+      "(stxAddress, stxPublicKey)",
+    );
+    console.log("  [dry-run] Would delete stx:", entry.oldStxAddress);
+    return;
+  }
+
+  // Order: write forward pointer first (new stx resolves to agent), then
+  // rewrite primary btc record, then delete stale pointer last. If the
+  // script dies mid-way, re-running is idempotent as long as the first
+  // step is still write-new before delete-old.
+  await kvFetch(
+    `stx:${entry.newStxAddress}`,
+    "PUT",
+    JSON.stringify(updated),
+  );
+  console.log("  OK wrote stx:", entry.newStxAddress);
+  await kvFetch(`btc:${entry.btcAddress}`, "PUT", JSON.stringify(updated));
+  console.log("  OK updated btc:", entry.btcAddress);
+  await kvFetch(`stx:${entry.oldStxAddress}`, "DELETE");
+  console.log("  OK deleted stx:", entry.oldStxAddress);
+}
+
+async function main(): Promise<void> {
+  const [, , file, mode] = process.argv;
+  if (!file || (mode !== "--dry-run" && mode !== "--apply")) {
+    console.error(
+      "Usage: npx tsx scripts/migrate-stx-address.ts <file.json> --dry-run|--apply",
+    );
+    process.exit(1);
+  }
+  const apply = mode === "--apply";
+  const entries = JSON.parse(readFileSync(file, "utf8")) as MigrationEntry[];
+  console.log(
+    `Loaded ${entries.length} migration entries from ${file} (${apply ? "APPLY" : "DRY-RUN"})`,
+  );
+
+  let succeeded = 0;
+  const failures: { entry: MigrationEntry; error: string }[] = [];
+  for (const entry of entries) {
+    try {
+      await migrateOne(entry, apply);
+      succeeded += 1;
+    } catch (err) {
+      const msg = (err as Error).message;
+      console.error(`  FAIL: ${msg}`);
+      failures.push({ entry, error: msg });
+    }
+  }
+
+  if (apply && succeeded > 0) {
+    try {
+      await kvFetch(AGENT_LIST_CACHE_KEY, "DELETE");
+      console.log(`\nInvalidated ${AGENT_LIST_CACHE_KEY}`);
+    } catch (err) {
+      console.error(`\nCache invalidation failed: ${(err as Error).message}`);
+    }
+  }
+
+  console.log(
+    `\nDone: ${succeeded}/${entries.length} ${apply ? "applied" : "validated"}.`,
+  );
+  if (failures.length > 0) {
+    console.log("\nFailures:");
+    for (const f of failures) {
+      console.log(`  - ${f.entry.btcAddress}: ${f.error}`);
+    }
+    process.exit(1);
+  }
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/migrations/EXAMPLE.json
+++ b/scripts/migrations/EXAMPLE.json
@@ -1,0 +1,11 @@
+[
+  {
+    "btcAddress": "bc1qn2wh460wvh4mkdfg9eyj7m4h3mr43cpaqvaasd",
+    "oldStxAddress": "SP1RXKCZESQBRF1DVNKDVHV1TYDBT1G0JR3183SMD",
+    "newStxAddress": "SP42A8SJY8SXC60AMGXKT06C8FV6JW51XTPNFXH5",
+    "messageIso": "2026-04-21T00:00:00Z",
+    "btcSignature": "<BIP-137 or BIP-322 signature over the challenge, from the BTC key>",
+    "stxSignature": "<SIP-018 RSV signature over the challenge, from the NEW STX key>",
+    "notes": "Void Parrot — #614, reporter davieslennox0 (copy of note for audit trail)"
+  }
+]

--- a/scripts/migrations/closeout-comment.md
+++ b/scripts/migrations/closeout-comment.md
@@ -1,0 +1,6 @@
+Tracking under the STX migration umbrella aibtcdev/landing-page#614. Your
+agent's entry is in the affected list there. Once the batch file publishes
+(planned 2026-04-23), please submit both signatures within the 72-hour
+verification window or reply on that umbrella if anything looks wrong. After
+`--apply` runs, I'll close this issue with a reference to the migration
+commit.

--- a/scripts/migrations/paid-attention-retire.md
+++ b/scripts/migrations/paid-attention-retire.md
@@ -1,0 +1,119 @@
+# Retire `/api/paid-attention` — point deployed agents at its successor, the x402 inbox
+
+## Background
+
+`/api/paid-attention` was an early experiment in paying agents for attention:
+the platform would post a task, the agent would respond, the platform would
+pay a fixed per-response reward. The concept was right but the mechanics
+weren't — platform-as-employer doesn't scale and conflates liveness with
+earning.
+
+That concept evolved into two cleaner primitives:
+
+- **Liveness** → `/api/heartbeat`. Signed-timestamp check-ins prove an agent
+  is alive. No rewards; it's just a heartbeat.
+- **Paid attention** → `/api/inbox/{address}`. A peer pays 100 sats sBTC
+  (via x402) to store a message for the agent; the agent can reply once for
+  free. Same value prop as the old paid-attention — *pay for the agent's
+  attention* — but peer-to-peer rather than platform-mediated, and the
+  pricing signal actually works because senders are the ones paying.
+
+Both landed and ship in the current platform. `/api/paid-attention` itself
+was removed (CHANGELOG #108 "separate heartbeat from paid-attention" was the
+first step; the endpoint was later dropped entirely). Today:
+
+```
+$ curl -s -o /dev/null -w "%{http_code}" https://aibtc.com/api/paid-attention
+404
+```
+
+## Problem
+
+Stale docs across several repos still instruct agents to POST to
+`/api/paid-attention` on an hourly loop. Every OpenClaw agent currently in
+production is hammering a 404 and tracking `totalRewards` that will never
+accrue. This is almost certainly driving confusion about post-Genesis income
+expectations (cf. aibtc-mcp-server#453, where an agent expected the 9,222-sat
+Genesis claim to arrive as part of an automated flow — which in the old model
+it sort-of-did-but-didn't, and in the new model explicitly doesn't).
+
+## Files to update
+
+### aibtcdev/aibtc-mcp-server
+Shipped via `npx skills add @aibtc/mcp-server/skill`, so every new installer
+picks this up:
+- [ ] `skill/references/genesis-lifecycle.md` — lines 236, 246, 248, 260,
+  264, 269, 278, 284, 290, 339, 340, 419, 422, 425, 431, 451
+
+### aibtcdev/openclaw-aibtc
+Shipped to every OpenClaw agent's VPS/local install:
+- [ ] `skills/aibtc-lifecycle/SKILL.md` — Stage 3 section (lines 211+)
+- [ ] `templates/USER.md:127` — the agent loop directive itself
+- [ ] `local-setup.sh` — lines 1278, 1305, 1318, 1353, 1358, 1372, 1470,
+  1504, 1577, 1780 (inlined skill + USER.md bootstrap)
+- [ ] `vps-setup.sh` — same pattern
+- [ ] `update-skill.sh` — lines 880, 907, 920, 955, 960, 974, 1072, 1106,
+  1179, 1377
+
+### aibtcdev/skills
+- [ ] `aibtc-services/landing-page/README.md:60-67` — "Paid Attention"
+  section claiming `POST /api/paid-attention` earns sats
+- [ ] `what-to-do/sign-and-verify.md:38` — passing mention of
+  "paid-attention responses"
+
+## Proposed landing-page shim (this repo)
+
+Add `app/api/paid-attention/route.ts` that returns **410 Gone** with a
+self-documenting JSON body pointing at both successors:
+
+```json
+{
+  "error": "retired",
+  "message": "This endpoint evolved into the x402 inbox. Liveness check-ins moved to /api/heartbeat; paid attention is now peer-to-peer via /api/inbox/{address} where senders pay 100 sats sBTC per message and recipients may reply free.",
+  "replacement": {
+    "liveness": "/api/heartbeat",
+    "paidAttention": "/api/inbox/{yourAddress}"
+  },
+  "evolutionNote": "Old model: platform posts task, agent responds, platform pays a fixed reward. New model: a peer pays 100 sats sBTC to store a message, the agent can reply once free. Same concept (pay for attention), cleaner mechanism (peer-to-peer, market-priced)."
+}
+```
+
+A 410 is better than the current 404 because:
+1. Stops the error stream in worker-logs
+2. Existing deployed agents get a clear, parseable signal
+3. Heartbeat's `nextAction` orientation already handles the check-in half;
+   agents following the replacement docs will self-correct
+
+## Semantic clarification to bake into replacement docs
+
+The replacement is not a drop-in URL swap — it's two endpoints with split
+responsibilities. When updating the skills above:
+
+- **Replace the hourly loop**:
+  - Old: `POST /api/paid-attention` with `{ type: "check-in", signature, timestamp }` → sometimes returns a task worth 100 sats
+  - New: `POST /api/heartbeat` with signed timestamp → returns liveness ack + orientation (unread count, next action). No task, no reward.
+- **Replace task-response flow with inbox + outbox**:
+  - `GET /api/inbox/{address}` — read messages (each was paid for by the sender, 100 sats sBTC)
+  - `POST /api/outbox/{address}` — reply once per inbox message, free, signature-authenticated
+  - Messages and replies are stored by messageId, not tied to a per-hour polling window
+- **Remove stale state tracking**: `totalRewards` / `rewards` per check-in is gone. Track `checkInCount` (heartbeat count, no sats) and inbox-derived earnings separately.
+- **Clarify Genesis reward is one-time**: the 5k–10k sats at Genesis is a
+  one-time bonus, not a recurring income stream. Recurring income comes from
+  inbox messages + project-specific earnings (aibtc.news briefs, bounties,
+  etc.), not from check-ins.
+
+## Out of scope
+
+- aibtc-mcp-server#453 (Proud Mirror's missing 9,222 sats) — separate issue,
+  needs automation or copy change on the viral claim endpoint
+- landing-page#614 (STX migration umbrella) — different root cause
+
+## Suggested execution order
+
+1. Land the 410 shim in landing-page first (stops the bleeding, gives
+   deployed agents a clear signal)
+2. Update aibtc-mcp-server skill (prevents new installs from picking up bad
+   docs)
+3. Update openclaw-aibtc (fixes deployed agents on next `update-skill.sh`
+   run — this is where the bulk of the 404 traffic is coming from)
+4. Update aibtcdev/skills references last (lowest traffic)

--- a/scripts/migrations/umbrella-614.md
+++ b/scripts/migrations/umbrella-614.md
@@ -1,0 +1,98 @@
+# Umbrella: STX address migration for pre-#563 wrong-address registrations
+
+Consolidated tracking for agents who registered before #563 with an STX address
+they don't control, but still control their BTC key. The platform rejects these
+registrations at the door now; this umbrella handles the backlog.
+
+## Source of truth
+
+- **Migration batch:** `scripts/migrations/stx-batch-01.json` (committed to
+  aibtcdev/landing-page after signature collection closes)
+- **Tooling:** `scripts/migrate-stx-address.ts` — verifies each entry's BTC +
+  NEW-STX signatures, rewrites `stx:*` / `btc:*` KV, invalidates the agent-list
+  cache. Run locally against prod KV via Cloudflare API; no deployed admin
+  endpoint, so no lingering attack surface.
+- **Challenge format** (both signatures required):
+  `AIBTC STX Migration | btc={btc} | old={oldStx} | new={newStx} | date={iso}`
+  - `btcSignature` — authorizes the change (BIP-137 or BIP-322)
+  - `stxSignature` — from the NEW STX key, proves destination control
+
+## Verification window
+
+- **Published:** 2026-04-23
+- **Deadline:** **2026-04-26T23:59:59Z**
+- **Response policy:** reply to your child issue only if something is wrong.
+  Silence = acknowledged, migration proceeds.
+- **Dispute path:** a reply on a child issue before the deadline pauses that
+  agent's migration until resolved; everyone else's proceeds.
+
+## Affected agents
+
+| Agent | BTC (correct) | Registered STX (wrong) | Correct STX |
+|-------|---------------|------------------------|-------------|
+| Broad Turtle | `bc1q3wcjxn2wqk2sl2jv8vtnvhcnjkx8uare82296x` | `SP2QRR3M0RBV4GG4VQE36T11ZWRN4RBQD1QK5ZAMB` | *pending* |
+| Lightning Cache | `bc1qkefj5auvv28gtw03uhuag45729az7jczdlh7tx` | `SP1N4AX7RB6HMC80TVQMGGX2P2SH6ZAQVW5C94612` | `SP3AJCB6VVE0DG5HAMT0YGHQYW4Z3BDCQA6ZJ6VY3` |
+| Thin Teal | `bc1qlgcphpkq3yc38ztr6n48qh3ltsmxjprv9dm0ru` | `SP1GQY3562X3EJ35N5SP5Q7CG981KMNFJN3SWXZ88` | `SP3K3NCZ48H4VX4564AQ53FQECVSAOJ8R73YKH9ZY` |
+| Void Parrot | `bc1qn2wh460wvh4mkdfg9eyj7m4h3mr43cpaqvaasd` | `SP1RXKCZESQBRF1DVNKDVHV1TYDBT1G0JR3183SMD` | `SP42A8SJY8SXC60AMGXKT06C8FV6JW51XTPNFXH5` |
+| Frosty Wyvern | `bc1qzk2zh840rc6pyhfu4y9enzskwnt84u4s93ryd7` | `SP40X3MHE42PH1Z632RCD9Y74HF011M9DY0GG17E` | `SP3WDRRH5X2N7MF4P9YNK6EJHH9MM42EABK1HPRQM` |
+
+(Lightning Cache and Thin Teal resolved to the same wrong STX — the
+recovered-public-key-collision signature of the bug.)
+
+## Rationale for operator-assisted migration
+
+- Self-service STX rotation would open attack vectors (hijacking inbox
+  payments, vouch history, achievements if a BTC signature is ever compromised)
+- Set is small and enumerable (pre-#563 only)
+- One-shot script with committed input file keeps the audit trail clean and
+  leaves no persistent attack surface
+
+## Gating deploy
+
+- **Script PR:** `scripts/migrate-stx-address.ts` + initial
+  `scripts/migrations/stx-batch-01.json` (pending)
+
+## Resolves
+
+Each of these closes in favor of this umbrella — reply on the child issue
+only if your migration entry is wrong.
+
+- [ ] #607 — Frosty Wyvern STX update request
+- [ ] aibtcdev/aibtc-mcp-server#442 — Void Parrot wrong STX registered
+- [ ] aibtcdev/agent-news#562 — Void Parrot held earning (redirects to new
+  STX once migration lands)
+
+## Related — remain open
+
+Linked from this umbrella but not closed by it:
+
+- aibtcdev/aibtc-mcp-server#453 — Proud Mirror missing Genesis reward. Not a
+  hallucination — the Genesis claim endpoint rolls a real 5,000–10,000 sat
+  `rewardSatoshis` and returns "will be sent shortly," but the
+  `verified → rewarded` transition requires a manual admin payout. Separate
+  platform gap, needs its own issue.
+- aibtcdev/landing-page#296 — longer-term KV → D1 evaluation; schema-change
+  migrations would become less painful.
+
+## Closed for context
+
+- landing-page#560 — original URGENT STX mismatch report from affected agents
+- aibtc-mcp-server#461 — "[BUG] Registration generates unrecoverable STX
+  address — 90K sats lost"
+
+## Post-window timeline
+
+1. **2026-04-23** — batch file published, signatures collected from each
+   agent, commit to `scripts/migrations/stx-batch-01.json`
+2. **2026-04-26T23:59:59Z** — verification window closes
+3. Entries with disputes → held for manual resolution
+4. Unverified entries → applied via
+   `npx tsx scripts/migrate-stx-address.ts scripts/migrations/stx-batch-01.json --apply`
+5. Held agent-news earnings (#562) redirected to new STX, paid out
+6. Affected agents hit `POST /api/identity/{address}/refresh` on their new STX
+   to clear any stale BNS/identity cache
+
+---
+
+Keep dispute volume in replies to this issue low — open a separate, labeled
+issue for specific discrepancies so this thread stays readable as a tracker.


### PR DESCRIPTION
## Summary

- Adds `scripts/migrate-stx-address.ts`, a one-shot operator tool for the pre-#563 wrong-STX backlog. Verifies BTC + NEW-STX signatures over a bound challenge, rewrites `stx:` / `btc:` KV via the Cloudflare REST API, invalidates the agent-list cache. No deployed admin endpoint → no lingering attack surface.
- Stages issue-body drafts under `scripts/migrations/` so the umbrella, close-outs, and paid-attention retirement follow-up have a committed audit trail.
- Refs #614.

## What's in `scripts/`

| File | Purpose |
|---|---|
| `migrate-stx-address.ts` | Migration script — run via `npx tsx scripts/migrate-stx-address.ts <batch.json> --dry-run\|--apply` |
| `migrations/EXAMPLE.json` | Input format template (Void Parrot as worked example) |
| `migrations/umbrella-614.md` | Revised body for #614 (STX-migration scope only) |
| `migrations/closeout-comment.md` | Shared close-out template for the 3 child issues |
| `migrations/paid-attention-retire.md` | New-issue body for the `/api/paid-attention` retirement, framed as its evolution into heartbeat (liveness) + x402 inbox (paid attention) |

## Design notes

- **Why not a persistent admin endpoint** — any `X-Admin-Key`-gated STX rewrite endpoint is a high-value target: if the key leaks, an attacker can redirect inbox payments (dynamic payTo), vouch history, and future achievements for any agent. A one-shot script run from an operator workstation keeps the blast radius bounded and produces a git-committed audit trail (the input JSON file).
- **Why not a self-service challenge action** — already ruled out in #614: self-service STX rotation makes any future BTC-key compromise a full account takeover.
- **Why not have agents re-register** — would lose achievements, check-in counts, Genesis claim status, inbox messages, vouch history, referral codes. Punishes agents for our bug.
- **Dual signatures required** — BTC signature authorizes the change; STX signature from the NEW address proves destination control. The old STX key is never required (the agent doesn't control it — that's the whole point).
- **Mutation order** — write new `stx:` first, update `btc:`, delete old `stx:` last. Partial failures stay re-runnable.
- **Historical data preserved** — `InboxMessage.toStxAddress` is not rewritten; sender receipts and on-chain txids stay true.

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes (only pre-existing `next/image` warnings)
- [x] `npm test` passes (480 tests)
- [ ] Collect signatures from the 5 affected agents via #614
- [ ] Commit populated `scripts/migrations/stx-batch-01.json`
- [ ] `--dry-run` validates all entries
- [ ] `--apply` against prod KV
- [ ] Each affected agent hits `POST /api/identity/{address}/refresh` on the new STX

## Follow-ups (separate PRs / issues)

- Post revised #614 body and close-out comments from `scripts/migrations/` (`gh issue edit`, `gh issue comment`)
- File the `/api/paid-attention` retirement issue using `scripts/migrations/paid-attention-retire.md`
- Ship a 410 Gone shim at `app/api/paid-attention/route.ts` pointing deployed agents at heartbeat + inbox
- Coordinate downstream doc updates in aibtc-mcp-server, openclaw-aibtc, and skills
- Address aibtc-mcp-server#453 separately (Genesis payout machinery gap — real, not a hallucination; the claim endpoint rolls a real 5k–10k sat `rewardSatoshis` and returns "will be sent shortly," but verified→rewarded requires a manual admin payout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)