### PR TITLE
docs(CLAUDE.md): sample real KV records before locking specs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,6 +382,8 @@ Both `stx:` and `btc:` keys point to identical records and must be updated toget
 
 **Note on AgentRecord**: The `erc8004AgentId` field (optional number) stores the agent's on-chain identity NFT ID when detected. The `referredBy` field (optional string) stores the BTC address of the agent who vouched for this agent during registration (immutable once set).
 
+**Spec from real records, not from concepts**: When writing a spec that touches existing KV records (migrations, reconciliation, dual-writes, type changes), sample the real shape with `wrangler kv key get <namespace> <sample-key>` BEFORE locking the spec — concept names ≠ stored field names. Example: `OutboxReply` records store the reply target in `toBtcAddress` (sometimes STX-shaped pre-resolution), not `replyTo` — three fix-up PRs (#680/#681/#682) chased that mismatch during the Phase 1.4 reconcile build before the actual record was sampled.
+
 ## Key Files
 
 ### Library

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -382,7 +382,7 @@ Both `stx:` and `btc:` keys point to identical records and must be updated toget
 
 **Note on AgentRecord**: The `erc8004AgentId` field (optional number) stores the agent's on-chain identity NFT ID when detected. The `referredBy` field (optional string) stores the BTC address of the agent who vouched for this agent during registration (immutable once set).
 
-**Spec from real records, not from concepts**: When writing a spec that touches existing KV records (migrations, reconciliation, dual-writes, type changes), sample the real shape with `wrangler kv key get <namespace> <sample-key>` BEFORE locking the spec — concept names ≠ stored field names. Example: `OutboxReply` records store the reply target in `toBtcAddress` (sometimes STX-shaped pre-resolution), not `replyTo` — three fix-up PRs (#680/#681/#682) chased that mismatch during the Phase 1.4 reconcile build before the actual record was sampled.
+**Spec from real records, not from concepts**: When writing a spec that touches existing KV records (migrations, reconciliation, dual-writes, type changes), sample the real shape with `wrangler kv key get <namespace> <sample-key>` BEFORE locking the spec — concept names ≠ stored field names. Example: `OutboxReply` records store the reply target in `toBtcAddress` (sometimes a Stacks address pre-resolution, resolved to the BTC address via the `kv:stx:{addr}` lookup before persisting), not `replyTo` — three fix-up PRs (#680/#681/#682) chased that mismatch during the Phase 1.4 reconcile build before the actual record was sampled.
 
 ## Key Files
 


### PR DESCRIPTION
## Summary

One-paragraph addition to `CLAUDE.md` (after the AgentRecord note in the KV Storage Patterns section) capturing the field-name lesson from the Phase 1.4 reconcile build:

> **Spec from real records, not from concepts**: When writing a spec that touches existing KV records (migrations, reconciliation, dual-writes, type changes), sample the real shape with `wrangler kv key get <namespace> <sample-key>` BEFORE locking the spec — concept names ≠ stored field names. Example: `OutboxReply` records store the reply target in `toBtcAddress` (sometimes STX-shaped pre-resolution), not `replyTo` — three fix-up PRs (#680/#681/#682) chased that mismatch during the Phase 1.4 reconcile build before the actual record was sampled.

Per the synthesis-comment ask on [#675](https://github.com/aibtcdev/landing-page/issues/675#issuecomment-4414261596) + my v113 offer in [#675](https://github.com/aibtcdev/landing-page/issues/675#issuecomment-4414239326). Two reviewers (arc + me) and the maintainer converged on the rule; this lands the rule as a contributor doc so the next person touching KV-shape-affecting code has the discipline named at the natural place.

## Why here

The KV Storage Patterns section already names the patterns + values + TTLs; the rule fits as the next contributor note after `**Note on AgentRecord**`. Other locations considered:

- **As a new section** — risks breaking the linear "Patterns → Note on type → Key Files" flow
- **In Architecture (CF KV bullet)** — too high-level; the rule is specific to spec-writing for migrations/reconciliation, not architecture
- **In a contributing.md** — doesn't exist; CLAUDE.md is the de-facto contributor doc

## Cross-repo lift

Same shape as recurring [aibtcdev/skills](https://github.com/aibtcdev/skills) PRs (#376 / #377 / #378) where `metadata.requires` is omitted because the spec was written from a conceptual term rather than from a sampled real frontmatter. If the rule reads cleanly here, considering proposing the analogous spec-from-sampled-data discipline in skills repo's contributor doc.

## Test plan

- [x] CLAUDE.md renders correctly on GitHub (markdown only, no code change)
- [x] No CI gate on docs-only PRs except markdown-lint (none configured per `.github/`)

## Refs

- Closes the field-name lesson follow-up from [#675](https://github.com/aibtcdev/landing-page/issues/675) synthesis comment
- Companion to [#685](https://github.com/aibtcdev/landing-page/pull/685) (diff-report artifact) and [#684](https://github.com/aibtcdev/landing-page/issues/684) (path-A pagination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
