### PR TITLE
fix(backfill): classify PartialAgentRecord exclusions as skipped_partial (closes #677)

### DIFF
--- a/app/api/admin/backfill/__tests__/route.test.ts
+++ b/app/api/admin/backfill/__tests__/route.test.ts
@@ -193,6 +193,14 @@ const PARTIAL_AGENT = JSON.stringify({
   // No stxAddress — this is a PartialAgentRecord
 });
 
+// Pre-type-enforcement partial: no btcPublicKey either (older production records).
+// These slipped through isPartialAgentRecord but must still land in skipped_partial.
+const PARTIAL_AGENT_NO_BTC_PUBKEY = JSON.stringify({
+  btcAddress: "bc1qlegacypartial",
+  verifiedAt: "2025-12-01T00:00:00Z",
+  // No stxAddress, no btcPublicKey — raw partial from before type enforcement
+});
+
 const CLAIM_1 = JSON.stringify({
   btcAddress: "bc1qagent1",
   displayName: "Agent One",
@@ -331,6 +339,71 @@ describe("dry-run mode", () => {
 
     // KV put for referral code must NOT have been called in dry run
     expect((kv.put as Mock)).not.toHaveBeenCalled();
+  });
+});
+
+// ── Test: PartialAgentRecord classification ──────────────────────────────
+// Locks the contract from #677: partials must land in skipped_partial, never failed[].
+
+describe("PartialAgentRecord classification", () => {
+  it("classifies standard partial (has btcPublicKey, no stxAddress) as skipped_partial", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qpartial": PARTIAL_AGENT,
+    });
+    const { db, runMock } = buildD1Mock();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents" }));
+    const body = await resp.json() as {
+      skipped_partial: number;
+      failed: { key: string; reason: string }[];
+      inserted: number;
+    };
+
+    expect(body.skipped_partial).toBe(1);
+    expect(body.failed).toHaveLength(0);
+    expect(body.inserted).toBe(0);
+    // D1 must NOT have been touched for partial records
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it("classifies legacy partial (no btcPublicKey, no stxAddress) as skipped_partial, not failed", async () => {
+    // Reproduces the production case from the 2026-05-09 operational run where
+    // 1421 partials appeared in failed[] because isPartialAgentRecord() required
+    // btcPublicKey — older KV records had no btcPublicKey at all.
+    const kv = buildKvMock({
+      "btc:bc1qlegacypartial": PARTIAL_AGENT_NO_BTC_PUBKEY,
+    });
+    const { db, runMock } = buildD1Mock();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents" }));
+    const body = await resp.json() as {
+      skipped_partial: number;
+      failed: { key: string; reason: string }[];
+      inserted: number;
+    };
+
+    expect(body.skipped_partial).toBe(1);
+    expect(body.failed).toHaveLength(0);
+    expect(body.inserted).toBe(0);
+    expect(runMock).not.toHaveBeenCalled();
   });
 });
 

--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -180,19 +180,26 @@ async function backfillAgents(
 
     const agent = parsedAgentRecord as AgentRecord;
 
-    // Validate minimum required fields for D1 insert
-    if (
-      !agent.stxAddress ||
-      !agent.stxPublicKey ||
-      !agent.btcPublicKey ||
-      !agent.verifiedAt
-    ) {
-        counts.failed.push({
-          key: kvKey.name,
-          reason: "Missing required AgentRecord fields (stxAddress/stxPublicKey/btcPublicKey/verifiedAt)",
-        });
-        continue;
+    // Secondary partial-detection: records that slipped through isPartialAgentRecord
+    // because btcPublicKey was absent (pre-type-enforcement production records).
+    // Any record without stxAddress is a partial — intentionally not migrated.
+    if (!agent.stxAddress || !agent.stxPublicKey) {
+      if (pass === "insert") {
+        counts.skipped_partial++;
       }
+      continue;
+    }
+
+    // Validate remaining required fields for D1 insert — these are actual data errors
+    // on records that claimed to be full agents (have stxAddress/stxPublicKey) but
+    // are missing other non-nullable columns.
+    if (!agent.btcPublicKey || !agent.verifiedAt) {
+      counts.failed.push({
+        key: kvKey.name,
+        reason: "Missing required AgentRecord fields (btcPublicKey/verifiedAt)",
+      });
+      continue;
+    }
 
     if (pass === "insert") {
       // Resolve or generate referral code


### PR DESCRIPTION
## Summary

The 2026-05-09T23:55Z operational backfill run reported 1421 agents in `failed[]` with reason `"Missing required AgentRecord fields"`. All 1421 were `PartialAgentRecord` cases — intentionally excluded from migration per Phase 1.3 RFC §1, not actual errors.

- `isPartialAgentRecord()` requires `btcPublicKey` to be a string, but older production records were created before that field was enforced. Records without `btcPublicKey` returned `false` from the guard and fell through to the secondary validation, which pushed them to `failed[]`.
- The fix splits the secondary validation: missing `stxAddress`/`stxPublicKey` → `skipped_partial`; a record claiming to be full-agent but missing `btcPublicKey`/`verifiedAt` → `failed[]`.
- `failed[]` now exclusively contains actual exceptions (D1 errors, FK constraints, network errors).

## Changes

- `app/api/admin/backfill/route.ts`: split the secondary agent-field validation into partial-detection (→ `skipped_partial`) and actual-data-error detection (→ `failed[]`)
- `app/api/admin/backfill/__tests__/route.test.ts`: two new locked-contract tests assert standard and legacy partials land in `skipped_partial`, never `failed[]`

## Test plan

- [x] `npm test backfill` — 15 tests pass (13 existing + 2 new)
- [x] Full suite: `og-d1.test.ts` failure is pre-existing on `origin/main`, not introduced here
- [x] `npx tsc --noEmit` — same error count (14 lines) before and after; all pre-existing

## Related

- Closes #677
- Refs #671 (operational run with 1421 partial failures)
- Refs #672 (Phase 1.3 backfill PR)
- Refs #652 (D1 migration umbrella)

## Out of scope (per issue)

- The 7 UNIQUE-constraint failures on `inbox_messages.payment_txid` (#671 comments — separate investigation)
- Claims/inbox/vouch classification logic — untouched
- Response shape — unchanged (`skipped_partial` field already existed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)