### PR TITLE
feat(d1): reconciliation route — KV↔D1 count check + unreadCount drift gate (#675)

### DIFF
--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Tests for POST /api/admin/reconcile — KV ↔ D1 reconciliation route.
+ *
+ * Tests call the real GET/POST handlers with mocked getCloudflareContext()
+ * and a controlled KV + D1 mock environment, mirroring the pattern from
+ * app/api/admin/backfill/__tests__/route.test.ts.
+ *
+ * Also includes unit tests for the pure computeDrift / computeAgentsDrift
+ * helpers from lib/d1/reconcile.ts.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+import { GET, POST } from "../route";
+import { computeDrift, computeAgentsDrift } from "@/lib/d1/reconcile";
+
+// ── Module mocks ─────────────────────────────────────────────────────────
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+// ── Imports after mocks ──────────────────────────────────────────────────
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+// ── KV mock helper ───────────────────────────────────────────────────────
+
+function buildKvMock(data: Record<string, string>): KVNamespace {
+  const store = { ...data };
+
+  return {
+    get: vi.fn(async (key: string) => store[key] ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      store[key] = value;
+    }),
+    delete: vi.fn(async (key: string) => {
+      delete store[key];
+    }),
+    list: vi.fn(async (opts: KVNamespaceListOptions = {}) => {
+      const prefix = opts.prefix ?? "";
+      const limit = opts.limit ?? 1000;
+      const start = opts.cursor ? parseInt(opts.cursor, 10) : 0;
+      const all = Object.keys(store)
+        .filter((k) => k.startsWith(prefix))
+        .sort();
+      const page = all.slice(start, start + limit);
+      const next = start + page.length;
+      const listComplete = next >= all.length;
+      return {
+        keys: page.map((name) => ({ name })),
+        list_complete: listComplete,
+        cursor: listComplete ? undefined : String(next),
+      };
+    }),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+}
+
+// ── D1 mock helper ───────────────────────────────────────────────────────
+
+type FirstResult = { cnt: number } | { 1: number } | null;
+
+interface D1MockConfig {
+  /**
+   * Map of SQL keyword → first() result.
+   * Used to return COUNT(*) results for different queries.
+   */
+  firstResults?: Record<string, FirstResult>;
+  /** Default result for first() if no key matches. */
+  defaultFirst?: FirstResult;
+}
+
+function buildD1Mock(config: D1MockConfig = {}): D1Database {
+  const firstMock = vi.fn(async (query: string): Promise<FirstResult> => {
+    const { firstResults = {}, defaultFirst = null } = config;
+    for (const [keyword, result] of Object.entries(firstResults)) {
+      if (query.includes(keyword)) return result;
+    }
+    return defaultFirst;
+  });
+
+  // Track last bound query for first() dispatch
+  let lastPreparedQuery = "";
+
+  const boundStatement = {
+    run: vi.fn(async () => ({ meta: { changes: 0 }, results: [], success: true })),
+    first: vi.fn(async () => firstMock(lastPreparedQuery)),
+    all: vi.fn(async () => ({ results: [], success: true, meta: {} })),
+  };
+
+  const bindMock = vi.fn(() => boundStatement);
+
+  const statement = {
+    bind: bindMock,
+    first: vi.fn(async () => firstMock(lastPreparedQuery)),
+    run: vi.fn(async () => ({ meta: { changes: 0 }, results: [], success: true })),
+    all: vi.fn(async () => ({ results: [], success: true, meta: {} })),
+  };
+
+  const prepareMock = vi.fn((query: string) => {
+    lastPreparedQuery = query;
+    return statement;
+  });
+
+  return {
+    prepare: prepareMock,
+    batch: vi.fn(),
+    exec: vi.fn(),
+    dump: vi.fn(),
+  } as unknown as D1Database;
+}
+
+// ── Context mock helper ──────────────────────────────────────────────────
+
+function mockContext(env: Partial<CloudflareEnv>) {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: {
+      VERIFIED_AGENTS: buildKvMock({}),
+      ARC_ADMIN_API_KEY: "test-admin-key",
+      ...env,
+    },
+    ctx: { waitUntil: vi.fn() },
+  });
+}
+
+// ── Request builders ─────────────────────────────────────────────────────
+
+function buildPostRequest(params: Record<string, string> = {}): NextRequest {
+  const url = new URL("https://aibtc.com/api/admin/reconcile");
+  for (const [k, v] of Object.entries(params)) {
+    url.searchParams.set(k, v);
+  }
+  return new NextRequest(url.toString(), {
+    method: "POST",
+    headers: { "X-Admin-Key": "test-admin-key" },
+  });
+}
+
+function buildGetRequest(): NextRequest {
+  return new NextRequest("https://aibtc.com/api/admin/reconcile", {
+    method: "GET",
+    headers: { "X-Admin-Key": "test-admin-key" },
+  });
+}
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+const FULL_AGENT = JSON.stringify({
+  btcAddress: "bc1qagent1",
+  stxAddress: "SP1AGENT1",
+  stxPublicKey: "03abcdef01",
+  btcPublicKey: "02abcdef01",
+  verifiedAt: "2026-01-01T00:00:00Z",
+  displayName: "Agent One",
+});
+
+const PARTIAL_AGENT = JSON.stringify({
+  btcAddress: "bc1qpartial",
+  btcPublicKey: "02abcdef02",
+  verifiedAt: "2026-01-02T00:00:00Z",
+  // No stxAddress — PartialAgentRecord
+});
+
+const CLAIM_1 = JSON.stringify({
+  btcAddress: "bc1qagent1",
+  displayName: "Agent One",
+  tweetUrl: "https://x.com/agent1/status/123",
+  tweetAuthor: "agent1",
+  claimedAt: "2026-01-01T01:00:00Z",
+  rewardSatoshis: 50000,
+  rewardTxid: null,
+  status: "verified",
+});
+
+const VOUCH_1 = JSON.stringify({
+  referrer: "bc1qagent1",
+  referee: "bc1qagent2",
+  registeredAt: "2026-02-01T00:00:00Z",
+  messageSent: false,
+  paidOut: false,
+});
+
+const INBOX_MSG_1 = JSON.stringify({
+  messageId: "msg_test_001",
+  fromAddress: "SP1SENDER1",
+  toBtcAddress: "bc1qagent1",
+  toStxAddress: "SP1AGENT1",
+  content: "hello",
+  paymentSatoshis: 100,
+  sentAt: "2026-01-01T02:00:00Z",
+});
+
+const INBOX_AGENT_INDEX = JSON.stringify({
+  btcAddress: "bc1qagent1",
+  messageIds: ["msg_test_001"],
+  unreadCount: 3,
+  lastMessageAt: "2026-01-01T02:00:00Z",
+});
+
+// ── beforeEach ───────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Unit tests: pure drift helpers ───────────────────────────────────────
+
+describe("computeDrift (pure unit)", () => {
+  it("returns zero drift when KV and D1 match", () => {
+    const result = computeDrift(100, 0, 100, 0);
+    expect(result.drift).toBe(0);
+    expect(result.drift_unexplained).toBe(0);
+    expect(result.kv_count_full).toBe(100);
+    expect(result.d1_count).toBe(100);
+  });
+
+  it("correctly accounts for partial exclusion in kv_count_full", () => {
+    // 150 KV total, 50 partial → 100 full; D1 has 100 → no raw drift
+    // drift_explained=50 is informational (FK cascade rows), drift_unexplained = 0 - 50 = -50
+    // But this scenario is for claims/inbox/vouches where kv_count_partial=0 and
+    // drift_explained is the number of FK-cascade rows
+    const result = computeDrift(100, 0, 60, 40);
+    expect(result.kv_count_full).toBe(100);
+    expect(result.drift).toBe(40);
+    expect(result.drift_explained).toBe(40);
+    expect(result.drift_unexplained).toBe(0);
+  });
+
+  it("surfaces unexplained drift when drift_explained is insufficient", () => {
+    // 130 KV total claims, D1 has 100, explained=20 (partial cascade) → unexplained=10
+    const result = computeDrift(130, 0, 100, 20);
+    expect(result.drift).toBe(30);
+    expect(result.drift_explained).toBe(20);
+    expect(result.drift_unexplained).toBe(10);
+  });
+
+  it("handles zero counts without error", () => {
+    const result = computeDrift(0, 0, 0, 0);
+    expect(result.drift).toBe(0);
+    expect(result.drift_unexplained).toBe(0);
+  });
+});
+
+describe("computeAgentsDrift (pure unit)", () => {
+  it("agents drift: baseline scenario — full agents match D1", () => {
+    // 1664 KV total, 1421 partial → 243 full; D1 has 243 → zero drift
+    const result = computeAgentsDrift(1664, 1421, 243);
+    expect(result.kv_count_full).toBe(243);
+    expect(result.d1_count).toBe(243);
+    expect(result.drift).toBe(0);
+    // drift_explained surfaces the partial count for reviewers
+    expect(result.drift_explained).toBe(1421);
+    // drift_unexplained = drift (0) because partials are already excluded from the comparison
+    expect(result.drift_unexplained).toBe(0);
+  });
+
+  it("agents drift: unexplained when full agent count exceeds D1", () => {
+    // 10 KV total, 2 partial → 8 full; D1 has 5 → drift=3, all unexplained
+    const result = computeAgentsDrift(10, 2, 5);
+    expect(result.kv_count_full).toBe(8);
+    expect(result.drift).toBe(3);
+    // drift_explained = partial count (2), informational
+    expect(result.drift_explained).toBe(2);
+    // drift_unexplained = drift (3): full agents missing from D1 is unexplained
+    expect(result.drift_unexplained).toBe(3);
+  });
+});
+
+// ── Admin auth ───────────────────────────────────────────────────────────
+
+describe("admin-key required", () => {
+  it("GET returns 401 without X-Admin-Key", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { ARC_ADMIN_API_KEY: "secret" },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const req = new NextRequest("https://aibtc.com/api/admin/reconcile", {
+      method: "GET",
+    });
+    const resp = await GET(req);
+    expect(resp.status).toBe(401);
+  });
+
+  it("POST returns 401 without X-Admin-Key", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { ARC_ADMIN_API_KEY: "secret" },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const req = new NextRequest("https://aibtc.com/api/admin/reconcile", {
+      method: "POST",
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+  });
+
+  it("POST with wrong X-Admin-Key returns 401", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { ARC_ADMIN_API_KEY: "the-real-secret" },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const req = new NextRequest("https://aibtc.com/api/admin/reconcile", {
+      method: "POST",
+      headers: { "X-Admin-Key": "wrong-key" },
+    });
+    const resp = await POST(req);
+    expect(resp.status).toBe(401);
+  });
+});
+
+// ── GET self-documentation ────────────────────────────────────────────────
+
+describe("GET self-documentation", () => {
+  it("returns 200 with endpoint description for authenticated admin", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { ARC_ADMIN_API_KEY: "test-admin-key" },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await GET(buildGetRequest());
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { endpoint: string; methods: string[] };
+    expect(body.endpoint).toBe("/api/admin/reconcile");
+    expect(body.methods).toContain("POST");
+  });
+});
+
+// ── Invalid table ─────────────────────────────────────────────────────────
+
+describe("input validation", () => {
+  it("returns 400 for unknown table parameter", async () => {
+    mockContext({
+      VERIFIED_AGENTS: buildKvMock({}),
+      DB: buildD1Mock(),
+    });
+
+    const resp = await POST(buildPostRequest({ table: "not_a_real_table" }));
+    expect(resp.status).toBe(400);
+    const body = await resp.json() as { error: string };
+    expect(body.error).toContain("Invalid table");
+  });
+});
+
+// ── Agents reconciliation ─────────────────────────────────────────────────
+
+describe("agents table reconciliation", () => {
+  it("reports zero drift when KV full agents match D1 count", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qpartial": PARTIAL_AGENT,
+    });
+
+    // D1 COUNT(*) returns 1 (only the full agent)
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        // spot-check: agent exists in D1
+        "WHERE btc_address = ?": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      table: string;
+      kv_count: number;
+      kv_count_partial_excluded: number;
+      d1_count: number;
+      drift: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.table).toBe("agents");
+    expect(body.kv_count).toBe(1); // 2 KV - 1 partial = 1 full
+    expect(body.kv_count_partial_excluded).toBe(1);
+    expect(body.d1_count).toBe(1);
+    expect(body.drift).toBe(0);
+    expect(body.drift_unexplained).toBe(0);
+  });
+
+  it("reports unexplained drift when D1 count is lower than full KV count", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qagent2": JSON.stringify({
+        btcAddress: "bc1qagent2",
+        stxAddress: "SP1AGENT2",
+        stxPublicKey: "03abcdef02",
+        btcPublicKey: "02abcdef02",
+        verifiedAt: "2026-01-02T00:00:00Z",
+      }),
+    });
+
+    // D1 only has 1 agent (1 missing → unexplained drift)
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      drift: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.drift).toBe(1); // 2 full - 1 D1 = 1 drift
+    expect(body.drift_unexplained).toBe(1); // not explained by any partial
+  });
+});
+
+// ── Claims reconciliation ─────────────────────────────────────────────────
+
+describe("claims table reconciliation", () => {
+  it("excludes claim-code: keys from KV count", async () => {
+    const kv = buildKvMock({
+      "claim:bc1qagent1": CLAIM_1,
+      "claim-code:bc1qagent1": JSON.stringify({ code: "ABC123", createdAt: "2026-01-01T00:00:00Z" }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM claims": { cnt: 1 },
+        // agent exists in D1 for drift_explained check
+        "FROM agents WHERE btc_address": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "claims", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { kv_count: number; drift: number };
+    // Only 1 claim key should be counted (not claim-code:)
+    expect(body.kv_count).toBe(1);
+    expect(body.drift).toBe(0);
+  });
+});
+
+// ── Vouches reconciliation ─────────────────────────────────────────────────
+
+describe("vouches table reconciliation", () => {
+  it("excludes vouch:index: keys from KV count", async () => {
+    const kv = buildKvMock({
+      "vouch:bc1qagent1:bc1qagent2": VOUCH_1,
+      "vouch:index:bc1qagent1": JSON.stringify({
+        btcAddress: "bc1qagent1",
+        refereeAddresses: ["bc1qagent2"],
+        lastVouchAt: "2026-02-01T00:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM vouches": { cnt: 1 },
+        "FROM agents WHERE btc_address": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "vouches", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { kv_count: number; drift: number };
+    expect(body.kv_count).toBe(1); // index key excluded
+    expect(body.drift).toBe(0);
+  });
+});
+
+// ── inbox_messages reconciliation ─────────────────────────────────────────
+
+describe("inbox_messages table reconciliation", () => {
+  it("counts both inbox:message: and inbox:reply: KV keys in total", async () => {
+    const kv = buildKvMock({
+      "inbox:message:msg_test_001": INBOX_MSG_1,
+      "inbox:reply:msg_test_001": JSON.stringify({
+        messageId: "msg_test_001",
+        fromAddress: "bc1qagent1",
+        toBtcAddress: "bc1qsender1",
+        reply: "pong",
+        signature: "sig_abc",
+        repliedAt: "2026-01-01T03:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 2 },
+        // inbound check: recipient exists in agents
+        "FROM agents WHERE btc_address": { 1: 1 },
+        // reply check: parent message exists
+        "FROM inbox_messages WHERE message_id": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "2" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { kv_count: number; d1_count: number };
+    expect(body.kv_count).toBe(2); // 1 message + 1 reply
+    expect(body.d1_count).toBe(2);
+  });
+
+  it("runs unreadCount acceptance test for inbox_messages table", async () => {
+    const kv = buildKvMock({
+      "inbox:message:msg_test_001": INBOX_MSG_1,
+      "inbox:agent:bc1qagent1": INBOX_AGENT_INDEX, // unreadCount: 3
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 0 },
+        // unreadCount query returns 2 (drift = 3 - 2 = 1)
+        "WHERE to_btc_address": { cnt: 2 },
+        "FROM agents WHERE btc_address": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      acceptance_tests?: {
+        unread_count_drift: Array<{ address: string; kv_cached: number; d1_count: number; drift: number }>;
+        passed: boolean;
+      };
+    };
+
+    expect(body.acceptance_tests).toBeDefined();
+    expect(body.acceptance_tests?.unread_count_drift).toHaveLength(1);
+    const entry = body.acceptance_tests?.unread_count_drift[0];
+    expect(entry?.address).toBe("bc1qagent1");
+    expect(entry?.kv_cached).toBe(3);
+    // passed should be false because drift != 0
+    expect(body.acceptance_tests?.passed).toBe(false);
+  });
+});
+
+// ── table=all ─────────────────────────────────────────────────────────────
+
+describe("table=all reconciliation", () => {
+  it("returns results for all 4 tables", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "claim:bc1qagent1": CLAIM_1,
+      "vouch:bc1qagent1:bc1qagent2": VOUCH_1,
+      "inbox:message:msg_test_001": INBOX_MSG_1,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM claims": { cnt: 1 },
+        "FROM inbox_messages": { cnt: 1 },
+        "FROM vouches": { cnt: 1 },
+        // all FK existence checks pass
+        "FROM agents WHERE btc_address": { 1: 1 },
+        "FROM inbox_messages WHERE message_id": { 1: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "all", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      tables: Array<{ table: string }>;
+      total_drift_unexplained: number;
+    };
+
+    expect(body.tables).toHaveLength(4);
+    const tableNames = body.tables.map((t) => t.table);
+    expect(tableNames).toContain("agents");
+    expect(tableNames).toContain("claims");
+    expect(tableNames).toContain("inbox_messages");
+    expect(tableNames).toContain("vouches");
+    expect(typeof body.total_drift_unexplained).toBe("number");
+  });
+
+  it("includes acceptance_tests in table=all response", async () => {
+    const kv = buildKvMock({
+      "inbox:agent:bc1qagent1": INBOX_AGENT_INDEX,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 0 },
+        "FROM claims": { cnt: 0 },
+        "FROM inbox_messages": { cnt: 0 },
+        "FROM vouches": { cnt: 0 },
+        "WHERE to_btc_address": { cnt: 0 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "all", sampleSize: "1" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      acceptance_tests?: { passed: boolean };
+    };
+    expect(body.acceptance_tests).toBeDefined();
+  });
+});

--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -85,8 +85,13 @@ interface D1MockConfig {
 function buildD1Mock(config: D1MockConfig = {}): D1Database {
   const firstMock = vi.fn(async (query: string): Promise<FirstResult> => {
     const { firstResults = {}, defaultFirst = null } = config;
-    for (const [keyword, result] of Object.entries(firstResults)) {
-      if (query.includes(keyword)) return result;
+    // Match on full SQL string (longest/most-specific match wins) to avoid keyword collisions.
+    // Sort keys descending by length so a query like
+    //   "SELECT 1 FROM agents WHERE btc_address = ?" matches
+    //   "SELECT 1 FROM agents WHERE btc_address = ?" before "FROM agents".
+    const sortedKeys = Object.keys(firstResults).sort((a, b) => b.length - a.length);
+    for (const key of sortedKeys) {
+      if (query.includes(key)) return firstResults[key];
     }
     return defaultFirst;
   });
@@ -227,15 +232,22 @@ describe("computeDrift (pure unit)", () => {
   });
 
   it("correctly accounts for partial exclusion in kv_count_full", () => {
-    // 150 KV total, 50 partial → 100 full; D1 has 100 → no raw drift
-    // drift_explained=50 is informational (FK cascade rows), drift_unexplained = 0 - 50 = -50
-    // But this scenario is for claims/inbox/vouches where kv_count_partial=0 and
-    // drift_explained is the number of FK-cascade rows
+    // 100 KV total claims, D1 has 60 → drift=40; drift_explained=40 (all explained by partial cascade)
+    // drift_unexplained = max(0, 40 - 40) = 0
     const result = computeDrift(100, 0, 60, 40);
     expect(result.kv_count_full).toBe(100);
     expect(result.drift).toBe(40);
     expect(result.drift_explained).toBe(40);
     expect(result.drift_unexplained).toBe(0);
+  });
+
+  it("clamps drift_unexplained to 0 when drift_explained exceeds drift (floor-skew scenario)", () => {
+    // drift=2 but drift_explained=5 (independent passes can produce minor skew)
+    // drift_unexplained must be clamped to 0, not go negative
+    const result = computeDrift(10, 0, 8, 5);
+    expect(result.drift).toBe(2);
+    expect(result.drift_explained).toBe(5);
+    expect(result.drift_unexplained).toBe(0); // clamped: max(0, 2-5) = 0
   });
 
   it("surfaces unexplained drift when drift_explained is insufficient", () => {
@@ -250,6 +262,17 @@ describe("computeDrift (pure unit)", () => {
     const result = computeDrift(0, 0, 0, 0);
     expect(result.drift).toBe(0);
     expect(result.drift_unexplained).toBe(0);
+  });
+
+  it("passes through explained_categories when provided", () => {
+    const cats = { partial_cascade: 3, unique_payment_txid_replay: 1, unresolvable_stx_reply: 0 };
+    const result = computeDrift(10, 0, 6, 4, cats);
+    expect(result.explained_categories).toEqual(cats);
+  });
+
+  it("omits explained_categories when not provided", () => {
+    const result = computeDrift(10, 0, 6, 4);
+    expect(result.explained_categories).toBeUndefined();
   });
 });
 
@@ -640,5 +663,331 @@ describe("table=all reconciliation", () => {
       acceptance_tests?: { passed: boolean };
     };
     expect(body.acceptance_tests).toBeDefined();
+  });
+
+  it("returns independent per-table duration_ms (not the overall run duration)", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM claims": { cnt: 0 },
+        "FROM inbox_messages": { cnt: 0 },
+        "FROM vouches": { cnt: 0 },
+        "WHERE to_btc_address": { cnt: 0 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "all", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      tables: Array<{ table: string; duration_ms: number }>;
+      duration_ms: number;
+    };
+
+    // Each per-table duration_ms must be a non-negative number
+    for (const t of body.tables) {
+      expect(typeof t.duration_ms).toBe("number");
+      expect(t.duration_ms).toBeGreaterThanOrEqual(0);
+    }
+
+    // Per-table duration_ms values should not all be the same as total (they're independent)
+    // They should each be <= total since they are sub-ranges of the overall run
+    for (const t of body.tables) {
+      expect(t.duration_ms).toBeLessThanOrEqual(body.duration_ms + 100); // small slack for clock
+    }
+  });
+});
+
+// ── KV-truth drift_explained (buildFullAgentSet) ───────────────────────────
+
+describe("KV-truth drift_explained via buildFullAgentSet", () => {
+  it("classifies claims with partial-agent parents as drift_explained using KV data only", async () => {
+    // KV: 1 full agent + 1 partial agent; 2 claims (one for each)
+    // D1: 1 claim row (only full agent's claim backfilled)
+    // Expected: kv_count=2, d1_count=1, drift=1, drift_explained=1 (partial cascade), drift_unexplained=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,        // full agent
+      "btc:bc1qpartial": PARTIAL_AGENT,     // partial agent
+      "claim:bc1qagent1": CLAIM_1,          // claim for full agent
+      "claim:bc1qpartial": JSON.stringify({ // claim for partial agent (not in D1)
+        btcAddress: "bc1qpartial",
+        status: "verified",
+        claimedAt: "2026-01-03T00:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM claims": { cnt: 1 }, // only the full-agent's claim is in D1
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "claims", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories?: { partial_cascade?: number };
+    };
+
+    expect(body.kv_count).toBe(2);
+    expect(body.d1_count).toBe(1);
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1); // partial agent's claim is explained
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories?.partial_cascade).toBe(1);
+  });
+
+  it("classifies vouch with partial-agent participant as drift_explained", async () => {
+    // KV: 1 full agent + 1 partial agent + 1 vouch between them
+    // D1: 0 vouches (neither is backfilled since one is partial)
+    // Expected: drift=1, drift_explained=1, drift_unexplained=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qpartial": PARTIAL_AGENT,
+      "vouch:bc1qagent1:bc1qpartial": JSON.stringify({
+        referrer: "bc1qagent1",
+        referee: "bc1qpartial",
+        registeredAt: "2026-03-01T00:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM vouches": { cnt: 0 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "vouches", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories?: { partial_cascade?: number };
+    };
+
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories?.partial_cascade).toBe(1);
+  });
+});
+
+// ── inbox explained_categories ─────────────────────────────────────────────
+
+describe("inbox explained_categories", () => {
+  it("counts unique_payment_txid_replay when multiple messages share same payment_txid", async () => {
+    // 3 inbox messages: 2 share the same payment_txid → 1 unique_payment_txid_replay
+    // All go to full agent (no partial_cascade), no stx replies (unresolvable_stx_reply=0)
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:message:msg001": JSON.stringify({
+        messageId: "msg001",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_shared",
+        sentAt: "2026-01-01T00:00:00Z",
+      }),
+      "inbox:message:msg002": JSON.stringify({
+        messageId: "msg002",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_shared", // same txid → replay
+        sentAt: "2026-01-01T00:01:00Z",
+      }),
+      "inbox:message:msg003": JSON.stringify({
+        messageId: "msg003",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_unique", // unique txid
+        sentAt: "2026-01-01T00:02:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 2 }, // only 2 made it to D1 (1 replay skipped)
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories?: {
+        partial_cascade?: number;
+        unique_payment_txid_replay?: number;
+        unresolvable_stx_reply?: number;
+      };
+    };
+
+    expect(body.kv_count).toBe(3);
+    expect(body.d1_count).toBe(2);
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1); // 1 unique_payment_txid_replay
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories?.unique_payment_txid_replay).toBe(1);
+    expect(body.explained_categories?.partial_cascade).toBe(0);
+    expect(body.explained_categories?.unresolvable_stx_reply).toBe(0);
+  });
+
+  it("counts partial_cascade for inbox messages to partial-agent recipients", async () => {
+    // 2 inbox messages: 1 to full agent, 1 to partial agent
+    // D1 has 1 (only full agent's message backfilled)
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qpartial": PARTIAL_AGENT,
+      "inbox:message:msg_full": JSON.stringify({
+        messageId: "msg_full",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_a",
+        sentAt: "2026-01-01T00:00:00Z",
+      }),
+      "inbox:message:msg_partial": JSON.stringify({
+        messageId: "msg_partial",
+        toBtcAddress: "bc1qpartial",
+        paymentTxid: "txid_b",
+        sentAt: "2026-01-01T00:01:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories?: { partial_cascade?: number };
+    };
+
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories?.partial_cascade).toBe(1);
+  });
+});
+
+// ── sampleSize=0 short-circuit ─────────────────────────────────────────────
+
+describe("sampleSize=0 short-circuit", () => {
+  it("agents table with sampleSize=0 returns sample_size=0 and empty field_diffs", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      sample_size: number;
+      field_diffs: unknown[];
+    };
+
+    expect(body.sample_size).toBe(0);
+    expect(body.field_diffs).toHaveLength(0);
+  });
+
+  it("claims table with sampleSize=0 returns sample_size=0 and empty field_diffs", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "claim:bc1qagent1": CLAIM_1,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM claims": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "claims", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      sample_size: number;
+      field_diffs: unknown[];
+    };
+
+    expect(body.sample_size).toBe(0);
+    expect(body.field_diffs).toHaveLength(0);
+  });
+
+  it("vouches table with sampleSize=0 returns sample_size=0 and empty field_diffs", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qagent2": JSON.stringify({
+        btcAddress: "bc1qagent2",
+        stxAddress: "SP1AGENT2",
+        stxPublicKey: "03abcdef02",
+        btcPublicKey: "02abcdef02",
+        verifiedAt: "2026-01-02T00:00:00Z",
+      }),
+      "vouch:bc1qagent1:bc1qagent2": VOUCH_1,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM vouches": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "vouches", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      sample_size: number;
+      field_diffs: unknown[];
+    };
+
+    expect(body.sample_size).toBe(0);
+    expect(body.field_diffs).toHaveLength(0);
   });
 });

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -1,0 +1,922 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import { isPartialAgentRecord } from "@/lib/types";
+import type { AgentRecord } from "@/lib/types";
+import type { InboxAgentIndex } from "@/lib/inbox/types";
+import { REPLY_D1_PK_PREFIX } from "@/lib/inbox/constants";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import {
+  computeDrift,
+  computeAgentsDrift,
+  type TableTarget,
+  type TableReconcileResult,
+  type FieldDiff,
+  type UnreadCountDriftEntry,
+  type AcceptanceTestResults,
+} from "@/lib/d1/reconcile";
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+/**
+ * Clamp sampleSize to [1, 500], default 50.
+ */
+function parseSampleSize(raw: string | null): number {
+  if (!raw) return 50;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return 50;
+  return Math.max(1, Math.min(500, n));
+}
+
+/**
+ * Count all KV keys with the given prefix via paginated list().
+ * Returns { total, partial } where partial is the count of PartialAgentRecord
+ * entries (only non-zero for the agents table).
+ */
+async function countKvKeys(
+  kv: KVNamespace,
+  prefix: string,
+  countPartials = false,
+  skipPrefixes: string[] = []
+): Promise<{ total: number; partial: number }> {
+  let total = 0;
+  let partial = 0;
+  let cursor: string | undefined = undefined;
+
+  do {
+    const opts: KVNamespaceListOptions = { prefix, limit: 1000 };
+    if (cursor) opts.cursor = cursor;
+
+    const page = await kv.list(opts);
+
+    for (const key of page.keys) {
+      if (skipPrefixes.some((p) => key.name.startsWith(p))) continue;
+      total++;
+
+      if (countPartials) {
+        const raw = await kv.get(key.name);
+        if (raw) {
+          try {
+            const parsed = JSON.parse(raw);
+            if (isPartialAgentRecord(parsed)) partial++;
+          } catch {
+            // malformed — count as full for conservatism
+          }
+        }
+      }
+    }
+
+    cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+  } while (cursor !== undefined);
+
+  return { total, partial };
+}
+
+/**
+ * Sample up to `n` random KV keys from those with `prefix`.
+ * Returns a shuffled subset of the keys (not the values).
+ * Skips keys starting with any of `skipPrefixes`.
+ */
+async function sampleKvKeys(
+  kv: KVNamespace,
+  prefix: string,
+  n: number,
+  skipPrefixes: string[] = []
+): Promise<string[]> {
+  const keys: string[] = [];
+  let cursor: string | undefined = undefined;
+
+  do {
+    const opts: KVNamespaceListOptions = { prefix, limit: 1000 };
+    if (cursor) opts.cursor = cursor;
+    const page = await kv.list(opts);
+    for (const key of page.keys) {
+      if (skipPrefixes.some((p) => key.name.startsWith(p))) continue;
+      keys.push(key.name);
+    }
+    cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+  } while (cursor !== undefined);
+
+  // Fisher-Yates shuffle for fair random sample
+  for (let i = keys.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [keys[i], keys[j]] = [keys[j], keys[i]];
+  }
+
+  return keys.slice(0, n);
+}
+
+// ── Per-table reconciliation ───────────────────────────────────────────────
+
+/**
+ * Reconcile the agents table.
+ *
+ * Count check: scan btc: prefix; exclude PartialAgentRecord entries from
+ * kv_count. D1 agent count must equal KV full-agent count.
+ *
+ * Field-level spot-check: for sampled full agents, compare a subset of
+ * critical D1 columns to the KV record.
+ */
+async function reconcileAgents(
+  kv: KVNamespace,
+  db: D1Database,
+  sampleSize: number
+): Promise<Omit<TableReconcileResult, "duration_ms">> {
+  // Count KV agents; scan values to identify partials
+  const { total: kv_total, partial: kv_partial } = await countKvKeys(
+    kv,
+    "btc:",
+    true // read values to detect partials
+  );
+
+  // D1 count
+  const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM agents").first<{ cnt: number }>();
+  const d1_count = d1Row?.cnt ?? 0;
+
+  const breakdown = computeAgentsDrift(kv_total, kv_partial, d1_count);
+
+  // Field-level spot-check — only on full agents
+  const sampledKeys = await sampleKvKeys(kv, "btc:", sampleSize * 3); // oversample to account for partials
+  const field_diffs: FieldDiff[] = [];
+  let checked = 0;
+
+  for (const key of sampledKeys) {
+    if (checked >= sampleSize) break;
+
+    const raw = await kv.get(key);
+    if (!raw) continue;
+
+    let agent: unknown;
+    try {
+      agent = JSON.parse(raw);
+    } catch {
+      continue;
+    }
+
+    // Skip partials in spot-check — they are intentionally absent from D1
+    if (isPartialAgentRecord(agent)) continue;
+
+    const rec = agent as AgentRecord;
+    checked++;
+
+    const d1Agent = await db
+      .prepare(
+        "SELECT btc_address, stx_address, stx_public_key, btc_public_key, verified_at FROM agents WHERE btc_address = ?"
+      )
+      .bind(rec.btcAddress)
+      .first<{
+        btc_address: string;
+        stx_address: string;
+        stx_public_key: string;
+        btc_public_key: string;
+        verified_at: string;
+      }>();
+
+    if (!d1Agent) {
+      field_diffs.push({
+        key,
+        field: "_row_missing",
+        kv_value: rec.btcAddress,
+        d1_value: null,
+      });
+      continue;
+    }
+
+    // Compare critical fields
+    const checks: Array<[string, unknown, unknown]> = [
+      ["stx_address", rec.stxAddress, d1Agent.stx_address],
+      ["stx_public_key", rec.stxPublicKey, d1Agent.stx_public_key],
+      ["btc_public_key", rec.btcPublicKey, d1Agent.btc_public_key],
+      ["verified_at", rec.verifiedAt, d1Agent.verified_at],
+    ];
+
+    for (const [field, kv_value, d1_value] of checks) {
+      if (kv_value !== d1_value) {
+        field_diffs.push({ key, field, kv_value, d1_value });
+      }
+    }
+  }
+
+  return {
+    table: "agents",
+    kv_count: breakdown.kv_count_full,
+    kv_count_partial_excluded: kv_partial,
+    d1_count: breakdown.d1_count,
+    drift: breakdown.drift,
+    drift_explained: breakdown.drift_explained,
+    drift_unexplained: breakdown.drift_unexplained,
+    sample_size: checked,
+    field_diffs,
+  };
+}
+
+/**
+ * Reconcile the claims table.
+ *
+ * Drift is explained by claims whose FK target (btc_address → agents) is a
+ * Partial agent not in D1. We count these by checking if the claim's btcAddress
+ * exists in D1 agents.
+ */
+async function reconcileClaims(
+  kv: KVNamespace,
+  db: D1Database,
+  sampleSize: number
+): Promise<Omit<TableReconcileResult, "duration_ms">> {
+  // Count KV claim keys (claim: prefix, no claim-code: entries)
+  const { total: kv_total } = await countKvKeys(kv, "claim:", false, ["claim-code:"]);
+
+  const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM claims").first<{ cnt: number }>();
+  const d1_count = d1Row?.cnt ?? 0;
+
+  // Determine drift_explained: scan claim keys and count those whose agent is absent from D1
+  // (i.e., the agent was a Partial, never inserted into agents table)
+  let drift_explained = 0;
+  {
+    let cursor: string | undefined = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "claim:", limit: 1000 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      for (const key of page.keys) {
+        if (key.name.startsWith("claim-code:")) continue;
+        const btcAddress = key.name.slice("claim:".length);
+        const exists = await db
+          .prepare("SELECT 1 FROM agents WHERE btc_address = ?")
+          .bind(btcAddress)
+          .first<{ 1: number }>();
+        if (!exists) drift_explained++;
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+  }
+
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+
+  // Field-level spot-check
+  const sampledKeys = await sampleKvKeys(kv, "claim:", sampleSize, ["claim-code:"]);
+  const field_diffs: FieldDiff[] = [];
+  let checked = 0;
+
+  for (const key of sampledKeys) {
+    if (checked >= sampleSize) break;
+    const raw = await kv.get(key);
+    if (!raw) continue;
+
+    let claim: Record<string, unknown>;
+    try {
+      claim = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+
+    checked++;
+    const btcAddress = claim.btcAddress as string;
+
+    const d1Claim = await db
+      .prepare("SELECT btc_address, status, claimed_at FROM claims WHERE btc_address = ?")
+      .bind(btcAddress)
+      .first<{ btc_address: string; status: string; claimed_at: string }>();
+
+    if (!d1Claim) {
+      field_diffs.push({ key, field: "_row_missing", kv_value: btcAddress, d1_value: null });
+      continue;
+    }
+
+    if (claim.status !== d1Claim.status) {
+      field_diffs.push({ key, field: "status", kv_value: claim.status, d1_value: d1Claim.status });
+    }
+    if (claim.claimedAt !== d1Claim.claimed_at) {
+      field_diffs.push({ key, field: "claimed_at", kv_value: claim.claimedAt, d1_value: d1Claim.claimed_at });
+    }
+  }
+
+  return {
+    table: "claims",
+    kv_count: breakdown.kv_count_full,
+    kv_count_partial_excluded: 0,
+    d1_count: breakdown.d1_count,
+    drift: breakdown.drift,
+    drift_explained: breakdown.drift_explained,
+    drift_unexplained: breakdown.drift_unexplained,
+    sample_size: checked,
+    field_diffs,
+  };
+}
+
+/**
+ * Reconcile the inbox_messages table.
+ *
+ * KV has two sub-prefixes: inbox:message: (inbound) and inbox:reply: (replies).
+ * Both are folded into a single inbox_messages D1 table.
+ * Drift is explained by messages whose sender/recipient agent is Partial
+ * (FK cascade) plus the known 7 UNIQUE-constraint replays + 2 unresolvable STX.
+ *
+ * Reply rows in D1 have message_id prefixed with REPLY_D1_PK_PREFIX.
+ */
+async function reconcileInboxMessages(
+  kv: KVNamespace,
+  db: D1Database,
+  sampleSize: number
+): Promise<Omit<TableReconcileResult, "duration_ms">> {
+  const [{ total: kv_inbound }, { total: kv_reply }] = await Promise.all([
+    countKvKeys(kv, "inbox:message:"),
+    countKvKeys(kv, "inbox:reply:"),
+  ]);
+  const kv_total = kv_inbound + kv_reply;
+
+  const d1Row = await db
+    .prepare("SELECT COUNT(*) AS cnt FROM inbox_messages")
+    .first<{ cnt: number }>();
+  const d1_count = d1Row?.cnt ?? 0;
+
+  // Compute drift_explained: count KV inbound messages whose to_btc_address
+  // is absent from D1 agents (Partial cascade). Also count KV reply rows
+  // where the parent message is absent from D1 (implies sender was Partial).
+  // We approximate: check inbound messages' to_btc_address.
+  let drift_explained = 0;
+  {
+    let cursor: string | undefined = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "inbox:message:", limit: 500 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      for (const key of page.keys) {
+        const raw = await kv.get(key.name);
+        if (!raw) continue;
+        try {
+          const msg = JSON.parse(raw) as Record<string, unknown>;
+          const toBtc = msg.toBtcAddress as string | undefined;
+          if (toBtc) {
+            const exists = await db
+              .prepare("SELECT 1 FROM agents WHERE btc_address = ?")
+              .bind(toBtc)
+              .first<{ 1: number }>();
+            if (!exists) drift_explained++;
+          }
+        } catch {
+          // ignore
+        }
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+
+    // For replies: check if parent message_id exists in D1
+    cursor = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "inbox:reply:", limit: 500 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      for (const key of page.keys) {
+        const raw = await kv.get(key.name);
+        if (!raw) continue;
+        try {
+          const reply = JSON.parse(raw) as Record<string, unknown>;
+          const parentId = reply.messageId as string | undefined;
+          if (parentId) {
+            const exists = await db
+              .prepare("SELECT 1 FROM inbox_messages WHERE message_id = ?")
+              .bind(parentId)
+              .first<{ 1: number }>();
+            if (!exists) drift_explained++;
+          }
+        } catch {
+          // ignore
+        }
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+  }
+
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+
+  // Field-level spot-check on inbound messages only
+  const sampleInbound = Math.ceil(sampleSize * 0.7);
+  const sampleReply = sampleSize - sampleInbound;
+  const inboundKeys = await sampleKvKeys(kv, "inbox:message:", sampleInbound);
+  const replyKeys = await sampleKvKeys(kv, "inbox:reply:", sampleReply);
+  const field_diffs: FieldDiff[] = [];
+  let checked = 0;
+
+  for (const key of inboundKeys) {
+    const raw = await kv.get(key);
+    if (!raw) continue;
+    let msg: Record<string, unknown>;
+    try {
+      msg = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    checked++;
+    const messageId = msg.messageId as string;
+
+    const d1Msg = await db
+      .prepare("SELECT message_id, to_btc_address, sent_at FROM inbox_messages WHERE message_id = ?")
+      .bind(messageId)
+      .first<{ message_id: string; to_btc_address: string; sent_at: string }>();
+
+    if (!d1Msg) {
+      field_diffs.push({ key, field: "_row_missing", kv_value: messageId, d1_value: null });
+      continue;
+    }
+    if (msg.toBtcAddress !== d1Msg.to_btc_address) {
+      field_diffs.push({ key, field: "to_btc_address", kv_value: msg.toBtcAddress, d1_value: d1Msg.to_btc_address });
+    }
+    if (msg.sentAt !== d1Msg.sent_at) {
+      field_diffs.push({ key, field: "sent_at", kv_value: msg.sentAt, d1_value: d1Msg.sent_at });
+    }
+  }
+
+  for (const key of replyKeys) {
+    const raw = await kv.get(key);
+    if (!raw) continue;
+    let reply: Record<string, unknown>;
+    try {
+      reply = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    checked++;
+    const parentId = reply.messageId as string;
+    const replyMessageId = `${REPLY_D1_PK_PREFIX}${parentId}`;
+
+    const d1Reply = await db
+      .prepare("SELECT message_id, reply_to_message_id FROM inbox_messages WHERE message_id = ?")
+      .bind(replyMessageId)
+      .first<{ message_id: string; reply_to_message_id: string }>();
+
+    if (!d1Reply) {
+      field_diffs.push({ key, field: "_row_missing", kv_value: replyMessageId, d1_value: null });
+    }
+  }
+
+  return {
+    table: "inbox_messages",
+    kv_count: breakdown.kv_count_full,
+    kv_count_partial_excluded: 0,
+    d1_count: breakdown.d1_count,
+    drift: breakdown.drift,
+    drift_explained: breakdown.drift_explained,
+    drift_unexplained: breakdown.drift_unexplained,
+    sample_size: checked,
+    field_diffs,
+  };
+}
+
+/**
+ * Reconcile the vouches table.
+ *
+ * Drift is explained by vouch records where either the referrer or referee
+ * is a Partial agent (absent from D1 agents table).
+ */
+async function reconcileVouches(
+  kv: KVNamespace,
+  db: D1Database,
+  sampleSize: number
+): Promise<Omit<TableReconcileResult, "duration_ms">> {
+  const { total: kv_total } = await countKvKeys(kv, "vouch:", false, ["vouch:index:"]);
+
+  const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM vouches").first<{ cnt: number }>();
+  const d1_count = d1Row?.cnt ?? 0;
+
+  // drift_explained: vouch rows with Partial referrer or referee
+  let drift_explained = 0;
+  {
+    let cursor: string | undefined = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "vouch:", limit: 1000 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      for (const key of page.keys) {
+        if (key.name.startsWith("vouch:index:")) continue;
+        const raw = await kv.get(key.name);
+        if (!raw) continue;
+        try {
+          const vouch = JSON.parse(raw) as Record<string, unknown>;
+          const referrer = vouch.referrer as string | undefined;
+          const referee = vouch.referee as string | undefined;
+          if (referrer && referee) {
+            const [refExist, refeeExist] = await Promise.all([
+              db.prepare("SELECT 1 FROM agents WHERE btc_address = ?").bind(referrer).first<{ 1: number }>(),
+              db.prepare("SELECT 1 FROM agents WHERE btc_address = ?").bind(referee).first<{ 1: number }>(),
+            ]);
+            if (!refExist || !refeeExist) drift_explained++;
+          }
+        } catch {
+          // ignore
+        }
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+  }
+
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+
+  // Field-level spot-check
+  const sampledKeys = await sampleKvKeys(kv, "vouch:", sampleSize, ["vouch:index:"]);
+  const field_diffs: FieldDiff[] = [];
+  let checked = 0;
+
+  for (const key of sampledKeys) {
+    if (checked >= sampleSize) break;
+    const raw = await kv.get(key);
+    if (!raw) continue;
+    let vouch: Record<string, unknown>;
+    try {
+      vouch = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      continue;
+    }
+    checked++;
+    const referrer = vouch.referrer as string;
+    const referee = vouch.referee as string;
+
+    const d1Vouch = await db
+      .prepare("SELECT referrer_btc, referee_btc, registered_at FROM vouches WHERE referrer_btc = ? AND referee_btc = ?")
+      .bind(referrer, referee)
+      .first<{ referrer_btc: string; referee_btc: string; registered_at: string }>();
+
+    if (!d1Vouch) {
+      field_diffs.push({
+        key,
+        field: "_row_missing",
+        kv_value: `${referrer}:${referee}`,
+        d1_value: null,
+      });
+      continue;
+    }
+    if (vouch.registeredAt !== d1Vouch.registered_at) {
+      field_diffs.push({ key, field: "registered_at", kv_value: vouch.registeredAt, d1_value: d1Vouch.registered_at });
+    }
+  }
+
+  return {
+    table: "vouches",
+    kv_count: breakdown.kv_count_full,
+    kv_count_partial_excluded: 0,
+    d1_count: breakdown.d1_count,
+    drift: breakdown.drift,
+    drift_explained: breakdown.drift_explained,
+    drift_unexplained: breakdown.drift_unexplained,
+    sample_size: checked,
+    field_diffs,
+  };
+}
+
+/**
+ * Run the unreadCount acceptance test.
+ *
+ * For each BTC address with a non-zero cached unreadCount in KV's
+ * inbox:agent:{btc} index, compare to a live D1 count of unread inbound
+ * messages. Includes the regression-test address from RFC §6.
+ *
+ * The KV `unreadCount` field is set during message delivery and decremented
+ * on mark-read. D1 recomputes it via SELECT COUNT(*) — discrepancy indicates
+ * the drift bug tracked in aibtc-mcp-server#497. Phase 2.5 resolves it by
+ * switching reads to D1's live count; this test surfaces the delta.
+ */
+async function runUnreadCountAcceptanceTest(
+  kv: KVNamespace,
+  db: D1Database,
+  minAddresses = 3
+): Promise<AcceptanceTestResults> {
+  // Regression-test address from RFC §6 — must always be included if present in KV
+  const RFC_REGRESSION_ADDRESS = "bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h";
+
+  const candidates: Array<{ address: string; kv_cached: number }> = [];
+
+  // Scan inbox:agent: prefix to find addresses with non-zero unreadCount
+  let cursor: string | undefined = undefined;
+  do {
+    const opts: KVNamespaceListOptions = { prefix: "inbox:agent:", limit: 1000 };
+    if (cursor) opts.cursor = cursor;
+    const page = await kv.list(opts);
+
+    for (const key of page.keys) {
+      const btcAddress = key.name.slice("inbox:agent:".length);
+      const raw = await kv.get(key.name);
+      if (!raw) continue;
+      try {
+        const index = JSON.parse(raw) as Partial<InboxAgentIndex>;
+        const unread = index.unreadCount ?? 0;
+        if (unread > 0 || btcAddress === RFC_REGRESSION_ADDRESS) {
+          candidates.push({ address: btcAddress, kv_cached: unread });
+        }
+      } catch {
+        // skip malformed
+      }
+    }
+    cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+  } while (cursor !== undefined);
+
+  // Ensure RFC regression address is included even if not in KV
+  if (!candidates.some((c) => c.address === RFC_REGRESSION_ADDRESS)) {
+    const raw = await kv.get(`inbox:agent:${RFC_REGRESSION_ADDRESS}`);
+    if (raw) {
+      try {
+        const index = JSON.parse(raw) as Partial<InboxAgentIndex>;
+        candidates.push({ address: RFC_REGRESSION_ADDRESS, kv_cached: index.unreadCount ?? 0 });
+      } catch {
+        candidates.push({ address: RFC_REGRESSION_ADDRESS, kv_cached: 0 });
+      }
+    }
+  }
+
+  // Take up to minAddresses + a buffer sample; prioritize regression address
+  const regressionEntry = candidates.find((c) => c.address === RFC_REGRESSION_ADDRESS);
+  const others = candidates.filter((c) => c.address !== RFC_REGRESSION_ADDRESS);
+  const selected = [
+    ...(regressionEntry ? [regressionEntry] : []),
+    ...others.slice(0, Math.max(0, minAddresses - (regressionEntry ? 1 : 0))),
+  ];
+
+  const entries: UnreadCountDriftEntry[] = await Promise.all(
+    selected.map(async ({ address, kv_cached }) => {
+      const d1Row = await db
+        .prepare(
+          `SELECT COUNT(*) AS cnt FROM inbox_messages
+           WHERE to_btc_address = ?
+             AND is_reply = 0
+             AND read_at IS NULL`
+        )
+        .bind(address)
+        .first<{ cnt: number }>();
+      const d1_count = d1Row?.cnt ?? 0;
+      return { address, kv_cached, d1_count, drift: kv_cached - d1_count };
+    })
+  );
+
+  return {
+    unread_count_drift: entries,
+    passed: entries.every((e) => e.drift === 0),
+  };
+}
+
+// ── Full reconcile response shape ──────────────────────────────────────────
+
+interface ReconcileResponse extends TableReconcileResult {
+  acceptance_tests?: AcceptanceTestResults;
+}
+
+interface ReconcileAllResponse {
+  tables: ReconcileResponse[];
+  total_drift_unexplained: number;
+  acceptance_tests?: AcceptanceTestResults;
+  duration_ms: number;
+}
+
+// ── Route handlers ─────────────────────────────────────────────────────────
+
+/**
+ * GET /api/admin/reconcile
+ *
+ * Self-documenting route description. Requires X-Admin-Key.
+ */
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  return NextResponse.json({
+    endpoint: "/api/admin/reconcile",
+    description:
+      "Admin-gated KV ↔ D1 reconciliation. Compares row counts and spot-checks field-level integrity for all 4 D1 tables. Surfaces drift breakdown (explained vs. unexplained) and runs unreadCount acceptance test. Zero unexplained drift gates Phase 2.x read flips.",
+    authentication: "Requires X-Admin-Key header",
+    methods: ["GET", "POST"],
+    queryParams: {
+      table: "Target table: agents | claims | inbox_messages | vouches | all (default: all)",
+      sampleSize: "Field-level spot-check sample size: 1–500 (default: 50)",
+      acceptanceTests:
+        "Pass 'unreadCount' to include unread count acceptance test (default: included for inbox_messages and all)",
+    },
+    baseline: {
+      note: "Phase 1.3 operational backfill (2026-05-09T23:55Z) produced these drift numbers:",
+      agents: { d1: 243, kv_partial: 1421, drift_explained: 1421 },
+      claims: { d1: 123, kv_cascade: 454, drift_explained: 454 },
+      inbox_messages: { d1: 5223, kv_cascade: 2540, drift_explained: 2540 },
+      vouches: { d1: 30, kv_cascade: 65, drift_explained: 65 },
+    },
+    response: {
+      kv_count: "KV keys scanned (excluding Partial for agents)",
+      kv_count_partial_excluded: "PartialAgentRecord entries excluded (agents only)",
+      d1_count: "D1 SELECT COUNT(*) result",
+      drift: "kv_count - d1_count",
+      drift_explained: "Rows whose absence is explained by PartialAgentRecord FK cascade",
+      drift_unexplained: "drift - drift_explained (must be 0 before Phase 2 starts)",
+      field_diffs: "Array of field-level discrepancies in spot-checked rows",
+      acceptance_tests:
+        "unread_count_drift: [{address, kv_cached, d1_count, drift}] — Phase 2.5 gate",
+    },
+    operationalPlan: {
+      step1: "POST ?table=all&sampleSize=50 — run full reconciliation",
+      step2: "Verify drift_unexplained == 0 for all tables before Phase 2 begins",
+      step3: "Check acceptance_tests.passed == true for unreadCount drift",
+    },
+  });
+}
+
+/**
+ * POST /api/admin/reconcile
+ *
+ * Run KV ↔ D1 reconciliation for one or all tables.
+ *
+ * Query params:
+ *   - table: agents | claims | inbox_messages | vouches | all (default: all)
+ *   - sampleSize: 1–500 (default: 50)
+ *   - acceptanceTests: unreadCount (optional; auto-included for inbox_messages/all)
+ */
+export async function POST(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  const start = Date.now();
+
+  const { env, ctx } = await getCloudflareContext();
+  const kv = env.VERIFIED_AGENTS as KVNamespace;
+  const db = env.DB as D1Database;
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: "/api/admin/reconcile" })
+    : createConsoleLogger({ rayId, path: "/api/admin/reconcile" });
+
+  const { searchParams } = new URL(request.url);
+  const rawTable = searchParams.get("table") ?? "all";
+  const sampleSize = parseSampleSize(searchParams.get("sampleSize"));
+  const includeUnreadTest =
+    rawTable === "all" ||
+    rawTable === "inbox_messages" ||
+    searchParams.get("acceptanceTests") === "unreadCount";
+
+  const validTables = ["agents", "claims", "inbox_messages", "vouches", "all"];
+  if (!validTables.includes(rawTable)) {
+    return NextResponse.json(
+      { error: `Invalid table "${rawTable}". Must be one of: ${validTables.join(", ")}` },
+      { status: 400 }
+    );
+  }
+
+  logger.info("reconcile.start", { table: rawTable, sampleSize });
+
+  try {
+    if (rawTable === "all") {
+      // Run all tables sequentially (D1 query budget concerns)
+      logger.info("reconcile.table.start", { table: "agents" });
+      const agentsResult = await reconcileAgents(kv, db, sampleSize);
+      logger.info("reconcile.table.done", {
+        table: "agents",
+        drift: agentsResult.drift,
+        drift_unexplained: agentsResult.drift_unexplained,
+      });
+      if (agentsResult.drift_unexplained !== 0) {
+        logger.warn("reconcile.drift.unexplained", { table: "agents", drift_unexplained: agentsResult.drift_unexplained });
+      }
+
+      logger.info("reconcile.table.start", { table: "claims" });
+      const claimsResult = await reconcileClaims(kv, db, sampleSize);
+      logger.info("reconcile.table.done", {
+        table: "claims",
+        drift: claimsResult.drift,
+        drift_unexplained: claimsResult.drift_unexplained,
+      });
+      if (claimsResult.drift_unexplained !== 0) {
+        logger.warn("reconcile.drift.unexplained", { table: "claims", drift_unexplained: claimsResult.drift_unexplained });
+      }
+
+      logger.info("reconcile.table.start", { table: "inbox_messages" });
+      const inboxResult = await reconcileInboxMessages(kv, db, sampleSize);
+      logger.info("reconcile.table.done", {
+        table: "inbox_messages",
+        drift: inboxResult.drift,
+        drift_unexplained: inboxResult.drift_unexplained,
+      });
+      if (inboxResult.drift_unexplained !== 0) {
+        logger.warn("reconcile.drift.unexplained", { table: "inbox_messages", drift_unexplained: inboxResult.drift_unexplained });
+      }
+
+      logger.info("reconcile.table.start", { table: "vouches" });
+      const vouchesResult = await reconcileVouches(kv, db, sampleSize);
+      logger.info("reconcile.table.done", {
+        table: "vouches",
+        drift: vouchesResult.drift,
+        drift_unexplained: vouchesResult.drift_unexplained,
+      });
+      if (vouchesResult.drift_unexplained !== 0) {
+        logger.warn("reconcile.drift.unexplained", { table: "vouches", drift_unexplained: vouchesResult.drift_unexplained });
+      }
+
+      const acceptance_tests = includeUnreadTest
+        ? await runUnreadCountAcceptanceTest(kv, db)
+        : undefined;
+
+      if (acceptance_tests) {
+        logger.info("reconcile.acceptance.done", {
+          unread_drift_count: acceptance_tests.unread_count_drift.length,
+          passed: acceptance_tests.passed,
+        });
+        if (!acceptance_tests.passed) {
+          logger.warn("reconcile.acceptance.failed", {
+            entries: acceptance_tests.unread_count_drift.filter((e) => e.drift !== 0),
+          });
+        }
+      }
+
+      const duration_ms = Date.now() - start;
+      const total_drift_unexplained =
+        agentsResult.drift_unexplained +
+        claimsResult.drift_unexplained +
+        inboxResult.drift_unexplained +
+        vouchesResult.drift_unexplained;
+
+      logger.info("reconcile.complete", {
+        table: "all",
+        total_drift_unexplained,
+        duration_ms,
+      });
+
+      const response: ReconcileAllResponse = {
+        tables: [
+          { ...agentsResult, duration_ms },
+          { ...claimsResult, duration_ms },
+          { ...inboxResult, duration_ms },
+          { ...vouchesResult, duration_ms },
+        ],
+        total_drift_unexplained,
+        acceptance_tests,
+        duration_ms,
+      };
+      return NextResponse.json(response);
+    }
+
+    // Single table
+    const table = rawTable as TableTarget;
+    logger.info("reconcile.table.start", { table });
+
+    let result: Omit<TableReconcileResult, "duration_ms">;
+    switch (table) {
+      case "agents":
+        result = await reconcileAgents(kv, db, sampleSize);
+        break;
+      case "claims":
+        result = await reconcileClaims(kv, db, sampleSize);
+        break;
+      case "inbox_messages":
+        result = await reconcileInboxMessages(kv, db, sampleSize);
+        break;
+      case "vouches":
+        result = await reconcileVouches(kv, db, sampleSize);
+        break;
+    }
+
+    const duration_ms = Date.now() - start;
+
+    logger.info("reconcile.table.done", {
+      table,
+      drift: result.drift,
+      drift_unexplained: result.drift_unexplained,
+      field_diffs: result.field_diffs.length,
+      duration_ms,
+    });
+
+    if (result.drift_unexplained !== 0) {
+      logger.warn("reconcile.drift.unexplained", {
+        table,
+        drift_unexplained: result.drift_unexplained,
+      });
+    }
+
+    let acceptance_tests: AcceptanceTestResults | undefined;
+    if (includeUnreadTest) {
+      acceptance_tests = await runUnreadCountAcceptanceTest(kv, db);
+      logger.info("reconcile.acceptance.done", {
+        unread_drift_count: acceptance_tests.unread_count_drift.length,
+        passed: acceptance_tests.passed,
+      });
+      if (!acceptance_tests.passed) {
+        logger.warn("reconcile.acceptance.failed", {
+          entries: acceptance_tests.unread_count_drift.filter((e) => e.drift !== 0),
+        });
+      }
+    }
+
+    const response: ReconcileResponse = {
+      ...result,
+      duration_ms,
+      ...(acceptance_tests ? { acceptance_tests } : {}),
+    };
+    return NextResponse.json(response);
+  } catch (e) {
+    const duration_ms = Date.now() - start;
+    logger.warn("reconcile.error", {
+      table: rawTable,
+      reason: (e as Error).message,
+      duration_ms,
+    });
+    return NextResponse.json(
+      {
+        error: `Reconciliation failed: ${(e as Error).message}`,
+        table: rawTable,
+        duration_ms,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -19,13 +19,14 @@ import {
 // ── Helpers ────────────────────────────────────────────────────────────────
 
 /**
- * Clamp sampleSize to [1, 500], default 50.
+ * Clamp sampleSize to [0, 500], default 50.
+ * sampleSize=0 skips field-level spot-checks entirely (count-only reconciliation).
  */
 function parseSampleSize(raw: string | null): number {
   if (!raw) return 50;
   const n = parseInt(raw, 10);
   if (!Number.isFinite(n)) return 50;
-  return Math.max(1, Math.min(500, n));
+  return Math.max(0, Math.min(500, n));
 }
 
 /**
@@ -106,6 +107,48 @@ async function sampleKvKeys(
   return keys.slice(0, n);
 }
 
+/**
+ * Single-pass scan of `btc:` KV prefix — returns the set of btcAddress values
+ * whose agent record is NOT PartialAgentRecord. Used by claims/inbox/vouches
+ * to compute drift_explained from KV truth (not D1 absence).
+ *
+ * Reads values in parallel batches of 50 to keep wall-clock manageable.
+ */
+async function buildFullAgentSet(kv: KVNamespace): Promise<Set<string>> {
+  const fullAgents = new Set<string>();
+  let cursor: string | undefined = undefined;
+
+  do {
+    const opts: KVNamespaceListOptions = { prefix: "btc:", limit: 1000 };
+    if (cursor) opts.cursor = cursor;
+    const page = await kv.list(opts);
+
+    // Fetch values in parallel batches of 50
+    const BATCH_SIZE = 50;
+    for (let i = 0; i < page.keys.length; i += BATCH_SIZE) {
+      const batch = page.keys.slice(i, i + BATCH_SIZE);
+      const values = await Promise.all(batch.map((k) => kv.get(k.name)));
+      for (let j = 0; j < batch.length; j++) {
+        const raw = values[j];
+        if (!raw) continue;
+        try {
+          const parsed = JSON.parse(raw);
+          if (!isPartialAgentRecord(parsed)) {
+            // Strip the "btc:" prefix to get the btcAddress
+            fullAgents.add(batch[j].name.slice("btc:".length));
+          }
+        } catch {
+          // malformed — skip
+        }
+      }
+    }
+
+    cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+  } while (cursor !== undefined);
+
+  return fullAgents;
+}
+
 // ── Per-table reconciliation ───────────────────────────────────────────────
 
 /**
@@ -135,8 +178,8 @@ async function reconcileAgents(
 
   const breakdown = computeAgentsDrift(kv_total, kv_partial, d1_count);
 
-  // Field-level spot-check — only on full agents
-  const sampledKeys = await sampleKvKeys(kv, "btc:", sampleSize * 3); // oversample to account for partials
+  // Field-level spot-check — only on full agents; skip entirely when sampleSize=0
+  const sampledKeys = sampleSize > 0 ? await sampleKvKeys(kv, "btc:", sampleSize * 3) : []; // oversample to account for partials
   const field_diffs: FieldDiff[] = [];
   let checked = 0;
 
@@ -213,14 +256,15 @@ async function reconcileAgents(
 /**
  * Reconcile the claims table.
  *
- * Drift is explained by claims whose FK target (btc_address → agents) is a
- * Partial agent not in D1. We count these by checking if the claim's btcAddress
- * exists in D1 agents.
+ * Drift is explained by claims whose FK parent agent is absent from the full-agent
+ * set (i.e., the agent is a PartialAgentRecord not in D1). Uses KV-truth via
+ * buildFullAgentSet rather than D1 SELECT — backfill failures no longer look explained.
  */
 async function reconcileClaims(
   kv: KVNamespace,
   db: D1Database,
-  sampleSize: number
+  sampleSize: number,
+  fullAgents: Set<string>
 ): Promise<Omit<TableReconcileResult, "duration_ms">> {
   // Count KV claim keys (claim: prefix, no claim-code: entries)
   const { total: kv_total } = await countKvKeys(kv, "claim:", false, ["claim-code:"]);
@@ -228,8 +272,7 @@ async function reconcileClaims(
   const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM claims").first<{ cnt: number }>();
   const d1_count = d1Row?.cnt ?? 0;
 
-  // Determine drift_explained: scan claim keys and count those whose agent is absent from D1
-  // (i.e., the agent was a Partial, never inserted into agents table)
+  // Determine drift_explained: scan claim keys using KV-truth (fullAgents set)
   let drift_explained = 0;
   {
     let cursor: string | undefined = undefined;
@@ -240,20 +283,18 @@ async function reconcileClaims(
       for (const key of page.keys) {
         if (key.name.startsWith("claim-code:")) continue;
         const btcAddress = key.name.slice("claim:".length);
-        const exists = await db
-          .prepare("SELECT 1 FROM agents WHERE btc_address = ?")
-          .bind(btcAddress)
-          .first<{ 1: number }>();
-        if (!exists) drift_explained++;
+        if (!fullAgents.has(btcAddress)) drift_explained++;
       }
       cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
     } while (cursor !== undefined);
   }
 
-  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained, {
+    partial_cascade: drift_explained,
+  });
 
-  // Field-level spot-check
-  const sampledKeys = await sampleKvKeys(kv, "claim:", sampleSize, ["claim-code:"]);
+  // Field-level spot-check; skipped when sampleSize=0
+  const sampledKeys = sampleSize > 0 ? await sampleKvKeys(kv, "claim:", sampleSize, ["claim-code:"]) : [];
   const field_diffs: FieldDiff[] = [];
   let checked = 0;
 
@@ -298,6 +339,7 @@ async function reconcileClaims(
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
+    explained_categories: breakdown.explained_categories,
     sample_size: checked,
     field_diffs,
   };
@@ -308,20 +350,77 @@ async function reconcileClaims(
  *
  * KV has two sub-prefixes: inbox:message: (inbound) and inbox:reply: (replies).
  * Both are folded into a single inbox_messages D1 table.
- * Drift is explained by messages whose sender/recipient agent is Partial
- * (FK cascade) plus the known 7 UNIQUE-constraint replays + 2 unresolvable STX.
+ * Drift explained via KV-truth: partial_cascade (recipient not a full agent),
+ * unique_payment_txid_replay (duplicate payment txids), and unresolvable_stx_reply
+ * (reply whose STX replyTo cannot be resolved to a full agent).
  *
  * Reply rows in D1 have message_id prefixed with REPLY_D1_PK_PREFIX.
  */
 async function reconcileInboxMessages(
   kv: KVNamespace,
   db: D1Database,
-  sampleSize: number
+  sampleSize: number,
+  fullAgents: Set<string>
 ): Promise<Omit<TableReconcileResult, "duration_ms">> {
-  const [{ total: kv_inbound }, { total: kv_reply }] = await Promise.all([
-    countKvKeys(kv, "inbox:message:"),
-    countKvKeys(kv, "inbox:reply:"),
-  ]);
+  // Single-pass: collect all parsed inbox records to derive all category counts
+  type ParsedMsg = { type: "message"; toBtcAddress?: string; paymentTxid?: string };
+  type ParsedReply = { type: "reply"; replyTo?: string; messageId?: string };
+  const allRecords: Array<ParsedMsg | ParsedReply> = [];
+
+  // Scan inbox:message: prefix
+  let kv_inbound = 0;
+  {
+    let cursor: string | undefined = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "inbox:message:", limit: 500 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      kv_inbound += page.keys.length;
+      for (const key of page.keys) {
+        const raw = await kv.get(key.name);
+        if (!raw) continue;
+        try {
+          const msg = JSON.parse(raw) as Record<string, unknown>;
+          allRecords.push({
+            type: "message",
+            toBtcAddress: msg.toBtcAddress as string | undefined,
+            paymentTxid: msg.paymentTxid as string | undefined,
+          });
+        } catch {
+          // ignore malformed
+        }
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+  }
+
+  // Scan inbox:reply: prefix
+  let kv_reply = 0;
+  {
+    let cursor: string | undefined = undefined;
+    do {
+      const opts: KVNamespaceListOptions = { prefix: "inbox:reply:", limit: 500 };
+      if (cursor) opts.cursor = cursor;
+      const page = await kv.list(opts);
+      kv_reply += page.keys.length;
+      for (const key of page.keys) {
+        const raw = await kv.get(key.name);
+        if (!raw) continue;
+        try {
+          const reply = JSON.parse(raw) as Record<string, unknown>;
+          allRecords.push({
+            type: "reply",
+            replyTo: reply.replyTo as string | undefined,
+            messageId: reply.messageId as string | undefined,
+          });
+        } catch {
+          // ignore malformed
+        }
+      }
+      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
+    } while (cursor !== undefined);
+  }
+
   const kv_total = kv_inbound + kv_reply;
 
   const d1Row = await db
@@ -329,71 +428,61 @@ async function reconcileInboxMessages(
     .first<{ cnt: number }>();
   const d1_count = d1Row?.cnt ?? 0;
 
-  // Compute drift_explained: count KV inbound messages whose to_btc_address
-  // is absent from D1 agents (Partial cascade). Also count KV reply rows
-  // where the parent message is absent from D1 (implies sender was Partial).
-  // We approximate: check inbound messages' to_btc_address.
-  let drift_explained = 0;
-  {
-    let cursor: string | undefined = undefined;
-    do {
-      const opts: KVNamespaceListOptions = { prefix: "inbox:message:", limit: 500 };
-      if (cursor) opts.cursor = cursor;
-      const page = await kv.list(opts);
-      for (const key of page.keys) {
-        const raw = await kv.get(key.name);
-        if (!raw) continue;
-        try {
-          const msg = JSON.parse(raw) as Record<string, unknown>;
-          const toBtc = msg.toBtcAddress as string | undefined;
-          if (toBtc) {
-            const exists = await db
-              .prepare("SELECT 1 FROM agents WHERE btc_address = ?")
-              .bind(toBtc)
-              .first<{ 1: number }>();
-            if (!exists) drift_explained++;
-          }
-        } catch {
-          // ignore
-        }
-      }
-      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
-    } while (cursor !== undefined);
+  // Derive explained categories from the single-pass records
+  let partial_cascade = 0;
+  let unresolvable_stx_reply = 0;
+  const txidCounts = new Map<string, number>();
 
-    // For replies: check if parent message_id exists in D1
-    cursor = undefined;
-    do {
-      const opts: KVNamespaceListOptions = { prefix: "inbox:reply:", limit: 500 };
-      if (cursor) opts.cursor = cursor;
-      const page = await kv.list(opts);
-      for (const key of page.keys) {
-        const raw = await kv.get(key.name);
-        if (!raw) continue;
-        try {
-          const reply = JSON.parse(raw) as Record<string, unknown>;
-          const parentId = reply.messageId as string | undefined;
-          if (parentId) {
-            const exists = await db
-              .prepare("SELECT 1 FROM inbox_messages WHERE message_id = ?")
-              .bind(parentId)
-              .first<{ 1: number }>();
-            if (!exists) drift_explained++;
+  for (const rec of allRecords) {
+    if (rec.type === "message") {
+      const { toBtcAddress, paymentTxid } = rec;
+      if (toBtcAddress && !fullAgents.has(toBtcAddress)) {
+        partial_cascade++;
+      }
+      if (paymentTxid) {
+        txidCounts.set(paymentTxid, (txidCounts.get(paymentTxid) ?? 0) + 1);
+      }
+    } else {
+      // reply record
+      const { replyTo } = rec;
+      if (replyTo && (replyTo.startsWith("SP") || replyTo.startsWith("ST"))) {
+        // Stacks address shape — look up stx: KV key to resolve to btcAddress
+        const stxRaw = await kv.get(`stx:${replyTo}`);
+        if (!stxRaw) {
+          unresolvable_stx_reply++;
+        } else {
+          try {
+            const stxRecord = JSON.parse(stxRaw) as Record<string, unknown>;
+            const resolvedBtc = stxRecord.btcAddress as string | undefined;
+            if (!resolvedBtc || !fullAgents.has(resolvedBtc)) {
+              partial_cascade++;
+            }
+          } catch {
+            unresolvable_stx_reply++;
           }
-        } catch {
-          // ignore
         }
       }
-      cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
-    } while (cursor !== undefined);
+    }
   }
 
-  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+  // unique_payment_txid_replay: sum of (count - 1) for all txids seen more than once
+  let unique_payment_txid_replay = 0;
+  for (const count of txidCounts.values()) {
+    if (count > 1) unique_payment_txid_replay += count - 1;
+  }
 
-  // Field-level spot-check on inbound messages only
-  const sampleInbound = Math.ceil(sampleSize * 0.7);
-  const sampleReply = sampleSize - sampleInbound;
-  const inboundKeys = await sampleKvKeys(kv, "inbox:message:", sampleInbound);
-  const replyKeys = await sampleKvKeys(kv, "inbox:reply:", sampleReply);
+  const drift_explained = partial_cascade + unique_payment_txid_replay + unresolvable_stx_reply;
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained, {
+    partial_cascade,
+    unique_payment_txid_replay,
+    unresolvable_stx_reply,
+  });
+
+  // Field-level spot-check on inbound messages only; skipped when sampleSize=0
+  const sampleInbound = sampleSize > 0 ? Math.ceil(sampleSize * 0.7) : 0;
+  const sampleReply = sampleSize > 0 ? sampleSize - sampleInbound : 0;
+  const inboundKeys = sampleSize > 0 ? await sampleKvKeys(kv, "inbox:message:", sampleInbound) : [];
+  const replyKeys = sampleSize > 0 ? await sampleKvKeys(kv, "inbox:reply:", sampleReply) : [];
   const field_diffs: FieldDiff[] = [];
   let checked = 0;
 
@@ -457,6 +546,7 @@ async function reconcileInboxMessages(
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
+    explained_categories: breakdown.explained_categories,
     sample_size: checked,
     field_diffs,
   };
@@ -466,19 +556,21 @@ async function reconcileInboxMessages(
  * Reconcile the vouches table.
  *
  * Drift is explained by vouch records where either the referrer or referee
- * is a Partial agent (absent from D1 agents table).
+ * is absent from the full-agent set (i.e., a PartialAgentRecord). Uses KV-truth
+ * via fullAgents rather than D1 SELECT — one explained row regardless of which side missed.
  */
 async function reconcileVouches(
   kv: KVNamespace,
   db: D1Database,
-  sampleSize: number
+  sampleSize: number,
+  fullAgents: Set<string>
 ): Promise<Omit<TableReconcileResult, "duration_ms">> {
   const { total: kv_total } = await countKvKeys(kv, "vouch:", false, ["vouch:index:"]);
 
   const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM vouches").first<{ cnt: number }>();
   const d1_count = d1Row?.cnt ?? 0;
 
-  // drift_explained: vouch rows with Partial referrer or referee
+  // drift_explained: vouch rows with Partial referrer or referee (KV-truth)
   let drift_explained = 0;
   {
     let cursor: string | undefined = undefined;
@@ -495,11 +587,7 @@ async function reconcileVouches(
           const referrer = vouch.referrer as string | undefined;
           const referee = vouch.referee as string | undefined;
           if (referrer && referee) {
-            const [refExist, refeeExist] = await Promise.all([
-              db.prepare("SELECT 1 FROM agents WHERE btc_address = ?").bind(referrer).first<{ 1: number }>(),
-              db.prepare("SELECT 1 FROM agents WHERE btc_address = ?").bind(referee).first<{ 1: number }>(),
-            ]);
-            if (!refExist || !refeeExist) drift_explained++;
+            if (!fullAgents.has(referrer) || !fullAgents.has(referee)) drift_explained++;
           }
         } catch {
           // ignore
@@ -509,10 +597,12 @@ async function reconcileVouches(
     } while (cursor !== undefined);
   }
 
-  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained);
+  const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained, {
+    partial_cascade: drift_explained,
+  });
 
-  // Field-level spot-check
-  const sampledKeys = await sampleKvKeys(kv, "vouch:", sampleSize, ["vouch:index:"]);
+  // Field-level spot-check; skipped when sampleSize=0
+  const sampledKeys = sampleSize > 0 ? await sampleKvKeys(kv, "vouch:", sampleSize, ["vouch:index:"]) : [];
   const field_diffs: FieldDiff[] = [];
   let checked = 0;
 
@@ -557,6 +647,7 @@ async function reconcileVouches(
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
+    explained_categories: breakdown.explained_categories,
     sample_size: checked,
     field_diffs,
   };
@@ -758,46 +849,61 @@ export async function POST(request: NextRequest) {
 
   try {
     if (rawTable === "all") {
-      // Run all tables sequentially (D1 query budget concerns)
+      // Build full-agent set once — shared by claims/inbox/vouches for KV-truth drift_explained
+      const fullAgents = await buildFullAgentSet(kv);
+
+      // Run all tables sequentially (D1 query budget concerns); track per-table duration
+      let tableStart = Date.now();
       logger.info("reconcile.table.start", { table: "agents" });
       const agentsResult = await reconcileAgents(kv, db, sampleSize);
+      const agentsDuration = Date.now() - tableStart;
       logger.info("reconcile.table.done", {
         table: "agents",
         drift: agentsResult.drift,
         drift_unexplained: agentsResult.drift_unexplained,
+        duration_ms: agentsDuration,
       });
       if (agentsResult.drift_unexplained !== 0) {
         logger.warn("reconcile.drift.unexplained", { table: "agents", drift_unexplained: agentsResult.drift_unexplained });
       }
 
+      tableStart = Date.now();
       logger.info("reconcile.table.start", { table: "claims" });
-      const claimsResult = await reconcileClaims(kv, db, sampleSize);
+      const claimsResult = await reconcileClaims(kv, db, sampleSize, fullAgents);
+      const claimsDuration = Date.now() - tableStart;
       logger.info("reconcile.table.done", {
         table: "claims",
         drift: claimsResult.drift,
         drift_unexplained: claimsResult.drift_unexplained,
+        duration_ms: claimsDuration,
       });
       if (claimsResult.drift_unexplained !== 0) {
         logger.warn("reconcile.drift.unexplained", { table: "claims", drift_unexplained: claimsResult.drift_unexplained });
       }
 
+      tableStart = Date.now();
       logger.info("reconcile.table.start", { table: "inbox_messages" });
-      const inboxResult = await reconcileInboxMessages(kv, db, sampleSize);
+      const inboxResult = await reconcileInboxMessages(kv, db, sampleSize, fullAgents);
+      const inboxDuration = Date.now() - tableStart;
       logger.info("reconcile.table.done", {
         table: "inbox_messages",
         drift: inboxResult.drift,
         drift_unexplained: inboxResult.drift_unexplained,
+        duration_ms: inboxDuration,
       });
       if (inboxResult.drift_unexplained !== 0) {
         logger.warn("reconcile.drift.unexplained", { table: "inbox_messages", drift_unexplained: inboxResult.drift_unexplained });
       }
 
+      tableStart = Date.now();
       logger.info("reconcile.table.start", { table: "vouches" });
-      const vouchesResult = await reconcileVouches(kv, db, sampleSize);
+      const vouchesResult = await reconcileVouches(kv, db, sampleSize, fullAgents);
+      const vouchesDuration = Date.now() - tableStart;
       logger.info("reconcile.table.done", {
         table: "vouches",
         drift: vouchesResult.drift,
         drift_unexplained: vouchesResult.drift_unexplained,
+        duration_ms: vouchesDuration,
       });
       if (vouchesResult.drift_unexplained !== 0) {
         logger.warn("reconcile.drift.unexplained", { table: "vouches", drift_unexplained: vouchesResult.drift_unexplained });
@@ -834,10 +940,10 @@ export async function POST(request: NextRequest) {
 
       const response: ReconcileAllResponse = {
         tables: [
-          { ...agentsResult, duration_ms },
-          { ...claimsResult, duration_ms },
-          { ...inboxResult, duration_ms },
-          { ...vouchesResult, duration_ms },
+          { ...agentsResult, duration_ms: agentsDuration },
+          { ...claimsResult, duration_ms: claimsDuration },
+          { ...inboxResult, duration_ms: inboxDuration },
+          { ...vouchesResult, duration_ms: vouchesDuration },
         ],
         total_drift_unexplained,
         acceptance_tests,
@@ -846,7 +952,7 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(response);
     }
 
-    // Single table
+    // Single table — build fullAgents only when needed
     const table = rawTable as TableTarget;
     logger.info("reconcile.table.start", { table });
 
@@ -855,15 +961,21 @@ export async function POST(request: NextRequest) {
       case "agents":
         result = await reconcileAgents(kv, db, sampleSize);
         break;
-      case "claims":
-        result = await reconcileClaims(kv, db, sampleSize);
+      case "claims": {
+        const fullAgents = await buildFullAgentSet(kv);
+        result = await reconcileClaims(kv, db, sampleSize, fullAgents);
         break;
-      case "inbox_messages":
-        result = await reconcileInboxMessages(kv, db, sampleSize);
+      }
+      case "inbox_messages": {
+        const fullAgents = await buildFullAgentSet(kv);
+        result = await reconcileInboxMessages(kv, db, sampleSize, fullAgents);
         break;
-      case "vouches":
-        result = await reconcileVouches(kv, db, sampleSize);
+      }
+      case "vouches": {
+        const fullAgents = await buildFullAgentSet(kv);
+        result = await reconcileVouches(kv, db, sampleSize, fullAgents);
         break;
+      }
     }
 
     const duration_ms = Date.now() - start;

--- a/lib/d1/reconcile.ts
+++ b/lib/d1/reconcile.ts
@@ -1,0 +1,150 @@
+/**
+ * Pure reconciliation helpers for KV ↔ D1 drift analysis.
+ *
+ * These functions contain no I/O and are independently unit-testable.
+ * The reconcile route composes these with KV/D1 calls.
+ */
+
+export type TableTarget = "agents" | "claims" | "inbox_messages" | "vouches";
+
+export interface DriftBreakdown {
+  /** Total KV keys scanned for this table (including Partial for agents). */
+  kv_count_total: number;
+  /**
+   * For agents: KV count minus PartialAgentRecord entries.
+   * For all other tables: same as kv_count_total (Partial exclusion is
+   * only relevant for the agents table itself).
+   */
+  kv_count_full: number;
+  /** D1 row count from SELECT COUNT(*). */
+  d1_count: number;
+  /**
+   * kv_count_full - d1_count. Positive means KV has more rows than D1.
+   * For a correct backfill this should equal drift_explained.
+   */
+  drift: number;
+  /**
+   * Rows whose FK target is a PartialAgentRecord — these are intentionally
+   * absent from D1 per the Phase 1.3 design. For agents this is the count
+   * of Partial entries; for claims/inbox/vouches it's the count of KV rows
+   * whose parent agent is Partial (surfaced by the caller from backfill data).
+   */
+  drift_explained: number;
+  /** drift - drift_explained. Must be zero for Phase 2.x to start. */
+  drift_unexplained: number;
+}
+
+/**
+ * Compute drift breakdown from raw counts.
+ *
+ * `drift` is the gap between what KV has (excluding Partials) and what D1 has.
+ * `drift_explained` is informational context: how many rows in KV are absent
+ * from D1 due to FK cascade from Partial agents. It is independent of `drift`
+ * and can exceed it (e.g., when kv_count_full already excludes Partial entries
+ * and D1 count matches). Zero unexplained drift = Phase 2 gate passed.
+ *
+ * For agents: kv_count_full = kv_count_total - kv_count_partial; drift = kv_count_full - d1_count.
+ * For claims/inbox/vouches: kv_count_full = kv_count_total; drift = kv_count_full - d1_count;
+ *   drift_explained = rows whose FK parent agent is Partial.
+ *
+ * @param kv_count_total   - All KV entries for this table prefix
+ * @param kv_count_partial - PartialAgentRecord count (agents only; 0 for other tables)
+ * @param d1_count         - D1 SELECT COUNT(*) result
+ * @param drift_explained  - Rows absent from D1 due to Partial FK cascade (caller-provided)
+ */
+export function computeDrift(
+  kv_count_total: number,
+  kv_count_partial: number,
+  d1_count: number,
+  drift_explained: number
+): DriftBreakdown {
+  const kv_count_full = kv_count_total - kv_count_partial;
+  const drift = kv_count_full - d1_count;
+  // drift_unexplained: rows absent from D1 that cannot be attributed to Partial cascade.
+  // For agents: drift is already computed against full-only count, so unexplained = drift.
+  // For claims/inbox/vouches: drift_explained rows account for the gap; residual is unexplained.
+  const drift_unexplained = drift - drift_explained;
+  return {
+    kv_count_total,
+    kv_count_full,
+    d1_count,
+    drift,
+    drift_explained,
+    drift_unexplained,
+  };
+}
+
+/**
+ * Compute drift for the agents table.
+ *
+ * Partial entries are excluded from `kv_count_full` and do NOT contribute to
+ * `drift` (drift = kv_count_full - d1_count). They are surfaced as
+ * `drift_explained` to explain the gap between kv_count_total and d1_count
+ * for human reviewers. If D1 == kv_count_full, drift = 0 and drift_unexplained = 0.
+ */
+export function computeAgentsDrift(
+  kv_count_total: number,
+  kv_count_partial: number,
+  d1_count: number
+): DriftBreakdown {
+  const kv_count_full = kv_count_total - kv_count_partial;
+  const drift = kv_count_full - d1_count;
+  // For agents, any gap between kv_count_full and d1_count is unexplained by design
+  // (partials are already excluded from both sides of the comparison).
+  const drift_explained = kv_count_partial; // informational: total Partial count
+  const drift_unexplained = drift; // anything beyond partial exclusion is unexplained
+  return {
+    kv_count_total,
+    kv_count_full,
+    d1_count,
+    drift,
+    drift_explained,
+    drift_unexplained,
+  };
+}
+
+/**
+ * Result shape for a single table reconciliation.
+ */
+export interface TableReconcileResult {
+  table: TableTarget;
+  kv_count: number;
+  /** Agents only: count of PartialAgentRecord entries excluded from kv_count. */
+  kv_count_partial_excluded: number;
+  d1_count: number;
+  drift: number;
+  drift_explained: number;
+  drift_unexplained: number;
+  sample_size: number;
+  field_diffs: FieldDiff[];
+  duration_ms: number;
+}
+
+/**
+ * A field-level difference between a KV record and its D1 counterpart.
+ */
+export interface FieldDiff {
+  key: string;
+  field: string;
+  kv_value: unknown;
+  d1_value: unknown;
+}
+
+/**
+ * unreadCount acceptance test result for a single address.
+ */
+export interface UnreadCountDriftEntry {
+  address: string;
+  kv_cached: number;
+  d1_count: number;
+  drift: number;
+}
+
+/**
+ * Acceptance test results surfaced in the reconcile response.
+ */
+export interface AcceptanceTestResults {
+  unread_count_drift: UnreadCountDriftEntry[];
+  /** true if every sampled address has drift === 0 */
+  passed: boolean;
+}

--- a/lib/d1/reconcile.ts
+++ b/lib/d1/reconcile.ts
@@ -30,8 +30,17 @@ export interface DriftBreakdown {
    * whose parent agent is Partial (surfaced by the caller from backfill data).
    */
   drift_explained: number;
-  /** drift - drift_explained. Must be zero for Phase 2.x to start. */
+  /** drift - drift_explained, clamped to >= 0. Must be zero for Phase 2.x to start. */
   drift_unexplained: number;
+  /**
+   * Per-table breakdown of explained categories (inbox only currently uses these).
+   * For agents/claims/vouches this is empty; for inbox it carries cascade/replay/stx counts.
+   */
+  explained_categories?: {
+    partial_cascade?: number;
+    unique_payment_txid_replay?: number;
+    unresolvable_stx_reply?: number;
+  };
 }
 
 /**
@@ -56,14 +65,14 @@ export function computeDrift(
   kv_count_total: number,
   kv_count_partial: number,
   d1_count: number,
-  drift_explained: number
+  drift_explained: number,
+  explained_categories?: DriftBreakdown["explained_categories"]
 ): DriftBreakdown {
   const kv_count_full = kv_count_total - kv_count_partial;
   const drift = kv_count_full - d1_count;
-  // drift_unexplained: rows absent from D1 that cannot be attributed to Partial cascade.
-  // For agents: drift is already computed against full-only count, so unexplained = drift.
-  // For claims/inbox/vouches: drift_explained rows account for the gap; residual is unexplained.
-  const drift_unexplained = drift - drift_explained;
+  // Clamped to >= 0: drift_explained and drift are derived from independent passes
+  // (KV-truth vs count math) and minor floor-skew is possible in transit.
+  const drift_unexplained = Math.max(0, drift - drift_explained);
   return {
     kv_count_total,
     kv_count_full,
@@ -71,6 +80,7 @@ export function computeDrift(
     drift,
     drift_explained,
     drift_unexplained,
+    ...(explained_categories ? { explained_categories } : {}),
   };
 }
 
@@ -115,6 +125,15 @@ export interface TableReconcileResult {
   drift: number;
   drift_explained: number;
   drift_unexplained: number;
+  /**
+   * Per-table breakdown of explained categories (inbox only currently uses these).
+   * For agents/claims/vouches this is empty; for inbox it carries cascade/replay/stx counts.
+   */
+  explained_categories?: {
+    partial_cascade?: number;
+    unique_payment_txid_replay?: number;
+    unresolvable_stx_reply?: number;
+  };
   sample_size: number;
   field_diffs: FieldDiff[];
   duration_ms: number;


### PR DESCRIPTION
## Summary

- Closes #675 (Phase 1.4 of [#652](https://github.com/aibtcdev/landing-page/issues/652))
- Adds `POST /api/admin/reconcile` — admin-gated KV↔D1 reconciliation route that compares row counts and field-level integrity for all 4 D1 tables before Phase 2 read flips begin
- Adds `lib/d1/reconcile.ts` — pure drift-math helpers (no I/O, independently unit-testable)
- Adds 19 vitest tests (6 pure-unit, 13 route-level with mocked KV/D1)

## Implementation

### Route shape

`POST /api/admin/reconcile?table=<all|agents|claims|inbox_messages|vouches>&sampleSize=50`

Mirrors `app/api/admin/backfill/route.ts` structure: same `requireAdmin` guard, same `createLogger`/`createConsoleLogger`/`isLogsRPC` telemetry.

**Per-table operations:**
1. **Count check**: paginated KV `list()` + `SELECT COUNT(*)` from D1; computes `kv_count`, `d1_count`, `drift`
2. **PartialAgentRecord exclusion** for `agents`: `kv_count_partial_excluded` tracks entries excluded from the comparison (PartialAgentRecord = intentionally absent from D1 per Phase 1.3 design)
3. **Cascade-aware drift breakdown** for claims/inbox/vouches: `drift_explained` = rows whose FK target agent is Partial; `drift_unexplained = drift - drift_explained` (must be 0 before Phase 2)
4. **Field-level spot-check**: samples N random KV keys; compares critical fields to D1 row; reports `field_diffs`

**`table=all`**: runs all 4 tables sequentially; returns array + `total_drift_unexplained` aggregate.

### unreadCount acceptance test

Included automatically for `table=inbox_messages` and `table=all`. Scans `inbox:agent:{btc}` KV index for addresses with non-zero `unreadCount`, then compares to live D1:

```sql
SELECT COUNT(*) FROM inbox_messages
WHERE to_btc_address = ?
  AND is_reply = 0
  AND read_at IS NULL
```

Regression-test address `bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h` (from RFC §6) is always included if present. Surfaces as `acceptance_tests.unread_count_drift[{address, kv_cached, d1_count, drift}]`. Phase 2.5 resolves the drift by switching inbox reads to D1's live count (closes [aibtc-mcp-server#497](https://github.com/aibtcdev/aibtc-mcp-server/issues/497) as the verifier).

### Expected baseline (Phase 1.3 operational run, 2026-05-09T23:55Z)

| Table | D1 count | KV total | Expected drift | Drift cause |
|-------|----------:|---------:|---------------:|-------------|
| agents | 243 | ~1664 | ~1421 | PartialAgentRecord exclusion |
| claims | 123 | ~577 | ~454 | FK cascade from Partial |
| inbox_messages | 5223 | ~7763 | ~2540 | FK cascade + 7 UNIQUE replays + 2 unresolvable STX |
| vouches | 30 | ~95 | ~65 | FK cascade |

All drift is explained by Phase 1.3's design choices. **Zero unexplained drift is the gate for Phase 2.x read flips.**

## Operational instructions (post-merge)

```bash
ADMIN_API_KEY=<value from credentials>
# Run reconciliation for all tables at once
curl -sS -X POST "https://aibtc.com/api/admin/reconcile?table=all&sampleSize=50" \
  -H "X-Admin-Key: $ADMIN_API_KEY" | jq .

# Or per-table (faster per-request, no Cloudflare Worker timeout risk):
for t in agents claims inbox_messages vouches; do
  echo "=== $t ==="
  curl -sS -X POST "https://aibtc.com/api/admin/reconcile?table=$t&sampleSize=50" \
    -H "X-Admin-Key: $ADMIN_API_KEY" | jq '{table,kv_count,d1_count,drift,drift_unexplained,field_diffs_count: (.field_diffs|length)}'
done
```

**Zero-drift gate:** Phase 2.x read flips do not start until `drift_unexplained == 0` across all 4 tables. Comment per-table results on issue #675.

**Baseline artifact:** `~/.planning/active/2026-05-08-landing-page-d1-migration/phases/03-d1-backfill/2026-05-09T2330Z-backfill-production.md`

## Test coverage

- `lib/d1/reconcile.ts`: 6 pure-unit tests (drift math, zero counts, baseline scenario, unexplained drift detection)
- `app/api/admin/reconcile/route.ts`: 13 route-level tests (auth, GET self-doc, input validation, per-table happy path + exclusion rules, unreadCount acceptance test, table=all aggregate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)