### PR TITLE
feat(d1): provision landing-page D1 + migrations 001-007 (Phase 1.2, #667)

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -1,5 +1,6 @@
 interface CloudflareEnv {
   ASSETS: Fetcher;
+  DB: D1Database; // D1 relational database (agents, claims, inbox_messages, vouches, swaps, balances)
   VERIFIED_AGENTS: KVNamespace;
   RATE_LIMIT_READ: RateLimit;
   RATE_LIMIT_MUTATING: RateLimit;

--- a/migrations/001_agents.sql
+++ b/migrations/001_agents.sql
@@ -1,0 +1,40 @@
+-- Migration 001: agents table.
+-- See docs/rfc-d1-schema.md `### `agents`` section.
+-- Replaces KV pattern stx:{stxAddress} and btc:{btcAddress} (dual-indexed AgentRecord).
+-- Referral codes (referral-code:{btcAddress} + referral-lookup:{CODE}) folded in as columns.
+
+CREATE TABLE agents (
+  btc_address           TEXT PRIMARY KEY,
+  stx_address           TEXT NOT NULL UNIQUE,
+  stx_public_key        TEXT NOT NULL,
+  btc_public_key        TEXT NOT NULL,
+  taproot_address       TEXT,
+  display_name          TEXT,
+  description           TEXT,
+  bns_name              TEXT,
+  -- owner is the X (Twitter) handle
+  owner                 TEXT,
+  -- verified_at is ISO-8601
+  verified_at           TEXT NOT NULL,
+  last_active_at        TEXT,
+  erc8004_agent_id      INTEGER,
+  nostr_public_key      TEXT,
+  -- capabilities_json is a JSON array, optional
+  capabilities_json     TEXT,
+  last_identity_check   TEXT,
+  github_username       TEXT,
+  -- referred_by_btc is the BTC address of the referrer
+  referred_by_btc       TEXT,
+  -- referral_code is the 6-char code (was referral-code:{btcAddress})
+  referral_code         TEXT NOT NULL UNIQUE,
+  -- D1 enforces foreign keys by default (equivalent to PRAGMA foreign_keys=ON).
+  -- Cycle is intentional: agents.referred_by_btc -> agents.btc_address self-FK.
+  FOREIGN KEY (referred_by_btc) REFERENCES agents(btc_address)
+);
+
+-- stx_address already has an implicit unique index from the UNIQUE constraint;
+-- no separate idx_agents_stx needed.
+CREATE INDEX idx_agents_owner ON agents(lower(owner)) WHERE owner IS NOT NULL;
+CREATE INDEX idx_agents_referred_by ON agents(referred_by_btc) WHERE referred_by_btc IS NOT NULL;
+CREATE INDEX idx_agents_verified_at ON agents(verified_at);
+CREATE INDEX idx_agents_last_active_at ON agents(last_active_at) WHERE last_active_at IS NOT NULL;

--- a/migrations/002_claims.sql
+++ b/migrations/002_claims.sql
@@ -1,0 +1,18 @@
+-- Migration 002: claims table.
+-- See docs/rfc-d1-schema.md `### `claims`` section.
+-- Replaces KV pattern claim:{btcAddress} (ClaimRecord).
+
+CREATE TABLE claims (
+  btc_address       TEXT PRIMARY KEY,
+  display_name      TEXT NOT NULL,
+  tweet_url         TEXT NOT NULL,
+  tweet_author      TEXT,
+  claimed_at        TEXT NOT NULL,
+  reward_satoshis   INTEGER NOT NULL DEFAULT 0,
+  reward_txid       TEXT,
+  status            TEXT NOT NULL CHECK (status IN ('pending', 'verified', 'rewarded', 'failed')),
+  FOREIGN KEY (btc_address) REFERENCES agents(btc_address)
+);
+
+CREATE INDEX idx_claims_status ON claims(status);
+CREATE INDEX idx_claims_claimed_at ON claims(claimed_at);

--- a/migrations/003_inbox_messages.sql
+++ b/migrations/003_inbox_messages.sql
@@ -1,0 +1,86 @@
+-- Migration 003: inbox_messages table.
+-- See docs/rfc-d1-schema.md `### `inbox_messages`` section.
+-- Replaces KV patterns inbox:message:{messageId} (InboxMessage) and
+-- inbox:reply:{messageId} (OutboxReply). The two are folded into one table via is_reply.
+--
+-- Sender address columns: exactly one is populated per row.
+--   Inbound (is_reply=0) rows have from_stx_address (payer's STX from x402 settlement).
+--   Reply (is_reply=1) rows have from_btc_address (recipient's BTC, BIP-322 signed-in).
+--
+-- payment_status mirrors x402-sponsor-relay PaymentStatus terminal outcomes only.
+-- NULL when the row is a reply (no payment) or a fresh inbound before any settlement step.
+--
+-- bitcoin_signature is a single column for both inbound and reply paths (BIP-322 only:
+-- bc1q P2WPKH, bc1p P2TR). Generic name accommodates future BIP-340/Schnorr without rename.
+
+CREATE TABLE inbox_messages (
+  message_id            TEXT PRIMARY KEY,
+  -- is_reply: 0 = inbound message, 1 = outbox reply
+  is_reply              INTEGER NOT NULL DEFAULT 0,
+  -- reply_to_message_id is the message being replied to (NULL for inbound)
+  reply_to_message_id   TEXT,
+  -- from_stx_address is the payer's STX (inbound only)
+  from_stx_address      TEXT,
+  -- from_btc_address is the replier's BTC (reply only)
+  from_btc_address      TEXT,
+  to_btc_address        TEXT NOT NULL,
+  -- to_stx_address is NULL for replies (BTC routing only)
+  to_stx_address        TEXT,
+  content               TEXT NOT NULL,
+  payment_txid          TEXT,
+  -- payment_satoshis is NULL for replies (free)
+  payment_satoshis      INTEGER,
+  payment_status        TEXT CHECK (payment_status IN (
+                          'pending',
+                          'confirmed',
+                          'failed',
+                          'replaced'
+                        ) OR payment_status IS NULL),
+  -- payment_terminal_reason mirrors canonical TerminalReason from @aibtc/tx-schemas/core
+  payment_terminal_reason TEXT,
+  -- payment_error_code is machine-readable (e.g., INSUFFICIENT_FUNDS)
+  payment_error_code    TEXT,
+  -- payment_replacement_txid is the replacement on-chain txid for RBF tracking
+  payment_replacement_txid TEXT,
+  -- payment_id is the relay payment identity for staged/confirmed
+  payment_id            TEXT,
+  -- receipt_id is the relay verify endpoint
+  receipt_id            TEXT,
+  -- recovered_via_txid: 1 if delivered via txid recovery path
+  recovered_via_txid    INTEGER NOT NULL DEFAULT 0,
+  -- authenticated: 1 if Bitcoin signature verified at submit time
+  authenticated         INTEGER NOT NULL DEFAULT 0,
+  -- bitcoin_signature for both inbound and reply paths
+  bitcoin_signature     TEXT,
+  -- sender_btc_address recovered from bitcoin_signature on inbound
+  sender_btc_address    TEXT,
+  -- sent_at is ISO-8601
+  sent_at               TEXT NOT NULL,
+  -- read_at is an inbound-message-only field
+  read_at               TEXT,
+  -- replied_at is an inbound-message-only field
+  replied_at            TEXT,
+  CHECK (
+    (is_reply = 0 AND from_stx_address IS NOT NULL AND from_btc_address IS NULL) OR
+    (is_reply = 1 AND from_btc_address IS NOT NULL AND from_stx_address IS NULL)
+  ),
+  FOREIGN KEY (to_btc_address) REFERENCES agents(btc_address),
+  FOREIGN KEY (reply_to_message_id) REFERENCES inbox_messages(message_id)
+);
+
+-- Per-recipient inbox listing (the dominant read pattern)
+CREATE INDEX idx_inbox_to_btc_sent_at ON inbox_messages(to_btc_address, sent_at DESC) WHERE is_reply = 0;
+
+-- Per-recipient outbox listing (replies they've sent)
+CREATE INDEX idx_inbox_outbox_from_btc_sent_at ON inbox_messages(from_btc_address, sent_at DESC) WHERE is_reply = 1;
+
+-- Unread count per recipient (closes aibtc-mcp-server#497 via live SELECT COUNT(*))
+CREATE INDEX idx_inbox_unread ON inbox_messages(to_btc_address) WHERE is_reply = 0 AND read_at IS NULL;
+
+-- Reply chain lookups
+CREATE INDEX idx_inbox_reply_to ON inbox_messages(reply_to_message_id) WHERE reply_to_message_id IS NOT NULL;
+
+-- Txid double-redemption prevention (ALL recovery paths share this lookup).
+-- PERMANENT: replaces the 90-day KV TTL on inbox:redeemed-txid:{txid}.
+-- A txid is a one-time on-chain event; permanent uniqueness is the correct model.
+CREATE UNIQUE INDEX idx_inbox_payment_txid ON inbox_messages(payment_txid) WHERE payment_txid IS NOT NULL;

--- a/migrations/004_vouches.sql
+++ b/migrations/004_vouches.sql
@@ -1,0 +1,19 @@
+-- Migration 004: vouches table.
+-- See docs/rfc-d1-schema.md `### `vouches`` section.
+-- Replaces KV pattern vouch:{referrerBtc}:{refereeBtc} (VouchRecord).
+-- The vouch:index:{btcAddress} index becomes SELECT WHERE referrer_btc = ?
+
+CREATE TABLE vouches (
+  referrer_btc      TEXT NOT NULL,
+  referee_btc       TEXT NOT NULL,
+  registered_at     TEXT NOT NULL,
+  message_sent      INTEGER NOT NULL DEFAULT 0,
+  paid_out          INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (referrer_btc, referee_btc),
+  FOREIGN KEY (referrer_btc) REFERENCES agents(btc_address),
+  FOREIGN KEY (referee_btc)  REFERENCES agents(btc_address)
+);
+
+CREATE INDEX idx_vouches_referrer ON vouches(referrer_btc, registered_at DESC);
+CREATE INDEX idx_vouches_referee ON vouches(referee_btc);
+CREATE INDEX idx_vouches_paid_out ON vouches(paid_out, registered_at) WHERE paid_out = 0;

--- a/migrations/005_swaps.sql
+++ b/migrations/005_swaps.sql
@@ -1,0 +1,56 @@
+-- Migration 005: swaps table.
+-- See docs/rfc-d1-schema.md `### `swaps`` section.
+-- Bitflow trading-comp verifier surface (Phase 3).
+-- Populated by Phase 3.1 verifier; empty until Phase 3 ships.
+-- Included now so the schema is migration-stable and Phase 3 doesn't fight the substrate.
+--
+-- tx_status mirrors the TerminalFailureStatuses in x402-sponsor-relay's
+-- stacks-tx-verify.ts plus the success path. Pending/in-flight swaps don't get rows;
+-- only terminal states are persisted (one row per terminal txid).
+--
+-- source: ingestion path that wrote the row (agent-submit / cron / chainhook).
+-- All paths use INSERT OR IGNORE on txid for idempotency; first writer wins.
+
+CREATE TABLE swaps (
+  txid              TEXT PRIMARY KEY,
+  -- sender is the STX address
+  sender            TEXT NOT NULL,
+  -- contract_id e.g. "SP...xyk-core-v-1-1"
+  contract_id       TEXT NOT NULL,
+  function_name     TEXT NOT NULL,
+  -- token_in/token_out are contract_ids of input/output assets
+  token_in          TEXT NOT NULL,
+  token_out         TEXT NOT NULL,
+  -- amount_in/amount_out are raw on-chain units
+  amount_in         INTEGER NOT NULL,
+  amount_out        INTEGER NOT NULL,
+  -- burn_block_time is unix seconds
+  burn_block_time   INTEGER NOT NULL,
+  tx_status         TEXT NOT NULL CHECK (tx_status IN (
+                      'success',
+                      'abort_by_response',
+                      'abort_by_post_condition',
+                      'dropped_replace_by_fee',
+                      'dropped_replace_across_fork',
+                      'dropped_too_expensive',
+                      'dropped_stale_garbage_collect',
+                      'dropped_problematic'
+                    )),
+  -- scored_value is the comp-scoring numerator, NULL if not scored
+  scored_value      INTEGER,
+  -- scored_at is when scoring ran
+  scored_at         TEXT,
+  source            TEXT NOT NULL CHECK (source IN ('agent', 'cron', 'chainhook')),
+  -- raw_event_json is the FT/STX transfer event parsed (audit trail)
+  raw_event_json    TEXT,
+  FOREIGN KEY (sender) REFERENCES agents(stx_address)
+);
+
+-- Per-agent swap query (dashboard P&L drill-in)
+CREATE INDEX idx_swaps_sender_burn_time ON swaps(sender, burn_block_time DESC);
+
+-- Comp scoring sweeps (find unscored swaps within a comp window)
+CREATE INDEX idx_swaps_scored_at ON swaps(scored_at) WHERE scored_at IS NULL;
+
+-- Contract-level analytics
+CREATE INDEX idx_swaps_contract_burn_time ON swaps(contract_id, burn_block_time DESC);

--- a/migrations/006_balances.sql
+++ b/migrations/006_balances.sql
@@ -1,0 +1,31 @@
+-- Migration 006: balances table.
+-- See docs/rfc-d1-schema.md `### `balances`` section.
+-- Per-agent token balance snapshots (Phase 3).
+-- Populated by Phase 3.3 5-minute cron. Replaces #651 on-rebuild fan-out.
+--
+-- agent_address is the STX address.
+-- token_id: "stx", "sbtc", "btc-l1", or contract_id of SIP-10.
+-- captured_at is ISO-8601.
+-- raw_amount is in on-chain units; decimals stored per-row for display.
+-- usd_value is microUSD (x1_000_000), NULL if price-feed unavailable.
+-- source: "hiro" | "mempool.space" | "stacks-rpc"
+--
+-- Phase 3.3 cron ships a 90-day TTL sweep:
+--   DELETE FROM balances WHERE captured_at < datetime('now', '-90 days')
+-- See RFC Decision 6 (SpaceX-5 efficiency) for rationale.
+
+CREATE TABLE balances (
+  agent_address       TEXT NOT NULL,
+  token_id            TEXT NOT NULL,
+  captured_at         TEXT NOT NULL,
+  raw_amount          INTEGER NOT NULL,
+  decimals            INTEGER NOT NULL,
+  usd_value           INTEGER,
+  source              TEXT NOT NULL,
+  PRIMARY KEY (agent_address, token_id, captured_at),
+  FOREIGN KEY (agent_address) REFERENCES agents(stx_address)
+);
+
+-- Per-agent balance history (covers BOTH per-agent drill-in AND the dashboard
+-- "latest snapshot per agent per token" query -- leftmost prefix matches both).
+CREATE INDEX idx_balances_agent_token_time ON balances(agent_address, token_id, captured_at DESC);

--- a/migrations/007_registered_wallets_view.sql
+++ b/migrations/007_registered_wallets_view.sql
@@ -1,0 +1,19 @@
+-- Migration 007: registered_wallets view.
+-- See docs/rfc-d1-schema.md `### `registered_wallets` -- view` section.
+-- Thin projection over agents. No WHERE predicate: agents.stx_address is NOT NULL
+-- so all rows represent full registered agents (partial records stay in KV).
+--
+-- Two reasons for this view:
+--   1. Phase 3 verifier + Phase 3.4 dashboard both want to filter
+--      "swap sender in registered wallets" without joining the full agent record.
+--   2. Makes the "is this a registered AIBTC agent?" intent explicit.
+--      If membership criteria expand, this view is the only place to update.
+
+CREATE VIEW registered_wallets AS
+SELECT
+  btc_address,
+  stx_address,
+  taproot_address,
+  verified_at,
+  last_active_at
+FROM agents;

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -11,6 +11,19 @@
     "directory": ".open-next/assets",
     "binding": "ASSETS"
   },
+  // D1 database for relational data (agents, claims, inbox, vouches, swaps, balances).
+  // Provisioned in us-west (Cloudflare region hint: wnam) — matches highest-traffic Worker
+  // region per maintainer (whoabuddy). See RFC Decision 4 in docs/rfc-d1-schema.md.
+  // Provision: wrangler d1 create landing-page --location wnam
+  // Apply migrations: wrangler d1 migrations apply landing-page --remote --env production
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "landing-page",
+      "database_id": "<TBD-from-d1-create>",
+      "migrations_dir": "migrations"
+    }
+  ],
   // KV namespace for storing verified agent records
   // Keys: stx:{address} and btc:{address} for dual indexing
   // Note: The namespace ID is managed by Cloudflare integration and should not be changed manually
@@ -94,6 +107,17 @@
         "binding": "ASSETS"
       },
 
+      // D1 database binding — same database_id as top-level; D1 has no per-env isolation.
+      // Replace <TBD-from-d1-create> with UUID from: wrangler d1 create landing-page --location wnam
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "landing-page",
+          "database_id": "<TBD-from-d1-create>",
+          "migrations_dir": "migrations"
+        }
+      ],
+
       "kv_namespaces": [
         {
           "binding": "VERIFIED_AGENTS",
@@ -153,6 +177,17 @@
         "directory": ".open-next/assets",
         "binding": "ASSETS"
       },
+
+      // D1 database binding — same database_id as top-level; D1 has no per-env isolation.
+      // Replace <TBD-from-d1-create> with UUID from: wrangler d1 create landing-page --location wnam
+      "d1_databases": [
+        {
+          "binding": "DB",
+          "database_name": "landing-page",
+          "database_id": "<TBD-from-d1-create>",
+          "migrations_dir": "migrations"
+        }
+      ],
 
       "kv_namespaces": [
         {

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -20,7 +20,7 @@
     {
       "binding": "DB",
       "database_name": "landing-page",
-      "database_id": "<TBD-from-d1-create>",
+      "database_id": "89a00080-d1e1-48bd-823a-0fdd93bf0875",
       "migrations_dir": "migrations"
     }
   ],
@@ -108,12 +108,12 @@
       },
 
       // D1 database binding — same database_id as top-level; D1 has no per-env isolation.
-      // Replace <TBD-from-d1-create> with UUID from: wrangler d1 create landing-page --location wnam
+      // D1 binding (created 2026-05-09 via `wrangler d1 create landing-page --location wnam`).
       "d1_databases": [
         {
           "binding": "DB",
           "database_name": "landing-page",
-          "database_id": "<TBD-from-d1-create>",
+          "database_id": "89a00080-d1e1-48bd-823a-0fdd93bf0875",
           "migrations_dir": "migrations"
         }
       ],
@@ -179,12 +179,12 @@
       },
 
       // D1 database binding — same database_id as top-level; D1 has no per-env isolation.
-      // Replace <TBD-from-d1-create> with UUID from: wrangler d1 create landing-page --location wnam
+      // D1 binding (created 2026-05-09 via `wrangler d1 create landing-page --location wnam`).
       "d1_databases": [
         {
           "binding": "DB",
           "database_name": "landing-page",
-          "database_id": "<TBD-from-d1-create>",
+          "database_id": "89a00080-d1e1-48bd-823a-0fdd93bf0875",
           "migrations_dir": "migrations"
         }
       ],


### PR DESCRIPTION
## Maintainer action required before merging

The `CLOUDFLARE_API_TOKEN` environment variable was not available during automated execution, so the D1 database could not be provisioned. Run the following two commands (with Cloudflare auth configured) before or immediately after merging:

```bash
# 1. Create the D1 database in us-west
npx wrangler d1 create landing-page --location wnam

# 2. Copy the UUID from the output and replace <TBD-from-d1-create> in wrangler.jsonc
#    (all three occurrences: top-level, env.production, env.preview)

# 3. Apply migrations to production
npx wrangler d1 migrations apply landing-page --remote --env production
```

---

Closes #667
Refs #652, #665

## Summary

- **7 migration files** added to `migrations/` — SQL copied verbatim from `docs/rfc-d1-schema.md`
- **`DB` binding** wired in all three `wrangler.jsonc` blocks (top-level, `env.production`, `env.preview`) — Wrangler does not merge top-level into named envs, per the pattern established in #666
- **`cloudflare-env.d.ts`** updated with `DB: D1Database` (hand-edit, cf-typegen requires `.env` per #666 precedent)
- **`database_id` placeholder** — `<TBD-from-d1-create>` pending maintainer provisioning action above
- **Region: us-west (`wnam`)** — documented as inline comment in `wrangler.jsonc` per RFC Decision 4

## Files added

| File | Table / Object |
|------|---------------|
| `migrations/001_agents.sql` | `agents` table + 4 indexes |
| `migrations/002_claims.sql` | `claims` table + 2 indexes |
| `migrations/003_inbox_messages.sql` | `inbox_messages` table + 5 indexes (including permanent `UNIQUE` partial index on `payment_txid`) |
| `migrations/004_vouches.sql` | `vouches` table + 3 indexes |
| `migrations/005_swaps.sql` | `swaps` table + 3 indexes |
| `migrations/006_balances.sql` | `balances` table + 1 index |
| `migrations/007_registered_wallets_view.sql` | `registered_wallets` view (thin projection over `agents`, no `WHERE` predicate) |

## Files modified

- `wrangler.jsonc` — Added `d1_databases` block to top-level, `env.production`, and `env.preview`
- `cloudflare-env.d.ts` — Added `DB: D1Database`

## Acceptance criteria checklist

From #667:

- [x] `migrations/` directory created at repo root
- [x] 7 migration files added (001–007), SQL verbatim from `docs/rfc-d1-schema.md`
- [x] Inline column comments stripped (SQLite does not support them inside `CREATE TABLE`)
- [x] `wrangler.jsonc` `d1_databases` binding wired in all three blocks (top-level, production, preview)
- [x] `cloudflare-env.d.ts` updated with `DB: D1Database`
- [x] `database_id` set (placeholder — maintainer action required)
- [x] Region documented as inline comment (`wnam`, us-west)
- [x] No schema changes vs RFC (zero deviations)
- [x] No backfill code (Phase 1.3)
- [x] No route changes (Phase 2.x)
- [ ] D1 provisioned remotely (requires maintainer CLOUDFLARE_API_TOKEN — see top of PR body)
- [ ] `wrangler d1 migrations apply --remote --env production` (after provisioning)

## Test plan

- [x] `wrangler d1 migrations apply landing-page --local` — all 7 migrations applied cleanly against local D1 SQLite (load-bearing SQL correctness test)
- [x] `npm test` — 588 passed, 5 skipped, 0 failures; no existing tests reference `DB` binding yet
- [x] `npm run lint` — no code lint errors; worktree multi-lockfile warning is pre-existing environment noise
- [ ] After maintainer provisions D1: `wrangler d1 migrations apply landing-page --remote --env production`

## Provisioning state

`database_id` is `<TBD-from-d1-create>`. The automated executor ran without `CLOUDFLARE_API_TOKEN`. All code is shippable; the two-command provisioning sequence above is the only remaining step.

## Out of scope

- Phase 1.3: KV → D1 backfill
- Phase 1.4: reconciliation
- Phase 2.x: read flips and dual-write cutover
- Phase 3.x: trading-comp verifier, chainhook, balance cron, dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)