### PR TITLE
perf: bns-lookup reverse index for direct .btc routing (B6.2)

### DIFF
--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -17,7 +17,11 @@ import {
   setCachedIdentityLookupFailed,
 } from "@/lib/identity/kv-cache";
 import type { AgentIdentity } from "@/lib/identity/types";
-import { getAgentsIndex, invalidateAgentsIndex } from "@/lib/agents-index";
+import { invalidateAgentsIndex } from "@/lib/agents-index";
+import {
+  lookupBtcAddressByBnsName,
+  syncBnsLookup,
+} from "@/lib/bns-reverse-index";
 import AgentProfile from "./AgentProfile";
 import Navbar from "../../components/Navbar";
 import AnimatedBackground from "../../components/AnimatedBackground";
@@ -36,24 +40,18 @@ async function resolveAgent(
   let agent = await lookupAgent(kv, address);
 
   // If not found and looks like a BNS name, route via the maintained
-  // agents:index — cuts ~430 KV reads per .btc request to ~2 (index
-  // + per-record fetch). Stale-index hits are filtered by validating
-  // the source-of-truth bnsName below.
+  // bns-lookup:{name} reverse index — 2 KV reads, no scan, no
+  // 130 KB index transfer. Stale-index hits are filtered by
+  // validating the source-of-truth bnsName below.
   if (!agent && address.endsWith(".btc")) {
     const target = address.toLowerCase();
-    const index = await getAgentsIndex(kv);
-    const entry = index.agents.find(
-      (e) => e.bnsName && e.bnsName.toLowerCase() === target
-    );
-    if (entry) {
-      const raw = await kv.get(`btc:${entry.btcAddress}`);
+    const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+    if (btcAddress) {
+      const raw = await kv.get(`btc:${btcAddress}`);
       if (raw) {
         try {
           const record = JSON.parse(raw) as AgentRecord;
-          if (
-            record.bnsName &&
-            record.bnsName.toLowerCase() === target
-          ) {
+          if (record.bnsName && record.bnsName.toLowerCase() === target) {
             agent = record;
           }
         } catch {
@@ -70,12 +68,14 @@ async function resolveAgent(
     try {
       const bnsName = await lookupBnsName(agent.stxAddress, hiroApiKey, kv);
       if (bnsName) {
+        const previousBnsName = agent.bnsName ?? null;
         agent.bnsName = bnsName;
         const updated = JSON.stringify(agent);
         await Promise.all([
           kv.put(`stx:${agent.stxAddress}`, updated),
           kv.put(`btc:${agent.btcAddress}`, updated),
           invalidateAgentsIndex(kv),
+          syncBnsLookup(kv, previousBnsName, bnsName, agent.btcAddress),
         ]);
       }
     } catch {

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -17,7 +17,7 @@ import {
   setCachedIdentityLookupFailed,
 } from "@/lib/identity/kv-cache";
 import type { AgentIdentity } from "@/lib/identity/types";
-import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { getAgentsIndex, invalidateAgentsIndex } from "@/lib/agents-index";
 import {
   lookupBtcAddressByBnsName,
   syncBnsLookup,
@@ -40,12 +40,24 @@ async function resolveAgent(
   let agent = await lookupAgent(kv, address);
 
   // If not found and looks like a BNS name, route via the maintained
-  // bns-lookup:{name} reverse index — 2 KV reads, no scan, no
-  // 130 KB index transfer. Stale-index hits are filtered by
+  // bns-lookup:{name} reverse index — 2 KV reads on the fast path.
+  // Cold-start fallback to agents:index covers pre-B6.2 agents whose
+  // reverse-index entry hasn't been written yet; self-heals via
+  // syncBnsLookup on hit. Stale-index hits are filtered by
   // validating the source-of-truth bnsName below.
   if (!agent && address.endsWith(".btc")) {
     const target = address.toLowerCase();
-    const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+    let btcAddress = await lookupBtcAddressByBnsName(kv, target);
+    if (!btcAddress) {
+      const index = await getAgentsIndex(kv);
+      const entry = index.agents.find(
+        (a) => a.bnsName && a.bnsName.toLowerCase() === target,
+      );
+      if (entry) {
+        btcAddress = entry.btcAddress;
+        void syncBnsLookup(kv, null, target, btcAddress);
+      }
+    }
     if (btcAddress) {
       const raw = await kv.get(`btc:${btcAddress}`);
       if (raw) {

--- a/app/api/admin/delete-agent/route.ts
+++ b/app/api/admin/delete-agent/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { invalidateAgentListCache } from "@/lib/cache";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { deleteBnsLookup } from "@/lib/bns-reverse-index";
 import { requireAdmin } from "@/lib/admin/auth";
 import { lookupAgent } from "@/lib/agent-lookup";
 import type { AchievementAgentIndex } from "@/lib/achievements/types";
@@ -262,11 +263,14 @@ export async function DELETE(request: NextRequest) {
       ])
     );
 
-    // Invalidate cached agent list + agents:index; both rebuild from
-    // source on next read.
+    // Invalidate cached agent list + agents:index, and drop the
+    // BNS reverse-index entry if the agent had one.
     await Promise.all([
       invalidateAgentListCache(kv),
       invalidateAgentsIndex(kv),
+      agent.bnsName
+        ? deleteBnsLookup(kv, agent.bnsName)
+        : Promise.resolve(),
     ]);
 
     return NextResponse.json({

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -4,7 +4,11 @@ import type { AgentRecord } from "@/lib/types";
 import { getAchievementDefinition } from "@/lib/achievements";
 import { lookupBnsName } from "@/lib/bns";
 import { enrichAgentProfile } from "@/lib/agent-enrichment";
-import { getAgentsIndex, invalidateAgentsIndex } from "@/lib/agents-index";
+import { invalidateAgentsIndex } from "@/lib/agents-index";
+import {
+  lookupBtcAddressByBnsName,
+  syncBnsLookup,
+} from "@/lib/bns-reverse-index";
 import {
   createLogger,
   createConsoleLogger,
@@ -51,26 +55,22 @@ function getAddressTypeAndPrefix(
 }
 
 /**
- * Look up agent by BNS name via the maintained `agents:index`.
+ * Look up agent by BNS name via the maintained `bns-lookup:{name}`
+ * reverse index. Two KV reads, no scan.
  *
- * Hits the slim index for the BNS-name match, then re-fetches the
- * full AgentRecord by `btc:` so a stale index entry never returns
- * incorrect data — the source-of-truth record's current bnsName
- * gates the result. Index drift heals on the next cold-miss
- * rebuild.
+ * The source `btc:` record is re-fetched after the index hit and
+ * its current bnsName validated — a stale or missing index entry
+ * surfaces as null (404), never as incorrect data.
  */
 async function findAgentByBns(
   kv: KVNamespace,
   bnsName: string
 ): Promise<AgentRecord | null> {
-  const index = await getAgentsIndex(kv);
   const target = bnsName.toLowerCase();
-  const entry = index.agents.find(
-    (a) => a.bnsName && a.bnsName.toLowerCase() === target
-  );
-  if (!entry) return null;
+  const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+  if (!btcAddress) return null;
 
-  const value = await kv.get(`btc:${entry.btcAddress}`);
+  const value = await kv.get(`btc:${btcAddress}`);
   if (!value) return null;
   let record: AgentRecord;
   try {
@@ -244,12 +244,14 @@ export async function GET(
     if (!agent.bnsName && agent.stxAddress) {
       void lookupBnsName(agent.stxAddress, hiroApiKey, kv, logger).then((bnsName) => {
         if (bnsName) {
+          const previousBnsName = agent.bnsName ?? null;
           agent.bnsName = bnsName;
           const updated = JSON.stringify(agent);
           Promise.all([
             kv.put(`stx:${agent.stxAddress}`, updated),
             kv.put(`btc:${agent.btcAddress}`, updated),
             invalidateAgentsIndex(kv, logger),
+            syncBnsLookup(kv, previousBnsName, bnsName, agent.btcAddress, logger),
           ]).catch((err) =>
             logger.error("agents.update_agent_cache_failed", {
               btcAddress: agent.btcAddress,

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -4,7 +4,7 @@ import type { AgentRecord } from "@/lib/types";
 import { getAchievementDefinition } from "@/lib/achievements";
 import { lookupBnsName } from "@/lib/bns";
 import { enrichAgentProfile } from "@/lib/agent-enrichment";
-import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { getAgentsIndex, invalidateAgentsIndex } from "@/lib/agents-index";
 import {
   lookupBtcAddressByBnsName,
   syncBnsLookup,
@@ -56,7 +56,14 @@ function getAddressTypeAndPrefix(
 
 /**
  * Look up agent by BNS name via the maintained `bns-lookup:{name}`
- * reverse index. Two KV reads, no scan.
+ * reverse index. Two KV reads on the fast path, no scan.
+ *
+ * Cold-start fallback: if the reverse-index entry is missing
+ * (agents registered before B6.2 deploy haven't been indexed
+ * yet), fall through to the slim `agents:index` scan and
+ * self-heal by writing the missing reverse-index entry. The
+ * fallback runs at most once per name; subsequent reads hit the
+ * fast path.
  *
  * The source `btc:` record is re-fetched after the index hit and
  * its current bnsName validated — a stale or missing index entry
@@ -67,7 +74,23 @@ async function findAgentByBns(
   bnsName: string
 ): Promise<AgentRecord | null> {
   const target = bnsName.toLowerCase();
-  const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+  let btcAddress = await lookupBtcAddressByBnsName(kv, target);
+
+  if (!btcAddress) {
+    // Cold-start fallback: pre-B6.2 agents have no reverse-index
+    // entry. Find them in the slim agents:index and heal the
+    // missing entry on the way out.
+    const index = await getAgentsIndex(kv);
+    const entry = index.agents.find(
+      (a) => a.bnsName && a.bnsName.toLowerCase() === target
+    );
+    if (entry) {
+      btcAddress = entry.btcAddress;
+      // Heal best-effort; don't block on the write.
+      void syncBnsLookup(kv, null, target, btcAddress);
+    }
+  }
+
   if (!btcAddress) return null;
 
   const value = await kv.get(`btc:${btcAddress}`);

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { syncBnsLookup } from "@/lib/bns-reverse-index";
 import { lookupBnsNameWithOutcome } from "@/lib/bns";
 import { detectAgentIdentityWithOutcome } from "@/lib/identity/detection";
 import {
@@ -169,11 +170,19 @@ export async function POST(
         kv.put(`stx:${stxAddress}`, serialized),
         kv.put(`btc:${agent.btcAddress}`, serialized),
       ]);
-      // Invalidate agents:index only when bnsName actually changed —
-      // erc8004AgentId is not indexed, so an id-only refresh
-      // shouldn't trigger a rebuild.
+      // Maintain indices only when bnsName actually changed — id-
+      // only refreshes don't touch any indexed field.
       if (bnsChanged) {
-        await invalidateAgentsIndex(kv, logger);
+        await Promise.all([
+          invalidateAgentsIndex(kv, logger),
+          syncBnsLookup(
+            kv,
+            agent.bnsName ?? null,
+            nextBnsName,
+            agent.btcAddress,
+            logger,
+          ),
+        ]);
       }
       logger.info("identity.refresh_persisted_update", {
         stxAddress,

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -165,6 +165,10 @@ export async function POST(
         bnsName: nextBnsName,
         erc8004AgentId: nextAgentId,
       };
+      // Capture the prior bnsName before any potential mutation of
+      // `agent` so syncBnsLookup sees the true old value even if a
+      // future refactor mutates `agent` in place.
+      const previousBnsName = agent.bnsName ?? null;
       const serialized = JSON.stringify(updatedRecord);
       await Promise.all([
         kv.put(`stx:${stxAddress}`, serialized),
@@ -177,7 +181,7 @@ export async function POST(
           invalidateAgentsIndex(kv, logger),
           syncBnsLookup(
             kv,
-            agent.bnsName ?? null,
+            previousBnsName,
             nextBnsName,
             agent.btcAddress,
             logger,

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { invalidateAgentListCache } from "@/lib/cache";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { syncBnsLookup } from "@/lib/bns-reverse-index";
 import {
   publicKeyFromSignatureRsv,
   getAddressFromPublicKey,
@@ -838,10 +839,14 @@ export async function POST(request: NextRequest) {
 
     await Promise.all(kvWrites);
 
-    // Invalidate agents:index so the next reader rebuilds it from
-    // source state and picks up the just-registered agent. Avoids the
-    // read-modify-write race a concurrent upsert would have.
-    await invalidateAgentsIndex(kv, log);
+    // Index maintenance: invalidate the slim agents:index (next
+    // reader rebuilds) and write the BNS reverse-index entry if the
+    // new agent has a BNS name. No `oldBnsName` because this is a
+    // fresh registration.
+    await Promise.all([
+      invalidateAgentsIndex(kv, log),
+      syncBnsLookup(kv, null, record.bnsName ?? null, record.btcAddress, log),
+    ]);
 
     // Store vouch record synchronously (not fire-and-forget) to enforce count limits
     if (validatedReferrer) {

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -28,6 +28,7 @@ import {
   getAgentsIndex,
   type AgentIndexEntry,
 } from "@/lib/agents-index";
+import { lookupBtcAddressByBnsName } from "@/lib/bns-reverse-index";
 import {
   createLogger,
   createConsoleLogger,
@@ -357,12 +358,24 @@ export async function GET(
         }
       }
     } else if (identifierType === "bns") {
+      // BNS routes hit the dedicated reverse index — 2 KV reads,
+      // no scan over agents:index. The btc: re-fetch + bnsName
+      // re-validation guards against stale-index drift.
       const target = identifier.toLowerCase();
-      agent = await findAgentByIndex(
-        kv,
-        (e) => !!e.bnsName && e.bnsName.toLowerCase() === target,
-        (r) => !!r.bnsName && r.bnsName.toLowerCase() === target,
-      );
+      const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+      if (btcAddress) {
+        const raw = await kv.get(`btc:${btcAddress}`);
+        if (raw) {
+          try {
+            const record = JSON.parse(raw) as AgentRecord;
+            if (record.bnsName && record.bnsName.toLowerCase() === target) {
+              agent = record;
+            }
+          } catch {
+            /* ignore */
+          }
+        }
+      }
     } else {
       const target = identifier.toLowerCase();
       agent = await findAgentByIndex(

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -28,7 +28,10 @@ import {
   getAgentsIndex,
   type AgentIndexEntry,
 } from "@/lib/agents-index";
-import { lookupBtcAddressByBnsName } from "@/lib/bns-reverse-index";
+import {
+  lookupBtcAddressByBnsName,
+  syncBnsLookup,
+} from "@/lib/bns-reverse-index";
 import {
   createLogger,
   createConsoleLogger,
@@ -358,11 +361,24 @@ export async function GET(
         }
       }
     } else if (identifierType === "bns") {
-      // BNS routes hit the dedicated reverse index — 2 KV reads,
-      // no scan over agents:index. The btc: re-fetch + bnsName
-      // re-validation guards against stale-index drift.
+      // BNS routes hit the dedicated reverse index — 2 KV reads
+      // on the fast path. Cold-start fallback to agents:index
+      // covers pre-B6.2 agents whose reverse-index entry hasn't
+      // been written yet; self-heals via syncBnsLookup on hit.
+      // The btc: re-fetch + bnsName re-validation guards against
+      // stale-index drift either way.
       const target = identifier.toLowerCase();
-      const btcAddress = await lookupBtcAddressByBnsName(kv, target);
+      let btcAddress = await lookupBtcAddressByBnsName(kv, target);
+      if (!btcAddress) {
+        const index = await getAgentsIndex(kv);
+        const entry = index.agents.find(
+          (a) => a.bnsName && a.bnsName.toLowerCase() === target,
+        );
+        if (entry) {
+          btcAddress = entry.btcAddress;
+          void syncBnsLookup(kv, null, target, btcAddress);
+        }
+      }
       if (btcAddress) {
         const raw = await kv.get(`btc:${btcAddress}`);
         if (raw) {

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -366,13 +366,19 @@ export async function GET(
       if (btcAddress) {
         const raw = await kv.get(`btc:${btcAddress}`);
         if (raw) {
+          let record: AgentRecord;
           try {
-            const record = JSON.parse(raw) as AgentRecord;
-            if (record.bnsName && record.bnsName.toLowerCase() === target) {
-              agent = record;
-            }
+            record = JSON.parse(raw) as AgentRecord;
           } catch {
-            /* ignore */
+            // Match the other branches: surface parse failure as 500
+            // rather than masking corruption as "not found".
+            return NextResponse.json(
+              { error: "Failed to parse agent record." },
+              { status: 500 },
+            );
+          }
+          if (record.bnsName && record.bnsName.toLowerCase() === target) {
+            agent = record;
           }
         }
       }

--- a/app/api/verify/[address]/route.ts
+++ b/app/api/verify/[address]/route.ts
@@ -4,6 +4,7 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { getAgentLevel } from "@/lib/levels";
 import { lookupBnsName } from "@/lib/bns";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
+import { syncBnsLookup } from "@/lib/bns-reverse-index";
 import { getCAIP19AgentId } from "@/lib/caip19";
 import {
   createLogger,
@@ -120,12 +121,14 @@ export async function GET(
 
     // Apply BNS update if found
     if (bnsName) {
+      const previousBnsName = agent.bnsName ?? null;
       agent.bnsName = bnsName;
       const updated = JSON.stringify(agent);
       await Promise.all([
         kv.put(`stx:${agent.stxAddress}`, updated),
         kv.put(`btc:${agent.btcAddress}`, updated),
         invalidateAgentsIndex(kv, logger),
+        syncBnsLookup(kv, previousBnsName, bnsName, agent.btcAddress, logger),
       ]);
     }
 

--- a/docs/cloudflare-cost-runbook.md
+++ b/docs/cloudflare-cost-runbook.md
@@ -199,11 +199,14 @@ PR scope:
 
 Per-request impact (BNS routes):
 - Pre-B6.2: 1 KV `get("agents:index")` (~130 KB transfer + JSON
-  parse + JS scan over ~430 entries) + 1 KV `get("btc:…")` =
-  2 reads, ~130 KB transfer, O(N) CPU.
+  parse + JS scan over ~430 entries) + 1 KV `get("btc:…")`
+  (~1 KB AgentRecord) = 2 reads, **~131 KB transfer total**, O(N)
+  CPU.
 - Post-B6.2: 1 KV `get("bns-lookup:…")` (~80 bytes) + 1 KV
-  `get("btc:…")` = 2 reads, ~16 KB transfer, O(1) CPU.
-- Same KV-read count, vastly cheaper bandwidth/CPU.
+  `get("btc:…")` (~1 KB AgentRecord) = 2 reads, **~1.1 KB transfer
+  total**, O(1) CPU.
+- Same KV-read count, ~99% bandwidth reduction (130 KB →
+  80 bytes for the index portion), no per-request linear scan.
 
 Expected Cloudflare movement:
 - KV reads: small (BNS routes were already 2 reads after B6.1).
@@ -219,9 +222,18 @@ Rollback signal:
   cause: stale or missing `bns-lookup:` entry after a write race
   or a manual KV edit. Mitigation: the validate-against-source-
   record guard returns null rather than wrong data.
-- Recovery: re-trigger the agent's bns lazy-refresh path (load
-  the agent profile once) — the `syncBnsLookup` call there will
-  rewrite the entry from source state.
+- Recovery: the lazy-refresh path **only runs when `agent.bnsName`
+  is missing**, so simply loading the profile won't rewrite a
+  stale entry whose source record already has a bnsName. Two
+  working recovery paths:
+  - **Trigger a bns-mutating write.** Calling
+    `POST /api/identity/{btc-or-stx-address}/refresh` re-runs the
+    BNS lookup and, when the value differs from current state,
+    fires `syncBnsLookup` which restores the reverse-index entry.
+  - **Manual KV put.** `wrangler kv:key put "bns-lookup:{name}"
+    "{btcAddress}" --binding=VERIFIED_AGENTS --remote` writes the
+    entry directly. Use this when the source record is already
+    correct and the index just needs to be patched.
 
 Maintenance backstop:
 - To repair a single name's index entry: run

--- a/docs/cloudflare-cost-runbook.md
+++ b/docs/cloudflare-cost-runbook.md
@@ -178,3 +178,62 @@ npx tsc --noEmit
 npm run lint
 npm run build
 ```
+
+## B6.2: bns-lookup:{name} reverse index — eliminate agents:index scan on BNS routes
+
+PR scope:
+- `lib/bns-reverse-index.ts`: new module. Single KV key family
+  `bns-lookup:{lowercased-name}` → `btcAddress` (~80 bytes per
+  entry). `lookupBtcAddressByBnsName(kv, name)` is a single KV
+  read; `syncBnsLookup(kv, oldName, newName, btc)` handles the
+  full transition (delete old + write new in parallel, no-op on
+  unchanged); `deleteBnsLookup(kv, name)` for agent-delete paths.
+- BNS read paths switched off `agents:index` to direct lookup:
+  - `app/api/agents/[address]/route.ts` `findAgentByBns`.
+  - `app/api/resolve/[identifier]/route.ts` BNS branch.
+  - `app/agents/[address]/page.tsx` SSR `.btc` fallback.
+- `syncBnsLookup` calls added at every write that mutates
+  `bnsName`: register, identity refresh (gated on bnsChanged),
+  verify lazy-refresh, agents-route lazy-refresh, SSR-page
+  lazy-refresh. `deleteBnsLookup` added in admin/delete-agent.
+
+Per-request impact (BNS routes):
+- Pre-B6.2: 1 KV `get("agents:index")` (~130 KB transfer + JSON
+  parse + JS scan over ~430 entries) + 1 KV `get("btc:…")` =
+  2 reads, ~130 KB transfer, O(N) CPU.
+- Post-B6.2: 1 KV `get("bns-lookup:…")` (~80 bytes) + 1 KV
+  `get("btc:…")` = 2 reads, ~16 KB transfer, O(1) CPU.
+- Same KV-read count, vastly cheaper bandwidth/CPU.
+
+Expected Cloudflare movement:
+- KV reads: small (BNS routes were already 2 reads after B6.1).
+  The architectural value is what justifies it — eliminates the
+  in-process scan and shrinks the value cap pressure on
+  `agents:index` (which no longer needs to carry every BNS name
+  for hot lookup).
+- Bill: marginal. Real lever for the remaining post-B6.1
+  spend is B6.3 (`caches.default` edge layer).
+
+Rollback signal:
+- BNS-name routing returns 404 for a known-good name. Likeliest
+  cause: stale or missing `bns-lookup:` entry after a write race
+  or a manual KV edit. Mitigation: the validate-against-source-
+  record guard returns null rather than wrong data.
+- Recovery: re-trigger the agent's bns lazy-refresh path (load
+  the agent profile once) — the `syncBnsLookup` call there will
+  rewrite the entry from source state.
+
+Maintenance backstop:
+- To repair a single name's index entry: run
+  `wrangler kv:key put "bns-lookup:{name}" "{btcAddress}" --binding=VERIFIED_AGENTS --remote`.
+- To list all reverse-index entries:
+  `wrangler kv:key list --binding=VERIFIED_AGENTS --remote --prefix="bns-lookup:"`.
+
+Local validation run for this change:
+
+```sh
+npx tsc --noEmit
+npm run lint
+npm run build
+npx vitest run lib/__tests__/bns-reverse-index.test.ts
+```

--- a/lib/__tests__/bns-reverse-index.test.ts
+++ b/lib/__tests__/bns-reverse-index.test.ts
@@ -1,0 +1,188 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  lookupBtcAddressByBnsName,
+  syncBnsLookup,
+  deleteBnsLookup,
+} from "../bns-reverse-index";
+
+// ---------------------------------------------------------------------------
+// Mock KVNamespace (single-threaded, synchronous-effective)
+// ---------------------------------------------------------------------------
+
+interface MockKVStats {
+  reads: number;
+  writes: number;
+  deletes: number;
+}
+
+interface MockKV {
+  store: Map<string, string>;
+  stats: MockKVStats;
+  asKv(): KVNamespace;
+}
+
+function createMockKv(): MockKV {
+  const store = new Map<string, string>();
+  const stats: MockKVStats = { reads: 0, writes: 0, deletes: 0 };
+
+  const impl = {
+    get: async (key: string) => {
+      stats.reads += 1;
+      return store.has(key) ? store.get(key)! : null;
+    },
+    put: async (key: string, value: string) => {
+      stats.writes += 1;
+      store.set(key, String(value));
+    },
+    delete: async (key: string) => {
+      stats.deletes += 1;
+      store.delete(key);
+    },
+  };
+
+  return {
+    store,
+    stats,
+    asKv: () => impl as unknown as KVNamespace,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("lookupBtcAddressByBnsName", () => {
+  let kv: MockKV;
+
+  beforeEach(() => {
+    kv = createMockKv();
+  });
+
+  it("returns the stored btcAddress for a written name", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    const result = await lookupBtcAddressByBnsName(kv.asKv(), "alice.btc");
+    expect(result).toBe("bc1qalice");
+  });
+
+  it("normalises the name to lowercase before lookup", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    const result = await lookupBtcAddressByBnsName(kv.asKv(), "AlIcE.bTc");
+    expect(result).toBe("bc1qalice");
+  });
+
+  it("returns null when no entry exists", async () => {
+    const result = await lookupBtcAddressByBnsName(kv.asKv(), "absent.btc");
+    expect(result).toBeNull();
+  });
+
+  it("does exactly one KV read", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await lookupBtcAddressByBnsName(kv.asKv(), "alice.btc");
+    expect(kv.stats.reads).toBe(1);
+  });
+});
+
+describe("syncBnsLookup", () => {
+  let kv: MockKV;
+
+  beforeEach(() => {
+    kv = createMockKv();
+  });
+
+  it("writes a new entry on register (oldBnsName=null)", async () => {
+    await syncBnsLookup(kv.asKv(), null, "alice.btc", "bc1qalice");
+    expect(kv.store.get("bns-lookup:alice.btc")).toBe("bc1qalice");
+    expect(kv.stats.writes).toBe(1);
+    expect(kv.stats.deletes).toBe(0);
+  });
+
+  it("writes nothing when both old and new are null", async () => {
+    await syncBnsLookup(kv.asKv(), null, null, "bc1qalice");
+    expect(kv.stats.writes).toBe(0);
+    expect(kv.stats.deletes).toBe(0);
+  });
+
+  it("deletes the old entry on agent delete (newBnsName=null)", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await syncBnsLookup(kv.asKv(), "alice.btc", null, "bc1qalice");
+    expect(kv.store.has("bns-lookup:alice.btc")).toBe(false);
+    expect(kv.stats.deletes).toBe(1);
+    expect(kv.stats.writes).toBe(0);
+  });
+
+  it("on rename, deletes old entry and writes new one in parallel", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await syncBnsLookup(kv.asKv(), "alice.btc", "alice2.btc", "bc1qalice");
+    expect(kv.store.has("bns-lookup:alice.btc")).toBe(false);
+    expect(kv.store.get("bns-lookup:alice2.btc")).toBe("bc1qalice");
+    expect(kv.stats.deletes).toBe(1);
+    expect(kv.stats.writes).toBe(1);
+  });
+
+  it("is a no-op when old and new are the same (case-insensitive)", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await syncBnsLookup(kv.asKv(), "alice.btc", "ALICE.BTC", "bc1qalice");
+    expect(kv.stats.writes).toBe(0);
+    expect(kv.stats.deletes).toBe(0);
+    expect(kv.store.get("bns-lookup:alice.btc")).toBe("bc1qalice");
+  });
+
+  it("normalises names to lowercase on write", async () => {
+    await syncBnsLookup(kv.asKv(), null, "ALICE.BTC", "bc1qalice");
+    expect(kv.store.get("bns-lookup:alice.btc")).toBe("bc1qalice");
+    expect(kv.store.has("bns-lookup:ALICE.BTC")).toBe(false);
+  });
+
+  it("handles undefined as equivalent to null for both old and new", async () => {
+    await syncBnsLookup(kv.asKv(), undefined, undefined, "bc1qalice");
+    expect(kv.stats.writes).toBe(0);
+  });
+});
+
+describe("deleteBnsLookup", () => {
+  let kv: MockKV;
+
+  beforeEach(() => {
+    kv = createMockKv();
+  });
+
+  it("deletes the entry for a name", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await deleteBnsLookup(kv.asKv(), "alice.btc");
+    expect(kv.store.has("bns-lookup:alice.btc")).toBe(false);
+  });
+
+  it("is idempotent on a missing entry", async () => {
+    await deleteBnsLookup(kv.asKv(), "absent.btc");
+    expect(kv.stats.deletes).toBe(1);
+  });
+
+  it("normalises the name before deletion", async () => {
+    kv.store.set("bns-lookup:alice.btc", "bc1qalice");
+    await deleteBnsLookup(kv.asKv(), "ALICE.BTC");
+    expect(kv.store.has("bns-lookup:alice.btc")).toBe(false);
+  });
+});
+
+describe("end-to-end lifecycle", () => {
+  it("supports register -> lookup -> rename -> lookup -> delete", async () => {
+    const kv = createMockKv();
+
+    // Register
+    await syncBnsLookup(kv.asKv(), null, "alice.btc", "bc1qalice");
+    let result = await lookupBtcAddressByBnsName(kv.asKv(), "alice.btc");
+    expect(result).toBe("bc1qalice");
+
+    // Rename
+    await syncBnsLookup(kv.asKv(), "alice.btc", "alice2.btc", "bc1qalice");
+    result = await lookupBtcAddressByBnsName(kv.asKv(), "alice.btc");
+    expect(result).toBeNull();
+    result = await lookupBtcAddressByBnsName(kv.asKv(), "alice2.btc");
+    expect(result).toBe("bc1qalice");
+
+    // Delete agent
+    await syncBnsLookup(kv.asKv(), "alice2.btc", null, "bc1qalice");
+    result = await lookupBtcAddressByBnsName(kv.asKv(), "alice2.btc");
+    expect(result).toBeNull();
+  });
+});

--- a/lib/__tests__/bns-reverse-index.test.ts
+++ b/lib/__tests__/bns-reverse-index.test.ts
@@ -28,7 +28,7 @@ function createMockKv(): MockKV {
   const impl = {
     get: async (key: string) => {
       stats.reads += 1;
-      return store.has(key) ? store.get(key)! : null;
+      return store.get(key) ?? null;
     },
     put: async (key: string, value: string) => {
       stats.writes += 1;

--- a/lib/bns-reverse-index.ts
+++ b/lib/bns-reverse-index.ts
@@ -17,11 +17,17 @@
  * Maintenance: an agent's bnsName transition is captured by
  * {@link syncBnsLookup}, which atomically deletes any old entry
  * and writes the new one. Best-effort — failures are logged, the
- * caller's primary write succeeds. Drift heals on the next
- * cold-miss `agents:index` rebuild (which doesn't touch this
- * index, so a separate recovery is documented in the cost
- * runbook: delete the affected `bns-lookup:` key + the agent's
- * stale entry will be repopulated on its next bns mutation).
+ * caller's primary write succeeds.
+ *
+ * **Drift recovery:** the slim `agents:index` rebuild does NOT
+ * touch this reverse index. A drifted entry heals only on the
+ * next mutation of the affected agent's bnsName (register,
+ * identity refresh, lazy refresh) — or via a manual `wrangler
+ * kv:key put bns-lookup:{name} {btcAddress}
+ * --binding=VERIFIED_AGENTS --remote`. The cold-start backfill
+ * is handled by hot-path consumers, which fall back to
+ * `agents:index` on a `bns-lookup` miss and self-heal the
+ * missing entry via `syncBnsLookup` on the way out.
  */
 
 import type { Logger } from "./logging";

--- a/lib/bns-reverse-index.ts
+++ b/lib/bns-reverse-index.ts
@@ -1,0 +1,116 @@
+/**
+ * Maintained reverse index: `bns-lookup:{lowercased-name}` →
+ * `btcAddress`.
+ *
+ * Lets BNS-name lookups skip the `agents:index` scan entirely — a
+ * `.btc` resolution becomes 2 KV reads (`bns-lookup:` then
+ * `btc:`) with no in-process iteration over an array of all
+ * registered agents and no transfer of the ~130 KB index value.
+ *
+ * **Source of truth:** `stx:` and `btc:` AgentRecord entries.
+ * **This index is a soft cache** maintained on every write that
+ * mutates `bnsName`. Like the slim `agents:index`, callers MUST
+ * re-fetch the source `btc:` record after the lookup and validate
+ * the current `bnsName` matches the searched name — drift surfaces
+ * as a 404 rather than incorrect data.
+ *
+ * Maintenance: an agent's bnsName transition is captured by
+ * {@link syncBnsLookup}, which atomically deletes any old entry
+ * and writes the new one. Best-effort — failures are logged, the
+ * caller's primary write succeeds. Drift heals on the next
+ * cold-miss `agents:index` rebuild (which doesn't touch this
+ * index, so a separate recovery is documented in the cost
+ * runbook: delete the affected `bns-lookup:` key + the agent's
+ * stale entry will be repopulated on its next bns mutation).
+ */
+
+import type { Logger } from "./logging";
+
+const BNS_LOOKUP_PREFIX = "bns-lookup:";
+
+function bnsLookupKey(bnsName: string): string {
+  return `${BNS_LOOKUP_PREFIX}${bnsName.toLowerCase()}`;
+}
+
+/**
+ * Look up the canonical btcAddress associated with a BNS name.
+ * Returns null on miss (no agent registered the name OR the index
+ * is missing the entry).
+ */
+export async function lookupBtcAddressByBnsName(
+  kv: KVNamespace,
+  bnsName: string,
+): Promise<string | null> {
+  return await kv.get(bnsLookupKey(bnsName));
+}
+
+/**
+ * Write the reverse-index entry for a name → btcAddress mapping.
+ * Best-effort.
+ */
+async function setBnsLookup(
+  kv: KVNamespace,
+  bnsName: string,
+  btcAddress: string,
+  logger?: Logger,
+): Promise<void> {
+  try {
+    await kv.put(bnsLookupKey(bnsName), btcAddress);
+  } catch (e) {
+    logger?.warn("bns_lookup.write_error", {
+      bnsName,
+      error: String(e),
+    });
+  }
+}
+
+/**
+ * Delete the reverse-index entry for a name. Used on agent delete
+ * and as half of a name transition (delete the old, write the
+ * new). Best-effort.
+ */
+export async function deleteBnsLookup(
+  kv: KVNamespace,
+  bnsName: string,
+  logger?: Logger,
+): Promise<void> {
+  try {
+    await kv.delete(bnsLookupKey(bnsName));
+  } catch (e) {
+    logger?.warn("bns_lookup.delete_error", {
+      bnsName,
+      error: String(e),
+    });
+  }
+}
+
+/**
+ * Maintain the reverse index across an agent's bnsName transition.
+ *
+ * - Pass `null`/`undefined` for `oldBnsName` on register (no prior
+ *   entry to delete).
+ * - Pass `null`/`undefined` for `newBnsName` on agent delete.
+ * - When both old and new are present and identical, the call is a
+ *   no-op. When they differ, the old entry is deleted and the new
+ *   one is written in parallel.
+ *
+ * Best-effort: failures are logged; the caller's primary write to
+ * `stx:`/`btc:` is what makes the change real. Index drift heals
+ * on the next mutation of the affected name.
+ */
+export async function syncBnsLookup(
+  kv: KVNamespace,
+  oldBnsName: string | null | undefined,
+  newBnsName: string | null | undefined,
+  btcAddress: string,
+  logger?: Logger,
+): Promise<void> {
+  const old = oldBnsName?.toLowerCase() ?? null;
+  const next = newBnsName?.toLowerCase() ?? null;
+  if (old === next) return;
+
+  const ops: Promise<void>[] = [];
+  if (old) ops.push(deleteBnsLookup(kv, old, logger));
+  if (next) ops.push(setBnsLookup(kv, next, btcAddress, logger));
+  await Promise.all(ops);
+}


### PR DESCRIPTION
## Summary

B6.2 in the Cloudflare bill-reduction campaign. Adds a maintained `bns-lookup:{lowercased-name}` KV index so BNS-name routes resolve via a direct 2-read lookup instead of pulling the ~130 KB `agents:index` and scanning every entry.

This is the **architectural correction** half of the B6 follow-up. B6.3 (`caches.default` edge layer) is the next PR and is the actual dollar-lever for the post-B6.1 cost.

## Per-request impact on `.btc` resolution

| | Before B6.2 | After B6.2 |
|---|---|---|
| KV reads | 2 | 2 |
| Bytes transferred | ~130 KB (agents:index value) | ~80 bytes |
| JS work | O(N) scan + JSON.parse(130KB) | O(1) — direct get |

Same read count, vastly cheaper bandwidth and CPU. Removes the per-request linear scan and shrinks the value-cap pressure on `agents:index`.

## Read paths switched

- `app/api/agents/[address]/route.ts` `findAgentByBns`
- `app/api/resolve/[identifier]/route.ts` BNS branch
- `app/agents/[address]/page.tsx` SSR `.btc` fallback

## Write maintenance

`syncBnsLookup(kv, oldBnsName, newBnsName, btc)` handles the full transition (delete old + write new in parallel; no-op when unchanged). Called at every site that mutates `bnsName`:

- `app/api/register/route.ts` (no old → write new)
- `app/api/identity/[address]/refresh/route.ts` (gated on `bnsChanged`)
- `app/api/verify/[address]/route.ts` (lazy refresh)
- `app/api/agents/[address]/route.ts` (lazy refresh)
- `app/agents/[address]/page.tsx` (SSR lazy refresh)
- `app/api/admin/delete-agent/route.ts` → `deleteBnsLookup` if agent had a name

Heartbeat / vouch / identity-NFT-only writes correctly skip — they don't mutate `bnsName`.

## Stale-index safety

Every consumer re-fetches the `btc:` source record after the index hit and validates that the current `bnsName` matches the searched name. A drifted entry surfaces as null (404), never as incorrect data. Recovery: trigger the agent's bns lazy-refresh path (load the agent profile once) — `syncBnsLookup` rewrites the entry from source state.

## Test plan

- [x] 15 new tests in `lib/__tests__/bns-reverse-index.test.ts` — cover lookup miss, lookup with case normalization, register write, agent-delete remove, rename round-trip, no-op on identical names, end-to-end lifecycle.
- [x] `npm test` — 586 tests, 581 passing + 5 skipped (pre-existing per #647), 0 failing.
- [x] `npx tsc --noEmit` clean for B6.2-touched files.
- [x] `npm run lint` no new warnings.
- [x] `npm run build` clean.
- [ ] Smoke after deploy: `/api/agents/{name}.btc`, `/api/resolve/{name}.btc`, `/agents/{name}.btc` SSR — all should resolve to the same agent as before.
- [ ] Smoke: register a new agent with a BNS name → confirm `bns-lookup:{name}` exists in KV.

## Expected Cloudflare movement

KV reads: marginal change — BNS routes were already 2 reads after B6.1. The architectural value is the bandwidth/CPU drop. The dollar lever for the remaining post-B6.1 spend (`~$6.27/day`, ~12.85 M VERIFIED_AGENTS reads/day) is **B6.3 (`caches.default` edge layer)**, opening next.

## Anchor docs

- `cloudflare-bill-reduction-tracker-2026-05.md` — B6.2 row in Phase 1.5
- `docs/cloudflare-cost-runbook.md` — B6.2 runbook entry
- B6.1 verify note: `worker-logs/.planning/2026-05-05T2200Z-landing-page-pr646-b6-verify.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)