### PR TITLE
refactor(rate-limit): DRY fail-closed helper + remove void pattern in tests (#669)

### DIFF
--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -12,6 +12,7 @@ import {
   buildMarkReadMessage,
   decrementUnreadCount,
 } from "@/lib/inbox";
+import { shouldFailClosed } from "@/lib/env";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -122,8 +123,7 @@ export async function PATCH(
       // Binding unavailable — fail closed in production/preview, open in dev.
       // Mark-read is abuse-protection (not revenue), so prefer blocking on
       // binding errors over allowing signature-DoS during binding outages.
-      const deployEnv = env.DEPLOY_ENV;
-      const failClosed = deployEnv !== undefined;
+      const failClosed = shouldFailClosed(env);
       logger.warn("Mark-read rate limit binding error", { error: String(err), failClosed });
       if (failClosed) ipLimited = true;
     }

--- a/app/api/outbox/[address]/__tests__/rate-limit.test.ts
+++ b/app/api/outbox/[address]/__tests__/rate-limit.test.ts
@@ -191,8 +191,6 @@ describe("outbox rate limit — IP bucket blocks before address-keyed buckets", 
   });
 
   it("unregistered bucket is checked after IP passes; returns 429 for unregistered agent", async () => {
-    const passingIp = createRateLimitMock(true);
-    const exhaustedUnreg = createRateLimitMock(false);
     mockContext({
       RATE_LIMIT_MUTATING: {
         limit: vi.fn()
@@ -207,7 +205,6 @@ describe("outbox rate limit — IP bucket blocks before address-keyed buckets", 
     const resp = await POST(req, { params: Promise.resolve({ address: "bc1qunreg" }) });
 
     expect(resp.status).toBe(429);
-    void passingIp; void exhaustedUnreg; // consumed by mockContext
   });
 
   it("no-ip request skips IP bucket and falls through to unregistered 404", async () => {

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -14,6 +14,7 @@ import {
   decrementUnreadCount,
 } from "@/lib/inbox";
 import { isStxAddress } from "@/lib/validation/address";
+import { shouldFailClosed } from "@/lib/env";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -59,8 +60,7 @@ export async function POST(
       ipLimited = !result.success;
     } catch (err) {
       // Binding unavailable — fail closed in production/preview, open in dev.
-      const deployEnv = env.DEPLOY_ENV;
-      const failClosed = deployEnv !== undefined;
+      const failClosed = shouldFailClosed(env);
       logger.warn("IP rate limit binding error", { error: String(err), failClosed });
       if (failClosed) ipLimited = true;
     }
@@ -82,8 +82,7 @@ export async function POST(
       const result = await env.RATE_LIMIT_MUTATING.limit({ key: `outbox-unregistered:${address}` });
       unregLimited = !result.success;
     } catch (err) {
-      const deployEnv = env.DEPLOY_ENV;
-      const failClosed = deployEnv !== undefined;
+      const failClosed = shouldFailClosed(env);
       logger.warn("Unregistered rate limit binding error", { error: String(err), failClosed });
       if (failClosed) unregLimited = true;
     }
@@ -289,8 +288,7 @@ export async function POST(
     const result = await env.RATE_LIMIT_AUTHENTICATED.limit({ key: `outbox:${btcResult.address}` });
     registeredLimited = !result.success;
   } catch (err) {
-    const deployEnv = env.DEPLOY_ENV;
-    const failClosed = deployEnv !== undefined;
+    const failClosed = shouldFailClosed(env);
     logger.warn("Authenticated rate limit binding error", { error: String(err), failClosed });
     if (failClosed) registeredLimited = true;
   }

--- a/lib/__tests__/env.test.ts
+++ b/lib/__tests__/env.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import { shouldFailClosed } from "../env";
+
+describe("shouldFailClosed", () => {
+  it("returns true when DEPLOY_ENV is set (production)", () => {
+    expect(shouldFailClosed({ DEPLOY_ENV: "production" } as unknown as CloudflareEnv)).toBe(true);
+  });
+
+  it("returns false when DEPLOY_ENV is undefined (local dev)", () => {
+    expect(shouldFailClosed({} as unknown as CloudflareEnv)).toBe(false);
+  });
+});

--- a/lib/env.ts
+++ b/lib/env.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true when the binding should fail closed on error.
+ * DEPLOY_ENV is set in production and preview; absent in local dev.
+ */
+export function shouldFailClosed(env: CloudflareEnv): boolean {
+  return env.DEPLOY_ENV !== undefined;
+}


### PR DESCRIPTION
Closes #669

## Summary

- **New helper**: `lib/env.ts` exports `shouldFailClosed(env: CloudflareEnv): boolean` — single source of truth for the `DEPLOY_ENV !== undefined` predicate
- **4 sites updated**: `app/api/outbox/[address]/route.ts` (3 catch blocks) + `app/api/inbox/[address]/[messageId]/route.ts` (1 catch block) now call `shouldFailClosed(env)` instead of inlining the derivation
- **2 unit tests** added in `lib/__tests__/env.test.ts` covering production → true and undefined → false
- **Void pattern removed**: `outbox/__tests__/rate-limit.test.ts` no longer declares `passingIp`/`exhaustedUnreg` variables that were suppressed with `void` — the test uses an inline mock chain on `RATE_LIMIT_MUTATING` directly

No behavior change. Pure readability/maintainability cleanup.

## Test plan

- [ ] `lib/__tests__/env.test.ts` — 2 new unit tests pass
- [ ] Existing `outbox/__tests__/rate-limit.test.ts` tests still pass
- [ ] TypeScript compiles clean (no `deployEnv` or `void <name>` lint warnings)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)