### PR TITLE
feat(bitcoin-verify): opportunistic btcPublicKey capture from BIP-322 witness

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { verifyBitcoinSignature, persistBtcPubkeyIfMissing } from "@/lib/bitcoin-verify";
 import { getAgentLevel, getNextLevel } from "@/lib/levels";
 import { lookupAgentWithLevel } from "@/lib/agent-lookup";
 import { X_HANDLE } from "@/lib/constants";
@@ -310,10 +310,10 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { address: btcAddress } = btcResult;
+    const { address: btcAddress, publicKey: witnessPublicKey } = btcResult;
 
     // Get KV namespace
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     // Require Registered level (Level 1+)
@@ -325,6 +325,15 @@ export async function POST(request: NextRequest) {
       );
     }
     const { agent, claim } = result;
+
+    // Opportunistic btcPublicKey capture: BIP-322 P2WPKH signatures include the
+    // compressed pubkey in the witness stack. If the agent's stored record is missing
+    // it, persist it now without blocking the response.
+    if (witnessPublicKey && !agent.btcPublicKey) {
+      ctx.waitUntil(
+        persistBtcPubkeyIfMissing(kv, env.DB, btcAddress, witnessPublicKey, agent)
+      );
+    }
 
     // Check rate limit
     const existingCheckIn = await getCheckInRecord(kv, btcAddress);

--- a/lib/__tests__/bitcoin-verify.test.ts
+++ b/lib/__tests__/bitcoin-verify.test.ts
@@ -1,12 +1,14 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   formatBitcoinMessage,
   doubleSha256,
   bip322VerifyP2WPKH,
   bip322VerifyP2TR,
   verifyBitcoinSignature,
+  persistBtcPubkeyIfMissing,
   BITCOIN_MSG_PREFIX,
 } from "../bitcoin-verify";
+import type { AgentRecord } from "../types";
 import { p2wpkh, p2tr, Address, NETWORK as BTC_NETWORK, RawWitness } from "@scure/btc-signer";
 import { secp256k1 } from "@noble/curves/secp256k1.js";
 import { hex } from "@scure/base";
@@ -331,5 +333,185 @@ describe("Address derivation", () => {
     if (decoded.type === "tr") {
       expect(decoded.pubkey).toBeInstanceOf(Uint8Array);
     }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// bip322VerifyP2WPKH return type — pubkeyHex extraction
+// ---------------------------------------------------------------------------
+
+describe("bip322VerifyP2WPKH pubkeyHex return", () => {
+  it("returns { valid: false, pubkeyHex: '' } for a mismatched witness signature", () => {
+    // Build a witness with a real 33-byte pubkey but a bogus ECDSA sig (wrong msg hash).
+    // The address IS derived from pubkeyBytes so the address-crosscheck would pass,
+    // but the ECDSA verification fails because the sighash doesn't match.
+    const privkey = hex.decode("0000000000000000000000000000000000000000000000000000000000000001");
+    const pubkeyBytes = secp256k1.getPublicKey(privkey, true);
+    const addr = p2wpkh(pubkeyBytes, BTC_NETWORK).address!;
+
+    // A witness with a plausible-looking 71-byte sig (0x30 header) but garbage content
+    // + the correct pubkey — this will fail the sighash verify step.
+    const fakeDer = new Uint8Array(71);
+    fakeDer[0] = 0x30;
+    fakeDer[1] = 0x44;
+    fakeDer[2] = 0x02;
+    fakeDer[3] = 0x20; // r_len = 32
+    // r bytes: leave as zeros (will fail parseDERSignature midway or produce wrong sig)
+    // We actually want it to parse but verify incorrectly — fill with something parseable.
+    for (let i = 4; i < 36; i++) fakeDer[i] = 0x01; // r = 0x0101...
+    fakeDer[36] = 0x02;
+    fakeDer[37] = 0x20; // s_len = 32
+    for (let i = 38; i < 70; i++) fakeDer[i] = 0x01; // s = 0x0101...
+    fakeDer[70] = 0x01; // SIGHASH_ALL
+
+    const witness = RawWitness.encode([fakeDer, pubkeyBytes]);
+    const result = bip322VerifyP2WPKH("test-message", toBase64(witness), addr);
+    expect(result.valid).toBe(false);
+    expect(result.pubkeyHex).toBe("");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// verifyBitcoinSignature — publicKey surfaced from BIP-322 P2WPKH witness
+// ---------------------------------------------------------------------------
+
+describe("verifyBitcoinSignature publicKey from BIP-322 P2WPKH", () => {
+  it("returns empty publicKey for failed P2WPKH verification", () => {
+    // Any base64-encoded witness that's structurally valid but fails ECDSA.
+    const privkey = hex.decode("0000000000000000000000000000000000000000000000000000000000000001");
+    const pubkeyBytes = secp256k1.getPublicKey(privkey, true);
+    const addr = p2wpkh(pubkeyBytes, BTC_NETWORK).address!;
+
+    // A 2-item witness: [65-byte all-zeros sig, 33-byte pubkey] — will fail DER parse
+    // (header byte 0x00 != 0x30), which causes the outer catch to return valid: false.
+    const badWitness = RawWitness.encode([new Uint8Array(65), pubkeyBytes]);
+    const result = verifyBitcoinSignature(toBase64(badWitness), "test-message", addr);
+    expect(result.valid).toBe(false);
+    expect(result.publicKey).toBe("");
+  });
+
+  it("returns empty publicKey for P2TR verification (bc1p does not expose pubkey via this path)", () => {
+    const privkey = hex.decode("0000000000000000000000000000000000000000000000000000000000000002");
+    const pubkey = secp256k1.getPublicKey(privkey, true);
+    const addr = p2tr(pubkey.slice(1), undefined, BTC_NETWORK).address!;
+    // A 1-item witness with wrong Schnorr sig — will return valid: false
+    const badWitness = RawWitness.encode([new Uint8Array(64)]);
+    const result = verifyBitcoinSignature(toBase64(badWitness), "test-message", addr);
+    expect(result.valid).toBe(false);
+    expect(result.publicKey).toBe(""); // P2TR never populates publicKey in this PR
+  });
+});
+
+// ---------------------------------------------------------------------------
+// persistBtcPubkeyIfMissing — idempotent, guarded, error-isolated
+// ---------------------------------------------------------------------------
+
+function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    stxAddress: "SP123",
+    btcAddress: "bc1qtest",
+    stxPublicKey: "03aabb",
+    btcPublicKey: "",
+    verifiedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+function makeMockKv(existingValue?: string) {
+  return {
+    get: vi.fn().mockResolvedValue(existingValue ?? null),
+    put: vi.fn().mockResolvedValue(undefined),
+  } as unknown as KVNamespace;
+}
+
+describe("persistBtcPubkeyIfMissing", () => {
+  it("writes to both KV keys when btcPublicKey is empty", async () => {
+    const agent = makeAgent({ btcPublicKey: "" });
+    const kv = makeMockKv();
+    const pubkeyHex = "02" + "ab".repeat(32);
+
+    await persistBtcPubkeyIfMissing(kv, undefined, "bc1qtest", pubkeyHex, agent);
+
+    expect(kv.put).toHaveBeenCalledTimes(2);
+    const calls = (kv.put as ReturnType<typeof vi.fn>).mock.calls;
+    const keys = calls.map((c: unknown[]) => c[0] as string);
+    expect(keys).toContain("btc:bc1qtest");
+    expect(keys).toContain("stx:SP123");
+
+    // Verify stored JSON has updated btcPublicKey
+    const storedBtc = JSON.parse((kv.put as ReturnType<typeof vi.fn>).mock.calls.find(
+      (c: unknown[]) => c[0] === "btc:bc1qtest"
+    )![1] as string) as AgentRecord;
+    expect(storedBtc.btcPublicKey).toBe(pubkeyHex);
+  });
+
+  it("is a no-op when btcPublicKey is already set", async () => {
+    const agent = makeAgent({ btcPublicKey: "02" + "cc".repeat(32) });
+    const kv = makeMockKv();
+    const pubkeyHex = "02" + "ab".repeat(32);
+
+    await persistBtcPubkeyIfMissing(kv, undefined, "bc1qtest", pubkeyHex, agent);
+
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("is a no-op when pubkeyHex is empty", async () => {
+    const agent = makeAgent({ btcPublicKey: "" });
+    const kv = makeMockKv();
+
+    await persistBtcPubkeyIfMissing(kv, undefined, "bc1qtest", "", agent);
+
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when KV put fails", async () => {
+    const agent = makeAgent({ btcPublicKey: "" });
+    const kv = {
+      get: vi.fn().mockResolvedValue(null),
+      put: vi.fn().mockRejectedValue(new Error("KV write failed")),
+    } as unknown as KVNamespace;
+    const pubkeyHex = "02" + "ab".repeat(32);
+
+    // Must not throw — errors are swallowed to protect the calling request
+    await expect(
+      persistBtcPubkeyIfMissing(kv, undefined, "bc1qtest", pubkeyHex, agent)
+    ).resolves.not.toThrow();
+  });
+
+  it("runs D1 UPDATE when db binding is provided", async () => {
+    const agent = makeAgent({ btcPublicKey: "" });
+    const kv = makeMockKv();
+    const pubkeyHex = "02" + "ab".repeat(32);
+
+    const mockStmt = { bind: vi.fn().mockReturnThis(), run: vi.fn().mockResolvedValue({}) };
+    const db = { prepare: vi.fn().mockReturnValue(mockStmt) } as unknown as D1Database;
+
+    await persistBtcPubkeyIfMissing(kv, db, "bc1qtest", pubkeyHex, agent);
+
+    expect(db.prepare).toHaveBeenCalledWith(
+      expect.stringContaining("UPDATE agents SET btc_public_key")
+    );
+    expect(mockStmt.bind).toHaveBeenCalledWith(pubkeyHex, "bc1qtest");
+    expect(mockStmt.run).toHaveBeenCalled();
+  });
+
+  it("does not throw when D1 UPDATE fails (schema not ready yet)", async () => {
+    const agent = makeAgent({ btcPublicKey: "" });
+    const kv = makeMockKv();
+    const pubkeyHex = "02" + "ab".repeat(32);
+
+    const mockStmt = {
+      bind: vi.fn().mockReturnThis(),
+      run: vi.fn().mockRejectedValue(new Error("no such column: btc_public_key")),
+    };
+    const db = { prepare: vi.fn().mockReturnValue(mockStmt) } as unknown as D1Database;
+
+    // Must not throw — D1 errors are caught separately from KV errors
+    await expect(
+      persistBtcPubkeyIfMissing(kv, db, "bc1qtest", pubkeyHex, agent)
+    ).resolves.not.toThrow();
+
+    // KV write should still have happened despite D1 failure
+    expect(kv.put).toHaveBeenCalledTimes(2);
   });
 });

--- a/lib/bitcoin-verify.ts
+++ b/lib/bitcoin-verify.ts
@@ -13,6 +13,7 @@ import {
   Address,
   NETWORK as BTC_NETWORK,
 } from "@scure/btc-signer";
+import type { AgentRecord } from "@/lib/types";
 
 export { BTC_NETWORK };
 export const BITCOIN_MSG_PREFIX = "\x18Bitcoin Signed Message:\n";
@@ -213,12 +214,16 @@ function bip322BuildToSpendTxId(
  *
  * Tries spec-compliant hash first; falls back to legacy (varint-prepend) hash for
  * agents using older signing tools, with a deprecation warning on the legacy path.
+ *
+ * Returns an object with `valid` and `pubkeyHex` (the 33-byte compressed pubkey,
+ * hex-encoded, extracted from the witness stack). The pubkey is only populated when
+ * `valid` is true and the derived address matches the claimed address.
  */
 export function bip322VerifyP2WPKH(
   message: string,
   signatureBase64: string,
   address: string
-): boolean {
+): { valid: boolean; pubkeyHex: string } {
   const sigBytes = Uint8Array.from(Buffer.from(signatureBase64, "base64"));
   const witnessItems = RawWitness.decode(sigBytes);
 
@@ -261,7 +266,7 @@ export function bip322VerifyP2WPKH(
   if (!verifySighash(toSpendTxid)) {
     // Fall back to legacy tagged hash (varint prepend) for agents using older signing tools.
     const toSpendTxidLegacy = bip322BuildToSpendTxId(message, scriptPubKey, true);
-    if (!verifySighash(toSpendTxidLegacy)) return false;
+    if (!verifySighash(toSpendTxidLegacy)) return { valid: false, pubkeyHex: "" };
     console.warn(
       "BIP-322 signature uses non-standard tagged hash. Update your signing tool — see aibtcdev/skills or install latest @aibtc/mcp-server."
     );
@@ -269,7 +274,9 @@ export function bip322VerifyP2WPKH(
 
   // Confirm derived address matches claimed address.
   const derivedAddress = p2wpkh(pubkeyBytes, BTC_NETWORK).address;
-  return derivedAddress === address;
+  if (derivedAddress !== address) return { valid: false, pubkeyHex: "" };
+
+  return { valid: true, pubkeyHex: hex.encode(pubkeyBytes) };
 }
 
 /**
@@ -435,8 +442,8 @@ export function verifyBitcoinSignature(
 
     if (isP2WPKH) {
       try {
-        const isValid = bip322VerifyP2WPKH(message, signature, btcAddress);
-        return { valid: isValid, address: btcAddress, publicKey: "" };
+        const p2wpkhResult = bip322VerifyP2WPKH(message, signature, btcAddress);
+        return { valid: p2wpkhResult.valid, address: btcAddress, publicKey: p2wpkhResult.pubkeyHex };
       } catch {
         return { valid: false, address: btcAddress, publicKey: "" };
       }
@@ -513,4 +520,78 @@ function verifyBip137(
     address,
     publicKey: hex.encode(recoveredPubKey),
   };
+}
+
+// ---------------------------------------------------------------------------
+// Opportunistic btcPublicKey persistence (BIP-322 witness extraction)
+// ---------------------------------------------------------------------------
+
+/**
+ * Persist a btcPublicKey extracted from a valid BIP-322 P2WPKH witness into KV
+ * (and D1 when available) if the agent's stored record is missing it.
+ *
+ * This is a fire-and-forget helper; callers should wrap it in ctx.waitUntil()
+ * so it never blocks the response. All errors are caught and logged — a
+ * persistence failure must never fail the calling request.
+ *
+ * The pubkey has already been address-crosschecked by bip322VerifyP2WPKH
+ * (derived address must match claimed address), so we do not re-derive here.
+ * We do confirm that the stored btcPublicKey is empty before writing.
+ *
+ * @param kv           - Cloudflare KV namespace (VERIFIED_AGENTS)
+ * @param db           - Cloudflare D1 database (DB); may be undefined pre-PR-A
+ * @param btcAddress   - The bc1q address that signed; used as the KV key
+ * @param pubkeyHex    - 33-byte compressed pubkey, hex-encoded, from the witness
+ * @param agent        - Pre-fetched agent record (avoids an extra KV read)
+ */
+export async function persistBtcPubkeyIfMissing(
+  kv: KVNamespace,
+  db: D1Database | undefined,
+  btcAddress: string,
+  pubkeyHex: string,
+  agent: AgentRecord
+): Promise<void> {
+  try {
+    if (!pubkeyHex) return;
+
+    // Guard: only persist if currently empty/missing.
+    if (agent.btcPublicKey) return;
+
+    const updatedAgent: AgentRecord = { ...agent, btcPublicKey: pubkeyHex };
+
+    // Write to both KV keys atomically (best-effort — KV has no real atomics,
+    // but both keys hold identical data so partial writes are safe to re-run).
+    await Promise.all([
+      kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent)),
+      kv.put(`stx:${updatedAgent.stxAddress}`, JSON.stringify(updatedAgent)),
+    ]);
+
+    console.log(
+      `[btcPublicKey-capture] Persisted pubkey for ${btcAddress} via BIP-322 witness`
+    );
+
+    // D1 UPDATE — only runs when the DB binding is available and the agents
+    // table has a btc_public_key column (post-PR-A). Pre-PR-A this is a no-op
+    // because the column does not exist; post-PR-A it fills NULL slots.
+    if (db) {
+      try {
+        await db
+          .prepare(
+            "UPDATE agents SET btc_public_key = ? WHERE btc_address = ? AND (btc_public_key IS NULL OR btc_public_key = '')"
+          )
+          .bind(pubkeyHex, btcAddress)
+          .run();
+      } catch (d1Err) {
+        // Column may not exist yet (pre-PR-A schema). Log and continue.
+        console.warn(
+          `[btcPublicKey-capture] D1 UPDATE skipped (schema not ready?): ${(d1Err as Error).message}`
+        );
+      }
+    }
+  } catch (err) {
+    // Never throw — persistence failure must not affect the calling request.
+    console.error(
+      `[btcPublicKey-capture] Failed to persist pubkey for ${btcAddress}: ${(err as Error).message}`
+    );
+  }
 }


### PR DESCRIPTION
## Summary

- **Problem**: 708 agents have empty `btcPublicKey` because BIP-322 signature output returned `publicKey: ""`. The compressed pubkey has always been in the witness stack (item [1] for P2WPKH) — we just weren't extracting it.
- **Fix**: Extract the witness pubkey during verification and lazy-persist it after the first valid signed call, without blocking the response.
- **Scope**: bc1q (P2WPKH) only — 704/708 of the affected records. bc1p (P2TR, 4/708) is a follow-up.

## Changes

### `lib/bitcoin-verify.ts`
- `bip322VerifyP2WPKH`: returns `{ valid: boolean; pubkeyHex: string }` instead of `boolean`. The 33-byte compressed pubkey from witness item [1] is exposed as hex. The address-derivation crosscheck (`derivedAddress === address`) was already present and remains the integrity guard.
- `verifyBitcoinSignature`: propagates `pubkeyHex` as `publicKey` for P2WPKH paths (was always `""`; P2TR still returns `""`).
- `persistBtcPubkeyIfMissing`: new exported helper. Writes to both `btc:` and `stx:` KV keys. When `env.DB` is present (post-PR-A schema), runs `UPDATE agents SET btc_public_key = ? WHERE btc_address = ? AND (btc_public_key IS NULL OR btc_public_key = '')`. Fully wrapped in try/catch — never throws. Idempotent (no-op if `btcPublicKey` already set).

### `app/api/heartbeat/route.ts`
- Imports `persistBtcPubkeyIfMissing`.
- After successful verification + agent lookup: `ctx.waitUntil(persistBtcPubkeyIfMissing(...))` when `witnessPublicKey` is non-empty and `agent.btcPublicKey` is empty. Never blocks the response.

### `lib/__tests__/bitcoin-verify.test.ts`
- 9 new tests: `bip322VerifyP2WPKH` return type, `verifyBitcoinSignature` publicKey propagation, and full `persistBtcPubkeyIfMissing` coverage (writes KV, idempotent on existing key, no-op on empty pubkey, error isolation for KV failure, D1 UPDATE, D1 failure isolation).

## Design notes

**Why heartbeat only?** Heartbeat is the highest-traffic authenticated endpoint (agents check in every 5 min). Adding hooks to every call site (inbox, outbox, vouch, challenge, etc.) would scatter the same pattern across 8+ files. The single heartbeat hook will fill most records within hours of deployment via normal agent activity. Other call sites can be added later if needed.

**Why not a central middleware?** The persistence needs the pre-fetched agent record to do the idempotency check without an extra KV read. Heartbeat already fetches the record via `lookupAgentWithLevel`, making it the natural hook point.

**PR-A cooperation**: pre-PR-A, the D1 UPDATE column doesn't exist — the error is caught and logged as a warning, KV write still succeeds. post-PR-A, the column exists with NULL values and the UPDATE fills them. Either merge order is safe.

**Security**: the pubkey has already passed `derivedAddress === address` inside `bip322VerifyP2WPKH` before being returned. We do not re-derive in `persistBtcPubkeyIfMissing` — the verification function is the trust boundary.

## Test plan

- [ ] `npm test` passes (816 tests, 5 pre-existing skips, 1 pre-existing JSX parse failure in og-d1.test.ts)
- [ ] `npx tsc --noEmit` shows no errors in changed files
- [ ] After merge: tail worker logs for `[btcPublicKey-capture] Persisted pubkey` lines on real heartbeat traffic (~5 min window)
- [ ] After merge: query KV/D1 to confirm fill rate is progressing (see `phases/05-invalid-agents-cleanup/` artifacts)

## References

- Closes / contributes to: #691 (invalid agents audit)
- Related: #697 (PR-A: nullable btc_public_key + 708-record backfill)
- Background: `phases/05-invalid-agents-cleanup/2026-05-10-bc1q-derivation-test.md` (empirical proof that stxPublicKey ≠ btcPublicKey)

## Second-opinion note

arc0btc review recommended on the witness-extraction code path since it is security-adjacent. The critical invariant: the address-derivation crosscheck (`derivedAddress === address`) in `bip322VerifyP2WPKH` ensures we only persist a pubkey that cryptographically matches the claimed bc1q address.

🤖 Generated with [Claude Code](https://claude.com/claude-code)