### PR TITLE
fix(stacks-api): warn on monthly quota only, drop per-window noise

### DIFF
--- a/lib/__tests__/stacks-api-fetch.test.ts
+++ b/lib/__tests__/stacks-api-fetch.test.ts
@@ -37,45 +37,15 @@ describe("stacksApiFetch logger telemetry", () => {
     mockFetch.mockClear();
   });
 
-  it("emits stacksApi.rate_limit_remaining on every parseable response", async () => {
-    const logger = createMockLogger();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      status: 200,
-      url: "https://api.mainnet.hiro.so/v2/contracts/call-read/foo/bar/baz",
-      headers: mockHeaders({
-        "ratelimit-remaining": "123",
-        "ratelimit-limit": "500",
-        "ratelimit-reset": "42",
-      }),
-    });
-
-    await stacksApiFetch(
-      "https://api.mainnet.hiro.so/v2/contracts/call-read/foo/bar/baz",
-      {},
-      { logger }
-    );
-
-    const rlEvents = logger._events.filter(
-      (e) => e.message === "stacksApi.rate_limit_remaining"
-    );
-    expect(rlEvents).toHaveLength(1);
-    expect(rlEvents[0].context).toMatchObject({
-      path: "/v2/contracts/call-read/foo/bar/baz",
-      rlRemaining: 123,
-      rlLimit: 500,
-    });
-  });
-
-  it("emits stacksApi.approaching_rate_limit when remaining < 50", async () => {
+  it("emits stacksApi.approaching_monthly_quota when monthly remaining < 20% of limit", async () => {
     const logger = createMockLogger();
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
       url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
       headers: mockHeaders({
-        "ratelimit-remaining": "10",
-        "ratelimit-limit": "500",
+        "x-ratelimit-remaining-stacks-month": "20000",
+        "x-ratelimit-limit-stacks-month": "150000",
       }),
     });
 
@@ -86,23 +56,27 @@ describe("stacksApiFetch logger telemetry", () => {
     );
 
     const approaching = logger._events.filter(
-      (e) => e.message === "stacksApi.approaching_rate_limit"
+      (e) => e.message === "stacksApi.approaching_monthly_quota"
     );
     expect(approaching).toHaveLength(1);
     expect(approaching[0].level).toBe("warn");
     expect(approaching[0].context).toMatchObject({
-      rlRemaining: 10,
-      threshold: 50,
+      rlRemainingMonth: 20000,
+      rlLimitMonth: 150000,
+      threshold: 0.2,
     });
   });
 
-  it("does NOT emit approaching_rate_limit when remaining >= 50", async () => {
+  it("does NOT emit approaching_monthly_quota when monthly remaining >= 20% of limit", async () => {
     const logger = createMockLogger();
     mockFetch.mockResolvedValue({
       ok: true,
       status: 200,
       url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
-      headers: mockHeaders({ "ratelimit-remaining": "100" }),
+      headers: mockHeaders({
+        "x-ratelimit-remaining-stacks-month": "75000",
+        "x-ratelimit-limit-stacks-month": "150000",
+      }),
     });
 
     await stacksApiFetch(
@@ -112,7 +86,28 @@ describe("stacksApiFetch logger telemetry", () => {
     );
 
     const approaching = logger._events.filter(
-      (e) => e.message === "stacksApi.approaching_rate_limit"
+      (e) => e.message === "stacksApi.approaching_monthly_quota"
+    );
+    expect(approaching).toHaveLength(0);
+  });
+
+  it("does NOT emit approaching_monthly_quota when monthly headers are absent", async () => {
+    const logger = createMockLogger();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      url: "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      headers: mockHeaders({ "ratelimit-remaining": "5" }),
+    });
+
+    await stacksApiFetch(
+      "https://api.mainnet.hiro.so/extended/v1/tx/0xabc",
+      {},
+      { logger }
+    );
+
+    const approaching = logger._events.filter(
+      (e) => e.message === "stacksApi.approaching_monthly_quota"
     );
     expect(approaching).toHaveLength(0);
   });
@@ -180,17 +175,19 @@ describe("stacksApiFetch logger telemetry", () => {
     expect(rateLimited?.context).toMatchObject({ cfRay: "abc123" });
   });
 
-  it("extractRateLimitInfo returns parsed fields even without logger", () => {
+  it("extractRateLimitInfo returns parsed monthly fields even without logger", () => {
     const response = {
       url: "https://api.mainnet.hiro.so/x",
       headers: mockHeaders({
-        "ratelimit-remaining": "42",
-        "ratelimit-limit": "500",
+        "x-ratelimit-remaining-stacks-month": "120000",
+        "x-ratelimit-limit-stacks-month": "150000",
+        "x-ratelimit-cost-stacks": "1",
       }),
     } as unknown as Response;
 
     const info = extractRateLimitInfo(response);
-    expect(info.remaining).toBe(42);
-    expect(info.limit).toBe(500);
+    expect(info.remainingMonth).toBe(120000);
+    expect(info.limitMonth).toBe(150000);
+    expect(info.costStacks).toBe(1);
   });
 });

--- a/lib/stacks-api-fetch.ts
+++ b/lib/stacks-api-fetch.ts
@@ -66,40 +66,39 @@ export function detect429(
   return { isRateLimited };
 }
 
-/** Rate limit warning threshold — warn when remaining drops below this value. */
-const RATE_LIMIT_WARN_THRESHOLD = 50;
+/**
+ * Warn when monthly remaining drops below this fraction of the monthly limit.
+ * Percentage-based so it adapts to whichever plan tier the API key is on.
+ */
+const MONTHLY_QUOTA_WARN_FRACTION = 0.2;
 
-/** Parsed Hiro API rate limit headers from a response. */
+/** Parsed Hiro API monthly rate limit headers from a response. */
 export interface RateLimitInfo {
-  /** Remaining requests in the current window (ratelimit-remaining). */
-  remaining: number | null;
-  /** Total request budget for the current window (ratelimit-limit). */
-  limit: number | null;
-  /** Seconds until the current window resets (ratelimit-reset). */
-  reset: number | null;
-  /** Remaining per-minute request budget (x-ratelimit-remaining-stacks-minute). */
-  remainingMinute: number | null;
+  /** Remaining requests this month (x-ratelimit-remaining-stacks-month). */
+  remainingMonth: number | null;
+  /** Monthly request ceiling (x-ratelimit-limit-stacks-month). */
+  limitMonth: number | null;
   /** API cost units consumed by this request (x-ratelimit-cost-stacks). */
   costStacks: number | null;
 }
 
 /**
- * Extract Hiro API rate limit headers from a response.
+ * Extract Hiro API monthly quota headers from a response and warn when low.
  *
- * Reads ratelimit-remaining, ratelimit-limit, ratelimit-reset,
- * x-ratelimit-remaining-stacks-minute, and x-ratelimit-cost-stacks.
+ * Per-second / per-minute headers are intentionally ignored — short-window
+ * 429s are already absorbed by the retry logic in {@link stacksApiFetch}, so
+ * surfacing them as warns just creates noise. The monthly quota, by contrast,
+ * is the signal that actually requires action (plan upgrade or traffic shed).
  *
- * When a logger is provided, emits two structured events:
- * - `stacksApi.rate_limit_remaining` on every parseable response (for tracking
- *   how the remaining budget trends as cache hit rates rise).
- * - `stacksApi.approaching_rate_limit` (warn level) when remaining drops below
- *   RATE_LIMIT_WARN_THRESHOLD (50), so operators are alerted before key
- *   exhaustion.
+ * Emits `stacksApi.approaching_monthly_quota` (warn) when remaining drops
+ * below {@link MONTHLY_QUOTA_WARN_FRACTION} of the monthly limit. Once
+ * triggered it will fire on every subsequent call until the month rolls over;
+ * dedupe at the alerting layer if needed.
  *
  * @param response - The Response object from a Hiro API fetch
- * @param logger - Optional Logger for emitting rate-limit telemetry
+ * @param logger - Optional Logger for emitting the warn event
  * @param path - Optional precomputed pathname (avoids re-parsing response.url)
- * @returns Parsed rate limit fields (null for any header that is absent or unparseable)
+ * @returns Parsed monthly quota fields (null for any header absent or unparseable)
  */
 export function extractRateLimitInfo(
   response: Response,
@@ -113,35 +112,26 @@ export function extractRateLimitInfo(
     return isNaN(n) ? null : n;
   }
 
-  const remaining = parseIntHeader("ratelimit-remaining");
-  const limit = parseIntHeader("ratelimit-limit");
-  const reset = parseIntHeader("ratelimit-reset");
-  const remainingMinute = parseIntHeader("x-ratelimit-remaining-stacks-minute");
+  const remainingMonth = parseIntHeader("x-ratelimit-remaining-stacks-month");
+  const limitMonth = parseIntHeader("x-ratelimit-limit-stacks-month");
   const costStacks = parseIntHeader("x-ratelimit-cost-stacks");
 
-  if (logger && remaining !== null) {
-    const resolvedPath = path ?? extractPath(response.url);
-    logger.info("stacksApi.rate_limit_remaining", {
-      path: resolvedPath,
-      rlRemaining: remaining,
-      ...(limit !== null ? { rlLimit: limit } : {}),
-      ...(reset !== null ? { rlReset: reset } : {}),
-      ...(remainingMinute !== null ? { rlRemainingMinute: remainingMinute } : {}),
-      ...(costStacks !== null ? { rlCostStacks: costStacks } : {}),
+  if (
+    logger &&
+    remainingMonth !== null &&
+    limitMonth !== null &&
+    limitMonth > 0 &&
+    remainingMonth / limitMonth < MONTHLY_QUOTA_WARN_FRACTION
+  ) {
+    logger.warn("stacksApi.approaching_monthly_quota", {
+      path: path ?? extractPath(response.url),
+      rlRemainingMonth: remainingMonth,
+      rlLimitMonth: limitMonth,
+      threshold: MONTHLY_QUOTA_WARN_FRACTION,
     });
-
-    if (remaining < RATE_LIMIT_WARN_THRESHOLD) {
-      logger.warn("stacksApi.approaching_rate_limit", {
-        path: resolvedPath,
-        rlRemaining: remaining,
-        ...(limit !== null ? { rlLimit: limit } : {}),
-        ...(reset !== null ? { rlReset: reset } : {}),
-        threshold: RATE_LIMIT_WARN_THRESHOLD,
-      });
-    }
   }
 
-  return { remaining, limit, reset, remainingMinute, costStacks };
+  return { remainingMonth, limitMonth, costStacks };
 }
 
 /** Per-attempt fetch timeout in milliseconds. */
@@ -191,8 +181,8 @@ export interface StacksApiFetchConfig {
   retries429?: number;
   /**
    * Optional Logger; when provided, emits `stacksApi.*` telemetry events
-   * (rate_limit_remaining, approaching_rate_limit, retry_budget_exhausted,
-   * retrying). Silent when omitted — we do not fall back to `console.*`,
+   * (approaching_monthly_quota, retry_budget_exhausted, retrying). Silent
+   * when omitted — we do not fall back to `console.*`,
    * which would bypass the worker-logs pipeline.
    */
   logger?: Logger;
@@ -252,9 +242,9 @@ export async function stacksApiFetch(
     try {
       const response = await fetch(url, attemptOptions);
 
-      // Extract rate limit info on every response for observability (also emits
-      // stacksApi.rate_limit_remaining / approaching_rate_limit when logger present)
-      const rl = extractRateLimitInfo(response, logger, path);
+      // Side-effect only: emits stacksApi.approaching_monthly_quota when the
+      // logger is present and the monthly remaining drops below the threshold.
+      extractRateLimitInfo(response, logger, path);
 
       if (!isRetryableStatus(response.status)) {
         return response;
@@ -272,8 +262,6 @@ export async function stacksApiFetch(
             status: 429,
             attempts: retries429,
             budget: "429",
-            ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
-            ...(rl.limit !== null ? { rlLimit: rl.limit } : {}),
           });
           return response;
         }
@@ -290,7 +278,6 @@ export async function stacksApiFetch(
           attempt: attempts429,
           maxAttempts: retries429,
           delayMs,
-          ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
         });
         await sleep(delayMs);
       } else {
@@ -303,8 +290,6 @@ export async function stacksApiFetch(
             status: response.status,
             attempts: retries,
             budget: "5xx",
-            ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
-            ...(rl.limit !== null ? { rlLimit: rl.limit } : {}),
           });
           return response;
         }
@@ -317,7 +302,6 @@ export async function stacksApiFetch(
           attempt: attempts5xx,
           maxAttempts: retries,
           delayMs,
-          ...(rl.remaining !== null ? { rlRemaining: rl.remaining } : {}),
         });
         await sleep(delayMs);
       }


### PR DESCRIPTION
## Summary

- Replace noisy per-second rate-limit warn with a meaningful monthly-quota warn
- `extractRateLimitInfo` now reads `x-ratelimit-remaining-stacks-month` and `-limit-stacks-month` and emits `stacksApi.approaching_monthly_quota` when remaining drops below 20% of the monthly limit
- Drop the per-request `stacksApi.rate_limit_remaining` info event and the per-second `approaching_rate_limit` warn — neither was actionable since the retry wrapper already absorbs short-window 429s

## Why

Today's production logs (aibtc-landing) show `stacksApi.approaching_rate_limit` firing ~489x with `rlRemaining: 39, rlLimit: 40` — the threshold of 50 was set against per-second windows that cap at 20-40, so the warn was triggering on essentially every request and conveying no real signal. Meanwhile the monthly Hiro quota — the thing that actually requires action (plan upgrade or traffic shed) — wasn't being tracked at all.

This change replaces the noise with a single threshold-gated alert that only fires when we have <20% of the monthly budget left. Percentage-based so it adapts to whichever plan tier the API key is on.

## Net effect on log volume
- ~22k `stacksApi.rate_limit_remaining` info events/day → 0
- ~489 `stacksApi.approaching_rate_limit` warns/day → 0 (until we're actually near the cap)

## Test plan

- [x] `npx vitest run lib/__tests__/stacks-api-fetch.test.ts` — 7 tests pass
- [x] `npx vitest run` — full suite (518 tests) passes
- [x] `npx tsc --noEmit` — typecheck clean
- [ ] After deploy: verify `stacksApi.approaching_rate_limit` warns stop appearing and `stacksApi.approaching_monthly_quota` does NOT fire under normal traffic

🤖 Generated with [Claude Code](https://claude.com/claude-code)