### PR TITLE
fix(reconcile): align criteria + parallelize inbox scan

### DIFF
--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -991,3 +991,357 @@ describe("sampleSize=0 short-circuit", () => {
     expect(body.field_diffs).toHaveLength(0);
   });
 });
+
+// ── Bug 1: strict-criteria alignment with backfill ────────────────────────
+//
+// Records that pass isPartialAgentRecord===false but are missing one of the
+// four required fields (stxAddress / stxPublicKey / btcPublicKey / verifiedAt)
+// are rejected by backfill and therefore absent from D1. Before this fix,
+// reconcile counted them as full agents (false unexplained drift). After the
+// fix they appear in kv_count_invalid_excluded and do NOT contribute to drift.
+
+describe("Bug 1: invalid records excluded same as backfill (criteria alignment)", () => {
+  // Fixture: passes isPartialAgentRecord (has stxAddress) but missing btcPublicKey
+  const INVALID_AGENT_MISSING_BTC_PUBKEY = JSON.stringify({
+    btcAddress: "bc1qinvalid1",
+    stxAddress: "SP1INVALID1",
+    stxPublicKey: "03abcdef99",
+    // btcPublicKey intentionally missing
+    verifiedAt: "2026-01-05T00:00:00Z",
+  });
+
+  // Fixture: passes isPartialAgentRecord but has empty verifiedAt
+  const INVALID_AGENT_EMPTY_VERIFIED_AT = JSON.stringify({
+    btcAddress: "bc1qinvalid2",
+    stxAddress: "SP1INVALID2",
+    stxPublicKey: "03abcdef98",
+    btcPublicKey: "02abcdef98",
+    verifiedAt: "", // empty string — backfill rejects as falsy
+  });
+
+  it("agents: excludes invalid record (missing btcPublicKey) from kv_count and reports kv_count_invalid_excluded", async () => {
+    // KV: 1 full agent + 1 invalid (non-partial but missing btcPublicKey)
+    // D1: 1 agent (only full agent backfilled)
+    // Expected: kv_count=1, kv_count_invalid_excluded=1, drift=0, drift_unexplained=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      kv_count_partial_excluded: number;
+      kv_count_invalid_excluded: number;
+      d1_count: number;
+      drift: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.kv_count).toBe(1); // only full agent
+    expect(body.kv_count_partial_excluded).toBe(0); // none are partial
+    expect(body.kv_count_invalid_excluded).toBe(1); // invalid agent surfaced separately
+    expect(body.d1_count).toBe(1);
+    expect(body.drift).toBe(0); // no unexplained gap
+    expect(body.drift_unexplained).toBe(0);
+  });
+
+  it("agents: excludes invalid record (empty verifiedAt) — not counted as drift", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qinvalid2": INVALID_AGENT_EMPTY_VERIFIED_AT,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      kv_count_invalid_excluded: number;
+      drift: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.kv_count).toBe(1);
+    expect(body.kv_count_invalid_excluded).toBe(1);
+    expect(body.drift).toBe(0);
+    expect(body.drift_unexplained).toBe(0);
+  });
+
+  it("agents: distinguishes partial, invalid, and full counts in a mixed KV", async () => {
+    // KV: 1 full + 1 partial (isPartialAgentRecord) + 1 invalid (missing btcPublicKey)
+    // D1: 1 agent (only full backfilled)
+    // Expected: kv_count=1, partial_excluded=1, invalid_excluded=1, drift=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qpartial": PARTIAL_AGENT,
+      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      kv_count_partial_excluded: number;
+      kv_count_invalid_excluded: number;
+      d1_count: number;
+      drift: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.kv_count).toBe(1); // full only
+    expect(body.kv_count_partial_excluded).toBe(1); // true partial
+    expect(body.kv_count_invalid_excluded).toBe(1); // non-partial but missing field
+    expect(body.d1_count).toBe(1);
+    expect(body.drift).toBe(0);
+    expect(body.drift_unexplained).toBe(0);
+  });
+
+  it("claims: invalid agent's claim is also drift_explained (cascades from KV-truth)", async () => {
+    // KV: 1 full + 1 invalid; 2 claims; D1: 1 claim (only full agent's)
+    // The invalid agent's claim is not in D1 (backfill rejected the parent).
+    // reconcile should explain this via drift_explained, not drift_unexplained.
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+      "claim:bc1qagent1": CLAIM_1,
+      "claim:bc1qinvalid1": JSON.stringify({
+        btcAddress: "bc1qinvalid1",
+        status: "verified",
+        claimedAt: "2026-01-05T01:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM claims": { cnt: 1 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "claims", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+    };
+
+    expect(body.kv_count).toBe(2); // 2 claims in KV
+    expect(body.d1_count).toBe(1);
+    expect(body.drift).toBe(1);
+    // Invalid agent is not in fullAgents → claim is drift_explained
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+  });
+});
+
+// ── Bug 2: inbox parallelization — structural verification ────────────────
+//
+// The production timeout was caused by sequential kv.get() across ~10K inbox
+// keys. The fix parallelizes in batches of 50. We can't measure wall-clock
+// in unit tests, but we CAN verify the mock's get() is called for ALL keys
+// (not just a subset), and that count/drift results are identical before and
+// after the change (no regressions from the structural refactor).
+
+describe("Bug 2: inbox parallel scan — correctness after batched reads", () => {
+  it("reads all inbox:message: values (not just keys) for category derivation", async () => {
+    // KV: 3 messages (2 to full agent, 1 to partial agent)
+    // D1: 2 messages (partial agent's message not backfilled)
+    // After parallelization: drift_explained=1 (partial_cascade), drift_unexplained=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "btc:bc1qpartial": PARTIAL_AGENT,
+      "inbox:message:msg001": JSON.stringify({
+        messageId: "msg001",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_001",
+        sentAt: "2026-01-01T00:00:00Z",
+      }),
+      "inbox:message:msg002": JSON.stringify({
+        messageId: "msg002",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_002",
+        sentAt: "2026-01-01T01:00:00Z",
+      }),
+      "inbox:message:msg003": JSON.stringify({
+        messageId: "msg003",
+        toBtcAddress: "bc1qpartial", // partial agent — should be drift_explained
+        paymentTxid: "txid_003",
+        sentAt: "2026-01-01T02:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 2 },
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories: { partial_cascade?: number };
+    };
+
+    expect(body.kv_count).toBe(3);
+    expect(body.d1_count).toBe(2);
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories.partial_cascade).toBe(1);
+  });
+
+  it("reads all inbox:reply: values and counts unresolvable stx replies", async () => {
+    // KV: 1 reply with a Stacks address replyTo that does not have a stx: KV key
+    // D1: 1 reply
+    // Expected: unresolvable_stx_reply=1, drift_explained=1, drift_unexplained=0
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:reply:msg001": JSON.stringify({
+        messageId: "msg001",
+        replyTo: "SP1NOSUCHADDR",  // Stacks address but no stx: key in KV
+        repliedAt: "2026-01-01T03:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM inbox_messages": { cnt: 0 }, // reply not in D1 (unresolvable)
+      },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories: { unresolvable_stx_reply?: number };
+    };
+
+    expect(body.kv_count).toBe(1); // 1 reply key
+    expect(body.d1_count).toBe(0);
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories.unresolvable_stx_reply).toBe(1);
+  });
+});
+
+// ── explained_categories always present ──────────────────────────────────
+
+describe("explained_categories is always present in response", () => {
+  it("agents table returns explained_categories as empty object {}", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+    });
+
+    const db = buildD1Mock({
+      firstResults: { "FROM agents": { cnt: 1 } },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { explained_categories: unknown };
+    // Must be present and be an object (not undefined / null)
+    expect(body.explained_categories).toBeDefined();
+    expect(typeof body.explained_categories).toBe("object");
+    expect(body.explained_categories).not.toBeNull();
+  });
+
+  it("claims table returns explained_categories with partial_cascade", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "claim:bc1qagent1": CLAIM_1,
+    });
+
+    const db = buildD1Mock({
+      firstResults: { "FROM claims": { cnt: 1 } },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "claims", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { explained_categories: Record<string, unknown> };
+    expect(body.explained_categories).toBeDefined();
+    expect(typeof body.explained_categories).toBe("object");
+  });
+
+  it("kv_count_invalid_excluded field is always present", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+    });
+
+    const db = buildD1Mock({
+      firstResults: { "FROM agents": { cnt: 1 } },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "agents", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as { kv_count_invalid_excluded: unknown };
+    expect(body.kv_count_invalid_excluded).toBeDefined();
+    expect(typeof body.kv_count_invalid_excluded).toBe("number");
+  });
+});

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -109,13 +109,24 @@ async function sampleKvKeys(
 
 /**
  * Single-pass scan of `btc:` KV prefix — returns the set of btcAddress values
- * whose agent record is NOT PartialAgentRecord. Used by claims/inbox/vouches
+ * whose agent record passes BOTH the PartialAgentRecord check AND the strict
+ * required-field check that backfill applies. Used by claims/inbox/vouches
  * to compute drift_explained from KV truth (not D1 absence).
+ *
+ * Matches backfill's two-step rejection logic:
+ *   1. Skip isPartialAgentRecord — counted as partial_count
+ *   2. Skip records missing stxAddress/stxPublicKey/btcPublicKey/verifiedAt — invalid_count
  *
  * Reads values in parallel batches of 50 to keep wall-clock manageable.
  */
-async function buildFullAgentSet(kv: KVNamespace): Promise<Set<string>> {
+async function buildFullAgentSet(kv: KVNamespace): Promise<{
+  fullAgents: Set<string>;
+  partial_count: number;
+  invalid_count: number;
+}> {
   const fullAgents = new Set<string>();
+  let partial_count = 0;
+  let invalid_count = 0;
   let cursor: string | undefined = undefined;
 
   do {
@@ -131,22 +142,42 @@ async function buildFullAgentSet(kv: KVNamespace): Promise<Set<string>> {
       for (let j = 0; j < batch.length; j++) {
         const raw = values[j];
         if (!raw) continue;
+        let parsed: unknown;
         try {
-          const parsed = JSON.parse(raw);
-          if (!isPartialAgentRecord(parsed)) {
-            // Strip the "btc:" prefix to get the btcAddress
-            fullAgents.add(batch[j].name.slice("btc:".length));
-          }
+          parsed = JSON.parse(raw);
         } catch {
-          // malformed — skip
+          // malformed — skip (not counted as partial or invalid)
+          continue;
         }
+        if (isPartialAgentRecord(parsed)) {
+          partial_count++;
+          continue;
+        }
+        // Apply the same strict required-field check that backfill uses:
+        // records missing any of these are rejected by backfill and absent from D1.
+        const agent = parsed as Record<string, unknown>;
+        if (
+          typeof agent.stxAddress !== "string" ||
+          !agent.stxAddress ||
+          typeof agent.stxPublicKey !== "string" ||
+          !agent.stxPublicKey ||
+          typeof agent.btcPublicKey !== "string" ||
+          !agent.btcPublicKey ||
+          typeof agent.verifiedAt !== "string" ||
+          !agent.verifiedAt
+        ) {
+          invalid_count++;
+          continue;
+        }
+        // Strip the "btc:" prefix to get the btcAddress
+        fullAgents.add(batch[j].name.slice("btc:".length));
       }
     }
 
     cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
   } while (cursor !== undefined);
 
-  return fullAgents;
+  return { fullAgents, partial_count, invalid_count };
 }
 
 // ── Per-table reconciliation ───────────────────────────────────────────────
@@ -165,77 +196,84 @@ async function reconcileAgents(
   db: D1Database,
   sampleSize: number
 ): Promise<Omit<TableReconcileResult, "duration_ms">> {
-  // Count KV agents; scan values to identify partials
-  const { total: kv_total, partial: kv_partial } = await countKvKeys(
-    kv,
-    "btc:",
-    true // read values to detect partials
-  );
+  // Use buildFullAgentSet to apply the same strict criteria as backfill:
+  // both isPartialAgentRecord rejects AND missing-required-field rejects are excluded.
+  const { fullAgents, partial_count, invalid_count } = await buildFullAgentSet(kv);
+
+  const kv_total = fullAgents.size + partial_count + invalid_count;
+  // For computeAgentsDrift: treat partial + invalid both as "excluded"; D1 only contains full agents.
+  const kv_excluded = partial_count + invalid_count;
 
   // D1 count
   const d1Row = await db.prepare("SELECT COUNT(*) AS cnt FROM agents").first<{ cnt: number }>();
   const d1_count = d1Row?.cnt ?? 0;
 
-  const breakdown = computeAgentsDrift(kv_total, kv_partial, d1_count);
+  const breakdown = computeAgentsDrift(kv_total, kv_excluded, d1_count);
 
-  // Field-level spot-check — only on full agents; skip entirely when sampleSize=0
-  const sampledKeys = sampleSize > 0 ? await sampleKvKeys(kv, "btc:", sampleSize * 3) : []; // oversample to account for partials
+  // Field-level spot-check — sample from the fullAgents set (already known to be full+valid).
+  // Skip entirely when sampleSize=0.
   const field_diffs: FieldDiff[] = [];
   let checked = 0;
 
-  for (const key of sampledKeys) {
-    if (checked >= sampleSize) break;
-
-    const raw = await kv.get(key);
-    if (!raw) continue;
-
-    let agent: unknown;
-    try {
-      agent = JSON.parse(raw);
-    } catch {
-      continue;
+  if (sampleSize > 0) {
+    // Sample up to sampleSize addresses from the full-agent set (Fisher-Yates on array)
+    const allAddresses = Array.from(fullAgents);
+    for (let i = allAddresses.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [allAddresses[i], allAddresses[j]] = [allAddresses[j], allAddresses[i]];
     }
+    const sampledAddresses = allAddresses.slice(0, sampleSize);
 
-    // Skip partials in spot-check — they are intentionally absent from D1
-    if (isPartialAgentRecord(agent)) continue;
+    for (const address of sampledAddresses) {
+      const key = `btc:${address}`;
+      const raw = await kv.get(key);
+      if (!raw) continue;
 
-    const rec = agent as AgentRecord;
-    checked++;
+      let agent: unknown;
+      try {
+        agent = JSON.parse(raw);
+      } catch {
+        continue;
+      }
 
-    const d1Agent = await db
-      .prepare(
-        "SELECT btc_address, stx_address, stx_public_key, btc_public_key, verified_at FROM agents WHERE btc_address = ?"
-      )
-      .bind(rec.btcAddress)
-      .first<{
-        btc_address: string;
-        stx_address: string;
-        stx_public_key: string;
-        btc_public_key: string;
-        verified_at: string;
-      }>();
+      const rec = agent as AgentRecord;
+      checked++;
 
-    if (!d1Agent) {
-      field_diffs.push({
-        key,
-        field: "_row_missing",
-        kv_value: rec.btcAddress,
-        d1_value: null,
-      });
-      continue;
-    }
+      const d1Agent = await db
+        .prepare(
+          "SELECT btc_address, stx_address, stx_public_key, btc_public_key, verified_at FROM agents WHERE btc_address = ?"
+        )
+        .bind(rec.btcAddress)
+        .first<{
+          btc_address: string;
+          stx_address: string;
+          stx_public_key: string;
+          btc_public_key: string;
+          verified_at: string;
+        }>();
 
-    // Compare critical fields
-    const checks: Array<[string, unknown, unknown]> = [
-      ["stx_address", rec.stxAddress, d1Agent.stx_address],
-      ["stx_public_key", rec.stxPublicKey, d1Agent.stx_public_key],
-      ["btc_public_key", rec.btcPublicKey, d1Agent.btc_public_key],
-      ["verified_at", rec.verifiedAt, d1Agent.verified_at],
-    ];
+      if (!d1Agent) {
+        field_diffs.push({
+          key,
+          field: "_row_missing",
+          kv_value: rec.btcAddress,
+          d1_value: null,
+        });
+        continue;
+      }
 
-    for (const [field, kv_value, d1_value] of checks) {
-      if (kv_value !== d1_value) {
-        field_diffs.push({ key, field, kv_value, d1_value });
+      // Compare critical fields
+      const checks: Array<[string, unknown, unknown]> = [
+        ["stx_address", rec.stxAddress, d1Agent.stx_address],
+        ["stx_public_key", rec.stxPublicKey, d1Agent.stx_public_key],
+        ["btc_public_key", rec.btcPublicKey, d1Agent.btc_public_key],
+        ["verified_at", rec.verifiedAt, d1Agent.verified_at],
+      ];
+
+      for (const [field, kv_value, d1_value] of checks) {
+        if (kv_value !== d1_value) {
+          field_diffs.push({ key, field, kv_value, d1_value });
+        }
       }
     }
   }
@@ -243,11 +281,13 @@ async function reconcileAgents(
   return {
     table: "agents",
     kv_count: breakdown.kv_count_full,
-    kv_count_partial_excluded: kv_partial,
+    kv_count_partial_excluded: partial_count,
+    kv_count_invalid_excluded: invalid_count,
     d1_count: breakdown.d1_count,
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
+    explained_categories: {},
     sample_size: checked,
     field_diffs,
   };
@@ -335,11 +375,12 @@ async function reconcileClaims(
     table: "claims",
     kv_count: breakdown.kv_count_full,
     kv_count_partial_excluded: 0,
+    kv_count_invalid_excluded: 0,
     d1_count: breakdown.d1_count,
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
-    explained_categories: breakdown.explained_categories,
+    explained_categories: breakdown.explained_categories ?? {},
     sample_size: checked,
     field_diffs,
   };
@@ -362,12 +403,15 @@ async function reconcileInboxMessages(
   sampleSize: number,
   fullAgents: Set<string>
 ): Promise<Omit<TableReconcileResult, "duration_ms">> {
-  // Single-pass: collect all parsed inbox records to derive all category counts
+  // Single-pass: collect all parsed inbox records to derive all category counts.
+  // Reads in parallel batches of 50 to avoid sequential kv.get() across ~10K keys
+  // which exceeded the Worker 5-min wall budget in the 2026-05-10T01:25Z production run.
+  const INBOX_BATCH_SIZE = 50;
   type ParsedMsg = { type: "message"; toBtcAddress?: string; paymentTxid?: string };
   type ParsedReply = { type: "reply"; replyTo?: string; messageId?: string };
   const allRecords: Array<ParsedMsg | ParsedReply> = [];
 
-  // Scan inbox:message: prefix
+  // Scan inbox:message: prefix in parallel batches
   let kv_inbound = 0;
   {
     let cursor: string | undefined = undefined;
@@ -376,25 +420,28 @@ async function reconcileInboxMessages(
       if (cursor) opts.cursor = cursor;
       const page = await kv.list(opts);
       kv_inbound += page.keys.length;
-      for (const key of page.keys) {
-        const raw = await kv.get(key.name);
-        if (!raw) continue;
-        try {
-          const msg = JSON.parse(raw) as Record<string, unknown>;
-          allRecords.push({
-            type: "message",
-            toBtcAddress: msg.toBtcAddress as string | undefined,
-            paymentTxid: msg.paymentTxid as string | undefined,
-          });
-        } catch {
-          // ignore malformed
+      for (let i = 0; i < page.keys.length; i += INBOX_BATCH_SIZE) {
+        const batch = page.keys.slice(i, i + INBOX_BATCH_SIZE);
+        const values = await Promise.all(batch.map((k) => kv.get(k.name)));
+        for (const raw of values) {
+          if (!raw) continue;
+          try {
+            const msg = JSON.parse(raw) as Record<string, unknown>;
+            allRecords.push({
+              type: "message",
+              toBtcAddress: msg.toBtcAddress as string | undefined,
+              paymentTxid: msg.paymentTxid as string | undefined,
+            });
+          } catch {
+            // ignore malformed
+          }
         }
       }
       cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
     } while (cursor !== undefined);
   }
 
-  // Scan inbox:reply: prefix
+  // Scan inbox:reply: prefix in parallel batches
   let kv_reply = 0;
   {
     let cursor: string | undefined = undefined;
@@ -403,18 +450,21 @@ async function reconcileInboxMessages(
       if (cursor) opts.cursor = cursor;
       const page = await kv.list(opts);
       kv_reply += page.keys.length;
-      for (const key of page.keys) {
-        const raw = await kv.get(key.name);
-        if (!raw) continue;
-        try {
-          const reply = JSON.parse(raw) as Record<string, unknown>;
-          allRecords.push({
-            type: "reply",
-            replyTo: reply.replyTo as string | undefined,
-            messageId: reply.messageId as string | undefined,
-          });
-        } catch {
-          // ignore malformed
+      for (let i = 0; i < page.keys.length; i += INBOX_BATCH_SIZE) {
+        const batch = page.keys.slice(i, i + INBOX_BATCH_SIZE);
+        const values = await Promise.all(batch.map((k) => kv.get(k.name)));
+        for (const raw of values) {
+          if (!raw) continue;
+          try {
+            const reply = JSON.parse(raw) as Record<string, unknown>;
+            allRecords.push({
+              type: "reply",
+              replyTo: reply.replyTo as string | undefined,
+              messageId: reply.messageId as string | undefined,
+            });
+          } catch {
+            // ignore malformed
+          }
         }
       }
       cursor = page.list_complete ? undefined : (page.cursor ?? undefined);
@@ -542,11 +592,12 @@ async function reconcileInboxMessages(
     table: "inbox_messages",
     kv_count: breakdown.kv_count_full,
     kv_count_partial_excluded: 0,
+    kv_count_invalid_excluded: 0,
     d1_count: breakdown.d1_count,
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
-    explained_categories: breakdown.explained_categories,
+    explained_categories: breakdown.explained_categories ?? {},
     sample_size: checked,
     field_diffs,
   };
@@ -643,11 +694,12 @@ async function reconcileVouches(
     table: "vouches",
     kv_count: breakdown.kv_count_full,
     kv_count_partial_excluded: 0,
+    kv_count_invalid_excluded: 0,
     d1_count: breakdown.d1_count,
     drift: breakdown.drift,
     drift_explained: breakdown.drift_explained,
     drift_unexplained: breakdown.drift_unexplained,
-    explained_categories: breakdown.explained_categories,
+    explained_categories: breakdown.explained_categories ?? {},
     sample_size: checked,
     field_diffs,
   };
@@ -849,8 +901,9 @@ export async function POST(request: NextRequest) {
 
   try {
     if (rawTable === "all") {
-      // Build full-agent set once — shared by claims/inbox/vouches for KV-truth drift_explained
-      const fullAgents = await buildFullAgentSet(kv);
+      // Build full-agent set once — shared by claims/inbox/vouches for KV-truth drift_explained.
+      // buildFullAgentSet now applies the same two-step rejection as backfill (Partial + invalid).
+      const { fullAgents } = await buildFullAgentSet(kv);
 
       // Run all tables sequentially (D1 query budget concerns); track per-table duration
       let tableStart = Date.now();
@@ -962,17 +1015,17 @@ export async function POST(request: NextRequest) {
         result = await reconcileAgents(kv, db, sampleSize);
         break;
       case "claims": {
-        const fullAgents = await buildFullAgentSet(kv);
+        const { fullAgents } = await buildFullAgentSet(kv);
         result = await reconcileClaims(kv, db, sampleSize, fullAgents);
         break;
       }
       case "inbox_messages": {
-        const fullAgents = await buildFullAgentSet(kv);
+        const { fullAgents } = await buildFullAgentSet(kv);
         result = await reconcileInboxMessages(kv, db, sampleSize, fullAgents);
         break;
       }
       case "vouches": {
-        const fullAgents = await buildFullAgentSet(kv);
+        const { fullAgents } = await buildFullAgentSet(kv);
         result = await reconcileVouches(kv, db, sampleSize, fullAgents);
         break;
       }

--- a/lib/d1/reconcile.ts
+++ b/lib/d1/reconcile.ts
@@ -119,17 +119,30 @@ export function computeAgentsDrift(
 export interface TableReconcileResult {
   table: TableTarget;
   kv_count: number;
-  /** Agents only: count of PartialAgentRecord entries excluded from kv_count. */
+  /**
+   * Agents only: count of PartialAgentRecord entries excluded from kv_count.
+   * These are records without stxAddress — intentionally absent from D1.
+   */
   kv_count_partial_excluded: number;
+  /**
+   * Agents only: count of records that passed isPartialAgentRecord===false but
+   * are still missing a required field (stxAddress / stxPublicKey / btcPublicKey
+   * / verifiedAt). These match backfill's "Missing required AgentRecord fields"
+   * rejection path and are intentionally absent from D1. Kept separate from
+   * kv_count_partial_excluded to surface this category explicitly.
+   */
+  kv_count_invalid_excluded: number;
   d1_count: number;
   drift: number;
   drift_explained: number;
   drift_unexplained: number;
   /**
-   * Per-table breakdown of explained categories (inbox only currently uses these).
-   * For agents/claims/vouches this is empty; for inbox it carries cascade/replay/stx counts.
+   * Per-table breakdown of explained categories.
+   * Always present (may be empty object {}). For agents this is {}; for
+   * claims/vouches it carries partial_cascade; for inbox it also carries
+   * unique_payment_txid_replay and unresolvable_stx_reply.
    */
-  explained_categories?: {
+  explained_categories: {
     partial_cascade?: number;
     unique_payment_txid_replay?: number;
     unresolvable_stx_reply?: number;


### PR DESCRIPTION
## Summary

Two bugs surfaced by the 2026-05-10T01:25Z operational run against production data.
Run artifact: `~/.planning/active/2026-05-08-landing-page-d1-migration/phases/04-d1-reconcile/2026-05-10T0125Z-reconcile-first-run.md`

### Bug 1 — `buildFullAgentSet` criteria mismatch with backfill (708 unexplained agents)

The backfill route classifies an agent as "should be in D1" with two checks:
1. `!isPartialAgentRecord(parsed)` — skip Partial records
2. ALL of `stxAddress`, `stxPublicKey`, `btcPublicKey`, `verifiedAt` must be non-empty strings — otherwise rejected as "Missing required AgentRecord fields"

`buildFullAgentSet` in the reconcile route only applied check #1. Records that passed `isPartialAgentRecord===false` but failed check #2 were counted as full by reconcile but rejected by backfill — producing 708 false "unexplained drift" agents on the production run. The same cascade showed up in claims (454) and vouches (65) because those tables use `buildFullAgentSet` for their `drift_explained` computation.

**Fix:** `buildFullAgentSet` now returns `{ fullAgents, partial_count, invalid_count }` and applies the same strict two-step rejection. `reconcileAgents` uses this shape to:
- Set `kv_count` = full-agents-only (same as before)
- Set `kv_count_partial_excluded` = Partial-only count (PartialAgentRecord)
- Set `kv_count_invalid_excluded` = new field for the second-reject category
- Compute `drift` only against the truly-full set

`TableReconcileResult` gains `kv_count_invalid_excluded` (optional for non-agent tables, always 0). All three callers (`claims`, `inbox_messages`, `vouches`) now destructure `{ fullAgents }` from the new return shape.

### Bug 2 — Inbox reconciliation timeout from sequential `kv.get()` (~10K reads)

`reconcileInboxMessages` iterated `inbox:message:` (~7763 keys) and `inbox:reply:` (~2540 keys) with a sequential `kv.get(key.name)` per key. On production data this exceeded the Worker 5-minute wall budget. curl timed out at 180s on the operational run.

**Fix:** Both scan loops now read values in parallel batches of 50, exactly like `buildFullAgentSet`. The same structure applies to both the inbound-message and reply-message loops.

### Small follow-ups (in scope)

- `explained_categories` is now always present in `TableReconcileResult` (never `undefined`) — agents returns `{}`, all other tables return their populated object. Fixes the inconsistent JSON shape noted in the run output.
- `TableReconcileResult` JSDoc updated to describe what each count field represents.

## Test plan

- [ ] All 35 existing test files still pass (633 → 642 tests, 9 new)
- [ ] New test: invalid record (missing btcPublicKey) excluded from `kv_count`, appears in `kv_count_invalid_excluded`, `drift=0`
- [ ] New test: invalid record (empty verifiedAt) excluded — not counted as drift
- [ ] New test: mixed KV (full + partial + invalid) correctly populates all three count fields
- [ ] New test: invalid agent's claim cascades to `drift_explained` via KV-truth
- [ ] New test: inbox parallel scan — correctness for partial_cascade category
- [ ] New test: inbox parallel scan — correctness for unresolvable_stx_reply category
- [ ] New test: `explained_categories` always present for agents, claims
- [ ] New test: `kv_count_invalid_excluded` field always present
- [ ] `npm run lint` clean (only pre-existing `<img>` warnings, no errors)

## Phase gate impact

Phase 2.x gate (`drift_unexplained == 0`) was false-negative until this fix. The 708-agent gap was the reconcile route overcounting "full" agents that backfill had intentionally rejected. After this lands the gate should pass with the same production data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)