### PR TITLE
feat(d1): inbox/outbox dual-write to D1 (Phase 2.5 Step 1, reversible scaffolding, refs #697)

### DIFF
--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -1,0 +1,534 @@
+/**
+ * Regression tests for Phase 2.5 Step 1 — inbox/outbox dual-write to D1.
+ *
+ * Key properties verified:
+ *  - POST /api/inbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
+ *  - D1 INSERT failure does NOT fail the 201 response (logged-and-swallowed)
+ *  - POST /api/outbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
+ *  - D1 INSERT for reply uses is_reply=1 and synthesized PK via deriveReplyD1Id
+ *  - When DB binding is absent (env.DB falsy), dual-write is skipped silently
+ *
+ * These tests exercise the route handlers with mocked downstream functions.
+ * They do NOT test the full payment flow — only the dual-write wiring.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be declared before route imports) -------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateInboxMessage: vi.fn(),
+  verifyInboxPayment: vi.fn(),
+  verifyTxidPayment: vi.fn(),
+  storeMessage: vi.fn(),
+  storeStagedInboxPayment: vi.fn(),
+  updateAgentInbox: vi.fn(),
+  updateSentIndex: vi.fn(),
+  listInboxMessages: vi.fn(),
+  listSentMessages: vi.fn(),
+  INBOX_PRICE_SATS: 100,
+  REDEEMED_TXID_TTL_SECONDS: 7776000,
+  RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS: 300,
+  buildInboxPaymentRequirements: vi.fn().mockReturnValue({ scheme: "exact", network: "stacks:1" }),
+  buildSenderAuthMessage: vi.fn().mockReturnValue("Inbox Message | test content"),
+  DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
+  enqueueInboxReconciliation: vi.fn(),
+  validateOutboxReply: vi.fn(),
+  getMessage: vi.fn(),
+  getReply: vi.fn(),
+  storeReply: vi.fn(),
+  updateMessage: vi.fn(),
+  buildReplyMessage: vi.fn(),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/payment-logging", () => ({
+  getPaymentRepoVersion: vi.fn().mockReturnValue("1.0.0"),
+  logPaymentEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
+  insertReplyToD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: vi.fn(),
+}));
+
+vi.mock("x402-stacks", () => ({
+  networkToCAIP2: vi.fn().mockReturnValue("stacks:1"),
+  X402_HEADERS: {
+    PAYMENT_SIGNATURE: "payment-signature",
+    PAYMENT_REQUIRED: "payment-required",
+    PAYMENT_RESPONSE: "payment-response",
+  },
+}));
+
+vi.mock("@aibtc/tx-schemas/http", () => ({
+  HttpPaymentPayloadSchema: {
+    safeParse: vi.fn().mockReturnValue({ success: true, data: {} }),
+  },
+}));
+
+vi.mock("@/lib/validation/address", () => ({
+  isStxAddress: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/env", () => ({
+  shouldFailClosed: vi.fn(() => false),
+}));
+
+// ---- imports after mocks ---------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  storeMessage,
+  updateAgentInbox,
+  validateInboxMessage,
+  verifyInboxPayment,
+  storeReply,
+  updateMessage,
+  validateOutboxReply,
+  getMessage,
+  getReply,
+  buildReplyMessage,
+  decrementUnreadCount,
+} from "@/lib/inbox";
+import { insertInboundMessageToD1, insertReplyToD1 } from "@/lib/inbox/d1-dual-write";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { POST as inboxPOST } from "../route";
+import { POST as outboxPOST } from "../.././../outbox/[address]/route";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const AGENT = {
+  btcAddress: "bc1qyu22hyqr406pus0g9jmfytk4ss5z8qsje74l76",
+  stxAddress: "SPKH9AWG0ENZ87J1X0PBD4HETP22G8W22AFNVF8K",
+  displayName: "Test Agent",
+};
+
+const MESSAGE_ID = "msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf";
+
+const INBOX_MESSAGE = {
+  messageId: MESSAGE_ID,
+  fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+  toBtcAddress: AGENT.btcAddress,
+  toStxAddress: AGENT.stxAddress,
+  content: "Hello agent",
+  paymentTxid: "abc123",
+  paymentSatoshis: 100,
+  sentAt: "2026-02-18T02:26:42.598Z",
+  authenticated: false,
+  paymentStatus: "confirmed" as const,
+};
+
+// ---- helpers ----------------------------------------------------------------
+
+/** Build a mock D1 database */
+function createMockDB(): D1Database {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    first: vi.fn(),
+    all: vi.fn(),
+    raw: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+/** Build a mock KV namespace */
+function createMockKV(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+}
+
+/** waitUntil mock that executes the promise synchronously in tests */
+function createCtxWithWaitUntil(waitUntilFn: Mock = vi.fn()) {
+  return {
+    waitUntil: waitUntilFn,
+    passThroughOnException: vi.fn(),
+  };
+}
+
+/** Mock getCloudflareContext to return the given env + ctx */
+function mockCloudflareContext(env: Partial<CloudflareEnv>, ctx = createCtxWithWaitUntil()) {
+  (getCloudflareContext as Mock).mockResolvedValue({ env, ctx });
+}
+
+function createRateLimitMock(success = true): RateLimit {
+  return {
+    limit: vi.fn().mockResolvedValue({ success }),
+  } as unknown as RateLimit;
+}
+
+// ---- inbox POST dual-write tests -------------------------------------------
+
+describe("POST /api/inbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+    (storeMessage as Mock).mockResolvedValue(undefined);
+    (updateAgentInbox as Mock).mockResolvedValue(undefined);
+  });
+
+  it("schedules D1 INSERT via ctx.waitUntil after successful x402 KV write", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    }, ctx);
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: undefined,
+        paymentSatoshis: undefined,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+
+    (verifyInboxPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: "abc123",
+      paymentStatus: "confirmed",
+    });
+
+    const paymentSigHeader = btoa(JSON.stringify({ scheme: "exact" }));
+    const req = new NextRequest(`https://aibtc.com/api/inbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "payment-signature": paymentSigHeader,
+      },
+      body: JSON.stringify({ content: "Hello agent" }),
+    });
+
+    const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    expect(resp.status).toBe(201);
+    // ctx.waitUntil must have been called (D1 INSERT scheduled)
+    expect(waitUntilFn).toHaveBeenCalled();
+    // insertInboundMessageToD1 must have been called (inside waitUntil promise)
+    expect(insertInboundMessageToD1).toHaveBeenCalledOnce();
+    // Verify DB is passed
+    const [calledDb] = (insertInboundMessageToD1 as Mock).mock.calls[0];
+    expect(calledDb).toBe(db);
+  });
+
+  it("D1 INSERT failure does NOT fail the 201 response", async () => {
+    const d1Error = new Error("D1 unavailable");
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(d1Error);
+
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
+      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
+    });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    }, ctx);
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: undefined,
+        paymentSatoshis: undefined,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+
+    (verifyInboxPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: "abc123",
+      paymentStatus: "confirmed",
+    });
+
+    const paymentSigHeader = btoa(JSON.stringify({ scheme: "exact" }));
+    const req = new NextRequest(`https://aibtc.com/api/inbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "payment-signature": paymentSigHeader,
+      },
+      body: JSON.stringify({ content: "Hello agent" }),
+    });
+
+    const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    // Response must still be 201 — D1 failure must NOT propagate
+    expect(resp.status).toBe(201);
+  });
+
+  it("skips D1 INSERT when DB binding is absent (no env.DB)", async () => {
+    const waitUntilFn = vi.fn();
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      // DB is intentionally absent
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    }, ctx);
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: undefined,
+        paymentSatoshis: undefined,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+
+    (verifyInboxPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: "abc123",
+      paymentStatus: "confirmed",
+    });
+
+    const paymentSigHeader = btoa(JSON.stringify({ scheme: "exact" }));
+    const req = new NextRequest(`https://aibtc.com/api/inbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "payment-signature": paymentSigHeader,
+      },
+      body: JSON.stringify({ content: "Hello agent" }),
+    });
+
+    const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    expect(resp.status).toBe(201);
+    // ctx.waitUntil should NOT have been called — no DB binding
+    expect(waitUntilFn).not.toHaveBeenCalled();
+    expect(insertInboundMessageToD1).not.toHaveBeenCalled();
+  });
+});
+
+// ---- outbox POST dual-write tests ------------------------------------------
+
+describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+    (storeReply as Mock).mockResolvedValue(undefined);
+    (updateMessage as Mock).mockResolvedValue(undefined);
+    (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+    (getReply as Mock).mockResolvedValue(null); // no existing reply
+    (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
+  });
+
+  it("schedules D1 INSERT via ctx.waitUntil after successful KV reply write", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    }, ctx);
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    expect(resp.status).toBe(201);
+    // ctx.waitUntil must have been called (D1 INSERT scheduled)
+    expect(waitUntilFn).toHaveBeenCalled();
+    // insertReplyToD1 must have been called
+    expect(insertReplyToD1).toHaveBeenCalledOnce();
+    // Verify DB and KV are passed
+    const [calledDb, calledKv] = (insertReplyToD1 as Mock).mock.calls[0];
+    expect(calledDb).toBe(db);
+    expect(calledKv).toBe(kv);
+  });
+
+  it("D1 INSERT failure does NOT fail the 201 response", async () => {
+    const d1Error = new Error("D1 constraint violation");
+    (insertReplyToD1 as Mock).mockRejectedValue(d1Error);
+
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
+      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
+    });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    }, ctx);
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    // Response must still be 201 — D1 failure must NOT propagate
+    expect(resp.status).toBe(201);
+  });
+
+  it("D1 INSERT is called with is_reply=1 semantics (reply shape with synthesized PK)", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: kv,
+      DB: db,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    }, ctx);
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    // Verify insertReplyToD1 was called with an OutboxReply object
+    expect(insertReplyToD1).toHaveBeenCalledOnce();
+    const [, , outboxReplyArg] = (insertReplyToD1 as Mock).mock.calls[0];
+    // The reply object should have messageId = parent message ID (not the derived PK)
+    // deriveReplyD1Id is called INSIDE insertReplyToD1, not in the route
+    expect(outboxReplyArg.messageId).toBe(MESSAGE_ID);
+    expect(outboxReplyArg.fromAddress).toBe(AGENT.btcAddress);
+  });
+});

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -30,6 +30,7 @@ import {
   getPaymentRepoVersion,
   logPaymentEvent,
 } from "@/lib/inbox/payment-logging";
+import { insertInboundMessageToD1 } from "@/lib/inbox/d1-dual-write";
 
 /** Maps nonce-related error codes to structured action strings for agents and operators. */
 const NONCE_ACTION_MAP: Record<string, string> = {
@@ -988,6 +989,21 @@ export async function POST(
         : []),
     ]);
 
+    // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
+    // KV is still the source of truth; D1 INSERT is fire-and-forget.
+    // D1 failure is logged-and-swallowed — it must NOT fail the response.
+    if (env.DB) {
+      ctx.waitUntil(
+        insertInboundMessageToD1(env.DB as D1Database, message).catch((err) =>
+          logger.error("inbox.dual_write_d1_failed", {
+            messageId: message.messageId,
+            path: "txid_recovery",
+            error: String(err),
+          })
+        )
+      );
+    }
+
     logger.info("Message stored via txid recovery", {
       messageId,
       fromAddress,
@@ -1497,6 +1513,21 @@ export async function POST(
       ? [updateSentIndex(kv, senderAgent.btcAddress, messageId, now)]
       : []),
   ]);
+
+  // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
+  // KV is still the source of truth; D1 INSERT is fire-and-forget.
+  // D1 failure is logged-and-swallowed — it must NOT fail the response.
+  if (env.DB) {
+    ctx.waitUntil(
+      insertInboundMessageToD1(env.DB as D1Database, message).catch((err) =>
+        logger.error("inbox.dual_write_d1_failed", {
+          messageId: message.messageId,
+          path: "x402_payment",
+          error: String(err),
+        })
+      )
+    );
+  }
 
   const deliveredPaymentStatus = message.paymentStatus ?? "confirmed";
   const deliveredCheckStatusUrl = paymentResult.paymentId

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -15,6 +15,7 @@ import {
 } from "@/lib/inbox";
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
+import { insertReplyToD1 } from "@/lib/inbox/d1-dual-write";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -391,6 +392,23 @@ export async function POST(
   // Decrement unreadCount if message was unread
   if (wasUnread) {
     await decrementUnreadCount(kv, message.toBtcAddress);
+  }
+
+  // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
+  // KV is still the source of truth; D1 INSERT is fire-and-forget.
+  // D1 failure is logged-and-swallowed — it must NOT fail the response.
+  // Note: insertReplyToD1 resolves outboxReply.toBtcAddress (may be STX) to BTC
+  // via KV lookup before inserting. If resolution fails, it throws and the catch
+  // logs it as a dual-write failure.
+  if (env.DB) {
+    ctx.waitUntil(
+      insertReplyToD1(env.DB as D1Database, kv, outboxReply).catch((err) =>
+        logger.error("outbox.dual_write_d1_failed", {
+          messageId: outboxReply.messageId,
+          error: String(err),
+        })
+      )
+    );
   }
 
   // Generate reputationPayload (ERC-8004 feedbackHash) using Web Crypto API

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -405,6 +405,7 @@ export async function POST(
       insertReplyToD1(env.DB as D1Database, kv, outboxReply).catch((err) =>
         logger.error("outbox.dual_write_d1_failed", {
           messageId: outboxReply.messageId,
+          path: "kv_reply",
           error: String(err),
         })
       )

--- a/lib/inbox/__tests__/d1-dual-write.test.ts
+++ b/lib/inbox/__tests__/d1-dual-write.test.ts
@@ -1,0 +1,364 @@
+/**
+ * Tests for lib/inbox/d1-dual-write.ts
+ *
+ * Phase 2.5 Step 1 — reversible scaffolding.
+ * Verifies:
+ *  - insertInboundMessageToD1 calls D1 with correct column mapping and is_reply=0
+ *  - insertReplyToD1 calls D1 with is_reply=1 and synthesized message_id via deriveReplyD1Id
+ *  - insertReplyToD1 resolves STX toBtcAddress to BTC via KV lookup
+ *  - insertReplyToD1 throws when BTC address cannot be resolved (caller catches)
+ *  - Both helpers use ON CONFLICT(message_id) DO NOTHING (idempotent)
+ *  - resolveReplyRecipientBtcAddress passes BTC addresses through unchanged
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import {
+  insertInboundMessageToD1,
+  insertReplyToD1,
+  resolveReplyRecipientBtcAddress,
+} from "../d1-dual-write";
+import { deriveReplyD1Id } from "../d1-pk";
+import type { InboxMessage, OutboxReply } from "../types";
+
+// ---- D1 mock ----------------------------------------------------------------
+
+/** Build a minimal D1 PreparedStatement mock. */
+function createPreparedStatement(runResult: { meta: { changes: number } } = { meta: { changes: 1 } }) {
+  const stmt = {
+    bind: vi.fn(),
+    run: vi.fn().mockResolvedValue(runResult),
+    first: vi.fn(),
+    all: vi.fn(),
+    raw: vi.fn(),
+  };
+  // bind() returns the same stmt (chainable)
+  stmt.bind.mockReturnValue(stmt);
+  return stmt;
+}
+
+function createMockD1(runResult?: { meta: { changes: number } }): D1Database {
+  const stmt = createPreparedStatement(runResult);
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+// ---- KV mock ----------------------------------------------------------------
+
+function createMockKV(data: Record<string, string> = {}): KVNamespace {
+  return {
+    get: vi.fn(async (key: string) => data[key] ?? null),
+    put: vi.fn(),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+}
+
+// ---- Fixtures ---------------------------------------------------------------
+
+const INBOUND_MESSAGE: InboxMessage = {
+  messageId: "msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf",
+  fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+  toBtcAddress: "bc1qyu22hyqr406pus0g9jmfytk4ss5z8qsje74l76",
+  toStxAddress: "SPKH9AWG0ENZ87J1X0PBD4HETP22G8W22AFNVF8K",
+  content: "gm agent — shipping update today",
+  paymentTxid: "602f097b3de853e05546015af6ac9c32e858efcc9fd5ff92edb860d5cadc8c21",
+  paymentSatoshis: 100,
+  sentAt: "2026-02-18T02:26:42.598Z",
+  authenticated: false,
+};
+
+const OUTBOX_REPLY: OutboxReply = {
+  messageId: "msg_1771381860132_537377a5-2550-4753-a11f-841e9ddecd90",
+  fromAddress: "bc1qp66jvxe765wgwpzqk8kcrmgh2mucyxg540mtzv",
+  toBtcAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE", // STX address — must be resolved
+  reply: "Great work — bookmarked.",
+  signature: "Jx52I99dmnoFqmKkJXsLP4ELktANgZ6v1m1CFA7c5kz+Xr9W45m29QnabzGim5ubEzJP1eoynU/GjuRWMjRD9nQ=",
+  repliedAt: "2026-02-19T22:14:43.426Z",
+};
+
+const STX_SENDER_BTC = "bc1qoriginal1111111111111111111111111111111";
+
+// ── resolveReplyRecipientBtcAddress ──────────────────────────────────────────
+
+describe("resolveReplyRecipientBtcAddress", () => {
+  it("returns BTC address unchanged when already BTC-shaped (bc1q...)", async () => {
+    const kv = createMockKV();
+    const btcAddr = "bc1qp66jvxe765wgwpzqk8kcrmgh2mucyxg540mtzv";
+    const result = await resolveReplyRecipientBtcAddress(kv, btcAddr);
+    expect(result).toBe(btcAddr);
+    expect(kv.get).not.toHaveBeenCalled();
+  });
+
+  it("resolves STX address to BTC address via KV lookup", async () => {
+    const stxAddr = "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE";
+    const kv = createMockKV({
+      [`stx:${stxAddr}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+    const result = await resolveReplyRecipientBtcAddress(kv, stxAddr);
+    expect(result).toBe(STX_SENDER_BTC);
+    expect(kv.get).toHaveBeenCalledWith(`stx:${stxAddr}`);
+  });
+
+  it("returns null when STX address KV record not found", async () => {
+    const kv = createMockKV();
+    const result = await resolveReplyRecipientBtcAddress(kv, "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE");
+    expect(result).toBeNull();
+  });
+
+  it("returns null when KV record has no btcAddress field", async () => {
+    const stxAddr = "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE";
+    const kv = createMockKV({ [`stx:${stxAddr}`]: JSON.stringify({ stxAddress: stxAddr }) });
+    const result = await resolveReplyRecipientBtcAddress(kv, stxAddr);
+    expect(result).toBeNull();
+  });
+});
+
+// ── insertInboundMessageToD1 ─────────────────────────────────────────────────
+
+describe("insertInboundMessageToD1", () => {
+  it("calls D1 prepare() with an INSERT INTO inbox_messages statement", async () => {
+    const db = createMockD1();
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+    expect(db.prepare).toHaveBeenCalledOnce();
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("INSERT INTO inbox_messages");
+  });
+
+  it("uses ON CONFLICT(message_id) DO NOTHING for idempotency", async () => {
+    const db = createMockD1();
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("ON CONFLICT(message_id) DO NOTHING");
+  });
+
+  it("passes is_reply=0 as the second positional bind parameter", async () => {
+    const db = createMockD1();
+    const stmt = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0];
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+    // is_reply=0 is hardcoded in the SQL literal, not a bind param — verify SQL contains ", 0,"
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain(", 0,"); // "?, 0, ?," — is_reply literal
+    void stmt; // satisfy TS
+  });
+
+  it("binds message_id to message.messageId", async () => {
+    const db = createMockD1();
+    // After prepare() is called, get the stmt mock to inspect bind args
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(INBOUND_MESSAGE.messageId);
+  });
+
+  it("binds from_stx_address to message.fromAddress", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // fromAddress is the 3rd bind param (after messageId, replyTo)
+    expect(bindArgs[2]).toBe(INBOUND_MESSAGE.fromAddress);
+  });
+
+  it("binds to_btc_address to message.toBtcAddress", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[3]).toBe(INBOUND_MESSAGE.toBtcAddress);
+  });
+
+  it("binds paymentTxid as null when absent", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    const msgWithoutTxid = { ...INBOUND_MESSAGE, paymentTxid: undefined };
+    await insertInboundMessageToD1(db, msgWithoutTxid);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // paymentTxid is bound after content (index 6 = messageId, replyTo, fromStx, toBtc, toStx, content, paymentTxid)
+    // => index 6
+    expect(bindArgs[6]).toBeNull();
+  });
+
+  it("resolves and calls .run()", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await insertInboundMessageToD1(db, INBOUND_MESSAGE);
+
+    expect(stmtMock.run).toHaveBeenCalledOnce();
+  });
+});
+
+// ── insertReplyToD1 ───────────────────────────────────────────────────────────
+
+describe("insertReplyToD1", () => {
+  it("calls D1 prepare() with an INSERT INTO inbox_messages statement", async () => {
+    const db = createMockD1();
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+    expect(db.prepare).toHaveBeenCalledOnce();
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("INSERT INTO inbox_messages");
+  });
+
+  it("uses ON CONFLICT(message_id) DO NOTHING for idempotency", async () => {
+    const db = createMockD1();
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("ON CONFLICT(message_id) DO NOTHING");
+  });
+
+  it("synthesizes message_id via deriveReplyD1Id (not the parent ID directly)", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // First bind param is message_id — must be the derived reply PK, not the parent
+    expect(bindArgs[0]).toBe(deriveReplyD1Id(OUTBOX_REPLY.messageId));
+    expect(bindArgs[0]).not.toBe(OUTBOX_REPLY.messageId);
+  });
+
+  it("sets is_reply=1 as a SQL literal in the statement", async () => {
+    const db = createMockD1();
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain(", 1,"); // is_reply=1 literal
+  });
+
+  it("binds reply_to_message_id to the parent messageId", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // Second bind param is reply_to_message_id = parent's messageId unchanged
+    expect(bindArgs[1]).toBe(OUTBOX_REPLY.messageId);
+  });
+
+  it("resolves STX toBtcAddress to BTC via KV and binds resolved address", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // to_btc_address (4th bind param: replyMsgId, replyToId, fromBtc, toBtc)
+    expect(bindArgs[3]).toBe(STX_SENDER_BTC);
+    // Must NOT be the raw STX address
+    expect(bindArgs[3]).not.toBe(OUTBOX_REPLY.toBtcAddress);
+  });
+
+  it("binds from_btc_address to reply.fromAddress", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // from_btc_address (3rd bind param)
+    expect(bindArgs[2]).toBe(OUTBOX_REPLY.fromAddress);
+  });
+
+  it("binds content to reply.reply field", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // content is 5th bind param (replyMsgId, replyToId, fromBtc, toBtc, reply.reply)
+    expect(bindArgs[4]).toBe(OUTBOX_REPLY.reply);
+  });
+
+  it("throws when reply recipient BTC address cannot be resolved", async () => {
+    const db = createMockD1();
+    const kv = createMockKV(); // empty — STX lookup will return null
+
+    await expect(
+      insertReplyToD1(db, kv, OUTBOX_REPLY)
+    ).rejects.toThrow(/Unable to resolve reply recipient BTC address/);
+
+    // D1 should NOT have been called — resolution failure aborts before INSERT
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  it("resolves and calls .run()", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV({
+      [`stx:${OUTBOX_REPLY.toBtcAddress}`]: JSON.stringify({ btcAddress: STX_SENDER_BTC }),
+    });
+
+    await insertReplyToD1(db, kv, OUTBOX_REPLY);
+
+    expect(stmtMock.run).toHaveBeenCalledOnce();
+  });
+
+  it("works when toBtcAddress is already a BTC address (no KV lookup needed)", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+    const kv = createMockKV(); // no KV data needed
+
+    const replyWithBtcRecipient: OutboxReply = {
+      ...OUTBOX_REPLY,
+      toBtcAddress: "bc1qoriginal_sender_btc_address_here_111111",
+    };
+
+    await insertReplyToD1(db, kv, replyWithBtcRecipient);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // to_btc_address = the BTC address passed through unchanged
+    expect(bindArgs[3]).toBe(replyWithBtcRecipient.toBtcAddress);
+    expect(kv.get).not.toHaveBeenCalled();
+  });
+});

--- a/lib/inbox/__tests__/d1-dual-write.test.ts
+++ b/lib/inbox/__tests__/d1-dual-write.test.ts
@@ -138,12 +138,10 @@ describe("insertInboundMessageToD1", () => {
 
   it("passes is_reply=0 as the second positional bind parameter", async () => {
     const db = createMockD1();
-    const stmt = (db.prepare as ReturnType<typeof vi.fn>).mock.results[0];
     await insertInboundMessageToD1(db, INBOUND_MESSAGE);
     // is_reply=0 is hardcoded in the SQL literal, not a bind param — verify SQL contains ", 0,"
     const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(sql).toContain(", 0,"); // "?, 0, ?," — is_reply literal
-    void stmt; // satisfy TS
   });
 
   it("binds message_id to message.messageId", async () => {

--- a/lib/inbox/d1-dual-write.ts
+++ b/lib/inbox/d1-dual-write.ts
@@ -1,0 +1,222 @@
+/**
+ * D1 dual-write helpers for inbox_messages table.
+ *
+ * Phase 2.5 Step 1 — reversible scaffolding.
+ * These helpers INSERT alongside existing KV writes; they do NOT replace them.
+ * Reads still come from KV. The cutover (read flip + write removal) is Steps 3+4.
+ *
+ * Failure contract: callers wrap these in ctx.waitUntil(...).catch(logger.error)
+ * so a D1 INSERT failure is logged-and-swallowed and never blocks the response.
+ *
+ * Field mapping verified against real KV records sampled 2026-05-09:
+ *   inbox:message:msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf
+ *   inbox:reply:msg_1771381860132_537377a5-2550-4753-a11f-841e9ddecd90
+ *
+ * InboxMessage fields: messageId, fromAddress (STX payer), toBtcAddress, toStxAddress,
+ *   content, paymentTxid?, paymentSatoshis, sentAt, authenticated, recoveredViaTxid?,
+ *   senderBtcAddress?, senderSignature?, replyTo?, paymentStatus?, paymentId?, receiptId?
+ *
+ * OutboxReply fields: messageId (parent), fromAddress (replier BTC), toBtcAddress
+ *   (sender STX — may need resolution to BTC via kv stx: key), reply, signature, repliedAt
+ *
+ * Note on OutboxReply.toBtcAddress: the field name is "toBtcAddress" but the value
+ * can be a Stacks address (SP...). Always call resolveReplyRecipientBtcAddress before
+ * persisting. See Phase 1.4 post-mortem (#680/#681/#682).
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/697
+ */
+
+import type { InboxMessage, OutboxReply } from "./types";
+import { deriveReplyD1Id } from "./d1-pk";
+import { isStxAddress } from "@/lib/validation/address";
+import type { AgentRecord } from "@/lib/types";
+
+/**
+ * Resolve the reply recipient's BTC address.
+ *
+ * OutboxReply.toBtcAddress can be a Stacks address (pre-resolution) because the
+ * outbox route stores message.fromAddress (which is a STX address for inbound messages)
+ * directly into the toBtcAddress field. If the value is already a BTC address, return it
+ * directly. If it's a Stacks address, look up the agent record from KV.
+ *
+ * Returns null if the STX address cannot be resolved — caller should skip the D1 INSERT.
+ */
+export async function resolveReplyRecipientBtcAddress(
+  kv: KVNamespace,
+  candidateAddress: string
+): Promise<string | null> {
+  if (!isStxAddress(candidateAddress)) return candidateAddress;
+
+  const stxRecordRaw = await kv.get(`stx:${candidateAddress}`);
+  if (!stxRecordRaw) return null;
+
+  try {
+    const parsed = JSON.parse(stxRecordRaw) as Partial<AgentRecord>;
+    return typeof parsed.btcAddress === "string" ? parsed.btcAddress : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * INSERT an inbound inbox message (is_reply=0) into D1.
+ *
+ * Column mapping (verified against migrations/003_inbox_messages.sql):
+ *   message_id          <- message.messageId
+ *   is_reply            <- 0 (inbound)
+ *   reply_to_message_id <- message.replyTo ?? NULL (threading, not FK-enforced at dual-write time)
+ *   from_stx_address    <- message.fromAddress (x402 payer's STX address)
+ *   from_btc_address    <- NULL (inbound: sender identified by STX, not BTC)
+ *   to_btc_address      <- message.toBtcAddress
+ *   to_stx_address      <- message.toStxAddress
+ *   content             <- message.content
+ *   payment_txid        <- message.paymentTxid ?? NULL
+ *   payment_satoshis    <- message.paymentSatoshis ?? NULL
+ *   payment_status      <- message.paymentStatus ?? NULL
+ *   payment_terminal_reason <- NULL (set later by reconciliation worker)
+ *   payment_error_code  <- NULL (set later by reconciliation worker)
+ *   payment_replacement_txid <- NULL
+ *   payment_id          <- message.paymentId ?? NULL
+ *   receipt_id          <- message.receiptId ?? NULL
+ *   recovered_via_txid  <- message.recoveredViaTxid ? 1 : 0
+ *   authenticated       <- message.authenticated ? 1 : 0
+ *   bitcoin_signature   <- message.senderSignature ?? NULL
+ *   sender_btc_address  <- message.senderBtcAddress ?? NULL
+ *   sent_at             <- message.sentAt
+ *   read_at             <- NULL (message just delivered)
+ *   replied_at          <- NULL (no reply yet)
+ */
+export async function insertInboundMessageToD1(
+  db: D1Database,
+  message: InboxMessage
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO inbox_messages (
+        message_id, is_reply, reply_to_message_id,
+        from_stx_address, from_btc_address,
+        to_btc_address, to_stx_address,
+        content, payment_txid, payment_satoshis,
+        payment_status, payment_terminal_reason,
+        payment_error_code, payment_replacement_txid,
+        payment_id, receipt_id,
+        recovered_via_txid, authenticated,
+        bitcoin_signature, sender_btc_address,
+        sent_at, read_at, replied_at
+      ) VALUES (
+        ?, 0, ?,
+        ?, NULL,
+        ?, ?,
+        ?, ?, ?,
+        ?, NULL, NULL, NULL,
+        ?, ?,
+        ?, ?,
+        ?, ?,
+        ?, NULL, NULL
+      ) ON CONFLICT(message_id) DO NOTHING`
+    )
+    .bind(
+      message.messageId,
+      message.replyTo ?? null,
+      // from_stx_address = fromAddress (x402 payer's STX address)
+      message.fromAddress,
+      message.toBtcAddress,
+      message.toStxAddress ?? null,
+      message.content,
+      message.paymentTxid ?? null,
+      message.paymentSatoshis ?? null,
+      message.paymentStatus ?? null,
+      message.paymentId ?? null,
+      message.receiptId ?? null,
+      // recovered_via_txid: 0 = false, 1 = true
+      message.recoveredViaTxid ? 1 : 0,
+      message.authenticated ? 1 : 0,
+      message.senderSignature ?? null,
+      message.senderBtcAddress ?? null,
+      message.sentAt
+    )
+    .run();
+}
+
+/**
+ * INSERT a reply (is_reply=1) into D1.
+ *
+ * Column mapping (verified against migrations/003_inbox_messages.sql):
+ *   message_id          <- deriveReplyD1Id(reply.messageId) (synthesized PK, avoids collision with inbound)
+ *   is_reply            <- 1 (reply)
+ *   reply_to_message_id <- reply.messageId (FK to parent inbound row)
+ *   from_stx_address    <- NULL (reply: sender identified by BTC, not STX)
+ *   from_btc_address    <- reply.fromAddress (replier's BTC address)
+ *   to_btc_address      <- resolvedToBtcAddress (resolved from reply.toBtcAddress — may be STX)
+ *   to_stx_address      <- NULL (replies route by BTC)
+ *   content             <- reply.reply
+ *   payment_txid        <- NULL (replies are free)
+ *   payment_satoshis    <- NULL (replies are free)
+ *   payment_status      <- NULL (no payment)
+ *   payment_terminal_reason <- NULL
+ *   payment_error_code  <- NULL
+ *   payment_replacement_txid <- NULL
+ *   payment_id          <- NULL
+ *   receipt_id          <- NULL
+ *   recovered_via_txid  <- 0
+ *   authenticated       <- 0 (BIP-322 signature stored in bitcoin_signature)
+ *   bitcoin_signature   <- reply.signature
+ *   sender_btc_address  <- NULL (for replies, from_btc_address is the signer)
+ *   sent_at             <- reply.repliedAt
+ *   read_at             <- NULL
+ *   replied_at          <- NULL
+ */
+export async function insertReplyToD1(
+  db: D1Database,
+  kv: KVNamespace,
+  reply: OutboxReply
+): Promise<void> {
+  const resolvedToBtcAddress = await resolveReplyRecipientBtcAddress(kv, reply.toBtcAddress);
+  if (!resolvedToBtcAddress) {
+    throw new Error(
+      `Unable to resolve reply recipient BTC address from "${reply.toBtcAddress}" for messageId "${reply.messageId}"`
+    );
+  }
+
+  const replyMessageId = deriveReplyD1Id(reply.messageId);
+
+  await db
+    .prepare(
+      `INSERT INTO inbox_messages (
+        message_id, is_reply, reply_to_message_id,
+        from_stx_address, from_btc_address,
+        to_btc_address, to_stx_address,
+        content, payment_txid, payment_satoshis,
+        payment_status, payment_terminal_reason,
+        payment_error_code, payment_replacement_txid,
+        payment_id, receipt_id,
+        recovered_via_txid, authenticated,
+        bitcoin_signature, sender_btc_address,
+        sent_at, read_at, replied_at
+      ) VALUES (
+        ?, 1, ?,
+        NULL, ?,
+        ?, NULL,
+        ?, NULL, NULL,
+        NULL, NULL, NULL, NULL,
+        NULL, NULL,
+        0, 0,
+        ?, NULL,
+        ?, NULL, NULL
+      ) ON CONFLICT(message_id) DO NOTHING`
+    )
+    .bind(
+      replyMessageId,
+      // reply_to_message_id = parent inbound message ID
+      reply.messageId,
+      // from_btc_address = replier's BTC address
+      reply.fromAddress,
+      resolvedToBtcAddress,
+      // content = reply text
+      reply.reply,
+      // bitcoin_signature = BIP-322 signature
+      reply.signature,
+      reply.repliedAt
+    )
+    .run();
+}


### PR DESCRIPTION
## Summary

**This is Step 1 only.** Adds D1 INSERTs alongside existing KV writes. Reads still come from KV. The cutover (Steps 3+4 — read flip + write removal) is checkpoint-gated and NOT in scope here.

- `lib/inbox/d1-dual-write.ts` — new helpers: `insertInboundMessageToD1`, `insertReplyToD1`, `resolveReplyRecipientBtcAddress`
- `app/api/inbox/[address]/route.ts` — D1 INSERT after KV write on both x402 payment path and txid recovery path
- `app/api/outbox/[address]/route.ts` — D1 INSERT after KV reply write
- 29 new tests (23 unit, 6 route-level), all passing; total suite 752 passed

## Field mapping (sample-verified 2026-05-09)

Sampled real KV records before writing — per CLAUDE.md lesson from Phase 1.4 (#680/#681/#682):

**InboxMessage** (`inbox:message:msg_1771381602504_30487f5e`):
- `fromAddress` → `from_stx_address` (x402 payer's STX address, NOT BTC)
- `toBtcAddress` → `to_btc_address`
- `toStxAddress` → `to_stx_address`
- `senderSignature` → `bitcoin_signature`
- `senderBtcAddress` → `sender_btc_address`
- `replyTo` → `reply_to_message_id` (threading, not FK-enforced at dual-write time)

**OutboxReply** (`inbox:reply:msg_1771381860132_537377a5`):
- `fromAddress` → `from_btc_address` (replier's BTC, BIP-322 signer)
- `toBtcAddress` → **STX address in real data** (field name is misleading; always resolve via `stx:` KV lookup before persisting — same as backfill route)
- `reply` → `content`
- `signature` → `bitcoin_signature`
- `messageId` (parent) → `reply_to_message_id`
- Synthesized PK: `deriveReplyD1Id(reply.messageId)` → `reply_` prefix avoids collision with inbound row

## Failure handling

D1 INSERT is wrapped in `ctx.waitUntil(promise.catch(logger.error))`. KV write success drives the response. D1 failure is logged as `inbox.dual_write_d1_failed` / `outbox.dual_write_d1_failed` and swallowed. The `env.DB` guard skips D1 INSERT silently in envs without the binding.

## Smoke probe plan (post-deploy)

1. Send a test inbox message via `POST /api/inbox/{btcAddress}`
2. Reply via `POST /api/outbox/{btcAddress}`
3. Verify rows appear: `wrangler d1 execute aibtcdev-landing-page-db --remote --command "SELECT COUNT(*) FROM inbox_messages;"`
4. Confirm GET /api/inbox and GET /api/outbox still serve from KV (behavior unchanged)

## Reverts cleanly

Removing the `ctx.waitUntil(insertInboundMessageToD1...)` and `ctx.waitUntil(insertReplyToD1...)` blocks from both routes reverts to pure-KV behavior. The `lib/inbox/d1-dual-write.ts` module can be deleted separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)