### PR TITLE
fix(claims): allow claim-code regen for legacy P2WPKH agents w/ empty stored pubkey (post-#712 regression)

### DIFF
--- a/app/api/claims/code/route.ts
+++ b/app/api/claims/code/route.ts
@@ -136,10 +136,19 @@ export async function POST(request: NextRequest) {
     }
 
     // Verify the signature came from the registered key.
-    // BIP-322 verifiers return publicKey: "" — address ownership is already
-    // proven via witness reconstruction, so skip the key-binding check for
-    // that path. BIP-137 recovers the pubkey from the signature, so enforce.
-    if (sigResult.publicKey && sigResult.publicKey !== agent.btcPublicKey) {
+    // BIP-137 always recovers a pubkey; BIP-322 P2WPKH exposes the witness
+    // pubkey post-#712; BIP-322 P2TR still returns publicKey: "" (witness
+    // path doesn't expose the key). The address-derivation crosscheck inside
+    // the BIP-322 verifier already binds witness → claimed address; this
+    // predicate adds a second integrity guard when both sides have a value
+    // to compare. The `agent.btcPublicKey &&` guard avoids a 403 against
+    // legacy records that pre-date #712 + #713 and still have an empty
+    // stored pubkey in KV until heartbeat backfill catches up.
+    if (
+      sigResult.publicKey &&
+      agent.btcPublicKey &&
+      sigResult.publicKey !== agent.btcPublicKey
+    ) {
       return NextResponse.json(
         { error: "Signature does not match the registered Bitcoin key" },
         { status: 403 }

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -717,16 +717,18 @@ export async function POST(request: NextRequest) {
       ? createLogger(env.LOGS, ctx, { rayId, path: "/api/register" })
       : createConsoleLogger({ rayId, path: "/api/register" });
 
-    // BIP-322 wallets (bc1q/bc1p) don't expose the public key via signature recovery.
-    // This is expected behavior, not an incident — registration completes
-    // normally with an empty publicKey. The remediation path (provide
-    // nostrPublicKey now, or update-pubkey via challenge later) is documented
-    // in the GET self-doc and surfaced in the response (#579).
+    // BIP-322 P2TR (bc1p) signatures don't expose the public key via the
+    // witness path; BIP-322 P2WPKH (bc1q) does post-#712 (witness item [1]
+    // is the 33-byte compressed pubkey). Empty publicKey at this point is
+    // expected for P2TR or any other path that doesn't surface the key — not
+    // an incident. Registration completes normally; remediation paths
+    // (provide nostrPublicKey now, or update-pubkey via challenge later)
+    // are documented in the GET self-doc and surfaced in the response (#579).
     const btcPublicKeyMissing = !btcResult.publicKey;
     if (btcPublicKeyMissing) {
       log.info(
         `btcPublicKey unavailable for address ${btcResult.address}: ` +
-        "BIP-322 signatures do not expose the public key via recovery. " +
+        "this signature path did not expose the public key. " +
         "Nostr npub derivation from btcPublicKey will not work for this agent."
       );
     }


### PR DESCRIPTION
## Summary

Post-#712 + #713 + #714 + #715, the predicate at `app/api/claims/code/route.ts:142` regressed for the 708 backfilled records and any other legacy agent whose KV record still has `btcPublicKey: ""`.

```ts
// before — short-circuits when sigResult.publicKey === "" (pre-#712 P2WPKH)
if (sigResult.publicKey && sigResult.publicKey !== agent.btcPublicKey) {
  return 403;
}
```

`verifyBitcoinSignature` now returns a real compressed pubkey hex for valid BIP-322 P2WPKH signatures (was always `""` pre-#712). For agents whose KV record still has `btcPublicKey: ""`:

- **Pre-#712:** `sigResult.publicKey === ""` → first conjunct short-circuits → check skipped → request proceeds. ✓
- **Post-#712:** `sigResult.publicKey === <hex>`, `agent.btcPublicKey === ""` → comparison `<hex> !== ""` → returns **403**.

This locks affected agents out of claim-code regeneration until their first post-#712 heartbeat triggers the opportunistic KV write in `persistBtcPubkeyIfMissing`. For dormant agents the window could be indefinite.

## Fix

Added an `agent.btcPublicKey &&` guard so the integrity check only fires when both sides have a value to compare:

```ts
if (
  sigResult.publicKey &&
  agent.btcPublicKey &&
  sigResult.publicKey !== agent.btcPublicKey
) {
  return 403;
}
```

The address-derivation crosscheck inside `bip322VerifyP2WPKH` already binds witness pubkey → claimed address, so this predicate remains a second integrity guard, not the primary trust boundary. Behavior matrix:

| `sigResult.publicKey` | `agent.btcPublicKey` | predicate fires? | reason |
|---|---|---|---|
| empty | empty | no | (legacy P2WPKH/P2TR pre-#712, address-crosscheck still binds) |
| empty | populated | no | (P2TR caller, no witness pubkey to compare) |
| populated | empty | **no (changed)** | (legacy record post-#712, awaiting heartbeat KV backfill) |
| populated | populated, equal | no | (key match) |
| populated | populated, different | **yes** | (genuine mismatch) |

Only the third row changes; all other rows match prior behavior.

## Stale-comment refresh (same PR for atomicity)

- `app/api/claims/code/route.ts:139-141` — was "BIP-322 verifiers return publicKey: ''"; now reflects P2WPKH/P2TR split + the legacy-record reason for the new guard.
- `app/api/register/route.ts:720-724` — was "BIP-322 wallets (bc1q/bc1p) don't expose the public key"; narrowed to P2TR + non-recovery paths post-#712.

## Out of scope (separate PRs / tickets)

- **Positive-path test** asserting a valid P2WPKH signature returns the correctly-extracted compressed pubkey via `verifyBitcoinSignature(...).publicKey` (@steel-yeti finding 1 from the #712 advisory). Building a valid BIP-322 fixture requires either exporting a sign helper from `lib/bitcoin-verify.ts` or capturing a real signature fixture — substantial enough for its own PR.
- **KV ↔ D1 reconcile path** for new agents whose helper D1 write fails silently while KV write succeeds — steel-yeti finding 2 from the #712 advisory.
- **bc1p (P2TR) witness extraction** — explicitly out of scope per the #712 body.

## Test plan

- [ ] CI passes (no existing test asserts the old 403 behavior — confirmed via `grep -rn claims/code __tests__/`)
- [ ] Manual: pre-#712 record (`btcPublicKey: ""`) + valid BIP-322 P2WPKH signature → request succeeds (200) instead of 403
- [ ] Manual: post-heartbeat record (`btcPublicKey: <hex>`) + valid BIP-322 P2WPKH signature with matching pubkey → request succeeds (200)
- [ ] Manual: post-heartbeat record + valid BIP-322 P2WPKH signature with mismatched pubkey (signed by different key for a different address) → returns 403
- [ ] Manual: P2TR (bc1p) signature path unchanged — `sigResult.publicKey === ""` still short-circuits the predicate

## References

- Triggered by: #712 (BIP-322 witness pubkey extraction)
- Related: #713 (D1 NULLable column + 708-record backfill)
- Surfaced in: my v143 review on #712 (#issuecomment-pre-merge) + v144 synthesis (#issuecomment-4415669465)
- Steel-yeti pre-merge advisory: #712 [#issuecomment-4415643839](https://github.com/aibtcdev/landing-page/pull/712#issuecomment-4415643839)