### PR TITLE
feat(d1): flip rebuildAgentListCache to D1 SELECT (Phase 2.1, #687)

### DIFF
--- a/lib/cache/__tests__/agent-list-d1.test.ts
+++ b/lib/cache/__tests__/agent-list-d1.test.ts
@@ -10,7 +10,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { mapRowToCachedAgent } from "../agent-list";
+
+// Mock @opennextjs/cloudflare BEFORE importing agent-list so the module's
+// transitive imports of getCloudflareContext pick up the mock. vi.mock is
+// hoisted by Vitest to the top of the transformed file, but listing it
+// explicitly above the agent-list import documents the dependency.
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { mapRowToCachedAgent, getCachedAgentList } from "../agent-list";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -220,15 +230,8 @@ describe("mapRowToCachedAgent", () => {
 // getCachedAgentList — cold miss D1 path with mock D1 + KV
 // ---------------------------------------------------------------------------
 
-// Mock getCloudflareContext before importing agent-list so the module picks
-// up the mock when rebuildAgentListCache calls it.
-vi.mock("@opennextjs/cloudflare", () => ({
-  getCloudflareContext: vi.fn(),
-}));
-
-// Import after mock registration
-import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { getCachedAgentList } from "../agent-list";
+// Mock + imports are at top of file (so getCloudflareContext + getCachedAgentList
+// are already in scope from the file-level imports above).
 
 interface MockKV {
   get: ReturnType<typeof vi.fn>;

--- a/lib/cache/__tests__/agent-list-d1.test.ts
+++ b/lib/cache/__tests__/agent-list-d1.test.ts
@@ -1,0 +1,367 @@
+/**
+ * Tests for the D1-backed rebuildAgentListCache path (Phase 2.1).
+ *
+ * Covers:
+ *  1. mapRowToCachedAgent — row mapping unit tests (3 level scenarios)
+ *  2. Empty D1 result — returns {agents: [], stats: {total:0, ...}}
+ *  3. Route-level integration — getCachedAgentList on cold miss uses D1,
+ *     asserts zero kv.get calls on the rebuild path (only kv.get(CACHE_KEY)
+ *     and kv.get(BUILDING_KEY) are allowed; no btc:, claim:, inbox:agent: reads)
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mapRowToCachedAgent } from "../agent-list";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a minimal AgentListRow for mapRowToCachedAgent tests.
+ * Required fields have sensible defaults; tests override what they need.
+ */
+function makeRow(
+  overrides: Partial<{
+    btc_address: string;
+    stx_address: string;
+    stx_public_key: string;
+    btc_public_key: string;
+    taproot_address: string | null;
+    display_name: string | null;
+    description: string | null;
+    bns_name: string | null;
+    owner: string | null;
+    verified_at: string;
+    last_active_at: string | null;
+    erc8004_agent_id: number | null;
+    nostr_public_key: string | null;
+    last_identity_check: string | null;
+    referred_by_btc: string | null;
+    github_username: string | null;
+    claim_status: string | null;
+    claimed_at: string | null;
+    message_count: number;
+    unread_count: number;
+  }> = {}
+) {
+  return {
+    btc_address: "bc1qagent1",
+    stx_address: "SP1AGENT1",
+    stx_public_key: "02abc",
+    btc_public_key: "03def",
+    taproot_address: null,
+    display_name: null,
+    description: null,
+    bns_name: null,
+    owner: null,
+    verified_at: "2026-01-01T00:00:00.000Z",
+    last_active_at: null,
+    erc8004_agent_id: null,
+    nostr_public_key: null,
+    last_identity_check: null,
+    referred_by_btc: null,
+    github_username: null,
+    claim_status: null,
+    claimed_at: null,
+    message_count: 0,
+    unread_count: 0,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// mapRowToCachedAgent — row mapping unit tests
+// ---------------------------------------------------------------------------
+
+describe("mapRowToCachedAgent", () => {
+  describe("level computation", () => {
+    it("(a) full agent with verified claim → level=2 (Genesis)", () => {
+      const row = makeRow({
+        claim_status: "verified",
+        claimed_at: "2026-02-01T00:00:00.000Z",
+        message_count: 5,
+        unread_count: 2,
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.level).toBe(2);
+      expect(agent.levelName).toBe("Genesis");
+    });
+
+    it("(a) full agent with rewarded claim → level=2 (Genesis)", () => {
+      const row = makeRow({
+        claim_status: "rewarded",
+        claimed_at: "2026-02-01T00:00:00.000Z",
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.level).toBe(2);
+      expect(agent.levelName).toBe("Genesis");
+    });
+
+    it("(b) full agent with no claim (LEFT JOIN miss) → level=1 (Verified Agent)", () => {
+      const row = makeRow({
+        claim_status: null,
+        claimed_at: null,
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.level).toBe(1);
+      // Match the actual LEVELS[1].name from lib/levels.ts
+      expect(agent.levelName).toBe("Verified Agent");
+    });
+
+    it("(c) full agent with claim_status='pending' → level=1 (Verified Agent)", () => {
+      const row = makeRow({
+        claim_status: "pending",
+        claimed_at: "2026-02-01T00:00:00.000Z",
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.level).toBe(1);
+      expect(agent.levelName).toBe("Verified Agent");
+    });
+
+    it("(c) full agent with claim_status='failed' → level=1 (Verified Agent)", () => {
+      const row = makeRow({
+        claim_status: "failed",
+        claimed_at: "2026-02-01T00:00:00.000Z",
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.level).toBe(1);
+      expect(agent.levelName).toBe("Verified Agent");
+    });
+  });
+
+  describe("field mapping", () => {
+    it("maps all snake_case D1 columns to camelCase CachedAgent fields", () => {
+      const row = makeRow({
+        btc_address: "bc1qtest",
+        stx_address: "SP1TEST",
+        stx_public_key: "02stxpub",
+        btc_public_key: "03btcpub",
+        taproot_address: "bc1ptest",
+        display_name: "Test Agent",
+        description: "A test agent",
+        bns_name: "test.btc",
+        owner: "testhandle",
+        verified_at: "2026-03-01T00:00:00.000Z",
+        last_active_at: "2026-03-02T00:00:00.000Z",
+        erc8004_agent_id: 42,
+        nostr_public_key: "npub1test",
+        last_identity_check: "2026-03-03T00:00:00.000Z",
+        referred_by_btc: "bc1qreferrer",
+        github_username: "testgithub",
+        claim_status: null,
+        claimed_at: null,
+        message_count: 7,
+        unread_count: 3,
+      });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.btcAddress).toBe("bc1qtest");
+      expect(agent.stxAddress).toBe("SP1TEST");
+      expect(agent.stxPublicKey).toBe("02stxpub");
+      expect(agent.btcPublicKey).toBe("03btcpub");
+      expect(agent.taprootAddress).toBe("bc1ptest");
+      expect(agent.displayName).toBe("Test Agent");
+      expect(agent.description).toBe("A test agent");
+      expect(agent.bnsName).toBe("test.btc");
+      expect(agent.owner).toBe("testhandle");
+      expect(agent.verifiedAt).toBe("2026-03-01T00:00:00.000Z");
+      expect(agent.lastActiveAt).toBe("2026-03-02T00:00:00.000Z");
+      expect(agent.erc8004AgentId).toBe(42);
+      expect(agent.nostrPublicKey).toBe("npub1test");
+      expect(agent.lastIdentityCheck).toBe("2026-03-03T00:00:00.000Z");
+      // referred_by_btc → referredBy (column name deviation from issue sketch)
+      expect(agent.referredBy).toBe("bc1qreferrer");
+      expect(agent.githubUsername).toBe("testgithub");
+      expect(agent.messageCount).toBe(7);
+      expect(agent.unreadCount).toBe(3);
+    });
+
+    it("passes null fields through as null", () => {
+      const row = makeRow(); // all optional fields are null by default
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.taprootAddress).toBeNull();
+      expect(agent.displayName).toBeNull();
+      expect(agent.description).toBeNull();
+      expect(agent.bnsName).toBeNull();
+      expect(agent.owner).toBeNull();
+      expect(agent.lastActiveAt).toBeNull();
+      expect(agent.erc8004AgentId).toBeNull();
+      expect(agent.nostrPublicKey).toBeNull();
+      expect(agent.lastIdentityCheck).toBeNull();
+      expect(agent.referredBy).toBeNull();
+      expect(agent.githubUsername).toBeNull();
+    });
+
+    it("message counts come from D1 subquery columns, not KV", () => {
+      const row = makeRow({ message_count: 12, unread_count: 4 });
+
+      const agent = mapRowToCachedAgent(row);
+
+      expect(agent.messageCount).toBe(12);
+      expect(agent.unreadCount).toBe(4);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getCachedAgentList — cold miss D1 path with mock D1 + KV
+// ---------------------------------------------------------------------------
+
+// Mock getCloudflareContext before importing agent-list so the module picks
+// up the mock when rebuildAgentListCache calls it.
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+// Import after mock registration
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { getCachedAgentList } from "../agent-list";
+
+interface MockKV {
+  get: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+}
+
+function mockKV(store: Record<string, string | null> = {}): MockKV {
+  const data = new Map<string, string | null>(Object.entries(store));
+  return {
+    get: vi.fn(async (key: string) => data.get(key) ?? null),
+    put: vi.fn(async (key: string, value: string) => {
+      data.set(key, value);
+    }),
+    delete: vi.fn(async (key: string) => {
+      data.delete(key);
+    }),
+  };
+}
+
+function mockD1(rows: unknown[] = []) {
+  return {
+    prepare: vi.fn().mockReturnValue({
+      all: vi.fn().mockResolvedValue({ results: rows }),
+    }),
+  };
+}
+
+describe("getCachedAgentList — cold miss uses D1", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("empty D1 result → returns {agents: [], stats: {total:0, genesisCount:0, messageCount:0}}", async () => {
+    const kv = mockKV({}); // cold miss — no cache
+    const db = mockD1([]); // D1 returns no rows
+
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: { DB: db },
+    } as unknown as Awaited<ReturnType<typeof getCloudflareContext>>);
+
+    const result = await getCachedAgentList(kv as unknown as KVNamespace);
+
+    expect(result.agents).toEqual([]);
+    expect(result.stats.total).toBe(0);
+    expect(result.stats.genesisCount).toBe(0);
+    expect(result.stats.messageCount).toBe(0);
+  });
+
+  it("cold miss: zero kv.get calls for btc:, claim:, or inbox:agent: prefixes", async () => {
+    const kv = mockKV({}); // cold miss
+
+    const rows = [
+      makeRow({
+        btc_address: "bc1qagent1",
+        claim_status: "verified",
+        claimed_at: "2026-01-01T00:00:00.000Z",
+        message_count: 3,
+        unread_count: 1,
+      }),
+      makeRow({
+        btc_address: "bc1qagent2",
+        stx_address: "SP2AGENT2",
+        claim_status: null,
+        claimed_at: null,
+        message_count: 0,
+        unread_count: 0,
+      }),
+    ];
+
+    const db = mockD1(rows);
+
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: { DB: db },
+    } as unknown as Awaited<ReturnType<typeof getCloudflareContext>>);
+
+    await getCachedAgentList(kv as unknown as KVNamespace);
+
+    // Confirm kv.get was called, but never with KV data keys
+    const kvGetCalls = (kv.get as ReturnType<typeof vi.fn>).mock.calls.map(
+      (args: unknown[]) => args[0] as string
+    );
+
+    const forbiddenPrefixes = ["btc:", "claim:", "inbox:agent:"];
+    for (const call of kvGetCalls) {
+      for (const prefix of forbiddenPrefixes) {
+        expect(call).not.toMatch(new RegExp(`^${prefix}`));
+      }
+    }
+  });
+
+  it("cold miss: D1 is queried once and result is written to KV cache", async () => {
+    const kv = mockKV({});
+    const db = mockD1([makeRow({ btc_address: "bc1qonly" })]);
+
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: { DB: db },
+    } as unknown as Awaited<ReturnType<typeof getCloudflareContext>>);
+
+    const result = await getCachedAgentList(kv as unknown as KVNamespace);
+
+    // D1 prepare() called exactly once (single query)
+    expect(db.prepare).toHaveBeenCalledTimes(1);
+
+    // Result should have 1 agent
+    expect(result.agents).toHaveLength(1);
+    expect(result.agents[0].btcAddress).toBe("bc1qonly");
+
+    // KV put should have been called to cache the snapshot
+    expect(kv.put).toHaveBeenCalledWith(
+      "cache:agent-list",
+      expect.any(String),
+      expect.objectContaining({ expirationTtl: 600 })
+    );
+  });
+
+  it("stats.genesisCount and stats.messageCount are derived from D1 rows", async () => {
+    const kv = mockKV({});
+    const rows = [
+      makeRow({ claim_status: "verified", claimed_at: "2026-01-01T00:00:00.000Z", message_count: 5 }),
+      makeRow({ btc_address: "bc1q2", stx_address: "SP2", claim_status: null, message_count: 3 }),
+      makeRow({ btc_address: "bc1q3", stx_address: "SP3", claim_status: "pending", claimed_at: "2026-01-01T00:00:00.000Z", message_count: 0 }),
+    ];
+    const db = mockD1(rows);
+
+    vi.mocked(getCloudflareContext).mockResolvedValue({
+      env: { DB: db },
+    } as unknown as Awaited<ReturnType<typeof getCloudflareContext>>);
+
+    const result = await getCachedAgentList(kv as unknown as KVNamespace);
+
+    expect(result.stats.total).toBe(3);
+    expect(result.stats.genesisCount).toBe(1); // only "verified"
+    expect(result.stats.messageCount).toBe(8); // 5+3+0
+  });
+});

--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -318,6 +318,12 @@ async function rebuildAgentListCache(
     )
     .all<AgentListRow>();
 
+  // Surface D1 errors to worker-logs — without this, a binding misconfig or
+  // schema drift produces a silent 0-agent snapshot cached for 600s.
+  if (!result.success) {
+    console.error("agent-list rebuild: D1 query failed", result.error);
+  }
+
   const rows = result.results ?? [];
   const cachedAgents: CachedAgent[] = rows.map(mapRowToCachedAgent);
 

--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -319,8 +319,11 @@ async function rebuildAgentListCache(
     .all<AgentListRow>();
 
   // Surface D1 errors to worker-logs — without this, a binding misconfig or
-  // schema drift produces a silent 0-agent snapshot cached for 600s.
+  // schema drift produces a silent 0-agent snapshot cached for 600s. This is
+  // a library module without request-scoped logger access; raw console is
+  // intentional for diagnostic visibility on a path that otherwise swallows.
   if (!result.success) {
+    // eslint-disable-next-line no-console
     console.error("agent-list rebuild: D1 query failed", result.error);
   }
 

--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -220,21 +220,23 @@ interface AgentListRow {
  *
  * level/levelName are computed via computeLevel() using a lightweight
  * AgentRecord + ClaimStatus reconstructed from the joined columns.
- * achievementCount is hardcoded to 0 (removed in Phase 0.1 via #654).
  */
 export function mapRowToCachedAgent(row: AgentListRow): CachedAgent {
   // Reconstruct the minimal shapes that computeLevel() requires.
   // Full AgentRecord is not needed — computeLevel only checks agent existence
   // and claim.status being "verified" or "rewarded".
-  const agentShape = { btcAddress: row.btc_address } as Parameters<
-    typeof computeLevel
-  >[0];
+  const agentShape: Parameters<typeof computeLevel>[0] = {
+    btcAddress: row.btc_address,
+  } as Parameters<typeof computeLevel>[0];
 
+  // claimed_at is NOT NULL by schema (migrations/002_claims.sql), so a non-null
+  // claim_status implies a present claimed_at; guard on status alone to avoid
+  // silently downgrading verified agents on hypothetical schema-violation rows.
   const claimShape =
-    row.claim_status !== null && row.claimed_at !== null
+    row.claim_status !== null
       ? ({
           status: row.claim_status as "pending" | "verified" | "rewarded" | "failed",
-          claimedAt: row.claimed_at,
+          claimedAt: row.claimed_at ?? "",
         } as Parameters<typeof computeLevel>[1])
       : null;
 

--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -8,11 +8,14 @@
  * empty list just because another request happens to be rebuilding.
  *
  * Mutation endpoints call invalidateAgentListCache() to force a rebuild.
+ *
+ * Phase 2.1: rebuildAgentListCache body replaced with a single D1 SELECT +
+ * LEFT JOIN claims + COUNT subqueries on inbox_messages. Zero KV reads on the
+ * rebuild path (vs ~750 fan-out reads before).
  */
 
-import type { AgentRecord, ClaimStatus } from "@/lib/types";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { computeLevel, LEVELS } from "@/lib/levels";
-import { getAgentsIndex } from "@/lib/agents-index";
 import type { CachedAgent, CachedAgentList } from "./types";
 
 const CACHE_KEY = "cache:agent-list";
@@ -58,6 +61,9 @@ function parseSnapshot(raw: string | null): CachedAgentList | null {
  * - Cold miss: if another request is already rebuilding, poll briefly so we
  *   can serve the fresh result instead of an empty list. Otherwise rebuild
  *   synchronously.
+ *
+ * @param kv - VERIFIED_AGENTS KV namespace (cache layer only; rebuild reads D1)
+ * @param waitUntil - optional Cloudflare Workers waitUntil for background tasks
  */
 export async function getCachedAgentList(
   kv: KVNamespace,
@@ -183,114 +189,138 @@ export async function invalidateAgentListCache(
 }
 
 /**
- * Rebuild the agent list cache from individual KV records.
- * This is the expensive operation that the cache avoids on every page load.
- *
- * The agent set is sourced from the maintained `agents:index`
- * (single KV read) instead of `kv.list({prefix:"stx:"}) + N gets` —
- * full AgentRecords are still fetched per agent for the auxiliary
- * fields (description, owner, lastActiveAt, …) the snapshot needs.
- *
- * Concurrency: per-record fetches are batched to bound peak
- * concurrent KV reads + JSON parses. The previous `kv.list`
- * implementation was already bounded by KV's 1000-keys-per-page
- * cap; sourcing from the index removed that natural bound, so we
- * re-impose one explicitly here.
+ * D1 row shape returned by the agent-list SELECT.
+ * Column names match the D1 schema exactly (snake_case).
  */
-const REBUILD_FETCH_BATCH_SIZE = 500;
+interface AgentListRow {
+  btc_address: string;
+  stx_address: string;
+  stx_public_key: string;
+  btc_public_key: string;
+  taproot_address: string | null;
+  display_name: string | null;
+  description: string | null;
+  bns_name: string | null;
+  owner: string | null;
+  verified_at: string;
+  last_active_at: string | null;
+  erc8004_agent_id: number | null;
+  nostr_public_key: string | null;
+  last_identity_check: string | null;
+  referred_by_btc: string | null;
+  github_username: string | null;
+  claim_status: string | null;
+  claimed_at: string | null;
+  message_count: number;
+  unread_count: number;
+}
 
+/**
+ * Map a single D1 row to a CachedAgent.
+ *
+ * level/levelName are computed via computeLevel() using a lightweight
+ * AgentRecord + ClaimStatus reconstructed from the joined columns.
+ * achievementCount is hardcoded to 0 (removed in Phase 0.1 via #654).
+ */
+export function mapRowToCachedAgent(row: AgentListRow): CachedAgent {
+  // Reconstruct the minimal shapes that computeLevel() requires.
+  // Full AgentRecord is not needed — computeLevel only checks agent existence
+  // and claim.status being "verified" or "rewarded".
+  const agentShape = { btcAddress: row.btc_address } as Parameters<
+    typeof computeLevel
+  >[0];
+
+  const claimShape =
+    row.claim_status !== null && row.claimed_at !== null
+      ? ({
+          status: row.claim_status as "pending" | "verified" | "rewarded" | "failed",
+          claimedAt: row.claimed_at,
+        } as Parameters<typeof computeLevel>[1])
+      : null;
+
+  const level = computeLevel(agentShape, claimShape);
+
+  return {
+    stxAddress: row.stx_address,
+    btcAddress: row.btc_address,
+    stxPublicKey: row.stx_public_key,
+    btcPublicKey: row.btc_public_key,
+    taprootAddress: row.taproot_address,
+    displayName: row.display_name,
+    description: row.description,
+    bnsName: row.bns_name,
+    owner: row.owner,
+    verifiedAt: row.verified_at,
+    lastActiveAt: row.last_active_at,
+    erc8004AgentId: row.erc8004_agent_id,
+    nostrPublicKey: row.nostr_public_key,
+    lastIdentityCheck: row.last_identity_check,
+    referredBy: row.referred_by_btc,
+    githubUsername: row.github_username,
+    level,
+    levelName: LEVELS[level].name,
+    messageCount: row.message_count,
+    unreadCount: row.unread_count,
+  };
+}
+
+/**
+ * Rebuild the agent list cache from a single D1 SELECT.
+ *
+ * Phase 2.1 source-flip: replaces ~750 KV fan-out reads (btc:, claim:,
+ * inbox:agent: per agent at ~250 agents) with one D1 query.
+ *
+ * The SELECT joins agents → claims (LEFT JOIN) and uses correlated
+ * COUNT subqueries on inbox_messages for messageCount / unreadCount.
+ * Results are ordered by verified_at DESC, matching the prior sort order.
+ *
+ * D1 binding is sourced from getCloudflareContext().env.DB to match the
+ * existing pattern in all route files; no new binding parameter needed.
+ */
 async function rebuildAgentListCache(
   kv: KVNamespace
 ): Promise<CachedAgentList> {
-  // 1. Source agent addresses from the maintained index.
-  const index = await getAgentsIndex(kv);
+  const { env } = await getCloudflareContext();
+  const db = env.DB as D1Database;
 
-  // 2. Fetch full AgentRecords by `btc:`, batched to keep peak
-  //    concurrency in line with the prior `kv.list` per-page bound.
-  const agents: AgentRecord[] = [];
-  for (let i = 0; i < index.agents.length; i += REBUILD_FETCH_BATCH_SIZE) {
-    const batch = index.agents.slice(i, i + REBUILD_FETCH_BATCH_SIZE);
-    const fetched = await Promise.all(
-      batch.map(async (entry) => {
-        const value = await kv.get(`btc:${entry.btcAddress}`);
-        if (!value) return null;
-        try {
-          return JSON.parse(value) as AgentRecord;
-        } catch {
-          return null;
-        }
-      })
-    );
-    for (const record of fetched) {
-      if (record) agents.push(record);
-    }
-  }
+  const result = await db
+    .prepare(
+      `SELECT
+        a.btc_address,
+        a.stx_address,
+        a.stx_public_key,
+        a.btc_public_key,
+        a.taproot_address,
+        a.display_name,
+        a.description,
+        a.bns_name,
+        a.owner,
+        a.verified_at,
+        a.last_active_at,
+        a.erc8004_agent_id,
+        a.nostr_public_key,
+        a.last_identity_check,
+        a.referred_by_btc,
+        a.github_username,
+        c.status   AS claim_status,
+        c.claimed_at,
+        (SELECT COUNT(*) FROM inbox_messages
+           WHERE to_btc_address = a.btc_address AND is_reply = 0
+        ) AS message_count,
+        (SELECT COUNT(*) FROM inbox_messages
+           WHERE to_btc_address = a.btc_address AND is_reply = 0 AND read_at IS NULL
+        ) AS unread_count
+      FROM agents a
+      LEFT JOIN claims c ON c.btc_address = a.btc_address
+      ORDER BY a.verified_at DESC`
+    )
+    .all<AgentListRow>();
 
-  // 2. Enrich: claims, inbox in parallel.
-  const [claims, inboxData] = await Promise.all([
-    Promise.all(
-      agents.map(async (agent) => {
-        const data = await kv.get(`claim:${agent.btcAddress}`);
-        if (!data) return null;
-        try {
-          return JSON.parse(data) as ClaimStatus;
-        } catch {
-          return null;
-        }
-      })
-    ),
-    Promise.all(
-      agents.map(async (agent) => {
-        const data = await kv.get(`inbox:agent:${agent.btcAddress}`);
-        if (!data) return null;
-        try {
-          return JSON.parse(data) as {
-            messageIds: string[];
-            unreadCount: number;
-          };
-        } catch {
-          return null;
-        }
-      })
-    ),
-  ]);
-
-  // 3. Build cached agents
-  const cachedAgents: CachedAgent[] = agents.map((agent, i) => {
-    const level = computeLevel(agent, claims[i]);
-    const inbox = inboxData[i];
-    return {
-      stxAddress: agent.stxAddress,
-      btcAddress: agent.btcAddress,
-      stxPublicKey: agent.stxPublicKey,
-      btcPublicKey: agent.btcPublicKey,
-      taprootAddress: agent.taprootAddress ?? null,
-      displayName: agent.displayName ?? null,
-      description: agent.description ?? null,
-      bnsName: agent.bnsName ?? null,
-      owner: agent.owner ?? null,
-      verifiedAt: agent.verifiedAt,
-      lastActiveAt: agent.lastActiveAt ?? null,
-      erc8004AgentId: agent.erc8004AgentId ?? null,
-      nostrPublicKey: agent.nostrPublicKey ?? null,
-      lastIdentityCheck: agent.lastIdentityCheck ?? null,
-      referredBy: agent.referredBy ?? null,
-      githubUsername: agent.githubUsername ?? null,
-      level,
-      levelName: LEVELS[level].name,
-      messageCount: inbox?.messageIds.length ?? 0,
-      unreadCount: inbox?.unreadCount ?? 0,
-    };
-  });
+  const rows = result.results ?? [];
+  const cachedAgents: CachedAgent[] = rows.map(mapRowToCachedAgent);
 
   const genesisCount = cachedAgents.filter((a) => a.level >= 2).length;
-
-  // Derive total message count from already-fetched inbox data
-  // (avoids a separate O(M) kv.list scan over inbox:message:* keys)
-  const messageCount = inboxData.reduce(
-    (sum, inbox) => sum + (inbox?.messageIds.length ?? 0),
-    0
-  );
+  const messageCount = cachedAgents.reduce((sum, a) => sum + a.messageCount, 0);
 
   const snapshot: CachedAgentList = {
     agents: cachedAgents,


### PR DESCRIPTION
## Summary

- Replaces the KV fan-out rebuild path (~750 KV reads at ~250 agents: `btc:`, `claim:`, `inbox:agent:` per agent) with a **single D1 SELECT** + `LEFT JOIN claims` + correlated `COUNT` subqueries on `inbox_messages`
- Zero KV reads on the rebuild path; cache layer (mark-stale, `getCachedAgentList`, sentinel keys) is **unchanged**
- `getAgentsIndex` KV index is no longer used on this path (import removed)

Closes #687

## Final SELECT

```sql
SELECT
  a.btc_address, a.stx_address, a.stx_public_key, a.btc_public_key,
  a.taproot_address, a.display_name, a.description, a.bns_name, a.owner,
  a.verified_at, a.last_active_at, a.erc8004_agent_id, a.nostr_public_key,
  a.last_identity_check, a.referred_by_btc, a.github_username,
  c.status   AS claim_status,
  c.claimed_at,
  (SELECT COUNT(*) FROM inbox_messages
     WHERE to_btc_address = a.btc_address AND is_reply = 0
  ) AS message_count,
  (SELECT COUNT(*) FROM inbox_messages
     WHERE to_btc_address = a.btc_address AND is_reply = 0 AND read_at IS NULL
  ) AS unread_count
FROM agents a
LEFT JOIN claims c ON c.btc_address = a.btc_address
ORDER BY a.verified_at DESC
```

**Schema deviation from issue sketch:** `referred_by` column is actually `referred_by_btc` in `migrations/001_agents.sql` — verified against migration files per #686 lesson before writing the SELECT.

## Implementation notes

- `mapRowToCachedAgent()` is exported for unit testing; calls `computeLevel()` with lightweight shape objects reconstructed from the joined D1 columns (no full `AgentRecord` fetch needed)
- D1 binding sourced from `getCloudflareContext().env.DB` — matches existing pattern in all route files
- `CachedAgent` / `CachedAgentList` types in `lib/cache/types.ts` are **unchanged** (frozen per spec)

## Test coverage

New: `lib/cache/__tests__/agent-list-d1.test.ts` (12 tests)

| Test | Scenario |
|------|----------|
| `claim_status='verified'` → level=2 (Genesis) | Row mapping: level computation |
| `claim_status='rewarded'` → level=2 (Genesis) | Row mapping: level computation |
| `claim_status=NULL` (LEFT JOIN miss) → level=1 (Verified Agent) | Row mapping: level computation |
| `claim_status='pending'` → level=1 (Verified Agent) | Row mapping: level computation |
| `claim_status='failed'` → level=1 (Verified Agent) | Row mapping: level computation |
| All snake_case → camelCase column mappings | Row mapping: field mapping |
| Null fields pass through as null | Row mapping: field mapping |
| message/unread counts from D1 subquery columns | Row mapping: field mapping |
| Empty D1 → `{agents: [], stats: {total:0, ...}}` | Cold miss: empty result |
| Zero `kv.get` calls for `btc:`, `claim:`, `inbox:agent:` prefixes | Cold miss: no KV reads |
| D1 queried once; result written to KV cache | Cold miss: D1 path |
| `stats.genesisCount` and `stats.messageCount` derived from D1 | Cold miss: stats |

Existing `lib/cache/__tests__/agent-list.test.ts` (mark-stale contract, 6 tests) still passes unchanged.

All 36 test files, 664 tests pass. `npm run lint` clean.

## Smoke window plan

30 min post-deploy:
1. Watch `https://aibtc.com/api/agents` — response shape identical, agents list populated
2. Check `https://logs.aibtc.com` with `X-Admin-Key` — filter for agent-list rebuild events, confirm `btc:`, `claim:`, `inbox:agent:` reads drop from the top KV consumers on the rebuild path
3. Comment cost-measurement update on #652 after 24h window

🤖 Generated with [Claude Code](https://claude.com/claude-code)