### PR TITLE
fix(inbox): validate payment-signature payload to prevent 500 on malformed input

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1042,7 +1042,6 @@ export async function POST(
   // Parse and validate payment signature (base64-encoded JSON per x402 v2, with plain JSON fallback)
   // Uses HttpPaymentPayloadSchema.safeParse to catch structurally invalid payloads before
   // downstream code touches optional fields like `accepted.asset` (prevents #629 TypeError).
-  let paymentPayload: PaymentPayloadV2;
   let decodedPaymentJson: unknown;
   let usedFallback = false;
   try {
@@ -1077,7 +1076,10 @@ export async function POST(
       { status: 400 }
     );
   }
-  paymentPayload = parsedPaymentPayload.data as PaymentPayloadV2;
+  // Keep the inferred schema type locally so `accepted` remains optional at every
+  // access site in this handler — TS will reject `paymentPayload.accepted.asset`
+  // without optional chaining, which is exactly the #629 regression this PR fixes.
+  const paymentPayload = parsedPaymentPayload.data;
 
   if (usedFallback) {
     logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
@@ -1094,8 +1096,11 @@ export async function POST(
     recipientStx: agent.stxAddress,
   });
 
+  // HttpPaymentPayloadSchema is a validated subset of PaymentPayloadV2 (the x402-stacks
+  // vendor type, which incorrectly declares `accepted` required). Bridge at this single
+  // boundary rather than leaking the vendor type back up through the handler.
   const paymentResult = await verifyInboxPayment(
-    paymentPayload,
+    paymentPayload as unknown as PaymentPayloadV2,
     agent.stxAddress,
     network,
     relayUrl,

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -27,6 +27,7 @@ import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { hasAchievement, grantAchievement } from "@/lib/achievements";
 import { networkToCAIP2, X402_HEADERS } from "x402-stacks";
 import type { PaymentPayloadV2 } from "x402-stacks";
+import { HttpPaymentPayloadSchema } from "@aibtc/tx-schemas/http";
 import {
   getPaymentRepoVersion,
   logPaymentEvent,
@@ -1038,20 +1039,19 @@ export async function POST(
     return NextResponse.json({ error: "Missing payment signature" }, { status: 400 });
   }
 
-  // Parse payment signature (base64-encoded JSON per x402 v2, with plain JSON fallback)
+  // Parse and validate payment signature (base64-encoded JSON per x402 v2, with plain JSON fallback)
+  // Uses HttpPaymentPayloadSchema.safeParse to catch structurally invalid payloads before
+  // downstream code touches optional fields like `accepted.asset` (prevents #629 TypeError).
   let paymentPayload: PaymentPayloadV2;
+  let decodedPaymentJson: unknown;
+  let usedFallback = false;
   try {
     const decoded = atob(paymentSigHeader);
-    paymentPayload = JSON.parse(decoded) as PaymentPayloadV2;
+    decodedPaymentJson = JSON.parse(decoded);
   } catch {
     try {
-      paymentPayload = JSON.parse(paymentSigHeader) as PaymentPayloadV2;
-      logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
-        route: request.nextUrl.pathname,
-        status: "compat",
-        action: "plain_json_payment_signature_header",
-        compatShimUsed: true,
-      });
+      decodedPaymentJson = JSON.parse(paymentSigHeader);
+      usedFallback = true;
     } catch {
       logger.error("Invalid payment signature format");
       return NextResponse.json(
@@ -1062,6 +1062,30 @@ export async function POST(
         { status: 400 }
       );
     }
+  }
+
+  const parsedPaymentPayload = HttpPaymentPayloadSchema.safeParse(decodedPaymentJson);
+  if (!parsedPaymentPayload.success) {
+    logger.warn("Invalid payment-signature payload structure", {
+      issues: parsedPaymentPayload.error.issues,
+    });
+    return NextResponse.json(
+      {
+        error: "invalid_payment_payload",
+        issues: parsedPaymentPayload.error.issues,
+      },
+      { status: 400 }
+    );
+  }
+  paymentPayload = parsedPaymentPayload.data as PaymentPayloadV2;
+
+  if (usedFallback) {
+    logPaymentEvent(logger, "warn", "payment.fallback_used", repoVersion, {
+      route: request.nextUrl.pathname,
+      status: "compat",
+      action: "plain_json_payment_signature_header",
+      compatShimUsed: true,
+    });
   }
 
   // Verify x402 payment

--- a/lib/inbox/__tests__/inbox-payload-validation.test.ts
+++ b/lib/inbox/__tests__/inbox-payload-validation.test.ts
@@ -1,0 +1,120 @@
+/**
+ * Regression tests for issue #629:
+ * POST /api/inbox/[address] returned 500 when the x402 payment-signature header
+ * contained a payload missing the optional `accepted` field.
+ *
+ * These tests exercise:
+ * 1. HttpPaymentPayloadSchema validation logic (mirrors the route's safeParse calls)
+ * 2. Both the base64 decode path and the plain-JSON fallback path
+ */
+
+import { describe, it, expect } from "vitest";
+import { HttpPaymentPayloadSchema } from "@aibtc/tx-schemas/http";
+
+// Minimal valid payload that satisfies the schema (accepted is optional)
+const minimalValidPayload = {
+  payload: { transaction: "0001aabbccdd" },
+};
+
+// Complete payload with the optional accepted field
+const completePayload = {
+  x402Version: 2,
+  accepted: {
+    scheme: "exact",
+    network: "stacks:1",
+    amount: "100",
+    asset: "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sbtc-token::sbtc-token",
+    payTo: "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  },
+  resource: {
+    url: "https://aibtc.com/api/inbox/SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  },
+  payload: {
+    transaction: "0001aabbccdd",
+  },
+};
+
+describe("HttpPaymentPayloadSchema — issue #629 regression", () => {
+  describe("base64 decode path", () => {
+    it("accepts a valid payload without the optional accepted field (base64-encoded)", () => {
+      // Simulates a client that sends only payload.transaction (no accepted)
+      const encoded = btoa(JSON.stringify(minimalValidPayload));
+      const decoded = atob(encoded);
+      const parsed = HttpPaymentPayloadSchema.safeParse(JSON.parse(decoded));
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        // accepted should be undefined since it was not provided
+        expect(parsed.data.accepted).toBeUndefined();
+        expect(parsed.data.payload.transaction).toBe("0001aabbccdd");
+      }
+    });
+
+    it("accepts a fully-populated payload (base64-encoded)", () => {
+      const encoded = btoa(JSON.stringify(completePayload));
+      const decoded = atob(encoded);
+      const parsed = HttpPaymentPayloadSchema.safeParse(JSON.parse(decoded));
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.accepted?.asset).toBe(
+          "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sbtc-token::sbtc-token"
+        );
+      }
+    });
+
+    it("rejects a payload missing the required transaction field", () => {
+      const invalid = { accepted: { scheme: "exact", network: "stacks:1", amount: "100", asset: "X", payTo: "Y" } };
+      const encoded = btoa(JSON.stringify(invalid));
+      const decoded = atob(encoded);
+      const parsed = HttpPaymentPayloadSchema.safeParse(JSON.parse(decoded));
+
+      // schema requires payload.transaction — this should fail
+      expect(parsed.success).toBe(false);
+      if (!parsed.success) {
+        expect(parsed.error.issues.length).toBeGreaterThan(0);
+      }
+    });
+  });
+
+  describe("plain-JSON fallback path", () => {
+    it("accepts a valid payload without the optional accepted field (plain JSON)", () => {
+      // Simulates clients that send plain JSON instead of base64 (compat fallback)
+      const raw = JSON.stringify(minimalValidPayload);
+      const parsed = HttpPaymentPayloadSchema.safeParse(JSON.parse(raw));
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.accepted).toBeUndefined();
+      }
+    });
+
+    it("accepts a fully-populated payload (plain JSON)", () => {
+      const raw = JSON.stringify(completePayload);
+      const parsed = HttpPaymentPayloadSchema.safeParse(JSON.parse(raw));
+
+      expect(parsed.success).toBe(true);
+      if (parsed.success) {
+        expect(parsed.data.payload.transaction).toBe("0001aabbccdd");
+      }
+    });
+
+    it("rejects completely non-JSON input", () => {
+      // Confirm that trying to JSON.parse garbage throws, which the route catches
+      expect(() => JSON.parse("not-json-at-all!!!")).toThrow();
+    });
+  });
+
+  describe("safeParse produces structured issues on failure (confirms 400 path)", () => {
+    it("issues list is non-empty when payload.transaction is missing", () => {
+      const result = HttpPaymentPayloadSchema.safeParse({});
+
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        // Zod issues are surfaced to callers so they can be returned as 400 body
+        expect(Array.isArray(result.error.issues)).toBe(true);
+        expect(result.error.issues.length).toBeGreaterThan(0);
+      }
+    });
+  });
+});

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -179,9 +179,11 @@ describe("inbox POST canonical staged-payment semantics", () => {
 
   function buildRequest(): NextRequest {
     // Build a valid x402 payment-signature header (base64-encoded JSON).
-    // accepted must include all required fields (scheme, network, amount, asset, payTo)
-    // so that HttpPaymentPayloadSchema.safeParse succeeds in the route before reaching
-    // the mocked verifyInboxPayment. verifyInboxPayment is mocked so asset value is irrelevant.
+    // `accepted` is optional overall, but if it is provided it must include the
+    // schema-required fields (scheme, network, amount, asset, payTo). This test
+    // includes `accepted` so HttpPaymentPayloadSchema.safeParse succeeds before
+    // reaching the mocked verifyInboxPayment; since verifyInboxPayment is mocked,
+    // the specific asset value is irrelevant here.
     const paymentPayload = {
       payload: { transaction: "a".repeat(64) },
       accepted: {

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -178,11 +178,20 @@ describe("inbox POST canonical staged-payment semantics", () => {
   });
 
   function buildRequest(): NextRequest {
-    // Build a valid x402 payment-signature header (base64-encoded JSON)
+    // Build a valid x402 payment-signature header (base64-encoded JSON).
+    // accepted must include all required fields (scheme, network, amount, asset, payTo)
+    // so that HttpPaymentPayloadSchema.safeParse succeeds in the route before reaching
+    // the mocked verifyInboxPayment. verifyInboxPayment is mocked so asset value is irrelevant.
     const paymentPayload = {
       payload: { transaction: "a".repeat(64) },
-      accepted: { asset: `eip155:1/slip44:5757::${RECIPIENT_STX}.sbtc-token::sbtc` },
-      resource: { url: `https://aibtc.com/api/inbox/${RECIPIENT_BTC}`, network: networkToCAIP2(NETWORK) },
+      accepted: {
+        scheme: "exact",
+        network: networkToCAIP2(NETWORK),
+        amount: "100",
+        asset: `SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sbtc-token::sbtc-token`,
+        payTo: RECIPIENT_STX,
+      },
+      resource: { url: `https://aibtc.com/api/inbox/${RECIPIENT_BTC}` },
     };
     const paymentSigHeader = btoa(JSON.stringify(paymentPayload));
 

--- a/lib/inbox/__tests__/x402-verify.test.ts
+++ b/lib/inbox/__tests__/x402-verify.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { verifyInboxPayment, isRelayTimeout } from "../x402-verify";
 import type { PaymentPayloadV2 } from "x402-stacks";
-import { networkToCAIP2 } from "x402-stacks";
+import { networkToCAIP2, X402_ERROR_CODES } from "x402-stacks";
 import { getSBTCAsset } from "../x402-config";
 
 describe("verifyInboxPayment", () => {
@@ -105,6 +105,33 @@ describe("verifyInboxPayment", () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toBe("Inbox messages require sBTC payment");
+    });
+  });
+
+  describe("accepted: undefined regression (#629)", () => {
+    it("returns INVALID_PAYLOAD (not TypeError) when accepted field is absent", async () => {
+      // Regression test for issue #629: pollers and some clients omit `accepted` entirely.
+      // Before the fix, paymentPayload.accepted.asset threw:
+      //   TypeError: Cannot read properties of undefined (reading 'asset')
+      // After the fix, optional chaining returns undefined and the check rejects cleanly.
+      const payload = {
+        payload: { transaction: "0030aabbccdd" },
+        // `accepted` deliberately absent
+        resource: { url: `https://aibtc.com/api/inbox/test`, network: networkCAIP2 },
+      } as unknown as PaymentPayloadV2;
+
+      // Must not throw — must return a structured error result
+      const result = await verifyInboxPayment(
+        payload,
+        recipientStxAddress,
+        network,
+        "https://fake-relay.test"
+      );
+
+      expect(result.success).toBe(false);
+      // The sBTC-asset guard fires first (accepted?.asset is undefined !== expectedAsset)
+      expect(result.error).toBe("Inbox messages require sBTC payment");
+      expect(result.errorCode).toBe(X402_ERROR_CODES.INVALID_PAYLOAD);
     });
   });
 });

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -408,8 +408,8 @@ export async function verifyInboxPayment(
   });
 
   // Check if payment is in sBTC (v2: check accepted.asset and payload.transaction)
-  // accepted is optional in the x402 v2 wire format; use optional chaining to avoid
-  // TypeError when the field is absent (defense-in-depth; route validates first).
+  // `accepted` is optional in the x402 v2 wire format; use optional chaining to avoid
+  // TypeError when the field is absent and defensively handle that case here.
   if (
     !paymentPayload.payload?.transaction ||
     paymentPayload.accepted?.asset !== expectedAsset

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -408,12 +408,14 @@ export async function verifyInboxPayment(
   });
 
   // Check if payment is in sBTC (v2: check accepted.asset and payload.transaction)
+  // accepted is optional in the x402 v2 wire format; use optional chaining to avoid
+  // TypeError when the field is absent (defense-in-depth; route validates first).
   if (
     !paymentPayload.payload?.transaction ||
-    paymentPayload.accepted.asset !== expectedAsset
+    paymentPayload.accepted?.asset !== expectedAsset
   ) {
     log.warn("Payment rejected: not sBTC", {
-      acceptedAsset: paymentPayload.accepted.asset,
+      acceptedAsset: paymentPayload.accepted?.asset,
       expectedAsset,
     });
     return {


### PR DESCRIPTION
## Summary

Closes #629

**Root cause**: `POST /api/inbox/[address]` was crashing ~3x/day with:

```
TypeError: Cannot read properties of undefined (reading 'asset')
```

The `payment-signature` header was decoded and passed through two bare `JSON.parse(...) as PaymentPayloadV2` casts. When a poller or client sent a payload missing the optional `accepted` field, the expression `paymentPayload.accepted.asset` in `lib/inbox/x402-verify.ts:413` threw an uncaught TypeError that escaped the route handler and became a 500.

**Fix** (two changes):

1. **Route-level validation** (`app/api/inbox/[address]/route.ts`, lines 1043-1065): Replace both `JSON.parse as` casts (base64 path + plain-JSON fallback) with `HttpPaymentPayloadSchema.safeParse()` from `@aibtc/tx-schemas/http`. Malformed payloads now return **400** `{ error: "invalid_payment_payload", issues: [...] }` before reaching `verifyInboxPayment`. Logged at `warn` (client error, not server error). Mirrors the pattern already used in `relay-rpc.ts`, `payment-contract.ts`, and `reconcile-staged-payment.ts`.

2. **Defense-in-depth** (`lib/inbox/x402-verify.ts:413,416`): Changed `paymentPayload.accepted.asset` → `paymentPayload.accepted?.asset` with optional chaining. The library function no longer throws on an optional field regardless of call-site validation.

## Files changed

- `app/api/inbox/[address]/route.ts` — safeParse replaces both cast paths; new `invalid_payment_payload` 400 response
- `lib/inbox/x402-verify.ts` — optional chaining on `accepted?.asset`
- `lib/inbox/__tests__/x402-verify.test.ts` — new `accepted: undefined` regression test
- `lib/inbox/__tests__/inbox-payload-validation.test.ts` — new schema validation unit tests for both parse paths
- `lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts` — updated `buildRequest()` to supply all required `accepted` fields so existing tests pass the new schema validation gate

## Notes

- **No dep bump** — `@aibtc/tx-schemas` stays at `^0.3.0`. The `HttpPaymentPayloadSchema` and its optional `accepted` field are already present in 0.3.0. Phase 2 (`chore/deps-tx-schemas-1.0.0`) handles the 1.0.0 upgrade.
- The pre-existing tests in `inbox-pending-no-paymentid.test.ts` were silently constructing an invalid `accepted` object (missing `scheme`, `network`, `amount`, `payTo`). The new validation gate surfaced this; those tests are fixed to supply a complete `accepted` shape (the mocked `verifyInboxPayment` ignores the actual asset value).

## Test plan

- [x] `npm run lint` — clean (pre-existing img warnings only)
- [x] `npm run test` — 488/488 pass
- [x] `npm run build` — succeeds
- [x] `npm run deploy:dry-run` — publishes cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)