### PR TITLE
refactor(inbox): extract d1-pk module, migrate all callers (supersedes #674)

### DIFF
--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -5,7 +5,7 @@ import { isPartialAgentRecord } from "@/lib/types";
 import type { AgentRecord, ClaimRecord } from "@/lib/types";
 import type { VouchRecord } from "@/lib/vouch/types";
 import type { InboxMessage, OutboxReply } from "@/lib/inbox/types";
-import { REPLY_D1_PK_PREFIX } from "@/lib/inbox/constants";
+import { deriveReplyD1Id } from "@/lib/inbox/d1-pk";
 import { generateClaimCode } from "@/lib/claim-code";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { isStxAddress } from "@/lib/validation/address";
@@ -587,7 +587,7 @@ async function backfillInboxMessages(
     // The KV key is `inbox:reply:{messageId}` where messageId is the parent message's
     // ID. The reply IS linked to that parent message row in D1.
     // We generate a distinct ID for the reply row itself to avoid PK collision.
-    const replyMessageId = `${REPLY_D1_PK_PREFIX}${reply.messageId}`;
+    const replyMessageId = deriveReplyD1Id(reply.messageId);
 
     const resolvedToBtcAddress = await resolveReplyRecipientBtcAddress(kv, reply.toBtcAddress);
     if (!resolvedToBtcAddress) {

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -4,7 +4,7 @@ import { requireAdmin } from "@/lib/admin/auth";
 import { isPartialAgentRecord } from "@/lib/types";
 import type { AgentRecord } from "@/lib/types";
 import type { InboxAgentIndex } from "@/lib/inbox/types";
-import { REPLY_D1_PK_PREFIX } from "@/lib/inbox/constants";
+import { deriveReplyD1Id } from "@/lib/inbox/d1-pk";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import {
   computeDrift,
@@ -593,7 +593,7 @@ async function reconcileInboxMessages(
     }
     checked++;
     const parentId = reply.messageId as string;
-    const replyMessageId = `${REPLY_D1_PK_PREFIX}${parentId}`;
+    const replyMessageId = deriveReplyD1Id(parentId);
 
     const d1Reply = await db
       .prepare("SELECT message_id, reply_to_message_id FROM inbox_messages WHERE message_id = ?")

--- a/lib/inbox/__tests__/d1-pk.test.ts
+++ b/lib/inbox/__tests__/d1-pk.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { REPLY_D1_PK_PREFIX, deriveReplyD1Id } from "../d1-pk";
+
+describe("d1-pk", () => {
+  it("prefix is 'reply_'", () => {
+    expect(REPLY_D1_PK_PREFIX).toBe("reply_");
+  });
+
+  it("helper prepends prefix to parent messageId", () => {
+    expect(deriveReplyD1Id("msg_1234")).toBe("reply_msg_1234");
+  });
+
+  it("helper is deterministic", () => {
+    const id = "msg_abc123";
+    expect(deriveReplyD1Id(id)).toBe(deriveReplyD1Id(id));
+  });
+
+  it("reply PK is distinct from the inbound row's PK", () => {
+    const parentId = "msg_xyz";
+    expect(deriveReplyD1Id(parentId)).not.toBe(parentId);
+  });
+});

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -20,8 +20,6 @@ export function buildMarkReadMessage(messageId: string): string {
 
 /** BIP-137 signing format for inbox replies (bound to specific message). */
 export const REPLY_MESSAGE_FORMAT = "Inbox Reply | {messageId} | {reply}";
-/** Prefix used when materializing KV outbox replies into D1 inbox_messages PKs. */
-export const REPLY_D1_PK_PREFIX = "reply_";
 
 export function buildReplyMessage(messageId: string, reply: string): string {
   return `Inbox Reply | ${messageId} | ${reply}`;

--- a/lib/inbox/d1-pk.ts
+++ b/lib/inbox/d1-pk.ts
@@ -1,0 +1,33 @@
+/**
+ * D1 primary-key helpers for the inbox_messages table.
+ *
+ * KV stores two shapes under the same messageId:
+ *   inbox:message:{messageId}  — inbound (InboxMessage)
+ *   inbox:reply:{messageId}    — reply (OutboxReply), keyed by the PARENT's ID
+ *
+ * If both rows used the KV-derived ID directly, they would collide on the
+ * message_id PK. Reply rows therefore get a synthesized PK by prepending this
+ * prefix to the parent's messageId.
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/673
+ */
+
+/** Prefix applied to the parent messageId to form a reply row's D1 PK. */
+export const REPLY_D1_PK_PREFIX = "reply_";
+
+/**
+ * Returns the D1 primary key for a reply row given its parent's messageId.
+ *
+ * Caller contract: `parentMessageId` must not begin with `REPLY_D1_PK_PREFIX`.
+ * Upstream message IDs are relay-sourced and structurally cannot carry this prefix.
+ *
+ * This derivation is intentionally one-way. To find the parent of a reply row,
+ * use the `reply_to_message_id` FK column plus the `is_reply` discriminator —
+ * do not strip this prefix from the synthesized PK.
+ *
+ * @example
+ * deriveReplyD1Id("msg_1234") // => "reply_msg_1234"
+ */
+export function deriveReplyD1Id(parentMessageId: string): string {
+  return `${REPLY_D1_PK_PREFIX}${parentMessageId}`;
+}

--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -23,7 +23,6 @@ export {
   MAX_REPLY_LENGTH,
   MARK_READ_MESSAGE_FORMAT,
   REPLY_MESSAGE_FORMAT,
-  REPLY_D1_PK_PREFIX,
   SENDER_AUTH_MESSAGE_FORMAT,
   SBTC_CONTRACTS,
   KV_PREFIXES,
@@ -43,6 +42,9 @@ export {
   buildReplyMessage,
   buildSenderAuthMessage,
 } from "./constants";
+
+// D1 PK helpers
+export { REPLY_D1_PK_PREFIX, deriveReplyD1Id } from "./d1-pk";
 
 // Payment Failure Cache
 export { getCachedPaymentFailure, cachePaymentFailure } from "./payment-cache";


### PR DESCRIPTION
## Summary

- Creates `lib/inbox/d1-pk.ts` as the canonical source of truth for `REPLY_D1_PK_PREFIX = "reply_"` and `deriveReplyD1Id(parentMessageId)`, with full JSDoc per the caller contract and one-way derivation note from arc0btc's original PR
- Removes `REPLY_D1_PK_PREFIX` from `lib/inbox/constants.ts` — no more dual-homing
- Re-exports both symbols from the `lib/inbox` barrel (`index.ts`)
- Migrates `app/api/admin/backfill/route.ts` and `app/api/admin/reconcile/route.ts` from inlined `` `${REPLY_D1_PK_PREFIX}${id}` `` template literals to `deriveReplyD1Id()` calls, importing from `@/lib/inbox/d1-pk`
- Adds `lib/inbox/__tests__/d1-pk.test.ts` (4 tests: prefix value, helper output, determinism, uniqueness vs inbound PK)

## Credit

This supersedes #674 by @arc0btc, which added `d1-pk.ts` and the barrel re-export. The only missing pieces were removing the constant from `constants.ts` and updating the two callers — this PR completes that. Review feedback from @secret-mars on #674 is fully honored. Fresh branch off current `main` so there are no stale base conflicts.

## Acceptance criteria

- [x] No more `REPLY_D1_PK_PREFIX` in `lib/inbox/constants.ts`
- [x] All call sites import from `lib/inbox/d1-pk` (or barrel)
- [x] `lib/inbox/__tests__/d1-pk.test.ts` — 4 tests covering prefix, output, determinism, distinctness
- [x] PR #674 will be closed as superseded with credit noted above

## Test plan

- [ ] `bun test lib/inbox/__tests__/d1-pk.test.ts` — 4 pass, 0 fail
- [ ] `npm run lint` clean
- [ ] Existing tests still pass

Closes #698
Supersedes #674

🤖 Generated with [Claude Code](https://claude.com/claude-code)