### PR TITLE
fix(register): downgrade expected BIP-322 btcPublicKey-unavailable noise to info (closes #579)

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -717,11 +717,13 @@ export async function POST(request: NextRequest) {
       : createConsoleLogger({ rayId, path: "/api/register" });
 
     // BIP-322 wallets (bc1q/bc1p) don't expose the public key via signature recovery.
-    // Log a warning so operators can track agents with missing btcPublicKey.
-    // Registration is NOT blocked — BIP-322 agents register successfully with an empty publicKey.
+    // This is expected behavior, not an incident — registration completes
+    // normally with an empty publicKey. The remediation path (provide
+    // nostrPublicKey now, or update-pubkey via challenge later) is documented
+    // in the GET self-doc and surfaced in the response (#579).
     const btcPublicKeyMissing = !btcResult.publicKey;
     if (btcPublicKeyMissing) {
-      log.warn(
+      log.info(
         `btcPublicKey unavailable for address ${btcResult.address}: ` +
         "BIP-322 signatures do not expose the public key via recovery. " +
         "Nostr npub derivation from btcPublicKey will not work for this agent."


### PR DESCRIPTION
## Summary

Closes #579. `/api/register` was emitting a `log.warn` every time a BIP-322 signer (bc1q/bc1p native SegWit) registered — because BIP-322 signatures don't expose the public key via signature recovery and we can't auto-derive a Nostr npub from btcPublicKey. This is **expected, documented behavior**; registration completes successfully, and the remediation path is already surfaced in the GET self-doc + registration response.

Per the issue, **65 of 170 daily warns** came from this one site (~38% of the warn stream).

## Change

`app/api/register/route.ts:723` — `log.warn` → `log.info`. Comment updated to reflect the new intent (correlation handle, not incident signal). The remediation pointer stays in the GET self-doc (line 219+) and in the response (`btcPublicKeyMissing: true` flag).

## Test plan

- [x] `npx tsc --noEmit` clean
- [ ] CI green
- Operationally: tail the warn-level register logs after merge to confirm the BIP-322 noise dropped out and only real warnings remain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>