### PR TITLE
fix(og-title): avoid doubled 'Agent' word for level=1 agents (closes #702)

### DIFF
--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 import Link from "next/link";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimRecord } from "@/lib/types";
-import { getAgentLevel, computeLevel, LEVELS } from "@/lib/levels";
+import { getAgentLevel, computeLevel, formatLevelTitleSuffix } from "@/lib/levels";
 import { generateName } from "@/lib/name-generator";
 import { lookupBnsName } from "@/lib/bns";
 import { X_HANDLE } from "@/lib/constants";
@@ -222,9 +222,8 @@ export async function generateMetadata({
       ? { status: claimRecord.status, claimedAt: claimRecord.claimedAt, rewardSatoshis: claimRecord.rewardSatoshis }
       : null;
     const level = computeLevel(agent, claimStatus);
-    const levelName = LEVELS[level].name;
 
-    const ogTitle = `${displayName} — ${levelName} Agent`;
+    const ogTitle = `${displayName} — ${formatLevelTitleSuffix(level)}`;
     const ogImage = `/api/og/${agent.btcAddress}`;
 
     return {

--- a/lib/__tests__/levels.test.ts
+++ b/lib/__tests__/levels.test.ts
@@ -3,6 +3,7 @@ import {
   computeLevel,
   getAgentLevel,
   getNextLevel,
+  formatLevelTitleSuffix,
   LEVELS,
   type ClaimStatus,
 } from "../levels";
@@ -293,5 +294,23 @@ describe("level progression flow", () => {
     level = computeLevel(mockAgent, verifiedClaim);
     expect(level).toBe(2);
     expect(LEVELS[level].name).toBe("Genesis");
+  });
+});
+
+describe("formatLevelTitleSuffix", () => {
+  it("level 0 (Unverified) appends ' Agent' — 'Unverified Agent'", () => {
+    expect(formatLevelTitleSuffix(0)).toBe("Unverified Agent");
+  });
+
+  it("level 1 (Verified Agent) does NOT append ' Agent' — already in name", () => {
+    // LEVELS[1].name = "Verified Agent" — naive `${levelName} Agent` would
+    // produce "Verified Agent Agent" (visible to crawlers / browser tab title).
+    expect(formatLevelTitleSuffix(1)).toBe("Verified Agent");
+    // Specifically guard against the doubled form
+    expect(formatLevelTitleSuffix(1)).not.toBe("Verified Agent Agent");
+  });
+
+  it("level 2 (Genesis) appends ' Agent' — 'Genesis Agent'", () => {
+    expect(formatLevelTitleSuffix(2)).toBe("Genesis Agent");
   });
 });

--- a/lib/levels.ts
+++ b/lib/levels.ts
@@ -104,6 +104,28 @@ export function getAgentLevel(
 }
 
 /**
+ * Format a level title suffix for use in HTML <title> and og:title strings.
+ *
+ * `LEVELS[1].name` is "Verified Agent" — already includes "Agent" suffix.
+ * `LEVELS[0].name` ("Unverified") and `LEVELS[2].name` ("Genesis") don't.
+ * Naive concatenation `${levelName} Agent` produces "Verified Agent Agent"
+ * for level=1, visible to social-media crawlers and browser tab titles.
+ *
+ * This helper is the single source of truth — both `middleware.ts` (crawler-bot
+ * OG path) and `app/agents/[address]/page.tsx` (SSR profile page) use it.
+ *
+ * @example
+ *   formatLevelTitleSuffix(0) // => "Unverified Agent"
+ *   formatLevelTitleSuffix(1) // => "Verified Agent"  (no doubled "Agent")
+ *   formatLevelTitleSuffix(2) // => "Genesis Agent"
+ */
+export function formatLevelTitleSuffix(level: number): string {
+  const levelName = LEVELS[level].name;
+  // LEVELS[1].name "Verified Agent" already contains "Agent"; avoid doubling.
+  return level === 1 ? levelName : `${levelName} Agent`;
+}
+
+/**
  * Given a current level, return what the agent needs to do to reach the next one.
  * Returns null for max level (Genesis = level 2).
  */

--- a/middleware.ts
+++ b/middleware.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { GITHUB_RAW } from "@/lib/github-proxy";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
-import { computeLevel, LEVELS } from "@/lib/levels";
+import { computeLevel, formatLevelTitleSuffix } from "@/lib/levels";
 import { generateName } from "@/lib/name-generator";
 import { X_HANDLE } from "@/lib/constants";
 import {
@@ -165,8 +165,7 @@ async function handleCrawlerAgentPage(
       "Verified AIBTC agent with Bitcoin and Stacks capabilities";
 
     const level = computeLevel(agent, claim);
-    const levelName = LEVELS[level].name;
-    const ogTitle = `${displayName} — ${levelName} Agent`;
+    const ogTitle = `${displayName} — ${formatLevelTitleSuffix(level)}`;
     const ogImage = `https://aibtc.com/api/og/${agent.btcAddress}`;
     const canonicalUrl = `https://aibtc.com/agents/${address}`;
 


### PR DESCRIPTION
## Summary

Closes #702 — `<title>` and `og:title` for level=1 agents render "Verified Agent Agent" because `LEVELS[1].name` already contains the "Agent" suffix and the OG title template appends another " Agent". Fixes both call sites by lifting a `formatLevelTitleSuffix(level)` helper into `lib/levels.ts`.

## Repro (verified pre-fix in production at 2026-05-10T08:30Z)

```bash
# Level 1 (Verified Agent) — BUG: doubled "Agent"
curl -s -A "Twitterbot/1.0" "https://aibtc.com/agents/bc1qxhj8qdlw2yalqpdwka8en9h29m6h4n3kyw8vcm" \
  | grep -oE '<title>[^<]+'
# → <title>Quasar Garuda — Verified Agent Agent | AIBTC

# Level 2 (Genesis) — correct
curl -s -A "Twitterbot/1.0" "https://aibtc.com/agents/bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h" \
  | grep -oE '<title>[^<]+'
# → <title>Frosty Narwhal — Genesis Agent | AIBTC

# Level 2 (Genesis, taproot) — correct
curl -s -A "Twitterbot/1.0" "https://aibtc.com/agents/bc1pme88yyvca6gjlu9zqpwhlg93j6gfzreu3l6j0zrsgz8el55zgfkq202ed2" \
  | grep -oE '<title>[^<]+'
# → <title>Coral Penguin — Genesis Agent | AIBTC
```

## Approach (Option A from #702)

Lifted a `formatLevelTitleSuffix(level: number): string` helper into `lib/levels.ts`:

```ts
export function formatLevelTitleSuffix(level: number): string {
  const levelName = LEVELS[level].name;
  // LEVELS[1].name "Verified Agent" already contains "Agent"; avoid doubling.
  return level === 1 ? levelName : `${levelName} Agent`;
}
```

Both call sites use the helper:
- `middleware.ts` (crawler-bot OG path)
- `app/agents/[address]/page.tsx` (SSR profile page metadata)

This makes the helper the single source of truth — future LEVELS naming changes have one place to update.

## Why Option A (not B or C from #702)

- **Option A (this PR)**: surgical, 4-file diff (helper + 2 call sites + tests). Doesn't change `LEVELS[1].name` or any consumer-visible field.
- **Option B**: rename `LEVELS[1].name` from "Verified Agent" to "Verified". Bigger blast radius — visible in `/api/agents`, `/api/agents/[address]`, `/api/leaderboard`, UI components rendering `levelName` standalone. External clients may key on the literal string.
- **Option C**: standardize all 3 levels with " Agent" suffix. Same blast radius as B; consumer-visible names change.

A is the smallest change that fixes the bug without committing to a wider naming standardization. B/C remain future hygiene options if the team wants to standardize.

## Files changed (4)

| File | Change |
|------|--------|
| `lib/levels.ts` | New `formatLevelTitleSuffix` helper + JSDoc |
| `middleware.ts` | Drop local `levelName` var + import; use helper |
| `app/agents/[address]/page.tsx` | Same — drop local `levelName` + `LEVELS` from import; use helper |
| `lib/__tests__/levels.test.ts` | 3 new tests for the helper (one specifically guards against the doubled "Agent" form) |

## Test plan

- [x] Unit tests added: 3 cases (level 0, 1, 2) including specific anti-regression guard for "Verified Agent Agent"
- [x] Existing `lib/__tests__/levels.test.ts` `LEVELS constant` + `computeLevel` tests untouched
- [ ] CI lint/typecheck pass (vitest not installed locally so CI is the runner)
- [ ] Post-merge: re-run the repro probes against production. All 3 should show no doubled "Agent" word.

## Out of scope

- `/api/agents` `responseFormat` self-doc drift (calls level=1 "Registered" while `LEVELS[1].name` is "Verified Agent") — flagged in #702 issue body, separable doc-fix PR.
- Level naming standardization (Option B or C from #702) — bigger surface, defer.

Closes #702.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
