### PR TITLE
feat(d1): NULLable btc_public_key + backfill 708 BIP-322-only registrations

### DIFF
--- a/app/api/admin/backfill/__tests__/route.test.ts
+++ b/app/api/admin/backfill/__tests__/route.test.ts
@@ -186,6 +186,18 @@ const FULL_AGENT_1 = JSON.stringify({
   referredBy: null,
 });
 
+// BIP-322 bc1q agent: has Stacks credentials + verifiedAt but NO btcPublicKey.
+// These are valid registrations — btcPublicKey is NULLable since migration 008.
+const BIP322_AGENT = JSON.stringify({
+  btcAddress: "bc1qbip322",
+  stxAddress: "SP1BIP322",
+  stxPublicKey: "03bip32200",
+  btcPublicKey: "",  // empty string — the actual KV shape for bc1q agents
+  verifiedAt: "2026-03-01T00:00:00Z",
+  displayName: "BIP-322 Agent",
+  referredBy: null,
+});
+
 const PARTIAL_AGENT = JSON.stringify({
   btcAddress: "bc1qpartial",
   btcPublicKey: "02abcdef02",
@@ -786,6 +798,149 @@ describe("claims backfill", () => {
     expect(body.failed[0].reason).toContain("Invalid status value");
 
     // D1 run should NOT have been called for the bad row
+    expect(runMock).not.toHaveBeenCalled();
+  });
+});
+
+// ── BIP-322 / nullable btcPublicKey backfill tests ───────────────────────
+// Locks the three-case contract introduced by migration 008:
+//   1. Full record (btcPublicKey present)  → inserted with non-null btcPublicKey
+//   2. BIP-322 record (btcPublicKey empty) → inserted with NULL, counted in inserted_null_btcpubkey
+//   3. Missing verifiedAt                  → failed[] (true data error)
+
+describe("BIP-322 nullable btcPublicKey backfill (migration 008)", () => {
+  it("case 1: full record with btcPublicKey is inserted with non-null btc_public_key", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT_1,
+      "referral-code:bc1qagent1": REFERRAL_CODE_1,
+    });
+    const { db, runMock, bindMock } = buildD1Mock({ changesSequence: [1] });
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents" }));
+    const body = await resp.json() as {
+      inserted: number;
+      inserted_null_btcpubkey: number;
+      failed: unknown[];
+    };
+
+    expect(body.inserted).toBe(1);
+    expect(body.inserted_null_btcpubkey).toBe(0);
+    expect(body.failed).toHaveLength(0);
+    expect(runMock).toHaveBeenCalledTimes(1);
+
+    // Verify btcPublicKey was passed as the 4th bind arg (non-null)
+    const bindArgs = bindMock.mock.calls[0] as unknown[];
+    expect(bindArgs[3]).toBe("02abcdef01");
+  });
+
+  it("case 2: BIP-322 record with empty btcPublicKey is inserted with NULL and counted in inserted_null_btcpubkey", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qbip322": BIP322_AGENT,
+      "referral-code:bc1qbip322": JSON.stringify({ code: "BIP322", createdAt: "2026-03-01T00:00:00Z" }),
+    });
+    const { db, runMock, bindMock } = buildD1Mock({ changesSequence: [1] });
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents" }));
+    const body = await resp.json() as {
+      inserted: number;
+      inserted_null_btcpubkey: number;
+      failed: unknown[];
+    };
+
+    expect(body.inserted).toBe(1);
+    expect(body.inserted_null_btcpubkey).toBe(1);
+    expect(body.failed).toHaveLength(0);
+    expect(runMock).toHaveBeenCalledTimes(1);
+
+    // Verify btcPublicKey was bound as null (not the empty string)
+    const bindArgs = bindMock.mock.calls[0] as unknown[];
+    expect(bindArgs[3]).toBeNull();
+  });
+
+  it("case 3: record missing verifiedAt (with or without btcPublicKey) goes to failed[]", async () => {
+    const missingVerifiedAt = JSON.stringify({
+      btcAddress: "bc1qnotime",
+      stxAddress: "SP1NOTIME",
+      stxPublicKey: "03notime00",
+      btcPublicKey: "",
+      // verifiedAt absent — true data error
+    });
+
+    const kv = buildKvMock({
+      "btc:bc1qnotime": missingVerifiedAt,
+    });
+    const { db, runMock } = buildD1Mock();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents" }));
+    const body = await resp.json() as {
+      inserted: number;
+      inserted_null_btcpubkey: number;
+      failed: { key: string; reason: string }[];
+    };
+
+    expect(body.inserted).toBe(0);
+    expect(body.inserted_null_btcpubkey).toBe(0);
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0].key).toBe("btc:bc1qnotime");
+    expect(body.failed[0].reason).toContain("verifiedAt");
+    expect(runMock).not.toHaveBeenCalled();
+  });
+
+  it("dry-run counts BIP-322 record in inserted_null_btcpubkey without writing to D1", async () => {
+    const kv = buildKvMock({
+      "btc:bc1qbip322": BIP322_AGENT,
+      "referral-code:bc1qbip322": JSON.stringify({ code: "BIP322", createdAt: "2026-03-01T00:00:00Z" }),
+    });
+    const { db, runMock } = buildD1Mock();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const resp = await POST(buildPostRequest({ table: "agents", dryRun: "true" }));
+    const body = await resp.json() as {
+      inserted: number;
+      inserted_null_btcpubkey: number;
+      dryRun: boolean;
+      failed: unknown[];
+    };
+
+    expect(body.dryRun).toBe(true);
+    expect(body.inserted).toBe(1);
+    expect(body.inserted_null_btcpubkey).toBe(1);
+    expect(body.failed).toHaveLength(0);
     expect(runMock).not.toHaveBeenCalled();
   });
 });

--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -19,6 +19,7 @@ interface BackfillResult {
   dryRun: boolean;
   batchSize: number;
   inserted: number;
+  inserted_null_btcpubkey: number;
   skipped_idempotent: number;
   skipped_partial: number;
   failed: { key: string; reason: string }[];
@@ -28,6 +29,7 @@ interface BackfillResult {
 
 interface AccumulatedCounts {
   inserted: number;
+  inserted_null_btcpubkey: number;
   skipped_idempotent: number;
   skipped_partial: number;
   failed: { key: string; reason: string }[];
@@ -147,6 +149,7 @@ async function backfillAgents(
 ): Promise<AccumulatedCounts & { nextCursor: string | null }> {
   const counts: AccumulatedCounts = {
     inserted: 0,
+    inserted_null_btcpubkey: 0,
     skipped_idempotent: 0,
     skipped_partial: 0,
     failed: [],
@@ -190,16 +193,22 @@ async function backfillAgents(
       continue;
     }
 
-    // Validate remaining required fields for D1 insert — these are actual data errors
-    // on records that claimed to be full agents (have stxAddress/stxPublicKey) but
-    // are missing other non-nullable columns.
-    if (!agent.btcPublicKey || !agent.verifiedAt) {
+    // Validate remaining required fields for D1 insert.
+    // btcPublicKey is NULLable in D1 (migration 008): agents registered via BIP-322
+    // segwit (bc1q) have no capturable pubkey in the signature. Records with
+    // stxAddress + stxPublicKey + btcAddress + verifiedAt are valid even when
+    // btcPublicKey is absent or empty — they are inserted with btc_public_key = NULL.
+    // Only missing verifiedAt is a true data error for a claimed-full agent.
+    if (!agent.verifiedAt) {
       counts.failed.push({
         key: kvKey.name,
-        reason: "Missing required AgentRecord fields (btcPublicKey/verifiedAt)",
+        reason: "Missing required AgentRecord field: verifiedAt",
       });
       continue;
     }
+
+    // Track whether this record has no BTC pubkey (for operational reporting).
+    const hasNullBtcPubkey = !agent.btcPublicKey;
 
     if (pass === "insert") {
       // Resolve or generate referral code
@@ -228,6 +237,7 @@ async function backfillAgents(
 
       if (dryRun) {
         counts.inserted++;
+        if (hasNullBtcPubkey) counts.inserted_null_btcpubkey++;
         continue;
       }
 
@@ -247,7 +257,9 @@ async function backfillAgents(
             agent.btcAddress,
             agent.stxAddress,
             agent.stxPublicKey,
-            agent.btcPublicKey,
+            // btc_public_key is NULLable (migration 008): store null when absent/empty.
+            // BIP-322 bc1q agents never had a capturable pubkey at registration time.
+            agent.btcPublicKey || null,
             agent.taprootAddress ?? null,
             agent.displayName ?? null,
             agent.description ?? null,
@@ -266,6 +278,7 @@ async function backfillAgents(
 
         if (result.meta.changes === 1) {
           counts.inserted++;
+          if (hasNullBtcPubkey) counts.inserted_null_btcpubkey++;
         } else {
           counts.skipped_idempotent++;
         }
@@ -334,6 +347,7 @@ async function backfillClaims(
 ): Promise<AccumulatedCounts & { nextCursor: string | null }> {
   const counts: AccumulatedCounts = {
     inserted: 0,
+    inserted_null_btcpubkey: 0,
     skipped_idempotent: 0,
     skipped_partial: 0,
     failed: [],
@@ -440,6 +454,7 @@ async function backfillInboxMessages(
 ): Promise<AccumulatedCounts & { nextCursor: string | null }> {
   const counts: AccumulatedCounts = {
     inserted: 0,
+    inserted_null_btcpubkey: 0,
     skipped_idempotent: 0,
     skipped_partial: 0,
     failed: [],
@@ -678,6 +693,7 @@ async function backfillVouches(
 ): Promise<AccumulatedCounts & { nextCursor: string | null }> {
   const counts: AccumulatedCounts = {
     inserted: 0,
+    inserted_null_btcpubkey: 0,
     skipped_idempotent: 0,
     skipped_partial: 0,
     failed: [],
@@ -774,9 +790,10 @@ export async function GET(request: NextRequest) {
       dryRun: "Whether this was a dry run",
       batchSize: "Effective batch size used",
       inserted: "Rows newly inserted",
+      inserted_null_btcpubkey: "Subset of inserted with btc_public_key = NULL (BIP-322 bc1q agents; expected ~708 on first full backfill)",
       skipped_idempotent: "Rows skipped due to existing D1 row (INSERT OR IGNORE)",
       skipped_partial: "PartialAgentRecord rows skipped (agents table only)",
-      failed: "Array of { key, reason } for rows that errored",
+      failed: "Array of { key, reason } for rows that errored (missing verifiedAt or D1 error)",
       cursor: "Opaque resume cursor; null when scan complete",
       duration_ms: "Wall-clock milliseconds for this request",
     },
@@ -841,6 +858,7 @@ export async function POST(request: NextRequest) {
     if (table === "all") {
       const totals: AccumulatedCounts = {
         inserted: 0,
+        inserted_null_btcpubkey: 0,
         skipped_idempotent: 0,
         skipped_partial: 0,
         failed: [],
@@ -851,6 +869,7 @@ export async function POST(request: NextRequest) {
       do {
         const res = await backfillAgents(kv, db, batchSize, agentCursor, dryRun);
         totals.inserted += res.inserted;
+        totals.inserted_null_btcpubkey += res.inserted_null_btcpubkey;
         totals.skipped_idempotent += res.skipped_idempotent;
         totals.skipped_partial += res.skipped_partial;
         totals.failed.push(...res.failed);
@@ -858,6 +877,7 @@ export async function POST(request: NextRequest) {
         logger.info("backfill.batch", {
           table: "agents",
           inserted_so_far: totals.inserted,
+          inserted_null_btcpubkey_so_far: totals.inserted_null_btcpubkey,
           scanned_so_far: totals.inserted + totals.skipped_idempotent + totals.skipped_partial + totals.failed.length,
           cursor: agentCursor,
         });
@@ -915,6 +935,7 @@ export async function POST(request: NextRequest) {
       logger.info("backfill.complete", {
         table: "all",
         inserted: totals.inserted,
+        inserted_null_btcpubkey: totals.inserted_null_btcpubkey,
         skipped_idempotent: totals.skipped_idempotent,
         skipped_partial: totals.skipped_partial,
         failed_count: totals.failed.length,
@@ -926,6 +947,7 @@ export async function POST(request: NextRequest) {
         dryRun,
         batchSize,
         inserted: totals.inserted,
+        inserted_null_btcpubkey: totals.inserted_null_btcpubkey,
         skipped_idempotent: totals.skipped_idempotent,
         skipped_partial: totals.skipped_partial,
         failed: totals.failed,
@@ -961,6 +983,7 @@ export async function POST(request: NextRequest) {
     logger.info("backfill.batch", {
       table,
       inserted_so_far: res.inserted,
+      inserted_null_btcpubkey_so_far: res.inserted_null_btcpubkey,
       scanned_so_far:
         res.inserted +
         res.skipped_idempotent +
@@ -973,6 +996,7 @@ export async function POST(request: NextRequest) {
       logger.info("backfill.complete", {
         table,
         inserted: res.inserted,
+        inserted_null_btcpubkey: res.inserted_null_btcpubkey,
         skipped_idempotent: res.skipped_idempotent,
         skipped_partial: res.skipped_partial,
         failed_count: res.failed.length,
@@ -989,6 +1013,7 @@ export async function POST(request: NextRequest) {
       dryRun,
       batchSize,
       inserted: res.inserted,
+      inserted_null_btcpubkey: res.inserted_null_btcpubkey,
       skipped_idempotent: res.skipped_idempotent,
       skipped_partial: res.skipped_partial,
       failed: res.failed,

--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -1038,16 +1038,20 @@ describe("sampleSize=0 short-circuit", () => {
 // fix they appear in kv_count_invalid_excluded and do NOT contribute to drift.
 
 describe("Bug 1: invalid records excluded same as backfill (criteria alignment)", () => {
-  // Fixture: passes isPartialAgentRecord (has stxAddress) but missing btcPublicKey
-  const INVALID_AGENT_MISSING_BTC_PUBKEY = JSON.stringify({
+  // Since migration 008: btcPublicKey is NULLable. A record with stxAddress +
+  // stxPublicKey + verifiedAt but NO btcPublicKey is now a VALID BIP-322 agent
+  // that belongs in D1 with btc_public_key = NULL. It is NOT invalid_excluded.
+
+  // Fixture: BIP-322 agent — valid post-migration-008 (btcPublicKey absent but all other fields present)
+  const BIP322_AGENT_RECONCILE = JSON.stringify({
     btcAddress: "bc1qinvalid1",
     stxAddress: "SP1INVALID1",
     stxPublicKey: "03abcdef99",
-    // btcPublicKey intentionally missing
+    // btcPublicKey intentionally missing — valid per migration 008
     verifiedAt: "2026-01-05T00:00:00Z",
   });
 
-  // Fixture: passes isPartialAgentRecord but has empty verifiedAt
+  // Fixture: truly invalid — empty verifiedAt (still rejected by backfill post-migration-008)
   const INVALID_AGENT_EMPTY_VERIFIED_AT = JSON.stringify({
     btcAddress: "bc1qinvalid2",
     stxAddress: "SP1INVALID2",
@@ -1056,18 +1060,19 @@ describe("Bug 1: invalid records excluded same as backfill (criteria alignment)"
     verifiedAt: "", // empty string — backfill rejects as falsy
   });
 
-  it("agents: excludes invalid record (missing btcPublicKey) from kv_count and reports kv_count_invalid_excluded", async () => {
-    // KV: 1 full agent + 1 invalid (non-partial but missing btcPublicKey)
-    // D1: 1 agent (only full agent backfilled)
-    // Expected: kv_count=1, kv_count_invalid_excluded=1, drift=0, drift_unexplained=0
+  it("agents: BIP-322 record (missing btcPublicKey) counts as full agent post-migration-008", async () => {
+    // Migration 008 made btc_public_key NULLable. Records with stxAddress + stxPublicKey +
+    // verifiedAt but no btcPublicKey are now VALID and go to D1. They must appear in
+    // kv_count (not kv_count_invalid_excluded) and D1 count must match for drift=0.
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
-      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+      "btc:bc1qinvalid1": BIP322_AGENT_RECONCILE,
     });
 
     const db = buildD1Mock({
       firstResults: {
-        "FROM agents": { cnt: 1 },
+        // D1 now has 2 agents (full + BIP-322), so drift=0
+        "FROM agents": { cnt: 2 },
       },
       defaultFirst: null,
     });
@@ -1086,15 +1091,17 @@ describe("Bug 1: invalid records excluded same as backfill (criteria alignment)"
       drift_unexplained: number;
     };
 
-    expect(body.kv_count).toBe(1); // only full agent
-    expect(body.kv_count_partial_excluded).toBe(0); // none are partial
-    expect(body.kv_count_invalid_excluded).toBe(1); // invalid agent surfaced separately
-    expect(body.d1_count).toBe(1);
-    expect(body.drift).toBe(0); // no unexplained gap
+    // Both agents are now "full" (BIP-322 record is valid post-migration-008)
+    expect(body.kv_count).toBe(2);
+    expect(body.kv_count_partial_excluded).toBe(0);
+    expect(body.kv_count_invalid_excluded).toBe(0);
+    expect(body.d1_count).toBe(2);
+    expect(body.drift).toBe(0);
     expect(body.drift_unexplained).toBe(0);
   });
 
   it("agents: excludes invalid record (empty verifiedAt) — not counted as drift", async () => {
+    // Empty verifiedAt is still a true data error post-migration-008.
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
       "btc:bc1qinvalid2": INVALID_AGENT_EMPTY_VERIFIED_AT,
@@ -1125,19 +1132,21 @@ describe("Bug 1: invalid records excluded same as backfill (criteria alignment)"
     expect(body.drift_unexplained).toBe(0);
   });
 
-  it("agents: distinguishes partial, invalid, and full counts in a mixed KV", async () => {
-    // KV: 1 full + 1 partial (isPartialAgentRecord) + 1 invalid (missing btcPublicKey)
-    // D1: 1 agent (only full backfilled)
-    // Expected: kv_count=1, partial_excluded=1, invalid_excluded=1, drift=0
+  it("agents: distinguishes partial, BIP-322, and full counts in a mixed KV", async () => {
+    // Post-migration-008:
+    //   - 1 full agent (has btcPublicKey)
+    //   - 1 partial (isPartialAgentRecord — no stxAddress)
+    //   - 1 BIP-322 (stxAddress + stxPublicKey + verifiedAt, no btcPublicKey — now VALID)
+    // D1: 2 agents (full + BIP-322 both inserted)
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
       "btc:bc1qpartial": PARTIAL_AGENT,
-      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+      "btc:bc1qinvalid1": BIP322_AGENT_RECONCILE,
     });
 
     const db = buildD1Mock({
       firstResults: {
-        "FROM agents": { cnt: 1 },
+        "FROM agents": { cnt: 2 },
       },
       defaultFirst: null,
     });
@@ -1156,32 +1165,38 @@ describe("Bug 1: invalid records excluded same as backfill (criteria alignment)"
       drift_unexplained: number;
     };
 
-    expect(body.kv_count).toBe(1); // full only
+    // full + BIP-322 = 2 full agents; partial excluded; 0 invalid
+    expect(body.kv_count).toBe(2);
     expect(body.kv_count_partial_excluded).toBe(1); // true partial
-    expect(body.kv_count_invalid_excluded).toBe(1); // non-partial but missing field
-    expect(body.d1_count).toBe(1);
+    expect(body.kv_count_invalid_excluded).toBe(0); // BIP-322 is now valid
+    expect(body.d1_count).toBe(2);
     expect(body.drift).toBe(0);
     expect(body.drift_unexplained).toBe(0);
   });
 
-  it("claims: invalid agent's claim is also drift_explained (cascades from KV-truth)", async () => {
-    // KV: 1 full + 1 invalid; 2 claims; D1: 1 claim (only full agent's)
-    // The invalid agent's claim is not in D1 (backfill rejected the parent).
-    // reconcile should explain this via drift_explained, not drift_unexplained.
+  it("claims: BIP-322 agent's claim is in fullAgents → NOT drift_explained (post-migration-008)", async () => {
+    // Post-migration-008: BIP-322 record is in fullAgents (it's a valid D1 agent).
+    // Its claim is also in D1. So kv_count=2, d1_count=2, drift=0.
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
-      "btc:bc1qinvalid1": INVALID_AGENT_MISSING_BTC_PUBKEY,
+      "btc:bc1qinvalid1": BIP322_AGENT_RECONCILE,
       "claim:bc1qagent1": CLAIM_1,
       "claim:bc1qinvalid1": JSON.stringify({
         btcAddress: "bc1qinvalid1",
         status: "verified",
         claimedAt: "2026-01-05T01:00:00Z",
+        displayName: "BIP-322 Agent",
+        tweetUrl: "https://x.com/bip322/status/456",
+        tweetAuthor: "bip322",
+        rewardSatoshis: 0,
+        rewardTxid: null,
       }),
     });
 
     const db = buildD1Mock({
       firstResults: {
-        "FROM claims": { cnt: 1 },
+        // Both claims in D1 (both agents are valid)
+        "FROM claims": { cnt: 2 },
       },
       defaultFirst: null,
     });
@@ -1200,10 +1215,9 @@ describe("Bug 1: invalid records excluded same as backfill (criteria alignment)"
     };
 
     expect(body.kv_count).toBe(2); // 2 claims in KV
-    expect(body.d1_count).toBe(1);
-    expect(body.drift).toBe(1);
-    // Invalid agent is not in fullAgents → claim is drift_explained
-    expect(body.drift_explained).toBe(1);
+    expect(body.d1_count).toBe(2); // 2 claims in D1 (BIP-322 is now a valid agent)
+    expect(body.drift).toBe(0);
+    expect(body.drift_explained).toBe(0);
     expect(body.drift_unexplained).toBe(0);
   });
 });

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -169,13 +169,16 @@ async function sampleKvKeys(
 
 /**
  * Single-pass scan of `btc:` KV prefix — returns the set of btcAddress values
- * whose agent record passes BOTH the PartialAgentRecord check AND the strict
- * required-field check that backfill applies. Used by claims/inbox/vouches
- * to compute drift_explained from KV truth (not D1 absence).
+ * whose agent record passes BOTH the PartialAgentRecord check AND the required-field
+ * check that backfill applies. Used by claims/inbox/vouches to compute drift_explained
+ * from KV truth (not D1 absence).
  *
- * Matches backfill's two-step rejection logic:
- *   1. Skip isPartialAgentRecord — counted as partial_count
- *   2. Skip records missing stxAddress/stxPublicKey/btcPublicKey/verifiedAt — invalid_count
+ * Matches backfill's two-step rejection logic (post-migration-008):
+ *   1. Skip isPartialAgentRecord — counted as partial_count (no stxAddress)
+ *   2. Skip records missing stxAddress/stxPublicKey/verifiedAt — invalid_count
+ *      NOTE: btcPublicKey is NULLable since migration 008; absent btcPublicKey alone
+ *      does NOT make a record invalid. BIP-322 bc1q agents with empty/absent btcPublicKey
+ *      are valid and belong in D1 with btc_public_key = NULL.
  *
  * Reads values in parallel batches of 50 to keep wall-clock manageable.
  */
@@ -213,16 +216,16 @@ async function buildFullAgentSet(kv: KVNamespace): Promise<{
           partial_count++;
           continue;
         }
-        // Apply the same strict required-field check that backfill uses:
-        // records missing any of these are rejected by backfill and absent from D1.
+        // Apply the same required-field check that backfill uses (post-migration-008):
+        // btcPublicKey is NULLable — BIP-322 bc1q records with empty/absent btcPublicKey
+        // are now valid and inserted into D1 with btc_public_key = NULL.
+        // Only missing stxAddress, stxPublicKey, or verifiedAt makes a record invalid.
         const agent = parsed as Record<string, unknown>;
         if (
           typeof agent.stxAddress !== "string" ||
           !agent.stxAddress ||
           typeof agent.stxPublicKey !== "string" ||
           !agent.stxPublicKey ||
-          typeof agent.btcPublicKey !== "string" ||
-          !agent.btcPublicKey ||
           typeof agent.verifiedAt !== "string" ||
           !agent.verifiedAt
         ) {

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -6,7 +6,17 @@ export interface AgentRecord {
   stxAddress: string;
   btcAddress: string;
   stxPublicKey: string;
-  btcPublicKey: string;
+  /**
+   * Bitcoin compressed public key (33 bytes, hex-encoded).
+   *
+   * Optional/NULLable: BIP-322 segwit (P2WPKH / bc1q) signing does not
+   * include the pubkey in the signature output. Agents that registered via
+   * a bc1q wallet have no capturable pubkey at registration time. NULL is
+   * the correct stored value — do NOT substitute stxPublicKey (different
+   * BIP-44 derivation path). Pubkey may be captured opportunistically later
+   * via the `update-pubkey` challenge action.
+   */
+  btcPublicKey?: string | null;
   taprootAddress?: string | null;
   displayName?: string;
   description?: string | null;

--- a/migrations/008_nullable_btc_public_key.sql
+++ b/migrations/008_nullable_btc_public_key.sql
@@ -1,0 +1,88 @@
+-- Migration 008: make btc_public_key NULLable for BIP-322 registrations.
+--
+-- Root cause: BIP-322 segwit signing (P2WPKH / bc1q) does not include the
+-- public key in the signature output. Agents that registered via a segwit
+-- wallet have btcPublicKey: "" (empty string) in KV — the pubkey was never
+-- captured at registration time. This is a structural consequence of the
+-- BIP-322 spec, not a data error.
+--
+-- As of 2026-05-10, 708 production KV records have stxAddress + stxPublicKey +
+-- btcAddress + verifiedAt populated but btcPublicKey is empty. These are valid
+-- registrations and must exist in the agents table so that all 951 agents are
+-- visible to D1-backed routes (Phase 2.x read flips). NULL is the correct
+-- stored value — do NOT copy stxPublicKey; the two keys derive from different
+-- BIP-44 paths (m/44'/5060'/0' for Stacks vs m/84'/0'/0' for Bitcoin segwit).
+--
+-- D1 SQLite does NOT support `ALTER TABLE ... ALTER COLUMN` to drop NOT NULL.
+-- The standard SQLite workaround is the table-rebuild dance:
+--   1. Create agents_new with the desired schema (btc_public_key NULL).
+--   2. Copy all rows from agents.
+--   3. Drop the old table.
+--   4. Rename the new table.
+--   5. Recreate all indexes.
+--
+-- This is a forward-only migration. If rollback is ever needed:
+--   Agents with NULL btc_public_key are missing pubkey for cross-system
+--   signature verification. However, live BIP-322 verification works because
+--   the witness pubkey is present in the signature itself. The NULL column
+--   only affects offline/batch lookups, not the verify endpoint.
+--
+-- References: #691 (D1 backfill sprint), SpaceX-5 (dual-sig + x402 flows).
+
+-- Step 1: Create the new table with btc_public_key NULL.
+CREATE TABLE agents_new (
+  btc_address           TEXT PRIMARY KEY,
+  stx_address           TEXT NOT NULL UNIQUE,
+  stx_public_key        TEXT NOT NULL,
+  btc_public_key        TEXT,                 -- NULLable: absent for BIP-322/bc1q agents
+  taproot_address       TEXT,
+  display_name          TEXT,
+  description           TEXT,
+  bns_name              TEXT,
+  owner                 TEXT,
+  verified_at           TEXT NOT NULL,
+  last_active_at        TEXT,
+  erc8004_agent_id      INTEGER,
+  nostr_public_key      TEXT,
+  capabilities_json     TEXT,
+  last_identity_check   TEXT,
+  github_username       TEXT,
+  referred_by_btc       TEXT,
+  referral_code         TEXT NOT NULL UNIQUE,
+  FOREIGN KEY (referred_by_btc) REFERENCES agents_new(btc_address)
+);
+
+-- Step 2: Copy all existing rows.
+INSERT INTO agents_new
+SELECT
+  btc_address,
+  stx_address,
+  stx_public_key,
+  btc_public_key,
+  taproot_address,
+  display_name,
+  description,
+  bns_name,
+  owner,
+  verified_at,
+  last_active_at,
+  erc8004_agent_id,
+  nostr_public_key,
+  capabilities_json,
+  last_identity_check,
+  github_username,
+  referred_by_btc,
+  referral_code
+FROM agents;
+
+-- Step 3: Drop the old table (and its indexes — they are table-scoped).
+DROP TABLE agents;
+
+-- Step 4: Rename the new table to agents.
+ALTER TABLE agents_new RENAME TO agents;
+
+-- Step 5: Recreate all indexes from migration 001.
+CREATE INDEX idx_agents_owner ON agents(lower(owner)) WHERE owner IS NOT NULL;
+CREATE INDEX idx_agents_referred_by ON agents(referred_by_btc) WHERE referred_by_btc IS NOT NULL;
+CREATE INDEX idx_agents_verified_at ON agents(verified_at);
+CREATE INDEX idx_agents_last_active_at ON agents(last_active_at) WHERE last_active_at IS NOT NULL;


### PR DESCRIPTION
## Summary

- **Bug fixed**: 708 agents were invisible to D1-backed routes (Phase 2.x read flips) because their KV records had `btcPublicKey: ""` and D1's `btc_public_key NOT NULL` constraint blocked backfill. These agents reported as "not registered" post-flip.
- **Root cause**: BIP-322 segwit (P2WPKH / bc1q) signing does not include the public key in the signature output. These are valid registrations — the pubkey was never capturable at registration time. As of 2026-05-10, 708/951 production KV agents are affected (704 are bc1q addresses where pubkey is unrecoverable from address without the witness).
- **Fix**: NULLable schema (migration 008) + backfill route extension to admit these records with `btc_public_key = NULL`. After merge + deploy + backfill run, all 951 agents will be in D1.

## Changes

### `migrations/008_nullable_btc_public_key.sql`

Table-rebuild dance to drop `NOT NULL` from `btc_public_key` (SQLite/D1 does not support `ALTER TABLE ALTER COLUMN`). Steps: create `agents_new` with nullable column, `INSERT INTO agents_new SELECT * FROM agents`, `DROP TABLE agents`, `ALTER TABLE agents_new RENAME TO agents`, recreate indexes.

**Schema rationale**: NULL is the correct stored value. Do NOT copy `stxPublicKey` — Stacks keys derive from `m/44'/5060'/0'` and Bitcoin segwit keys from `m/84'/0'/0'` (different BIP-44 paths). Pubkey can be captured opportunistically later via the existing `update-pubkey` challenge action.

**Rollback note**: This is forward-only. If rollback is ever needed: agents with `btc_public_key = NULL` are missing pubkey for offline/batch cross-system lookups, but live BIP-322 verification works because the witness pubkey is present in the signature itself.

### `lib/types.ts`

`AgentRecord.btcPublicKey` relaxed from `string` (required) to `string | null | undefined` (optional). JSDoc explains the BIP-44 path difference and directs to the `update-pubkey` challenge action for opportunistic capture.

### `app/api/admin/backfill/route.ts`

- Removed `!agent.btcPublicKey` from the required-field rejection. Only missing `verifiedAt` is now a true data error → `failed[]`.
- Added `hasNullBtcPubkey` flag; stores `agent.btcPublicKey || null` (empty string → NULL) in D1.
- New `inserted_null_btcpubkey` counter on `BackfillResult` and `AccumulatedCounts` for operational verification. Expected ~708 on first run.

### `app/api/admin/reconcile/route.ts`

`buildFullAgentSet()` no longer rejects records missing `btcPublicKey` from `fullAgents`. Post-migration-008 these records are valid D1 citizens — excluding them would cause `drift_unexplained > 0` after backfill.

### Tests

- 4 new backfill test cases: full record (btcPublicKey present), BIP-322 record (empty btcPublicKey → NULL + counted in `inserted_null_btcpubkey`), missing verifiedAt → `failed[]`, dry-run accounting.
- Updated reconcile "Bug 1" test suite to reflect new semantics: BIP-322 records are now `fullAgents`, not `kv_count_invalid_excluded`.

## Operational plan (after merge + auto-deploy)

```bash
# 1. Apply migration to remote D1
npm run wrangler -- d1 migrations apply landing-page --remote

# 2. Backfill — expect inserted_null_btcpubkey ~708, total D1 agents ~951
curl -X POST "https://aibtc.com/api/admin/backfill?table=agents" \
  -H "X-Admin-Key: $ADMIN_KEY" \
  -H "Content-Type: application/json" -d '{}'

# 3. Reconcile to verify zero unexplained drift
curl -X POST "https://aibtc.com/api/admin/reconcile?table=agents&sampleSize=50" \
  -H "X-Admin-Key: $ADMIN_KEY" \
  -H "Content-Type: application/json" -d '{}'

# 4. Rebuild agent-list cache (Phase 2.1) to reflect all 951 agents
curl -X POST "https://aibtc.com/api/admin/cache-rebuild" \
  -H "X-Admin-Key: $ADMIN_KEY"
```

## Test plan

- [ ] CI passes (pre-existing og-d1 JSX parse failure is unrelated — present on main)
- [ ] `npm test` shows 811 passed / 5 skipped (same as main minus og-d1 suite)
- [ ] `npx tsc --noEmit` shows no new errors beyond pre-existing ones on main
- [ ] After merge + deploy: `npm run wrangler -- d1 migrations apply landing-page --remote` succeeds
- [ ] Backfill run returns `inserted_null_btcpubkey` between 700–720
- [ ] Post-backfill reconcile: `drift_unexplained = 0`, `d1_count ~951`
- [ ] Agent profile load for a known bc1q agent that was previously "not registered"

🤖 Generated with [Claude Code](https://claude.com/claude-code)