### PR TITLE
feat(admin): invalid-agent inventory route (Step 1 of #691)

### DIFF
--- a/app/api/admin/audit-invalid-agents/route.ts
+++ b/app/api/admin/audit-invalid-agents/route.ts
@@ -1,0 +1,501 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import { isPartialAgentRecord } from "@/lib/types";
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+/**
+ * Required fields that backfill checks after the isPartialAgentRecord guard.
+ * A record that passes `isPartialAgentRecord` is already excluded from D1;
+ * these are records that *failed* isPartialAgentRecord (i.e., have at least one
+ * Stacks credential) but are still missing one or more of these four required
+ * fields.
+ */
+const REQUIRED_FIELDS = [
+  "stxAddress",
+  "stxPublicKey",
+  "btcPublicKey",
+  "verifiedAt",
+] as const;
+type RequiredField = (typeof REQUIRED_FIELDS)[number];
+
+/**
+ * Optional "marker" fields that indicate richer registration state.
+ * Presence/absence is noted for each record — useful for diagnosing
+ * which partial-repair path makes sense.
+ */
+const MARKER_FIELDS = [
+  "stxAddress",
+  "stxPublicKey",
+  "btcPublicKey",
+  "btcAddress",
+  "taprootAddress",
+  "displayName",
+  "description",
+  "verifiedAt",
+  "lastActiveAt",
+  "erc8004AgentId",
+  "nostrPublicKey",
+  "referredBy",
+] as const;
+type MarkerField = (typeof MARKER_FIELDS)[number];
+
+/**
+ * Classification of an invalid KV record into a tentative bucket.
+ *
+ * These are TENTATIVE suggestions based on field-presence patterns only.
+ * whoabuddy makes the final bucket assignment in Step 2.
+ *
+ * - "repairable"        — Missing only one required field; likely can be
+ *                          repaired if the missing value can be recovered
+ *                          (e.g., from a stx: twin record).
+ * - "retired"           — Missing multiple required fields but has some
+ *                          recognisable structure (btcAddress present). These
+ *                          may represent abandoned or interrupted registrations.
+ * - "schema-unfixable"  — Missing btcAddress or otherwise malformed. No safe
+ *                          repair path exists; archival is likely the only option.
+ */
+type TentativeBucket = "repairable" | "retired" | "schema-unfixable";
+
+export interface InvalidAgentEntry {
+  kv_key: string;
+  btc_address: string | null;
+  /** Fields present in the KV record (from MARKER_FIELDS list) */
+  present_fields: MarkerField[];
+  /** Required fields that are missing */
+  missing_required_fields: RequiredField[];
+  /**
+   * Count of missing required fields (0 means the record passed strict
+   * validation and should NOT appear in this report — sanity check only).
+   */
+  missing_required_count: number;
+  /** Why the record was rejected: "partial" means isPartialAgentRecord returned true */
+  rejection_reason: "partial" | "missing_required_fields" | "json_parse_error";
+  tentative_bucket: TentativeBucket;
+}
+
+interface FieldMissingnessFrequency {
+  field: RequiredField;
+  count: number;
+  percent_of_invalid: string;
+}
+
+interface MissingFieldPattern {
+  pattern: string; // comma-joined sorted field names
+  count: number;
+  percent_of_invalid: string;
+  tentative_bucket: TentativeBucket;
+}
+
+interface AuditReport {
+  generated_at: string;
+  total_btc_keys_scanned: number;
+  /** Records that passed both guards and are in D1 (excluded from this report) */
+  valid_count: number;
+  /** Records caught by isPartialAgentRecord guard */
+  partial_count: number;
+  /**
+   * Records that failed isPartialAgentRecord but have missing required fields.
+   * This is the core #691 population.
+   */
+  invalid_required_fields_count: number;
+  /** Records that failed JSON.parse */
+  json_parse_error_count: number;
+  /** Total invalid records (partial + invalid_required_fields + json_parse) */
+  total_invalid_count: number;
+  aggregate_buckets: {
+    repairable: number;
+    retired: number;
+    "schema-unfixable": number;
+  };
+  missing_field_frequency: FieldMissingnessFrequency[];
+  missing_field_patterns: MissingFieldPattern[];
+  /** Records grouped by how many required fields are missing */
+  missing_count_histogram: Record<string, number>;
+  records: InvalidAgentEntry[];
+  /** Pagination cursor; null when scan complete */
+  cursor: string | null;
+  duration_ms: number;
+}
+
+// ── Classification logic ──────────────────────────────────────────────────
+
+/**
+ * Classify an invalid record into a tentative bucket.
+ *
+ * Rules (field-presence only — no on-chain checks):
+ *   - schema-unfixable: btcAddress is missing or not a string (can't key the record)
+ *   - repairable:       exactly 1 required field missing
+ *   - retired:          2+ required fields missing but btcAddress is present
+ */
+function classifyBucket(
+  btcAddress: string | null,
+  missingRequired: RequiredField[]
+): TentativeBucket {
+  if (!btcAddress) return "schema-unfixable";
+  if (missingRequired.length === 1) return "repairable";
+  return "retired";
+}
+
+/**
+ * Build an InvalidAgentEntry for a record that failed strict validation.
+ */
+function buildEntry(
+  kvKey: string,
+  raw: string | null,
+  rejectionReason: InvalidAgentEntry["rejection_reason"],
+  parsed: Record<string, unknown> | null
+): InvalidAgentEntry {
+  if (rejectionReason === "json_parse_error" || !parsed) {
+    return {
+      kv_key: kvKey,
+      btc_address: null,
+      present_fields: [],
+      missing_required_fields: [...REQUIRED_FIELDS],
+      missing_required_count: REQUIRED_FIELDS.length,
+      rejection_reason: "json_parse_error",
+      tentative_bucket: "schema-unfixable",
+    };
+  }
+
+  const btcAddress =
+    typeof parsed.btcAddress === "string" && parsed.btcAddress
+      ? parsed.btcAddress
+      : null;
+
+  // Determine which marker fields are present (non-null, non-empty)
+  const presentFields: MarkerField[] = MARKER_FIELDS.filter((f) => {
+    const val = parsed[f];
+    return val !== undefined && val !== null && val !== "";
+  });
+
+  // Determine which required fields are missing
+  const missingRequired: RequiredField[] = REQUIRED_FIELDS.filter((f) => {
+    const val = parsed[f];
+    return typeof val !== "string" || !val;
+  });
+
+  return {
+    kv_key: kvKey,
+    btc_address: btcAddress,
+    present_fields: presentFields,
+    missing_required_fields: missingRequired,
+    missing_required_count: missingRequired.length,
+    rejection_reason: rejectionReason,
+    tentative_bucket: classifyBucket(btcAddress, missingRequired),
+  };
+}
+
+// ── Audit scan ────────────────────────────────────────────────────────────
+
+/**
+ * Scan `btc:` KV prefix and collect all records that fail strict validation.
+ *
+ * Reads values in parallel batches of 50 (mirrors the reconcile route pattern).
+ * Pagination is cursor-based for large datasets (expected ~1664 btc: keys).
+ *
+ * Returns the entries plus a next cursor (null when scan complete).
+ */
+async function scanInvalidAgents(
+  kv: KVNamespace,
+  batchSize: number,
+  cursor: string | null
+): Promise<{
+  entries: InvalidAgentEntry[];
+  validCount: number;
+  nextCursor: string | null;
+}> {
+  const entries: InvalidAgentEntry[] = [];
+  let validCount = 0;
+
+  const listOpts: KVNamespaceListOptions = { prefix: "btc:", limit: batchSize };
+  if (cursor) listOpts.cursor = cursor;
+
+  const page = await kv.list(listOpts);
+
+  // Fetch values in parallel batches of 50 to stay under subrequest budget
+  const FETCH_BATCH = 50;
+  for (let i = 0; i < page.keys.length; i += FETCH_BATCH) {
+    const batch = page.keys.slice(i, i + FETCH_BATCH);
+    const values = await Promise.all(batch.map((k) => kv.get(k.name)));
+
+    for (let j = 0; j < batch.length; j++) {
+      const kvKey = batch[j].name;
+      const raw = values[j];
+
+      if (!raw) {
+        // Key listed but value missing — treat as json_parse_error
+        entries.push(buildEntry(kvKey, null, "json_parse_error", null));
+        continue;
+      }
+
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        entries.push(buildEntry(kvKey, raw, "json_parse_error", null));
+        continue;
+      }
+
+      // Guard 1: isPartialAgentRecord (matches backfill's skip logic)
+      if (isPartialAgentRecord(parsed)) {
+        entries.push(
+          buildEntry(
+            kvKey,
+            raw,
+            "partial",
+            parsed as unknown as Record<string, unknown>
+          )
+        );
+        continue;
+      }
+
+      // Guard 2: strict required-field check (matches backfill's second rejection)
+      const rec = parsed as Record<string, unknown>;
+      const missingRequired: RequiredField[] = REQUIRED_FIELDS.filter((f) => {
+        const val = rec[f];
+        return typeof val !== "string" || !val;
+      });
+
+      if (missingRequired.length > 0) {
+        entries.push(
+          buildEntry(kvKey, raw, "missing_required_fields", rec)
+        );
+        continue;
+      }
+
+      // Passed both guards — valid record (in D1)
+      validCount++;
+    }
+  }
+
+  return {
+    entries,
+    validCount,
+    nextCursor: page.list_complete ? null : (page.cursor ?? null),
+  };
+}
+
+// ── Aggregate stats ───────────────────────────────────────────────────────
+
+function computeAggregates(records: InvalidAgentEntry[]): {
+  aggregate_buckets: AuditReport["aggregate_buckets"];
+  missing_field_frequency: FieldMissingnessFrequency[];
+  missing_field_patterns: MissingFieldPattern[];
+  missing_count_histogram: Record<string, number>;
+} {
+  const buckets: AuditReport["aggregate_buckets"] = {
+    repairable: 0,
+    retired: 0,
+    "schema-unfixable": 0,
+  };
+
+  const fieldCounts: Record<RequiredField, number> = {
+    stxAddress: 0,
+    stxPublicKey: 0,
+    btcPublicKey: 0,
+    verifiedAt: 0,
+  };
+
+  const patternMap = new Map<string, { count: number; bucket: TentativeBucket }>();
+  const histogram: Record<string, number> = {};
+
+  for (const rec of records) {
+    buckets[rec.tentative_bucket]++;
+
+    for (const f of rec.missing_required_fields) {
+      fieldCounts[f]++;
+    }
+
+    const patternKey = rec.missing_required_fields.slice().sort().join(",") || "(none)";
+    const existing = patternMap.get(patternKey);
+    if (existing) {
+      existing.count++;
+    } else {
+      patternMap.set(patternKey, { count: 1, bucket: rec.tentative_bucket });
+    }
+
+    const countKey = String(rec.missing_required_count);
+    histogram[countKey] = (histogram[countKey] ?? 0) + 1;
+  }
+
+  const total = records.length;
+  const missing_field_frequency: FieldMissingnessFrequency[] = REQUIRED_FIELDS.map((f) => ({
+    field: f,
+    count: fieldCounts[f],
+    percent_of_invalid: total > 0 ? ((fieldCounts[f] / total) * 100).toFixed(1) + "%" : "0%",
+  })).sort((a, b) => b.count - a.count);
+
+  const missing_field_patterns: MissingFieldPattern[] = Array.from(
+    patternMap.entries()
+  )
+    .map(([pattern, { count, bucket }]) => ({
+      pattern,
+      count,
+      percent_of_invalid:
+        total > 0 ? ((count / total) * 100).toFixed(1) + "%" : "0%",
+      tentative_bucket: bucket,
+    }))
+    .sort((a, b) => b.count - a.count);
+
+  return {
+    aggregate_buckets: buckets,
+    missing_field_frequency,
+    missing_field_patterns,
+    missing_count_histogram: histogram,
+  };
+}
+
+// ── Route handlers ─────────────────────────────────────────────────────────
+
+/**
+ * GET /api/admin/audit-invalid-agents
+ *
+ * Self-documenting description. Requires X-Admin-Key.
+ */
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  return NextResponse.json({
+    endpoint: "/api/admin/audit-invalid-agents",
+    description:
+      "Step 1 of issue #691: Inventory pass for invalid KV agent records. " +
+      "Scans all btc: keys, applies the same two-step rejection as the backfill route " +
+      "(isPartialAgentRecord guard + strict required-field check), and returns a structured " +
+      "report with per-record field presence/absence and tentative bucket suggestions. " +
+      "READ-ONLY — no writes to KV, D1, or any other storage.",
+    authentication: "Requires X-Admin-Key header",
+    methods: ["GET", "POST"],
+    queryParams: {
+      batchSize:
+        "KV page size per POST call: 10–500 (default: 200). Each call fetches one page of btc: keys.",
+      cursor:
+        "Resume cursor from prior POST response. Absent = first call. Accumulate `records` across calls.",
+    },
+    tentative_bucket_definitions: {
+      repairable:
+        "Missing exactly 1 required field. May be repairable if the missing value can be recovered " +
+        "(e.g., from the stx: twin record or on-chain lookup). whoabuddy confirms in Step 2.",
+      retired:
+        "Missing 2+ required fields but btcAddress is present. Likely an abandoned or interrupted " +
+        "registration. Archival is the probable path.",
+      "schema-unfixable":
+        "Missing btcAddress or failed JSON parse. No safe repair path.",
+    },
+    required_fields_checked: REQUIRED_FIELDS,
+    marker_fields_reported: MARKER_FIELDS,
+    pagination: {
+      note: "Use cursor to paginate across all btc: keys (~1664 expected). Accumulate records client-side.",
+      example: `cursor=""
+while :; do
+  payload=$(jq -nc --arg c "$cursor" '{cursor: $c}')
+  resp=$(curl -sS -X POST "https://aibtc.com/api/admin/audit-invalid-agents?batchSize=200" \\
+    -H "X-Admin-Key: $KEY" \\
+    -H "Content-Type: application/json" \\
+    -d "$payload")
+  cursor=$(echo "$resp" | jq -r '.cursor // empty')
+  [ -z "$cursor" ] && break
+done`,
+    },
+    response: {
+      total_btc_keys_scanned: "Total btc: keys processed in this call",
+      valid_count: "Records that passed strict validation (in D1)",
+      partial_count: "Records caught by isPartialAgentRecord guard",
+      invalid_required_fields_count: "Records with missing required fields (core #691 population)",
+      json_parse_error_count: "Records that failed JSON.parse",
+      total_invalid_count: "Sum of partial + invalid_required_fields + json_parse",
+      aggregate_buckets: "Tentative bucket counts: repairable / retired / schema-unfixable",
+      missing_field_frequency: "Per-field count of how often each required field is missing",
+      missing_field_patterns: "Distinct combinations of missing fields, sorted by frequency",
+      missing_count_histogram: "Distribution of records by missing-field count",
+      records: "Per-record detail array",
+      cursor: "Resume cursor; null when scan complete",
+      duration_ms: "Wall-clock milliseconds for this call",
+    },
+    step_gate:
+      "This route implements Step 1 (inventory only). " +
+      "Steps 2–5 (bucket assignment, repair, archive, fallback removal) require explicit user sign-off " +
+      "because they involve production writes/deletes affecting live agents.",
+  });
+}
+
+/**
+ * POST /api/admin/audit-invalid-agents
+ *
+ * Run one page of the invalid-agent inventory scan.
+ *
+ * Body: { cursor?: string } — resume cursor from prior response.
+ * Query params:
+ *   - batchSize: 10–500 (default: 200)
+ *
+ * Returns an AuditReport for the scanned page. Caller accumulates `records`
+ * across pages and re-runs aggregates on the full dataset at the end.
+ *
+ * Subrequest budget per call at batchSize=200:
+ *   - 1  kv.list
+ *   - ~200  kv.get (parallel batches of 50)
+ *   Total: ~201 — well under the Workers 1000-subrequest cap.
+ */
+export async function POST(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  const start = Date.now();
+
+  const { env } = await getCloudflareContext();
+  const kv = env.VERIFIED_AGENTS as KVNamespace;
+
+  const { searchParams } = new URL(request.url);
+  const rawBatchSize = searchParams.get("batchSize");
+  let batchSize = rawBatchSize ? parseInt(rawBatchSize, 10) : 200;
+  if (!Number.isFinite(batchSize)) batchSize = 200;
+  batchSize = Math.max(10, Math.min(500, batchSize));
+
+  // Cursor in POST body (avoids URL length issues if cursor grows large)
+  const body = await request.json().catch(() => ({}));
+  const cursor = (body as { cursor?: string }).cursor ?? null;
+
+  try {
+    const { entries, validCount, nextCursor } = await scanInvalidAgents(
+      kv,
+      batchSize,
+      cursor || null
+    );
+
+    const partialCount = entries.filter((e) => e.rejection_reason === "partial").length;
+    const invalidRequiredCount = entries.filter(
+      (e) => e.rejection_reason === "missing_required_fields"
+    ).length;
+    const jsonParseErrorCount = entries.filter(
+      (e) => e.rejection_reason === "json_parse_error"
+    ).length;
+
+    const aggregates = computeAggregates(entries);
+
+    const report: AuditReport = {
+      generated_at: new Date().toISOString(),
+      total_btc_keys_scanned: entries.length + validCount,
+      valid_count: validCount,
+      partial_count: partialCount,
+      invalid_required_fields_count: invalidRequiredCount,
+      json_parse_error_count: jsonParseErrorCount,
+      total_invalid_count: entries.length,
+      ...aggregates,
+      records: entries,
+      cursor: nextCursor,
+      duration_ms: Date.now() - start,
+    };
+
+    return NextResponse.json(report);
+  } catch (e) {
+    return NextResponse.json(
+      {
+        error: `Audit scan failed: ${(e as Error).message}`,
+        duration_ms: Date.now() - start,
+      },
+      { status: 500 }
+    );
+  }
+}

--- a/lib/__tests__/audit-invalid-agents.test.ts
+++ b/lib/__tests__/audit-invalid-agents.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for the audit-invalid-agents classification logic.
+ *
+ * Tests the pure classification functions in isolation (no KV or Cloudflare
+ * runtime dependencies). Validates that the same two-step rejection logic used
+ * by the backfill route is correctly mirrored in the audit route.
+ */
+
+import { describe, it, expect } from "vitest";
+import { isPartialAgentRecord } from "../types";
+
+// ── Inline copies of the classification helpers ───────────────────────────
+// These mirror the logic in app/api/admin/audit-invalid-agents/route.ts.
+// Keeping them inline avoids importing from the route (Next.js App Router
+// modules import Cloudflare runtime bindings which aren't available in vitest).
+
+const REQUIRED_FIELDS = [
+  "stxAddress",
+  "stxPublicKey",
+  "btcPublicKey",
+  "verifiedAt",
+] as const;
+type RequiredField = (typeof REQUIRED_FIELDS)[number];
+
+type TentativeBucket = "repairable" | "retired" | "schema-unfixable";
+
+function classifyBucket(
+  btcAddress: string | null,
+  missingRequired: RequiredField[]
+): TentativeBucket {
+  if (!btcAddress) return "schema-unfixable";
+  if (missingRequired.length === 1) return "repairable";
+  return "retired";
+}
+
+function getMissingRequired(parsed: Record<string, unknown>): RequiredField[] {
+  return REQUIRED_FIELDS.filter((f) => {
+    const val = parsed[f];
+    return typeof val !== "string" || !val;
+  });
+}
+
+// ── isPartialAgentRecord (from lib/types.ts) tests ────────────────────────
+
+describe("isPartialAgentRecord", () => {
+  it("returns true for a record with only BTC credentials and no STX fields", () => {
+    const partial = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(isPartialAgentRecord(partial)).toBe(true);
+  });
+
+  it("returns false for a full AgentRecord with both BTC and STX credentials", () => {
+    const full = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      stxAddress: "SP1234",
+      stxPublicKey: "0x03def",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(isPartialAgentRecord(full)).toBe(false);
+  });
+
+  it("returns false if stxAddress is present even without stxPublicKey", () => {
+    const record = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      stxAddress: "SP1234",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    // Has stxAddress => NOT a partial record
+    expect(isPartialAgentRecord(record)).toBe(false);
+  });
+
+  it("returns false for null", () => {
+    expect(isPartialAgentRecord(null)).toBe(false);
+  });
+
+  it("returns false for a non-object", () => {
+    expect(isPartialAgentRecord("string")).toBe(false);
+    expect(isPartialAgentRecord(42)).toBe(false);
+  });
+
+  it("returns false if btcAddress is missing", () => {
+    const record = {
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(isPartialAgentRecord(record)).toBe(false);
+  });
+});
+
+// ── classifyBucket tests ──────────────────────────────────────────────────
+
+describe("classifyBucket", () => {
+  it("returns schema-unfixable when btcAddress is null", () => {
+    expect(classifyBucket(null, ["stxAddress"])).toBe("schema-unfixable");
+    expect(classifyBucket(null, ["stxAddress", "stxPublicKey"])).toBe("schema-unfixable");
+    expect(classifyBucket(null, [])).toBe("schema-unfixable");
+  });
+
+  it("returns repairable when exactly one required field is missing", () => {
+    const addr = "bc1qexample";
+    expect(classifyBucket(addr, ["stxAddress"])).toBe("repairable");
+    expect(classifyBucket(addr, ["stxPublicKey"])).toBe("repairable");
+    expect(classifyBucket(addr, ["btcPublicKey"])).toBe("repairable");
+    expect(classifyBucket(addr, ["verifiedAt"])).toBe("repairable");
+  });
+
+  it("returns retired when two or more required fields are missing", () => {
+    const addr = "bc1qexample";
+    expect(classifyBucket(addr, ["stxAddress", "stxPublicKey"])).toBe("retired");
+    expect(classifyBucket(addr, ["stxAddress", "stxPublicKey", "btcPublicKey"])).toBe("retired");
+    expect(classifyBucket(addr, REQUIRED_FIELDS as unknown as RequiredField[])).toBe("retired");
+  });
+});
+
+// ── getMissingRequired tests ──────────────────────────────────────────────
+
+describe("getMissingRequired", () => {
+  it("returns empty array for a fully valid record", () => {
+    const record = {
+      stxAddress: "SP1234",
+      stxPublicKey: "0x03def",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(getMissingRequired(record)).toEqual([]);
+  });
+
+  it("detects a single missing field", () => {
+    const record = {
+      stxAddress: "SP1234",
+      stxPublicKey: "0x03def",
+      btcPublicKey: "0x02abc",
+      // verifiedAt missing
+    };
+    expect(getMissingRequired(record)).toEqual(["verifiedAt"]);
+  });
+
+  it("detects multiple missing fields", () => {
+    const record = {
+      btcPublicKey: "0x02abc",
+      // stxAddress, stxPublicKey, verifiedAt all missing
+    };
+    const missing = getMissingRequired(record);
+    expect(missing).toContain("stxAddress");
+    expect(missing).toContain("stxPublicKey");
+    expect(missing).toContain("verifiedAt");
+    expect(missing).not.toContain("btcPublicKey");
+  });
+
+  it("treats empty string values as missing", () => {
+    const record = {
+      stxAddress: "",
+      stxPublicKey: "0x03def",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(getMissingRequired(record)).toEqual(["stxAddress"]);
+  });
+
+  it("treats null values as missing", () => {
+    const record = {
+      stxAddress: null as unknown as string,
+      stxPublicKey: "0x03def",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(getMissingRequired(record)).toEqual(["stxAddress"]);
+  });
+});
+
+// ── End-to-end classification scenario tests ───────────────────────────────
+
+describe("end-to-end record classification", () => {
+  /**
+   * Simulates the two-step rejection logic from the audit route.
+   * Returns the tentative bucket for a given raw parsed record.
+   */
+  function classify(parsed: Record<string, unknown>): TentativeBucket {
+    // Step 1: isPartialAgentRecord guard
+    if (isPartialAgentRecord(parsed)) {
+      const btcAddress =
+        typeof parsed.btcAddress === "string" ? parsed.btcAddress : null;
+      // Partial records are always missing stxAddress and stxPublicKey
+      return classifyBucket(btcAddress, ["stxAddress", "stxPublicKey"]);
+    }
+    // Step 2: required-field check
+    const missing = getMissingRequired(parsed);
+    const btcAddress =
+      typeof parsed.btcAddress === "string" ? parsed.btcAddress : null;
+    return classifyBucket(btcAddress, missing);
+  }
+
+  it("classifies a valid full record correctly (0 missing fields)", () => {
+    // Valid records are excluded from the report; classifying them returns "repairable"
+    // only because missingRequired is [] — but in the route these are never emitted.
+    // Test the boundary: 0 missing fields with btcAddress -> classifyBucket returns "retired"
+    // since missingRequired.length is 0, which is > 1, so it would be "retired".
+    // But actually: classifyBucket(addr, []) returns "retired" (length 0, not === 1).
+    // This is intentional: zero missing = valid record excluded from report by the route.
+    const addr = "bc1qexample";
+    expect(classifyBucket(addr, [])).toBe("retired"); // boundary case — not emitted in practice
+  });
+
+  it("classifies a partial record (BTC-only) as retired with btcAddress present", () => {
+    const partial = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    expect(classify(partial)).toBe("retired"); // missing 2 fields: stxAddress + stxPublicKey
+  });
+
+  it("classifies a record missing only verifiedAt as repairable", () => {
+    const record = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      stxAddress: "SP1234",
+      stxPublicKey: "0x03def",
+      // verifiedAt missing
+    };
+    expect(classify(record)).toBe("repairable");
+  });
+
+  it("classifies a record missing stxAddress and stxPublicKey as retired", () => {
+    const record = {
+      btcAddress: "bc1qexample",
+      btcPublicKey: "0x02abc",
+      verifiedAt: "2024-01-01T00:00:00Z",
+      // stxAddress and stxPublicKey missing — but NOT caught by isPartialAgentRecord
+      // because isPartialAgentRecord would return true first
+    };
+    // This would be caught by isPartialAgentRecord — test the direct classification
+    const missing = getMissingRequired(record);
+    expect(classifyBucket("bc1qexample", missing)).toBe("retired");
+  });
+
+  it("classifies a record missing btcAddress as schema-unfixable", () => {
+    const record = {
+      // btcAddress missing
+      btcPublicKey: "0x02abc",
+      stxAddress: "SP1234",
+      stxPublicKey: "0x03def",
+      verifiedAt: "2024-01-01T00:00:00Z",
+    };
+    const missing = getMissingRequired(record);
+    expect(classifyBucket(null, missing)).toBe("schema-unfixable");
+  });
+
+  it("classifies a JSON parse error as schema-unfixable", () => {
+    // JSON parse errors produce btcAddress=null and all required fields missing
+    expect(classifyBucket(null, [...REQUIRED_FIELDS])).toBe("schema-unfixable");
+  });
+});


### PR DESCRIPTION
## Summary

This PR implements **Step 1 (inventory only)** of issue #691. Steps 2–5 (bucket assignment, repair, archive, fallback removal) are **gated for explicit user sign-off** because they involve production writes/deletes affecting live agents.

### What this adds

- `GET/POST /api/admin/audit-invalid-agents` — read-only admin route that scans all `btc:` KV keys and reports on the ~708 records that fail Phase 1.3 strict validation
- `lib/__tests__/audit-invalid-agents.test.ts` — 20 unit tests covering the classification logic

### How it works

Applies the same two-step rejection used by the backfill route:
1. `isPartialAgentRecord` guard — catches BTC-only (Partial) records
2. Strict required-field check — catches records with missing `stxAddress`, `stxPublicKey`, `btcPublicKey`, or `verifiedAt`

For each invalid record, reports:
- `kv_key`, `btc_address`, `present_fields`, `missing_required_fields`, `rejection_reason`
- `tentative_bucket` (field-presence only — whoabuddy makes final call in Step 2):
  - **repairable**: missing exactly 1 required field
  - **retired**: missing 2+ required fields (btcAddress present)
  - **schema-unfixable**: missing btcAddress or JSON parse failure

Aggregates: bucket counts, field-missingness frequencies, missing-field-pattern distribution, histogram by missing-field count.

### Pagination

Cursor-based pagination at `batchSize=200` default (~201 subrequests/call, well under Workers 1000-subrequest cap). Caller accumulates `records` across pages.

### What this does NOT do

- No writes to KV, D1, or any other storage
- No changes to `/api/agents/[address]` route or fallback behavior
- No repair or archive routes

## Test plan

- [x] `npm test` — 20 new tests pass, no regressions (792 total pass; 1 pre-existing og-d1 JSX parse failure unaffected)
- [x] `npx tsc --noEmit` — no new TypeScript errors in new files
- [ ] After merge and auto-deploy: call `POST /api/admin/audit-invalid-agents` with admin key to run inventory
- [ ] Save raw JSON + `.md` summary to `phases/05-invalid-agents-cleanup/` (Step 1 artifact)
- [ ] Update STATE.md noting Step 1 complete, Steps 2–5 awaiting sign-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)