### PR TITLE
fix(reconcile): read OutboxReply.toBtcAddress (not replyTo) for cascade detection

### DIFF
--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -1244,7 +1244,7 @@ describe("Bug 2: inbox parallel scan — correctness after batched reads", () =>
       "btc:bc1qagent1": FULL_AGENT,
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "SP1NOSUCHADDR",  // Stacks address but no stx: key in KV
+        toBtcAddress: "SP1NOSUCHADDR",  // Stacks address but no stx: key in KV
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });
@@ -1363,7 +1363,7 @@ describe("Bug A: BTC-shaped replyTo classified as partial_cascade", () => {
       "btc:bc1qagent1": FULL_AGENT,
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "bc1qnotanagent1234",  // BTC address NOT in fullAgents
+        toBtcAddress: "bc1qnotanagent1234",  // BTC address NOT in fullAgents
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });
@@ -1409,7 +1409,7 @@ describe("Bug A: BTC-shaped replyTo classified as partial_cascade", () => {
       "btc:bc1qagent1": FULL_AGENT,  // bc1qagent1 is a full agent
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "bc1qagent1",  // BTC address that IS in fullAgents
+        toBtcAddress: "bc1qagent1",  // BTC address that IS in fullAgents
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });
@@ -1486,19 +1486,19 @@ describe("Bug B: null payment_txid not counted in unique_payment_txid_replay", (
       // 3 replies — payment_txid is null (no payment required for replies)
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "bc1qagent1",
+        toBtcAddress: "bc1qagent1",
         payment_txid: null,
         repliedAt: "2026-01-01T01:00:00Z",
       }),
       "inbox:reply:msg002": JSON.stringify({
         messageId: "msg002",
-        replyTo: "bc1qagent1",
+        toBtcAddress: "bc1qagent1",
         payment_txid: null,
         repliedAt: "2026-01-01T01:01:00Z",
       }),
       "inbox:reply:msg003": JSON.stringify({
         messageId: "msg003",
-        replyTo: "bc1qagent1",
+        toBtcAddress: "bc1qagent1",
         payment_txid: null,
         repliedAt: "2026-01-01T01:02:00Z",
       }),
@@ -1563,7 +1563,7 @@ describe("Bug C: STX replyTo resolver — no btcAddress field → unresolvable_s
       }),
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "SP1NOSUCHBTC",  // STX address whose stx: record has no btcAddress
+        toBtcAddress: "SP1NOSUCHBTC",  // STX address whose stx: record has no btcAddress
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });
@@ -1615,7 +1615,7 @@ describe("Bug C: STX replyTo resolver — no btcAddress field → unresolvable_s
       }),
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        replyTo: "SP1RESOLVES",
+        toBtcAddress: "SP1RESOLVES",
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -459,7 +459,10 @@ async function reconcileInboxMessages(
             const reply = JSON.parse(raw) as Record<string, unknown>;
             allRecords.push({
               type: "reply",
-              replyTo: reply.replyTo as string | undefined,
+              // OutboxReply records store the reply target in `toBtcAddress`
+              // (despite the field name, the value can be STX-shaped per the
+              // backfill route's STX→BTC resolution helper added in c777549).
+              replyTo: reply.toBtcAddress as string | undefined,
               messageId: reply.messageId as string | undefined,
             });
           } catch {


### PR DESCRIPTION
## Summary

PR #680 + #681's reply-branch fix was a **no-op on real production data** because OutboxReply records (KV `inbox:reply:*`) have no `replyTo` field. The reply target is stored in `toBtcAddress` (despite the field name, the value can be STX-shaped per the backfill route's STX→BTC resolution helper from `c777549`).

Direct verification via `wrangler kv key get inbox:reply:msg_…`:
```json
{
  "messageId": "msg_1776887770597_...",
  "fromAddress": "bc1q...",
  "toBtcAddress": "SP1KGHF33817ZX...",   // <- STX address despite field name
  "reply": "...",
  "signature": "...",
  "repliedAt": "2026-04-23T07:42:13.468Z"
}
```

The reconcile route was reading `reply.replyTo` which is always `undefined` → no replies entered any classification branch → 675 false-unexplained inbox drift in the 2026-05-10T01:45Z and 2026-05-10T01:58Z operational runs.

## Fix

One-line source change in `reconcileInboxMessages`:
```diff
-              replyTo: reply.replyTo as string | undefined,
+              replyTo: reply.toBtcAddress as string | undefined,
```

Variable name kept as `replyTo` internally for compatibility with the existing STX/BTC dispatch logic — only the source field changes. Comment added explaining the field-name vs value-shape inversion.

Test fixtures updated from `replyTo:` to `toBtcAddress:` to match reality. 44 tests still pass.

## Expected impact

After merge + redeploy, the 2026-05-10T01:58Z baseline (`drift_unexplained: 675`) should drop toward 0 for inbox_messages, closing out Phase 1.4 gate.

Refs #675. Closes the no-op trail from #680/#681's reply branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)