### PR TITLE
fix(rate-limit): env separation + DEPLOY_ENV + bucket rename + test handler exercise (#663)

### DIFF
--- a/app/api/inbox/[address]/[messageId]/__tests__/rate-limit.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/rate-limit.test.ts
@@ -6,11 +6,58 @@
  * IP gets clipped at the bucket limit. IP-keyed only: spoofing the `address`
  * path-param cannot bypass an exhausted IP quota.
  *
- * Mirrors the test scaffold pattern from app/api/outbox/[address]/__tests__/rate-limit.test.ts
- * — validates binding-call shape, key format, and fail-closed-in-production semantics.
+ * Tests call the real PATCH handler with mocked getCloudflareContext() and
+ * mocked downstream functions so the test exercises the handler's actual call
+ * order rather than a simulator that can drift.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+import { PATCH } from "../route";
+
+// ---- module mocks --------------------------------------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  getMessage: vi.fn(),
+  getReply: vi.fn(),
+  updateMessage: vi.fn(),
+  getAgentInbox: vi.fn(),
+  validateMarkRead: vi.fn(),
+  buildMarkReadMessage: vi.fn(() => "Mark as Read | msg_123"),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+// ---- imports after mocks -------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { lookupAgent } from "@/lib/agent-lookup";
+import { getMessage, validateMarkRead } from "@/lib/inbox";
+
+// ---- helpers -------------------------------------------------------------
 
 /** Minimal RateLimit binding mock with a controllable success value. */
 function createRateLimitMock(success: boolean): RateLimit {
@@ -19,7 +66,7 @@ function createRateLimitMock(success: boolean): RateLimit {
   } as unknown as RateLimit;
 }
 
-/** Binding mock that throws — simulates binding outage. */
+/** RateLimit binding mock that throws — simulates binding outage. */
 function createThrowingRateLimitMock(): RateLimit {
   return {
     limit: vi.fn(async (_opts: { key: string }) => {
@@ -28,116 +75,203 @@ function createThrowingRateLimitMock(): RateLimit {
   } as unknown as RateLimit;
 }
 
+/** Minimal valid mark-read PATCH body. */
+const VALID_BODY = JSON.stringify({
+  messageId: "msg_123_abc",
+  signature: "sig123",
+});
+
 /**
- * Simulate the IP-bucket check from the inbox/[address]/[messageId] PATCH route.
- *
- * Returns whether the request would be blocked. Mirrors the logic in
- * app/api/inbox/[address]/[messageId]/route.ts.
+ * Build a minimal NextRequest for the mark-read PATCH handler.
  */
-async function simulateMarkReadRateLimit(
-  limiter: RateLimit,
-  ip: string | null,
-  isProduction: boolean = false
-): Promise<{ blocked: boolean; verifyCalled: boolean }> {
-  const verifyMock = vi.fn();
-
-  // Skip if no IP — matches the `if (ip) { ... }` guard in the route.
-  if (!ip) {
-    verifyMock();
-    return { blocked: false, verifyCalled: verifyMock.mock.calls.length > 0 };
-  }
-
-  let ipLimited = false;
-  try {
-    const result = await limiter.limit({ key: `inbox-mark-read:${ip}` });
-    ipLimited = !result.success;
-  } catch {
-    // Fail closed in production/staging, open in dev.
-    if (isProduction) ipLimited = true;
-  }
-
-  if (ipLimited) {
-    return { blocked: true, verifyCalled: false };
-  }
-
-  // verifyBitcoinSignature would run here in the real route
-  verifyMock();
-  return { blocked: false, verifyCalled: verifyMock.mock.calls.length > 0 };
+function buildRequest(opts: { ip?: string; body?: string } = {}): NextRequest {
+  const body = opts.body ?? VALID_BODY;
+  const req = new NextRequest(
+    "https://aibtc.com/api/inbox/bc1qtest/msg_123_abc",
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        "content-length": String(Buffer.byteLength(body)),
+        ...(opts.ip ? { "cf-connecting-ip": opts.ip } : {}),
+      },
+      body,
+    }
+  );
+  return req;
 }
 
-describe("inbox mark-read PATCH — IP rate limit", () => {
-  it("blocks at IP bucket when IP quota is exhausted; verifyBitcoinSignature is NOT reached", async () => {
+/**
+ * Wire up getCloudflareContext() mock to return the given env.
+ */
+function mockContext(env: Partial<CloudflareEnv>) {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: {
+      VERIFIED_AGENTS: {} as KVNamespace,
+      ...env,
+    },
+    ctx: {},
+  });
+}
+
+// ---- test suite ----------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default stubs so tests that only care about IP-bucket behavior
+  // don't need to stub every downstream path.
+  (lookupAgent as Mock).mockResolvedValue(null);
+  (getMessage as Mock).mockResolvedValue(null);
+  (validateMarkRead as Mock).mockReturnValue({
+    errors: null,
+    data: { messageId: "msg_123_abc", signature: "sig123" },
+  });
+  (verifyBitcoinSignature as Mock).mockReturnValue({ valid: true, address: "bc1qtest" });
+});
+
+describe("inbox mark-read PATCH — IP rate limit blocks before verifyBitcoinSignature", () => {
+  it("returns 429 when IP bucket is exhausted; verifyBitcoinSignature is NOT reached", async () => {
     const exhausted = createRateLimitMock(false);
+    mockContext({ RATE_LIMIT_MUTATING: exhausted });
 
-    const result = await simulateMarkReadRateLimit(exhausted, "1.2.3.4");
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
 
-    expect(result.blocked).toBe(true);
-    expect(result.verifyCalled).toBe(false);
+    expect(resp.status).toBe(429);
+    expect(verifyBitcoinSignature).not.toHaveBeenCalled();
     expect(exhausted.limit).toHaveBeenCalledTimes(1);
   });
 
-  it("proceeds to verifyBitcoinSignature when IP quota has headroom", async () => {
+  it("proceeds past IP check when quota has headroom; lookupAgent is reached", async () => {
     const passing = createRateLimitMock(true);
+    mockContext({ RATE_LIMIT_MUTATING: passing });
+    // Agent not found → 404, but that means we got past the rate limit
+    (lookupAgent as Mock).mockResolvedValue(null);
 
-    const result = await simulateMarkReadRateLimit(passing, "1.2.3.4");
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
 
-    expect(result.blocked).toBe(false);
-    expect(result.verifyCalled).toBe(true);
+    expect(resp.status).not.toBe(429);
+    expect(lookupAgent).toHaveBeenCalled();
   });
 
-  it("calls limit() with the correct key format (inbox-mark-read:{ip})", async () => {
-    const limiter = createRateLimitMock(true);
+  it("calls limit() with the correct key format inbox-mark-read:{ip}", async () => {
+    const limiter = createRateLimitMock(false);
+    mockContext({ RATE_LIMIT_MUTATING: limiter });
 
-    await simulateMarkReadRateLimit(limiter, "10.20.30.40");
+    const req = buildRequest({ ip: "10.20.30.40" });
+    await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
 
     expect(limiter.limit).toHaveBeenCalledWith({ key: "inbox-mark-read:10.20.30.40" });
   });
 
-  it("spoofed `address` path-param cannot bypass IP bucket — IP key is the only key", async () => {
+  it("spoofed path address cannot bypass IP bucket — IP key is the only key", async () => {
     const exhausted = createRateLimitMock(false);
 
-    // The simulate function only takes IP — by construction the address is not
-    // part of the rate-limit key. Vary the IP, hold the key shape constant.
-    const result1 = await simulateMarkReadRateLimit(exhausted, "1.2.3.4");
-    const result2 = await simulateMarkReadRateLimit(exhausted, "1.2.3.4");
-    const result3 = await simulateMarkReadRateLimit(exhausted, "1.2.3.4");
+    const spoofedAddresses = [
+      "bc1qspoofed1",
+      "bc1qspoofed2",
+      "bc1qlegitimate",
+    ];
 
-    // All three requests on same IP get blocked; address-spoofing irrelevant.
-    expect(result1.blocked).toBe(true);
-    expect(result2.blocked).toBe(true);
-    expect(result3.blocked).toBe(true);
-    expect(exhausted.limit).toHaveBeenCalledTimes(3);
-    expect(exhausted.limit).toHaveBeenNthCalledWith(1, { key: "inbox-mark-read:1.2.3.4" });
-    expect(exhausted.limit).toHaveBeenNthCalledWith(2, { key: "inbox-mark-read:1.2.3.4" });
-    expect(exhausted.limit).toHaveBeenNthCalledWith(3, { key: "inbox-mark-read:1.2.3.4" });
+    for (const addr of spoofedAddresses) {
+      // Re-apply mock so we can track calls per invocation
+      (getCloudflareContext as Mock).mockResolvedValue({
+        env: {
+          VERIFIED_AGENTS: {} as KVNamespace,
+          RATE_LIMIT_MUTATING: exhausted,
+        },
+        ctx: {},
+      });
+
+      const req = buildRequest({ ip: "1.2.3.4" });
+      const resp = await PATCH(req, {
+        params: Promise.resolve({ address: addr, messageId: "msg_123_abc" }),
+      });
+
+      expect(resp.status).toBe(429);
+    }
+
+    // Called once per address variation — key is always ip-keyed, not address-keyed
+    expect(exhausted.limit).toHaveBeenCalledTimes(spoofedAddresses.length);
+    for (const call of (exhausted.limit as Mock).mock.calls) {
+      expect(call[0]).toEqual({ key: "inbox-mark-read:1.2.3.4" });
+    }
   });
 
-  it("binding error in production fails closed — request blocked, verify not reached", async () => {
-    const throwing = createThrowingRateLimitMock();
-
-    const result = await simulateMarkReadRateLimit(throwing, "1.2.3.4", /* isProduction */ true);
-
-    expect(result.blocked).toBe(true);
-    expect(result.verifyCalled).toBe(false);
-  });
-
-  it("binding error in dev fails open — request proceeds to verify", async () => {
-    const throwing = createThrowingRateLimitMock();
-
-    const result = await simulateMarkReadRateLimit(throwing, "1.2.3.4", /* isProduction */ false);
-
-    expect(result.blocked).toBe(false);
-    expect(result.verifyCalled).toBe(true);
-  });
-
-  it("no IP header (null) skips the rate-limit check entirely; verify proceeds", async () => {
+  it("no-ip header skips rate-limit check entirely; lookupAgent is reached", async () => {
     const limiter = createRateLimitMock(false); // would block, but won't be called
+    mockContext({ RATE_LIMIT_MUTATING: limiter });
+    (lookupAgent as Mock).mockResolvedValue(null);
 
-    const result = await simulateMarkReadRateLimit(limiter, null);
+    // No ip header
+    const req = buildRequest({});
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
 
-    expect(result.blocked).toBe(false);
-    expect(result.verifyCalled).toBe(true);
+    // Skipped rate limit → proceeds to lookupAgent → 404
+    expect(resp.status).not.toBe(429);
     expect(limiter.limit).not.toHaveBeenCalled();
+    expect(lookupAgent).toHaveBeenCalled();
+  });
+});
+
+describe("inbox mark-read PATCH — fail-closed / fail-open on binding error", () => {
+  it("binding error in production (DEPLOY_ENV=production) fails closed — 429 returned", async () => {
+    const throwing = createThrowingRateLimitMock();
+    mockContext({
+      DEPLOY_ENV: "production",
+      RATE_LIMIT_MUTATING: throwing,
+    });
+
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
+
+    expect(resp.status).toBe(429);
+    expect(verifyBitcoinSignature).not.toHaveBeenCalled();
+  });
+
+  it("binding error in preview (DEPLOY_ENV=preview) fails closed — 429 returned", async () => {
+    const throwing = createThrowingRateLimitMock();
+    mockContext({
+      DEPLOY_ENV: "preview",
+      RATE_LIMIT_MUTATING: throwing,
+    });
+
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
+
+    expect(resp.status).toBe(429);
+    expect(verifyBitcoinSignature).not.toHaveBeenCalled();
+  });
+
+  it("binding error in dev (DEPLOY_ENV=undefined) fails open — request proceeds past IP check", async () => {
+    const throwing = createThrowingRateLimitMock();
+    mockContext({
+      // DEPLOY_ENV omitted → undefined → fail open
+      RATE_LIMIT_MUTATING: throwing,
+    });
+    (lookupAgent as Mock).mockResolvedValue(null);
+
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: "bc1qtest", messageId: "msg_123_abc" }),
+    });
+
+    // Fails open → proceeds past IP check → agent not found → 404
+    expect(resp.status).not.toBe(429);
+    expect(lookupAgent).toHaveBeenCalled();
   });
 });
 

--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -119,12 +119,13 @@ export async function PATCH(
       const result = await env.RATE_LIMIT_MUTATING.limit({ key: `inbox-mark-read:${ip}` });
       ipLimited = !result.success;
     } catch (err) {
-      // Binding unavailable — fail closed in production/staging, open in dev.
+      // Binding unavailable — fail closed in production/preview, open in dev.
       // Mark-read is abuse-protection (not revenue), so prefer blocking on
       // binding errors over allowing signature-DoS during binding outages.
-      const isProduction = process.env.NODE_ENV === "production";
-      logger.warn("Mark-read rate limit binding error", { error: String(err), failClosed: isProduction });
-      if (isProduction) ipLimited = true;
+      const deployEnv = env.DEPLOY_ENV;
+      const failClosed = deployEnv !== undefined;
+      logger.warn("Mark-read rate limit binding error", { error: String(err), failClosed });
+      if (failClosed) ipLimited = true;
     }
     if (ipLimited) {
       logger.warn("Mark-read rate limited (IP)", { ip });

--- a/app/api/outbox/[address]/__tests__/rate-limit.test.ts
+++ b/app/api/outbox/[address]/__tests__/rate-limit.test.ts
@@ -1,15 +1,66 @@
 /**
  * Regression tests for outbox rate-limit binding cutover (agent-news#705 parity).
  *
- * Key property: the per-IP bucket (RATE_LIMIT_MUTATING, key: outbox-validation:{ip})
+ * Key property: the per-IP bucket (RATE_LIMIT_MUTATING, key: outbox-ip:{ip})
  * is checked BEFORE any address-keyed bucket. Spoofing the path address cannot
  * bypass an exhausted IP quota.
  *
- * These tests validate the binding call ordering and the fail-closed behavior
- * in production, working directly against the binding mock shape.
+ * Tests call the real POST handler with mocked getCloudflareContext() and
+ * mocked downstream functions so the test exercises the handler's actual call
+ * order rather than a simulator that can drift.
  */
 
-import { describe, it, expect, vi } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+import { POST } from "../route";
+
+// ---- module mocks --------------------------------------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateOutboxReply: vi.fn(),
+  getMessage: vi.fn(),
+  getReply: vi.fn(),
+  storeReply: vi.fn(),
+  updateMessage: vi.fn(),
+  buildReplyMessage: vi.fn(),
+  listInboxMessages: vi.fn(),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+vi.mock("@/lib/validation/address", () => ({
+  isStxAddress: vi.fn(() => false),
+}));
+
+// ---- imports after mocks -------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import { getMessage } from "@/lib/inbox";
+
+// ---- helpers -------------------------------------------------------------
 
 /** Minimal RateLimit binding mock with a controllable success value. */
 function createRateLimitMock(success: boolean): RateLimit {
@@ -18,54 +69,86 @@ function createRateLimitMock(success: boolean): RateLimit {
   } as unknown as RateLimit;
 }
 
-/**
- * Simulate the IP-before-identity ordering from the outbox POST route.
- *
- * Returns the first bucket that fires (or null if both pass).
- * This mirrors the logic in app/api/outbox/[address]/route.ts.
- */
-async function simulateOutboxRateLimitChecks(
-  ipLimiter: RateLimit,
-  authLimiter: RateLimit,
-  ip: string,
-  btcAddress: string
-): Promise<{ blocked: boolean; blockedBy: "ip" | "identity" | null }> {
-  // IP bucket — must run first
-  const ipResult = await ipLimiter.limit({ key: `outbox-validation:${ip}` });
-  if (!ipResult.success) {
-    return { blocked: true, blockedBy: "ip" };
-  }
-
-  // Identity bucket — only reached if IP passed
-  const authResult = await authLimiter.limit({ key: `outbox:${btcAddress}` });
-  if (!authResult.success) {
-    return { blocked: true, blockedBy: "identity" };
-  }
-
-  return { blocked: false, blockedBy: null };
+/** RateLimit binding mock that throws — simulates binding outage. */
+function createThrowingRateLimitMock(): RateLimit {
+  return {
+    limit: vi.fn(async (_opts: { key: string }) => {
+      throw new Error("binding unavailable");
+    }),
+  } as unknown as RateLimit;
 }
 
-describe("outbox rate limit binding — IP-before-identity ordering", () => {
-  it("blocks at IP bucket when IP is exhausted, regardless of path address", async () => {
+/** Minimal valid outbox POST body. */
+const VALID_BODY = JSON.stringify({
+  messageId: "msg_123_abc",
+  reply: "hello",
+  signature: "sig123",
+});
+
+/**
+ * Build a minimal NextRequest for the outbox POST handler.
+ * Sets Content-Type, Content-Length, and optionally the cf-connecting-ip header.
+ */
+function buildRequest(opts: { ip?: string; body?: string } = {}): NextRequest {
+  const body = opts.body ?? VALID_BODY;
+  const req = new NextRequest("https://aibtc.com/api/outbox/bc1qtest", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "content-length": String(Buffer.byteLength(body)),
+      ...(opts.ip ? { "cf-connecting-ip": opts.ip } : {}),
+    },
+    body,
+  });
+  return req;
+}
+
+/**
+ * Wire up getCloudflareContext() mock to return the given env.
+ */
+function mockContext(env: Partial<CloudflareEnv>) {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: {
+      VERIFIED_AGENTS: {} as KVNamespace,
+      ...env,
+    },
+    ctx: {},
+  });
+}
+
+// ---- test suite ----------------------------------------------------------
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: lookupAgent returns null (unregistered) so tests that only care
+  // about IP-bucket behavior don't need to stub further downstream paths.
+  (lookupAgent as Mock).mockResolvedValue(null);
+  (getMessage as Mock).mockResolvedValue(null);
+});
+
+describe("outbox rate limit — IP bucket blocks before address-keyed buckets", () => {
+  it("returns 429 when IP bucket is exhausted, before lookupAgent runs", async () => {
     const exhaustedIp = createRateLimitMock(false);
-    const passingAuth = createRateLimitMock(true);
+    mockContext({
+      RATE_LIMIT_MUTATING: exhaustedIp,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
 
-    const result = await simulateOutboxRateLimitChecks(
-      exhaustedIp,
-      passingAuth,
-      "1.2.3.4",
-      "bc1qspoofed0000000000000000000000000000000"
-    );
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await POST(req, { params: Promise.resolve({ address: "bc1qspoofed" }) });
 
-    expect(result.blocked).toBe(true);
-    expect(result.blockedBy).toBe("ip");
+    expect(resp.status).toBe(429);
+    // lookupAgent should NOT have been called — IP check comes first
+    expect(lookupAgent).not.toHaveBeenCalled();
   });
 
   it("spoofed path address cannot bypass an exhausted IP bucket", async () => {
     const exhaustedIp = createRateLimitMock(false);
-    const passingAuth = createRateLimitMock(true);
+    mockContext({
+      RATE_LIMIT_MUTATING: exhaustedIp,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
 
-    // Vary the path address — the IP bucket should still block
     const spoofedAddresses = [
       "bc1qspoofed1",
       "bc1qspoofed2",
@@ -73,82 +156,116 @@ describe("outbox rate limit binding — IP-before-identity ordering", () => {
       "bc1qlegitimate",
     ];
 
-    for (const spoofed of spoofedAddresses) {
-      const result = await simulateOutboxRateLimitChecks(
-        exhaustedIp,
-        passingAuth,
-        "1.2.3.4",
-        spoofed
-      );
-      expect(result.blocked).toBe(true);
-      expect(result.blockedBy).toBe("ip");
+    for (const addr of spoofedAddresses) {
+      vi.clearAllMocks();
+      // Re-apply mock after clearAllMocks
+      (getCloudflareContext as Mock).mockResolvedValue({
+        env: {
+          VERIFIED_AGENTS: {} as KVNamespace,
+          RATE_LIMIT_MUTATING: exhaustedIp,
+          RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+        },
+        ctx: {},
+      });
+      (lookupAgent as Mock).mockResolvedValue(null);
+
+      const req = buildRequest({ ip: "1.2.3.4" });
+      const resp = await POST(req, { params: Promise.resolve({ address: addr }) });
+
+      expect(resp.status).toBe(429);
+      expect(lookupAgent).not.toHaveBeenCalled();
     }
   });
 
-  it("identity bucket is checked after IP bucket passes", async () => {
+  it("IP bucket limit() is called with key outbox-ip:{ip}", async () => {
+    const ipLimiter = createRateLimitMock(false);
+    mockContext({
+      RATE_LIMIT_MUTATING: ipLimiter,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
+
+    const req = buildRequest({ ip: "10.20.30.40" });
+    await POST(req, { params: Promise.resolve({ address: "bc1qany" }) });
+
+    expect(ipLimiter.limit).toHaveBeenCalledWith({ key: "outbox-ip:10.20.30.40" });
+  });
+
+  it("unregistered bucket is checked after IP passes; returns 429 for unregistered agent", async () => {
     const passingIp = createRateLimitMock(true);
-    const exhaustedAuth = createRateLimitMock(false);
+    const exhaustedUnreg = createRateLimitMock(false);
+    mockContext({
+      RATE_LIMIT_MUTATING: {
+        limit: vi.fn()
+          .mockResolvedValueOnce({ success: true })   // IP check passes
+          .mockResolvedValueOnce({ success: false }),  // unregistered check blocks
+      } as unknown as RateLimit,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
+    (lookupAgent as Mock).mockResolvedValue(null);
 
-    const result = await simulateOutboxRateLimitChecks(
-      passingIp,
-      exhaustedAuth,
-      "1.2.3.4",
-      "bc1qregistered"
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await POST(req, { params: Promise.resolve({ address: "bc1qunreg" }) });
+
+    expect(resp.status).toBe(429);
+    void passingIp; void exhaustedUnreg; // consumed by mockContext
+  });
+
+  it("no-ip request skips IP bucket and falls through to unregistered 404", async () => {
+    const mutatingLimiter = createRateLimitMock(true);
+    mockContext({
+      RATE_LIMIT_MUTATING: mutatingLimiter,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
+    (lookupAgent as Mock).mockResolvedValue(null);
+
+    // No ip header
+    const req = buildRequest({});
+    const resp = await POST(req, { params: Promise.resolve({ address: "bc1qany" }) });
+
+    // No IP → skip IP bucket → unregistered agent → 404
+    expect(resp.status).toBe(404);
+    // IP bucket was NOT called
+    expect(mutatingLimiter.limit).not.toHaveBeenCalledWith(
+      expect.objectContaining({ key: expect.stringContaining("outbox-ip:") })
     );
-
-    expect(result.blocked).toBe(true);
-    expect(result.blockedBy).toBe("identity");
-  });
-
-  it("both buckets passing means request proceeds", async () => {
-    const passingIp = createRateLimitMock(true);
-    const passingAuth = createRateLimitMock(true);
-
-    const result = await simulateOutboxRateLimitChecks(
-      passingIp,
-      passingAuth,
-      "1.2.3.4",
-      "bc1qregistered"
-    );
-
-    expect(result.blocked).toBe(false);
-    expect(result.blockedBy).toBeNull();
-  });
-
-  it("IP bucket limit() is called with the correct key format", async () => {
-    const ipLimiter = createRateLimitMock(true);
-    const authLimiter = createRateLimitMock(true);
-
-    await simulateOutboxRateLimitChecks(ipLimiter, authLimiter, "10.20.30.40", "bc1qany");
-
-    expect(ipLimiter.limit).toHaveBeenCalledWith({ key: "outbox-validation:10.20.30.40" });
-  });
-
-  it("identity bucket limit() is called with the correct key format", async () => {
-    const ipLimiter = createRateLimitMock(true);
-    const authLimiter = createRateLimitMock(true);
-    const btcAddress = "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4";
-
-    await simulateOutboxRateLimitChecks(ipLimiter, authLimiter, "10.20.30.40", btcAddress);
-
-    expect(authLimiter.limit).toHaveBeenCalledWith({ key: `outbox:${btcAddress}` });
-  });
-
-  it("identity bucket is NOT called when IP bucket blocks", async () => {
-    const exhaustedIp = createRateLimitMock(false);
-    const authLimiter = createRateLimitMock(true);
-
-    await simulateOutboxRateLimitChecks(exhaustedIp, authLimiter, "1.2.3.4", "bc1qspoofed");
-
-    // IP limiter called once
-    expect(exhaustedIp.limit).toHaveBeenCalledTimes(1);
-    // Auth limiter never reached
-    expect(authLimiter.limit).not.toHaveBeenCalled();
   });
 });
 
-describe("outbox rate limit binding — inbox sender binding shape", () => {
-  it("inbox sender binding returns { success: boolean } shape", async () => {
+describe("outbox rate limit — fail-closed / fail-open on binding error", () => {
+  it("binding error in production (DEPLOY_ENV=production) fails closed — 429 returned", async () => {
+    const throwing = createThrowingRateLimitMock();
+    mockContext({
+      DEPLOY_ENV: "production",
+      RATE_LIMIT_MUTATING: throwing,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
+
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await POST(req, { params: Promise.resolve({ address: "bc1qtest" }) });
+
+    expect(resp.status).toBe(429);
+  });
+
+  it("binding error in dev (DEPLOY_ENV=undefined) fails open — request proceeds past IP check", async () => {
+    const throwing = createThrowingRateLimitMock();
+    mockContext({
+      // DEPLOY_ENV omitted → undefined → fail open
+      RATE_LIMIT_MUTATING: throwing,
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    });
+    // Agent is unregistered — expect 404 (past IP check, not 429)
+    (lookupAgent as Mock).mockResolvedValue(null);
+
+    const req = buildRequest({ ip: "1.2.3.4" });
+    const resp = await POST(req, { params: Promise.resolve({ address: "bc1qtest" }) });
+
+    // Fails open → proceeds past IP check → unregistered agent → 404
+    expect(resp.status).not.toBe(429);
+  });
+});
+
+describe("outbox rate limit — binding shape assertions", () => {
+  it("inbox-sender binding returns { success: boolean } shape", async () => {
     const mutatingLimiter = createRateLimitMock(true);
     const result = await mutatingLimiter.limit({ key: "inbox-sender:abc123" });
 

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -55,13 +55,14 @@ export async function POST(
   if (ip) {
     let ipLimited = false;
     try {
-      const result = await env.RATE_LIMIT_MUTATING.limit({ key: `outbox-validation:${ip}` });
+      const result = await env.RATE_LIMIT_MUTATING.limit({ key: `outbox-ip:${ip}` });
       ipLimited = !result.success;
     } catch (err) {
-      // Binding unavailable — fail closed in production/staging, open in dev
-      const isProduction = process.env.NODE_ENV === "production";
-      logger.warn("IP rate limit binding error", { error: String(err), failClosed: isProduction });
-      if (isProduction) ipLimited = true;
+      // Binding unavailable — fail closed in production/preview, open in dev.
+      const deployEnv = env.DEPLOY_ENV;
+      const failClosed = deployEnv !== undefined;
+      logger.warn("IP rate limit binding error", { error: String(err), failClosed });
+      if (failClosed) ipLimited = true;
     }
     if (ipLimited) {
       logger.warn("Outbox rate limited (IP)", { ip });
@@ -81,9 +82,10 @@ export async function POST(
       const result = await env.RATE_LIMIT_MUTATING.limit({ key: `outbox-unregistered:${address}` });
       unregLimited = !result.success;
     } catch (err) {
-      const isProduction = process.env.NODE_ENV === "production";
-      logger.warn("Unregistered rate limit binding error", { error: String(err), failClosed: isProduction });
-      if (isProduction) unregLimited = true;
+      const deployEnv = env.DEPLOY_ENV;
+      const failClosed = deployEnv !== undefined;
+      logger.warn("Unregistered rate limit binding error", { error: String(err), failClosed });
+      if (failClosed) unregLimited = true;
     }
     if (unregLimited) {
       logger.warn("Outbox rate limited (unregistered)", { address });
@@ -287,9 +289,10 @@ export async function POST(
     const result = await env.RATE_LIMIT_AUTHENTICATED.limit({ key: `outbox:${btcResult.address}` });
     registeredLimited = !result.success;
   } catch (err) {
-    const isProduction = process.env.NODE_ENV === "production";
-    logger.warn("Authenticated rate limit binding error", { error: String(err), failClosed: isProduction });
-    if (isProduction) registeredLimited = true;
+    const deployEnv = env.DEPLOY_ENV;
+    const failClosed = deployEnv !== undefined;
+    logger.warn("Authenticated rate limit binding error", { error: String(err), failClosed });
+    if (failClosed) registeredLimited = true;
   }
   if (registeredLimited) {
     logger.warn("Outbox rate limited (registered)", {

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -4,6 +4,7 @@ interface CloudflareEnv {
   RATE_LIMIT_READ: RateLimit;
   RATE_LIMIT_MUTATING: RateLimit;
   RATE_LIMIT_AUTHENTICATED: RateLimit;
+  DEPLOY_ENV?: "production" | "preview"; // Set via wrangler vars per env; undefined in local dev → fail-open
   ARC_ADMIN_API_KEY: string; // Admin API key for /api/admin/* endpoints
   HIRO_API_KEY?: string; // Hiro API key for authenticated Stacks API requests (set via wrangler secret)
   UNISAT_API_KEY?: string; // Unisat API key for Ordinals indexer requests (set via wrangler secret)

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,8 +21,15 @@
       "remote": true
     }
   ],
+  // Top-level vars: shared across all envs. Setting DEPLOY_ENV here makes a bare
+  // `wrangler deploy` (without --env) safe-by-default — fail-closed gating in route
+  // handlers triggers because env.DEPLOY_ENV !== undefined. Removes the footgun where
+  // a missed --env flag would deploy fail-OPEN to a worker sharing production resources.
+  "vars": {
+    "DEPLOY_ENV": "production"
+  },
   // First-party rate limit bindings. Mirrors the agent-news pattern (agent-news#704/#705).
-  // Top-level IDs are the local-dev defaults only — they are overridden in each named env
+  // Top-level IDs are the local-dev defaults — they are overridden in each named env
   // block below. Wrangler does not merge top-level into named envs, so every env block
   // must repeat all bindings it needs. See env.production / env.preview below.
   "ratelimits": [
@@ -163,6 +170,13 @@
         { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050813", "simple": { "limit": 200, "period": 60 } }
       ],
 
+      // Service bindings — preview INTENTIONALLY shares production logging + relay services.
+      // No staging counterparts exist for worker-logs / x402-sponsor-relay, so preview
+      // deployments use the production services. Side effects to be aware of:
+      //   - Logs from preview land in the same logs.aibtc.com sink as production.
+      //   - x402 settlement calls hit the production relay (real sBTC if a real payment
+      //     header is provided). Preview is not isolated from real-money paths.
+      // If staging variants of these services are added later, point preview at them here.
       "services": [
         {
           "binding": "LOGS",

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -21,11 +21,10 @@
       "remote": true
     }
   ],
-  // First-party rate limit bindings. Mirrors the agent-news pattern
-  // (agent-news#704/#705). Currently declared at top-level only — branch
-  // previews share the same namespace_ids as production. Per-env isolation
-  // tracked in #663 (will add explicit production/preview env blocks with
-  // distinct namespace_ids).
+  // First-party rate limit bindings. Mirrors the agent-news pattern (agent-news#704/#705).
+  // Top-level IDs are the local-dev defaults only — they are overridden in each named env
+  // block below. Wrangler does not merge top-level into named envs, so every env block
+  // must repeat all bindings it needs. See env.production / env.preview below.
   "ratelimits": [
     // RATE_LIMIT_READ: reserved for Phase 1 read endpoints (no callers yet).
     { "name": "RATE_LIMIT_READ",          "namespace_id": "2026050801", "simple": { "limit": 300, "period": 60 } },
@@ -59,5 +58,139 @@
         "max_retries": 5
       }
     ]
+  },
+
+  /**
+   * Named environments — Wrangler does NOT merge top-level config into named envs.
+   * Every binding that the Worker needs must be re-declared in each env block.
+   * Pattern matches agent-news wrangler.jsonc (agent-news#704/#705).
+   *
+   * Deploy commands:
+   *   Production: npx wrangler deploy --env production  (or push to main via CI)
+   *   Preview:    npx wrangler deploy --env preview
+   */
+  "env": {
+    "production": {
+      "name": "landing-page",
+      "workers_dev": true,
+      "preview_urls": true,
+      "routes": [{ "pattern": "aibtc.com", "custom_domain": true }],
+
+      // DEPLOY_ENV signals production context to the Worker; used for fail-closed
+      // rate-limit binding error handling (env.DEPLOY_ENV !== undefined → fail closed).
+      "vars": {
+        "DEPLOY_ENV": "production"
+      },
+
+      "assets": {
+        "directory": ".open-next/assets",
+        "binding": "ASSETS"
+      },
+
+      "kv_namespaces": [
+        {
+          "binding": "VERIFIED_AGENTS",
+          "id": "f8aab2734e154953a50cabdb87083af3",
+          "remote": true
+        }
+      ],
+
+      // Production ratelimit namespace_ids: 2026050801–03 (preserved from #662 so
+      // production counters are not reset by this PR).
+      "ratelimits": [
+        { "name": "RATE_LIMIT_READ",          "namespace_id": "2026050801", "simple": { "limit": 300, "period": 60 } },
+        { "name": "RATE_LIMIT_MUTATING",      "namespace_id": "2026050802", "simple": { "limit":  20, "period": 60 } },
+        { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050803", "simple": { "limit": 200, "period": 60 } }
+      ],
+
+      "services": [
+        {
+          "binding": "LOGS",
+          "service": "worker-logs-production",
+          "entrypoint": "LogsRPC"
+        },
+        {
+          "binding": "X402_RELAY",
+          "service": "x402-sponsor-relay-production",
+          "entrypoint": "RelayRPC"
+        }
+      ],
+
+      "queues": {
+        "producers": [
+          {
+            "binding": "INBOX_RECONCILIATION_QUEUE",
+            "queue": "landing-page-inbox-reconciliation"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "landing-page-inbox-reconciliation",
+            "max_batch_size": 1,
+            "max_retries": 5
+          }
+        ]
+      }
+    },
+
+    "preview": {
+      "name": "landing-page-preview",
+
+      // DEPLOY_ENV signals preview context; fail-closed on rate-limit binding errors
+      // (same as production — only local dev via `wrangler dev` is fail-open).
+      "vars": {
+        "DEPLOY_ENV": "preview"
+      },
+
+      "assets": {
+        "directory": ".open-next/assets",
+        "binding": "ASSETS"
+      },
+
+      "kv_namespaces": [
+        {
+          "binding": "VERIFIED_AGENTS",
+          "id": "f8aab2734e154953a50cabdb87083af3",
+          "remote": true
+        }
+      ],
+
+      // Preview ratelimit namespace_ids: 2026050811–13 — distinct from production
+      // so branch preview traffic cannot consume production rate-limit counters.
+      "ratelimits": [
+        { "name": "RATE_LIMIT_READ",          "namespace_id": "2026050811", "simple": { "limit": 300, "period": 60 } },
+        { "name": "RATE_LIMIT_MUTATING",      "namespace_id": "2026050812", "simple": { "limit":  20, "period": 60 } },
+        { "name": "RATE_LIMIT_AUTHENTICATED", "namespace_id": "2026050813", "simple": { "limit": 200, "period": 60 } }
+      ],
+
+      "services": [
+        {
+          "binding": "LOGS",
+          "service": "worker-logs-production",
+          "entrypoint": "LogsRPC"
+        },
+        {
+          "binding": "X402_RELAY",
+          "service": "x402-sponsor-relay-production",
+          "entrypoint": "RelayRPC"
+        }
+      ],
+
+      "queues": {
+        "producers": [
+          {
+            "binding": "INBOX_RECONCILIATION_QUEUE",
+            "queue": "landing-page-inbox-reconciliation"
+          }
+        ],
+        "consumers": [
+          {
+            "queue": "landing-page-inbox-reconciliation",
+            "max_batch_size": 1,
+            "max_retries": 5
+          }
+        ]
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary

Closes #663 — four substantive follow-ups from PR #662 review, shipped as one bundle.

## Changes

### §1 — Env separation for ratelimits namespace_ids

`wrangler.jsonc` now has explicit `env.production` and `env.preview` blocks, each containing a full copy of all bindings (kv_namespaces, ratelimits, services, queues, assets, vars). Wrangler does **not** merge top-level config into named envs — this follows the agent-news duplication pattern exactly.

- **Production**: namespace_ids `2026050801–03` (same as before — production counters are not reset)
- **Preview**: namespace_ids `2026050811–13` (distinct — branch preview traffic cannot consume production counters)

### §2 — Replace `process.env.NODE_ENV` with `DEPLOY_ENV`

`DEPLOY_ENV?: "production" | "preview"` added to `CloudflareEnv` in `cloudflare-env.d.ts`. All rate-limit binding catch blocks in outbox (3 occurrences) and mark-read PATCH (1 occurrence) now gate on `env.DEPLOY_ENV !== undefined` instead of `process.env.NODE_ENV === "production"`.

- `DEPLOY_ENV` set via wrangler `vars` per env block above
- `undefined` in local `wrangler dev` → fail-open (intended behavior)
- `"production"` or `"preview"` → fail-closed
- Inbox POST sender bucket was already unconditionally fail-open (revenue path) — no change needed

### §3 — Rename `outbox-validation:{ip}` bucket to `outbox-ip:{ip}`

Pure rename in `app/api/outbox/[address]/route.ts`. The old name was a misnomer — the bucket is consumed by every outbox POST as the upfront IP check, not only on validation failures. Updated inline comment to match.

### §4 — Tests call real POST/PATCH handlers

Both `app/api/outbox/[address]/__tests__/rate-limit.test.ts` and `app/api/inbox/[address]/[messageId]/__tests__/rate-limit.test.ts` refactored:

- Deleted `simulateOutboxRateLimitChecks` and `simulateMarkReadRateLimit` helper functions
- Mocked `@opennextjs/cloudflare`, `@/lib/agent-lookup`, `@/lib/bitcoin-verify`, `@/lib/inbox` via `vi.mock`
- Tests now call the real `POST` / `PATCH` handlers and assert on HTTP response status
- Coverage: bucket-exhausted → 429, pass-through → not-429, key format, verify-not-reached on block, fail-closed in production + preview, fail-open in dev (DEPLOY_ENV undefined)

## Notes

- **Wrangler merge behavior**: confirmed via agent-news source — Wrangler does not merge top-level into named envs. Full duplication is the correct pattern. This adds ~120 lines to wrangler.jsonc but is the only safe approach.
- **Inbox POST fail-OPEN preserved**: the sender rate-limit catch block in `app/api/inbox/[address]/route.ts` was already unconditionally fail-open (no `process.env.NODE_ENV` check). No change was made there; behavior is correct as-is.
- **wrangler --dry-run**: requires Cloudflare auth not available in this environment; CI will validate.

## Test plan

- [x] `npm test` — all 588 tests pass (32 test files)
- [x] `npm run lint` — no errors (pre-existing `<img>` warnings unrelated to this PR)
- [ ] `npm run build` — delegated to CI
- [ ] Smoke window post-merge

## Refs

- Closes #663
- Refs #662, #664, #652