### PR TITLE
chore(d1-pk): migrate REPLY_D1_PK_PREFIX from constants to dedicated module (closes #698, supersedes #674)

### DIFF
--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -5,7 +5,7 @@ import { isPartialAgentRecord } from "@/lib/types";
 import type { AgentRecord, ClaimRecord } from "@/lib/types";
 import type { VouchRecord } from "@/lib/vouch/types";
 import type { InboxMessage, OutboxReply } from "@/lib/inbox/types";
-import { REPLY_D1_PK_PREFIX } from "@/lib/inbox/constants";
+import { deriveReplyD1Id } from "@/lib/inbox/d1-pk";
 import { generateClaimCode } from "@/lib/claim-code";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { isStxAddress } from "@/lib/validation/address";
@@ -587,7 +587,7 @@ async function backfillInboxMessages(
     // The KV key is `inbox:reply:{messageId}` where messageId is the parent message's
     // ID. The reply IS linked to that parent message row in D1.
     // We generate a distinct ID for the reply row itself to avoid PK collision.
-    const replyMessageId = `${REPLY_D1_PK_PREFIX}${reply.messageId}`;
+    const replyMessageId = deriveReplyD1Id(reply.messageId);
 
     const resolvedToBtcAddress = await resolveReplyRecipientBtcAddress(kv, reply.toBtcAddress);
     if (!resolvedToBtcAddress) {

--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -583,10 +583,10 @@ async function backfillInboxMessages(
       continue;
     }
 
-    // Replies use the messageId as both their own message_id and reply_to_message_id.
-    // The KV key is `inbox:reply:{messageId}` where messageId is the parent message's
-    // ID. The reply IS linked to that parent message row in D1.
-    // We generate a distinct ID for the reply row itself to avoid PK collision.
+    // KV key is `inbox:reply:{messageId}` where messageId is the parent's ID.
+    // The reply row's own message_id is synthesized via deriveReplyD1Id to avoid
+    // PK collision with the parent inbound row (which uses messageId directly).
+    // The reply_to_message_id FK column links back to the parent unchanged.
     const replyMessageId = deriveReplyD1Id(reply.messageId);
 
     const resolvedToBtcAddress = await resolveReplyRecipientBtcAddress(kv, reply.toBtcAddress);

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -4,7 +4,7 @@ import { requireAdmin } from "@/lib/admin/auth";
 import { isPartialAgentRecord } from "@/lib/types";
 import type { AgentRecord } from "@/lib/types";
 import type { InboxAgentIndex } from "@/lib/inbox/types";
-import { REPLY_D1_PK_PREFIX } from "@/lib/inbox/constants";
+import { deriveReplyD1Id } from "@/lib/inbox/d1-pk";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import {
   computeDrift,
@@ -593,7 +593,7 @@ async function reconcileInboxMessages(
     }
     checked++;
     const parentId = reply.messageId as string;
-    const replyMessageId = `${REPLY_D1_PK_PREFIX}${parentId}`;
+    const replyMessageId = deriveReplyD1Id(parentId);
 
     const d1Reply = await db
       .prepare("SELECT message_id, reply_to_message_id FROM inbox_messages WHERE message_id = ?")

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -395,7 +395,7 @@ async function reconcileClaims(
  * unique_payment_txid_replay (duplicate payment txids), and unresolvable_stx_reply
  * (reply whose STX replyTo cannot be resolved to a full agent).
  *
- * Reply rows in D1 have message_id prefixed with REPLY_D1_PK_PREFIX.
+ * Reply rows in D1 have message_id synthesized via `deriveReplyD1Id` (see `lib/inbox/d1-pk.ts`).
  */
 async function reconcileInboxMessages(
   kv: KVNamespace,

--- a/lib/inbox/__tests__/d1-pk.test.ts
+++ b/lib/inbox/__tests__/d1-pk.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { REPLY_D1_PK_PREFIX, deriveReplyD1Id } from "../d1-pk";
+
+describe("REPLY_D1_PK_PREFIX", () => {
+  it('prefix value is "reply_"', () => {
+    expect(REPLY_D1_PK_PREFIX).toBe("reply_");
+  });
+});
+
+describe("deriveReplyD1Id", () => {
+  it("prepends REPLY_D1_PK_PREFIX to the parent messageId", () => {
+    const parentId = "msg_1234";
+    const result = deriveReplyD1Id(parentId);
+    expect(result).toBe(`${REPLY_D1_PK_PREFIX}${parentId}`);
+  });
+
+  it("is deterministic — same input always returns same output", () => {
+    const parentId = "msg_abcdef";
+    expect(deriveReplyD1Id(parentId)).toBe(deriveReplyD1Id(parentId));
+  });
+
+  it("reply PK is distinct from the inbound row PK (no collision)", () => {
+    const parentId = "msg_5678";
+    const replyPk = deriveReplyD1Id(parentId);
+    expect(replyPk).not.toBe(parentId);
+  });
+
+  it("matches the expected full PK for a representative message ID", () => {
+    expect(deriveReplyD1Id("msg_1234")).toBe("reply_msg_1234");
+  });
+});

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -20,8 +20,6 @@ export function buildMarkReadMessage(messageId: string): string {
 
 /** BIP-137 signing format for inbox replies (bound to specific message). */
 export const REPLY_MESSAGE_FORMAT = "Inbox Reply | {messageId} | {reply}";
-/** Prefix used when materializing KV outbox replies into D1 inbox_messages PKs. */
-export const REPLY_D1_PK_PREFIX = "reply_";
 
 export function buildReplyMessage(messageId: string, reply: string): string {
   return `Inbox Reply | ${messageId} | ${reply}`;

--- a/lib/inbox/d1-pk.ts
+++ b/lib/inbox/d1-pk.ts
@@ -1,0 +1,33 @@
+/**
+ * D1 primary-key helpers for the inbox_messages table.
+ *
+ * KV stores two shapes under the same messageId:
+ *   inbox:message:{messageId}  — inbound (InboxMessage)
+ *   inbox:reply:{messageId}    — reply (OutboxReply), keyed by the PARENT's ID
+ *
+ * If both rows used the KV-derived ID directly, they would collide on the
+ * message_id PK. Reply rows therefore get a synthesized PK by prepending this
+ * prefix to the parent's messageId.
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/673
+ */
+
+/** Prefix applied to the parent messageId to form a reply row's D1 PK. */
+export const REPLY_D1_PK_PREFIX = "reply_";
+
+/**
+ * Returns the D1 primary key for a reply row given its parent's messageId.
+ *
+ * Caller contract: `parentMessageId` must not begin with `REPLY_D1_PK_PREFIX`.
+ * Upstream message IDs are relay-sourced and structurally cannot carry this prefix.
+ *
+ * This derivation is intentionally one-way. To find the parent of a reply row,
+ * use the `reply_to_message_id` FK column plus the `is_reply` discriminator —
+ * do not strip this prefix from the synthesized PK.
+ *
+ * @example
+ * deriveReplyD1Id("msg_1234") // => "reply_msg_1234"
+ */
+export function deriveReplyD1Id(parentMessageId: string): string {
+  return `${REPLY_D1_PK_PREFIX}${parentMessageId}`;
+}

--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -23,7 +23,6 @@ export {
   MAX_REPLY_LENGTH,
   MARK_READ_MESSAGE_FORMAT,
   REPLY_MESSAGE_FORMAT,
-  REPLY_D1_PK_PREFIX,
   SENDER_AUTH_MESSAGE_FORMAT,
   SBTC_CONTRACTS,
   KV_PREFIXES,
@@ -43,6 +42,9 @@ export {
   buildReplyMessage,
   buildSenderAuthMessage,
 } from "./constants";
+
+// D1 PK Helpers
+export { REPLY_D1_PK_PREFIX, deriveReplyD1Id } from "./d1-pk";
 
 // Payment Failure Cache
 export { getCachedPaymentFailure, cachePaymentFailure } from "./payment-cache";


### PR DESCRIPTION
## Summary

- Closes #698; supersedes #674
- Honors arc0btc's original module-shape design (commit `c7498063` in #674) with @secret-mars's forward-looking concern from #678 review (`c777549`) **fully resolved** — the constant and its derivation helper are now the canonical source of truth in a dedicated module
- PR #674 will be closed as "superseded by this PR" once this lands

## Changes

| File | Action |
|------|--------|
| `lib/inbox/d1-pk.ts` | **New** — `REPLY_D1_PK_PREFIX` constant + `deriveReplyD1Id()` helper with full JSDoc |
| `lib/inbox/constants.ts` | Remove `REPLY_D1_PK_PREFIX` (no longer lives here) |
| `lib/inbox/index.ts` | Drop from `./constants` re-export; add dedicated re-export from `./d1-pk` for both exports |
| `app/api/admin/backfill/route.ts` | Import from `@/lib/inbox/d1-pk`; template-literal replaced with `deriveReplyD1Id()` |
| `app/api/admin/reconcile/route.ts` | Same import + call-site cleanup |
| `lib/inbox/__tests__/d1-pk.test.ts` | **New** — 5 unit tests |

## Tests

4 spec'd + 1 bonus unit tests for `deriveReplyD1Id`:

1. `REPLY_D1_PK_PREFIX` value is `"reply_"`
2. Helper prepends prefix to parent messageId
3. Helper is deterministic (same input → same output)
4. Reply PK is distinct from the inbound row's PK (no collision)
5. Expected full PK for a representative message ID (`"reply_msg_1234"`)

All 713 existing tests continue to pass. The one failing test suite (`app/api/og/[address]/__tests__/og-d1.test.ts`) is a pre-existing JSX parse error on `main` unrelated to this change.

## Lint

`npm run lint` clean — no new errors or warnings introduced.

## Note on PR #674

Once this PR merges, PR #674 should be closed with "superseded by #699" (or whatever number this gets). Credit goes fully to @arc0btc for the original module-shape design and to @secret-mars for the forward-looking review that identified the need for this cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)