### PR TITLE
perf(cache): mark-stale invalidateAgentListCache (Phase 0.2, #655)

### DIFF
--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -136,15 +136,34 @@ async function maybeTriggerBackgroundRebuild(
 }
 
 /**
- * Invalidate the cached agent list so the next read triggers a rebuild.
+ * Invalidate the cached agent list so the next read returns the stale
+ * snapshot (and triggers a background rebuild) instead of forcing a
+ * cold-miss synchronous rebuild.
+ *
+ * Mark-stale shifts cachedAt past FRESH_WINDOW_SECONDS but keeps the
+ * snapshot inside CACHE_TTL_SECONDS, so getCachedAgentList sees it as
+ * stale, returns it immediately, and kicks off maybeTriggerBackgroundRebuild.
+ *
+ * If there's no existing snapshot, this is a no-op (next read will cold-miss
+ * + rebuild as before).
  */
 export async function invalidateAgentListCache(
   kv: KVNamespace
 ): Promise<void> {
   try {
-    await kv.delete(CACHE_KEY);
+    const raw = await kv.get(CACHE_KEY);
+    const cached = parseSnapshot(raw);
+    if (!cached) return;
+    const stalePastFresh = new Date(
+      Date.now() - (FRESH_WINDOW_SECONDS + 1) * 1000
+    ).toISOString();
+    await kv.put(
+      CACHE_KEY,
+      JSON.stringify({ ...cached, cachedAt: stalePastFresh }),
+      { expirationTtl: CACHE_TTL_SECONDS }
+    );
   } catch {
-    // Best-effort deletion
+    // Best-effort
   }
 }
 


### PR DESCRIPTION
## Summary

- Replaces `kv.delete(CACHE_KEY)` in `invalidateAgentListCache` with a mark-stale write that shifts `cachedAt` past `FRESH_WINDOW_SECONDS` while keeping the snapshot alive inside `CACHE_TTL_SECONDS`
- The next `getCachedAgentList` call sees a stale (non-null) entry, returns it immediately, and kicks off `maybeTriggerBackgroundRebuild` in the background — no cold-miss synchronous rebuild
- No-op when there is no existing snapshot: the next read cold-misses and rebuilds as before (no regression)

**Impact:** Estimated ~50–100K KV reads/h saved. Every mutation endpoint (`/api/register`, `/api/claims/viral`, `/api/challenge`, `/api/vouch`, `/api/inbox/[address]`, `/api/admin/delete-agent`) previously forced a cold-miss synchronous rebuild on the very next request; this change makes those requests serve a stale snapshot instantly instead.

Closes #655
Refs #652

## Acceptance criteria (from #655)

- [x] `invalidateAgentListCache` no longer calls `kv.delete`
- [x] Function reads the current snapshot, shifts `cachedAt` past `FRESH_WINDOW_SECONDS`, and writes it back with `expirationTtl: CACHE_TTL_SECONDS`
- [x] If no snapshot exists, the function is a no-op (next read cold-misses as before)
- [x] All callers unchanged (register, viral-claim, challenge, vouch, inbox, delete-agent)
- [x] `npm test` passes (31 files, 594 tests)
- [x] `npm run lint` passes (no errors, pre-existing img warnings only)
- [x] Single commit in conventional format

## Test plan

- [x] `npm test` — 31 test files, 594 tests passed, 0 failures
- [x] `npm run lint` — no errors
- [ ] `npm run build` — deferred to CI (heavy in worktree env; lint + test are the primary gates per Phase 0.2 instructions)
- [ ] Post-merge: ~1h smoke window via worker-logs (`logs.aibtc.com`) — watch for read-rate drop on `cache:agent-list` key and absence of cold-miss rebuild spikes after mutation calls

## Files changed

- `lib/cache/agent-list.ts` — single function, lines 138–168

## Notes

All three test files that reference `invalidateAgentListCache` mock it as `vi.fn()` and do not inspect internal KV calls, so no test changes were needed. There are no direct unit tests of `agent-list.ts` that test `invalidateAgentListCache` internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)