### PR TITLE
feat(reconcile): orphan_recipient explained category for dead-letter inbox messages

### DIFF
--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -1412,15 +1412,23 @@ describe("explained_categories is always present in response", () => {
 // under-counting partial_cascade by ~681 in the 2026-05-10T01:45Z production run.
 
 describe("Bug A: BTC-shaped replyTo classified as partial_cascade", () => {
-  it("reply with BTC replyTo not in fullAgents → partial_cascade incremented", async () => {
-    // KV: 1 full agent + 1 reply whose replyTo is a BTC address NOT in fullAgents
-    // The BTC replyTo recipient is a now-invalid agent, absent from fullAgents.
-    // D1: 0 messages (reply not backfilled — FK would fail on recipient)
+  it("reply with BTC replyTo that is a partial agent in KV but not in fullAgents → partial_cascade", async () => {
+    // KV: 1 full agent + 1 partial agent + 1 reply whose replyTo is the partial agent's BTC address.
+    // The partial agent IS in KV (as btc:bc1qpartial1234) but NOT in fullAgents (not in D1).
+    // partial_cascade explains the absence — the partial agent was excluded from D1 by FK design.
+    // D1: 0 messages (reply not backfilled — FK would fail on partial recipient)
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
+      // Partial agent whose BTC address is the reply target
+      "btc:bc1qpartial1234": JSON.stringify({
+        btcAddress: "bc1qpartial1234",
+        btcPublicKey: "02aabbcc77",
+        verifiedAt: "2026-01-04T00:00:00Z",
+        // No stxAddress — PartialAgentRecord
+      }),
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
-        toBtcAddress: "bc1qnotanagent1234",  // BTC address NOT in fullAgents
+        toBtcAddress: "bc1qpartial1234",  // partial agent's BTC address (in KV, not in D1)
         repliedAt: "2026-01-01T03:00:00Z",
       }),
     });
@@ -1448,6 +1456,7 @@ describe("Bug A: BTC-shaped replyTo classified as partial_cascade", () => {
       explained_categories: {
         partial_cascade?: number;
         unresolvable_stx_reply?: number;
+        orphan_recipient?: number;
       };
     };
 
@@ -1456,9 +1465,10 @@ describe("Bug A: BTC-shaped replyTo classified as partial_cascade", () => {
     expect(body.drift).toBe(1);
     expect(body.drift_explained).toBe(1);
     expect(body.drift_unexplained).toBe(0);
-    // Must be partial_cascade, not unresolvable_stx_reply
+    // Recipient is in KV (as partial) → partial_cascade, not orphan_recipient or stx_reply
     expect(body.explained_categories.partial_cascade).toBe(1);
     expect(body.explained_categories.unresolvable_stx_reply).toBe(0);
+    expect(body.explained_categories.orphan_recipient).toBe(0);
   });
 
   it("reply with BTC replyTo that IS in fullAgents → no drift increment", async () => {
@@ -1802,16 +1812,22 @@ describe("Bug C: STX replyTo resolver — no btcAddress field → unresolvable_s
     expect(body.explained_categories.partial_cascade).toBe(0);
   });
 
-  it("stx: record resolves to btcAddress but that BTC is not in fullAgents → partial_cascade (not unresolvable)", async () => {
-    // KV: 1 full agent + 1 stx: record WITH a btcAddress that is NOT in fullAgents
-    // The resolver returns a BTC address — resolution succeeded.
-    // But that BTC agent is not a full agent → FK would fail → partial_cascade.
+  it("stx: record resolves to btcAddress in KV (partial) but not in fullAgents → partial_cascade (not unresolvable)", async () => {
+    // KV: 1 full agent + 1 partial agent + 1 stx: record pointing to the partial agent.
+    // The resolver returns a BTC address that IS in KV (as a partial agent) but NOT in fullAgents.
+    // partial_cascade explains the absence — the partial agent was excluded from D1 by FK design.
     const kv = buildKvMock({
       "btc:bc1qagent1": FULL_AGENT,
-      // stx: record has a btcAddress but that address is NOT in fullAgents (no btc: key)
+      // The resolved BTC address IS in KV as a partial agent
+      "btc:bc1qpartial1234": JSON.stringify({
+        btcAddress: "bc1qpartial1234",
+        btcPublicKey: "02aabbcc99",
+        verifiedAt: "2026-01-04T00:00:00Z",
+        // No stxAddress — PartialAgentRecord
+      }),
       "stx:SP1RESOLVES": JSON.stringify({
         stxAddress: "SP1RESOLVES",
-        btcAddress: "bc1qnotafull1234",  // valid BTC, but no btc: key → not in fullAgents
+        btcAddress: "bc1qpartial1234",  // resolves to the partial agent above
       }),
       "inbox:reply:msg001": JSON.stringify({
         messageId: "msg001",
@@ -1841,15 +1857,17 @@ describe("Bug C: STX replyTo resolver — no btcAddress field → unresolvable_s
       explained_categories: {
         partial_cascade?: number;
         unresolvable_stx_reply?: number;
+        orphan_recipient?: number;
       };
     };
 
     expect(body.drift).toBe(1);
     expect(body.drift_explained).toBe(1);
     expect(body.drift_unexplained).toBe(0);
-    // Resolution succeeded (btcAddress found), but recipient not in fullAgents → partial_cascade
+    // Resolution succeeded (btcAddress found in KV as partial) → partial_cascade
     expect(body.explained_categories.partial_cascade).toBe(1);
     expect(body.explained_categories.unresolvable_stx_reply).toBe(0);
+    expect(body.explained_categories.orphan_recipient).toBe(0);
   });
 });
 
@@ -1865,6 +1883,7 @@ describe("cursor encode/decode roundtrip", () => {
         drift_explained_partial_cascade: 10,
         drift_explained_unique_payment_txid_replay: 2,
         drift_explained_unresolvable_stx_reply: 3,
+        drift_explained_orphan_recipient: 7,
         txidCounts: new Set(["txid_a", "txid_b"]),
       },
     };
@@ -1879,6 +1898,7 @@ describe("cursor encode/decode roundtrip", () => {
     expect(decoded.partialCounts.drift_explained_partial_cascade).toBe(10);
     expect(decoded.partialCounts.drift_explained_unique_payment_txid_replay).toBe(2);
     expect(decoded.partialCounts.drift_explained_unresolvable_stx_reply).toBe(3);
+    expect(decoded.partialCounts.drift_explained_orphan_recipient).toBe(7);
     expect(decoded.partialCounts.txidCounts).toBeInstanceOf(Set);
     expect(decoded.partialCounts.txidCounts.has("txid_a")).toBe(true);
     expect(decoded.partialCounts.txidCounts.has("txid_b")).toBe(true);
@@ -1894,6 +1914,7 @@ describe("cursor encode/decode roundtrip", () => {
         drift_explained_partial_cascade: 0,
         drift_explained_unique_payment_txid_replay: 0,
         drift_explained_unresolvable_stx_reply: 0,
+        drift_explained_orphan_recipient: 0,
         txidCounts: new Set<string>(),
       },
     };
@@ -1902,6 +1923,7 @@ describe("cursor encode/decode roundtrip", () => {
     expect(decoded.prefix).toBe("inbox:reply:");
     expect(decoded.kvCursor).toBeNull();
     expect(decoded.partialCounts.kv_count).toBe(1000);
+    expect(decoded.partialCounts.drift_explained_orphan_recipient).toBe(0);
     expect(decoded.partialCounts.txidCounts).toBeInstanceOf(Set);
     expect(decoded.partialCounts.txidCounts.size).toBe(0);
   });
@@ -1915,6 +1937,7 @@ describe("cursor encode/decode roundtrip", () => {
         drift_explained_partial_cascade: 0,
         drift_explained_unique_payment_txid_replay: 0,
         drift_explained_unresolvable_stx_reply: 0,
+        drift_explained_orphan_recipient: 0,
         txidCounts: new Set<string>(),
       },
     };
@@ -2193,6 +2216,7 @@ describe("paginated inbox reconciliation (Path A)", () => {
         drift_explained_partial_cascade: 0,
         drift_explained_unique_payment_txid_replay: 0,
         drift_explained_unresolvable_stx_reply: 0,
+        drift_explained_orphan_recipient: 0,
         txidCounts: new Set<string>(),
       },
     });
@@ -2282,5 +2306,239 @@ describe("paginated inbox reconciliation (Path A)", () => {
     expect(finalBody!.drift).toBe(1);
     expect(finalBody!.drift_explained).toBe(1);
     expect(finalBody!.explained_categories?.unique_payment_txid_replay).toBe(1);
+  });
+});
+
+// ── orphan_recipient explained category (issue #718) ─────────────────────
+//
+// Messages/replies whose to_btc_address is absent from BOTH the KV btc: set
+// (full + partial + invalid) AND D1 agents table. These are dead-letter messages
+// that can never be delivered via the inbox UI. Previously counted as unexplained
+// drift; now classified as orphan_recipient and subtracted from drift_unexplained.
+
+describe("orphan_recipient explained category", () => {
+  // Fixture: full agent for the registered recipient
+  const FULL_AGENT_2 = JSON.stringify({
+    btcAddress: "bc1qagent2",
+    stxAddress: "SP1AGENT2",
+    stxPublicKey: "03abcdef02",
+    btcPublicKey: "02abcdef02",
+    verifiedAt: "2026-01-02T00:00:00Z",
+  });
+
+  it("inbound message to a registered agent: no orphan_recipient increment", async () => {
+    // Message goes to bc1qagent1 which IS in fullAgents (D1 agents) → no orphan
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:message:msg_ok": JSON.stringify({
+        messageId: "msg_ok",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_ok",
+        sentAt: "2026-01-01T00:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM inbox_messages": { cnt: 1 },
+      },
+      allResults: { "SELECT btc_address FROM agents": [{ btc_address: "bc1qagent1" }] },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      drift: number;
+      drift_unexplained: number;
+      explained_categories: {
+        orphan_recipient?: number;
+        partial_cascade?: number;
+      };
+    };
+
+    expect(body.drift).toBe(0);
+    expect(body.drift_unexplained).toBe(0);
+    // Registered agent → no orphan
+    expect(body.explained_categories.orphan_recipient).toBe(0);
+    expect(body.explained_categories.partial_cascade).toBe(0);
+  });
+
+  it("inbound message to an orphan address (no KV record, no D1 row): increments orphan_recipient", async () => {
+    // Message to bc1qorphan9 which has no btc: KV entry and no D1 agents row.
+    // Should be classified as orphan_recipient, NOT partial_cascade.
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:message:msg_orphan": JSON.stringify({
+        messageId: "msg_orphan",
+        toBtcAddress: "bc1qorphan9",  // no btc: key, not in D1
+        paymentTxid: "txid_orphan",
+        sentAt: "2026-01-01T01:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM inbox_messages": { cnt: 0 },  // orphan message was FK-rejected from D1
+      },
+      allResults: { "SELECT btc_address FROM agents": [{ btc_address: "bc1qagent1" }] },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      kv_count: number;
+      d1_count: number;
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories: {
+        orphan_recipient?: number;
+        partial_cascade?: number;
+        unique_payment_txid_replay?: number;
+        unresolvable_stx_reply?: number;
+      };
+    };
+
+    expect(body.kv_count).toBe(1);
+    expect(body.d1_count).toBe(0);
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories.orphan_recipient).toBe(1);
+    expect(body.explained_categories.partial_cascade).toBe(0);
+  });
+
+  it("reply to an orphan BTC address: increments orphan_recipient", async () => {
+    // Reply whose toBtcAddress (bc1qorphan9) has no btc: KV entry → orphan_recipient.
+    // The reply field-path is also toBtcAddress per KV spec (OutboxReply uses that field name).
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:reply:msg_reply_orphan": JSON.stringify({
+        messageId: "msg_reply_orphan",
+        toBtcAddress: "bc1qorphan9",  // BTC-shaped but orphan (no btc: key)
+        reply: "hello?",
+        repliedAt: "2026-01-01T04:00:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM inbox_messages": { cnt: 0 },
+      },
+      allResults: { "SELECT btc_address FROM agents": [{ btc_address: "bc1qagent1" }] },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildPostRequest({ table: "inbox_messages", sampleSize: "0" }));
+    expect(resp.status).toBe(200);
+
+    const body = await resp.json() as {
+      drift: number;
+      drift_explained: number;
+      drift_unexplained: number;
+      explained_categories: {
+        orphan_recipient?: number;
+        partial_cascade?: number;
+      };
+    };
+
+    expect(body.drift).toBe(1);
+    expect(body.drift_explained).toBe(1);
+    expect(body.drift_unexplained).toBe(0);
+    expect(body.explained_categories.orphan_recipient).toBe(1);
+    expect(body.explained_categories.partial_cascade).toBe(0);
+  });
+
+  it("cross-page orphan_recipient accumulation: orphan count sums correctly across cursor pages", async () => {
+    // 3 messages: msg_a and msg_b go to a registered agent (no drift),
+    // msg_c goes to an orphan address. With maxKeysPerCall=1, messages span 3 pages.
+    // The orphan_recipient count of 1 must appear in the final response.
+    const kv = buildKvMock({
+      "btc:bc1qagent1": FULL_AGENT,
+      "inbox:message:msg_a": JSON.stringify({
+        messageId: "msg_a",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_a",
+        sentAt: "2026-01-01T00:00:00Z",
+      }),
+      "inbox:message:msg_b": JSON.stringify({
+        messageId: "msg_b",
+        toBtcAddress: "bc1qagent1",
+        paymentTxid: "txid_b",
+        sentAt: "2026-01-01T00:01:00Z",
+      }),
+      "inbox:message:msg_c": JSON.stringify({
+        messageId: "msg_c",
+        toBtcAddress: "bc1qorphan9",  // orphan: no btc: key, not in D1
+        paymentTxid: "txid_c",
+        sentAt: "2026-01-01T00:02:00Z",
+      }),
+    });
+
+    const db = buildD1Mock({
+      firstResults: {
+        "FROM agents": { cnt: 1 },
+        "FROM inbox_messages": { cnt: 2 },  // only 2 (msg_a + msg_b) made it to D1
+      },
+      allResults: { "SELECT btc_address FROM agents": [{ btc_address: "bc1qagent1" }] },
+      defaultFirst: null,
+    });
+
+    mockContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    // Drive cursor loop: maxKeysPerCall=1 forces 3 pages minimum
+    type OrphanLoopBody = {
+      partial: boolean;
+      cursor?: string | null;
+      kv_count?: number;
+      d1_count?: number;
+      drift?: number;
+      drift_explained?: number;
+      drift_unexplained?: number;
+      explained_categories?: {
+        orphan_recipient?: number;
+        partial_cascade?: number;
+      };
+    };
+
+    let cursor: string | null = null;
+    let finalBody: OrphanLoopBody | null = null;
+
+    do {
+      const params: Record<string, string> = { table: "inbox_messages", maxKeysPerCall: "1" };
+      if (cursor) params.cursor = cursor;
+      const resp = await POST(buildPostRequest(params));
+      expect(resp.status).toBe(200);
+      const body = await resp.json() as OrphanLoopBody;
+      if (body.partial === false) {
+        finalBody = body;
+        cursor = null;
+      } else {
+        cursor = body.cursor as string;
+      }
+    } while (cursor !== null);
+
+    expect(finalBody).not.toBeNull();
+    expect(finalBody!.kv_count).toBe(3);
+    expect(finalBody!.d1_count).toBe(2);
+    expect(finalBody!.drift).toBe(1);
+    expect(finalBody!.drift_explained).toBe(1);
+    expect(finalBody!.drift_unexplained).toBe(0);
+    // The orphan message (msg_c) is now explained as orphan_recipient
+    expect(finalBody!.explained_categories?.orphan_recipient).toBe(1);
+    expect(finalBody!.explained_categories?.partial_cascade).toBe(0);
   });
 });

--- a/app/api/admin/reconcile/route.ts
+++ b/app/api/admin/reconcile/route.ts
@@ -39,6 +39,7 @@ interface InboxPartialResponse {
     drift_explained_partial_cascade: number;
     drift_explained_unique_payment_txid_replay: number;
     drift_explained_unresolvable_stx_reply: number;
+    drift_explained_orphan_recipient: number;
   };
 }
 
@@ -564,16 +565,33 @@ async function reconcileInboxMessages(
     .first<{ cnt: number }>();
   const d1_count = d1Row?.cnt ?? 0;
 
-  // Derive explained categories from the single-pass records
+  // Derive explained categories from the single-pass records.
+  // orphan_recipient: messages to addresses absent from both KV btc: set and D1 agents.
+  // Detected lazily per address with an in-scan cache to avoid O(n) KV reads for repeated recipients.
   let partial_cascade = 0;
   let unresolvable_stx_reply = 0;
+  let orphan_recipient = 0;
   const txidCounts = new Map<string, number>();
+  // Cache for `btc:{address}` existence: true = KV record exists (partial_cascade), false = orphan
+  const btcExistenceCache = new Map<string, boolean>();
 
   for (const rec of allRecords) {
     if (rec.type === "message") {
       const { toBtcAddress, paymentTxid } = rec;
       if (toBtcAddress && !fullAgents.has(toBtcAddress)) {
-        partial_cascade++;
+        // Recipient is not a full agent — check if they have any btc: KV record (partial or invalid)
+        let existsInKv = btcExistenceCache.get(toBtcAddress);
+        if (existsInKv === undefined) {
+          existsInKv = (await kv.get(`btc:${toBtcAddress}`)) !== null;
+          btcExistenceCache.set(toBtcAddress, existsInKv);
+        }
+        if (existsInKv) {
+          // Has a KV record (partial or otherwise) — partial cascade explains the absence
+          partial_cascade++;
+        } else {
+          // No KV record at all — dead-letter to an orphan address
+          orphan_recipient++;
+        }
       }
       // Only count string txids — replies have payment_txid=null/undefined per RFC.
       // Use typeof guard (not just truthiness) to explicitly exclude null values
@@ -597,8 +615,17 @@ async function reconcileInboxMessages(
               // stx: record exists but has no btcAddress field — resolver returned no address
               unresolvable_stx_reply++;
             } else if (!fullAgents.has(resolvedBtc)) {
-              // resolved to a BTC address, but that agent is not in fullAgents
-              partial_cascade++;
+              // resolved to a BTC address — check if it exists in KV at all
+              let existsInKv = btcExistenceCache.get(resolvedBtc);
+              if (existsInKv === undefined) {
+                existsInKv = (await kv.get(`btc:${resolvedBtc}`)) !== null;
+                btcExistenceCache.set(resolvedBtc, existsInKv);
+              }
+              if (existsInKv) {
+                partial_cascade++;
+              } else {
+                orphan_recipient++;
+              }
             }
           } catch {
             unresolvable_stx_reply++;
@@ -607,7 +634,16 @@ async function reconcileInboxMessages(
       } else if (replyTo && (replyTo.startsWith("bc1q") || replyTo.startsWith("bc1p"))) {
         // BTC address shape — use replyTo directly as to_btc_address
         if (!fullAgents.has(replyTo)) {
-          partial_cascade++;
+          let existsInKv = btcExistenceCache.get(replyTo);
+          if (existsInKv === undefined) {
+            existsInKv = (await kv.get(`btc:${replyTo}`)) !== null;
+            btcExistenceCache.set(replyTo, existsInKv);
+          }
+          if (existsInKv) {
+            partial_cascade++;
+          } else {
+            orphan_recipient++;
+          }
         }
       }
     }
@@ -621,11 +657,12 @@ async function reconcileInboxMessages(
     if (count > 1) unique_payment_txid_replay += count - 1;
   }
 
-  const drift_explained = partial_cascade + unique_payment_txid_replay + unresolvable_stx_reply;
+  const drift_explained = partial_cascade + unique_payment_txid_replay + unresolvable_stx_reply + orphan_recipient;
   const breakdown = computeDrift(kv_total, 0, d1_count, drift_explained, {
     partial_cascade,
     unique_payment_txid_replay,
     unresolvable_stx_reply,
+    orphan_recipient,
   });
 
   // Field-level spot-check on inbound messages only; skipped when sampleSize=0
@@ -715,12 +752,15 @@ async function reconcileInboxMessages(
  *   - 1  kv.list (the page fetch)
  *   - ~500  kv.get (page values; batch-parallel, count as ~500 subrequests)
  *   - ≤50  stx: kv.get (cached within invocation via stxResolutionCache)
+ *   - ≤N  btc: kv.get (unique orphan-candidate addresses; cached within invocation via btcExistenceCache)
  *   - 1  SELECT btc_address FROM agents (first call only, passed in)
  *   - 1  SELECT COUNT(*) FROM inbox_messages (final page only)
- *   Total: ~552 first call, ~551 subsequent (well under 1000 cap).
+ *   Total: ~552+ first call (N extra for orphan checks; in practice N < unique orphan addresses per page).
+ *   Orphan addresses tend to be repeated senders (same orphan receives 100s of messages), so
+ *   btcExistenceCache keeps N low (typically 1–10 unique orphans per page vs 500 messages).
  *
  * With maxKeys=1000:
- *   Total: ~1052 first call, ~1051 subsequent (tight; use 500 if hitting cap).
+ *   Total: ~1052+ first call (same orphan-check caveat; use 500 if hitting cap).
  */
 async function reconcileInboxMessagesPaginated(
   kv: KVNamespace,
@@ -739,8 +779,13 @@ async function reconcileInboxMessagesPaginated(
     drift_explained_partial_cascade: 0,
     drift_explained_unique_payment_txid_replay: 0,
     drift_explained_unresolvable_stx_reply: 0,
+    drift_explained_orphan_recipient: 0,
     txidCounts: new Set<string>(),
   };
+
+  // Per-invocation cache for btc: KV existence checks (orphan_recipient detection).
+  // Not persisted in cursor — lookups are deterministic within a reconcile run.
+  const btcExistenceCache = new Map<string, boolean>();
 
   let currentPrefix: "inbox:message:" | "inbox:reply:" = cursorState?.prefix ?? "inbox:message:";
   let kvCursor: string | null = cursorState?.kvCursor ?? null;
@@ -788,7 +833,19 @@ async function reconcileInboxMessagesPaginated(
           const paymentTxid = parsed.paymentTxid as unknown;
 
           if (toBtcAddress && !fullAgents.has(toBtcAddress)) {
-            accumulated.drift_explained_partial_cascade++;
+            // Recipient is not a full agent — check if they have any btc: KV record
+            let existsInKv = btcExistenceCache.get(toBtcAddress);
+            if (existsInKv === undefined) {
+              existsInKv = (await kv.get(`btc:${toBtcAddress}`)) !== null;
+              btcExistenceCache.set(toBtcAddress, existsInKv);
+            }
+            if (existsInKv) {
+              // Has a KV record (partial or otherwise) — partial cascade explains the absence
+              accumulated.drift_explained_partial_cascade++;
+            } else {
+              // No KV record at all — dead-letter to an orphan address
+              accumulated.drift_explained_orphan_recipient++;
+            }
           }
 
           if (typeof paymentTxid === "string" && paymentTxid.length > 0) {
@@ -821,11 +878,30 @@ async function reconcileInboxMessagesPaginated(
             if (resolvedBtc === null) {
               accumulated.drift_explained_unresolvable_stx_reply++;
             } else if (!fullAgents.has(resolvedBtc)) {
-              accumulated.drift_explained_partial_cascade++;
+              // Resolved to a BTC address — check if it exists in KV at all
+              let existsInKv = btcExistenceCache.get(resolvedBtc);
+              if (existsInKv === undefined) {
+                existsInKv = (await kv.get(`btc:${resolvedBtc}`)) !== null;
+                btcExistenceCache.set(resolvedBtc, existsInKv);
+              }
+              if (existsInKv) {
+                accumulated.drift_explained_partial_cascade++;
+              } else {
+                accumulated.drift_explained_orphan_recipient++;
+              }
             }
           } else if (replyTo && (replyTo.startsWith("bc1q") || replyTo.startsWith("bc1p"))) {
             if (!fullAgents.has(replyTo)) {
-              accumulated.drift_explained_partial_cascade++;
+              let existsInKv = btcExistenceCache.get(replyTo);
+              if (existsInKv === undefined) {
+                existsInKv = (await kv.get(`btc:${replyTo}`)) !== null;
+                btcExistenceCache.set(replyTo, existsInKv);
+              }
+              if (existsInKv) {
+                accumulated.drift_explained_partial_cascade++;
+              } else {
+                accumulated.drift_explained_orphan_recipient++;
+              }
             }
           }
         }
@@ -868,6 +944,7 @@ async function reconcileInboxMessagesPaginated(
         drift_explained_unique_payment_txid_replay:
           accumulated.drift_explained_unique_payment_txid_replay,
         drift_explained_unresolvable_stx_reply: accumulated.drift_explained_unresolvable_stx_reply,
+        drift_explained_orphan_recipient: accumulated.drift_explained_orphan_recipient,
       },
     };
   }
@@ -881,12 +958,14 @@ async function reconcileInboxMessagesPaginated(
   const partial_cascade = accumulated.drift_explained_partial_cascade;
   const unique_payment_txid_replay = accumulated.drift_explained_unique_payment_txid_replay;
   const unresolvable_stx_reply = accumulated.drift_explained_unresolvable_stx_reply;
-  const drift_explained = partial_cascade + unique_payment_txid_replay + unresolvable_stx_reply;
+  const orphan_recipient = accumulated.drift_explained_orphan_recipient;
+  const drift_explained = partial_cascade + unique_payment_txid_replay + unresolvable_stx_reply + orphan_recipient;
 
   const breakdown = computeDrift(accumulated.kv_count, 0, d1_count, drift_explained, {
     partial_cascade,
     unique_payment_txid_replay,
     unresolvable_stx_reply,
+    orphan_recipient,
   });
 
   return {
@@ -1151,8 +1230,8 @@ while :; do
   cursor=$(echo "$resp" | jq -r '.cursor // empty')
   [ -z "$cursor" ] && break
 done`,
-      partialResponse: "{ table, partial: true, cursor, partial_counts: { kv_count, drift_explained_* } }",
-      finalResponse: "{ table, partial: false, cursor: null, kv_count, d1_count, drift, drift_explained, drift_unexplained, explained_categories }",
+      partialResponse: "{ table, partial: true, cursor, partial_counts: { kv_count, drift_explained_partial_cascade, drift_explained_unique_payment_txid_replay, drift_explained_unresolvable_stx_reply, drift_explained_orphan_recipient } }",
+      finalResponse: "{ table, partial: false, cursor: null, kv_count, d1_count, drift, drift_explained, drift_unexplained, explained_categories: { partial_cascade, unique_payment_txid_replay, unresolvable_stx_reply, orphan_recipient } }",
       precondition:
         "agents.drift_unexplained must be 0 before calling inbox_messages (first page only). The pre-condition runs on the first call (no cursor) and returns 409 if not met. Cursor continuation calls skip the check — if it passed on page 1, it holds for subsequent pages (agents table changes are rare at reconcile-run timescales). If the agents table changes mid-reconcile-run, the caller would still complete the run but cascade-detection results may be stale; recommend re-running the full loop.",
       subrequestBudget:
@@ -1182,6 +1261,12 @@ done`,
       step3: "POST ?table=claims and POST ?table=vouches separately — single calls each (small datasets, no cap risk)",
       step4: "Verify drift_unexplained == 0 for all tables before Phase 2 begins",
       step5: "Check acceptance_tests.passed == true for unreadCount drift",
+      inboxExplainedCategories: {
+        partial_cascade: "Messages/replies whose recipient exists in KV (as partial or invalid agent) but not in D1 — excluded by FK cascade",
+        unique_payment_txid_replay: "Inbound messages sharing a payment txid with a prior message — duplicate payment recovery attempts",
+        unresolvable_stx_reply: "Replies whose STX-address replyTo cannot be resolved to a btcAddress via kv stx: lookup",
+        orphan_recipient: "Messages/replies to addresses absent from both KV btc: set AND D1 agents — dead-letter mail, never reachable via inbox UI",
+      },
     },
   });
 }

--- a/lib/d1/reconcile-cursor.ts
+++ b/lib/d1/reconcile-cursor.ts
@@ -15,6 +15,8 @@ export interface InboxPartialCounts {
   drift_explained_partial_cascade: number;
   drift_explained_unique_payment_txid_replay: number;
   drift_explained_unresolvable_stx_reply: number;
+  /** Messages to addresses absent from both KV btc: set and D1 agents (dead-letter). */
+  drift_explained_orphan_recipient: number;
   /** Set of seen txids, carried between pages to detect cross-page duplicates */
   txidCounts: Set<string>;
 }
@@ -77,6 +79,7 @@ export function decodeCursor(encoded: string): InboxCursorState {
     typeof pc.drift_explained_partial_cascade !== "number" ||
     typeof pc.drift_explained_unique_payment_txid_replay !== "number" ||
     typeof pc.drift_explained_unresolvable_stx_reply !== "number" ||
+    typeof pc.drift_explained_orphan_recipient !== "number" ||
     !Array.isArray(pc.txidCounts) ||
     !(pc.txidCounts as unknown[]).every((v) => typeof v === "string")
   ) {

--- a/lib/d1/reconcile.ts
+++ b/lib/d1/reconcile.ts
@@ -40,6 +40,7 @@ export interface DriftBreakdown {
     partial_cascade?: number;
     unique_payment_txid_replay?: number;
     unresolvable_stx_reply?: number;
+    orphan_recipient?: number;
   };
 }
 
@@ -140,12 +141,14 @@ export interface TableReconcileResult {
    * Per-table breakdown of explained categories.
    * Always present (may be empty object {}). For agents this is {}; for
    * claims/vouches it carries partial_cascade; for inbox it also carries
-   * unique_payment_txid_replay and unresolvable_stx_reply.
+   * unique_payment_txid_replay, unresolvable_stx_reply, and orphan_recipient.
    */
   explained_categories: {
     partial_cascade?: number;
     unique_payment_txid_replay?: number;
     unresolvable_stx_reply?: number;
+    /** Messages to addresses with no KV btc: record AND no D1 agents row (dead-letter). */
+    orphan_recipient?: number;
   };
   sample_size: number;
   field_diffs: FieldDiff[];


### PR DESCRIPTION
## Summary

- Adds `orphan_recipient` as a new explained category in the inbox reconcile route (both `table=all` non-paginated path and the cursor-paginated path)
- Messages/replies whose `to_btc_address` has no KV `btc:` record AND no D1 `agents` row are classified as `orphan_recipient` instead of counting as `drift_unexplained`
- The 2517 `drift_unexplained` entries observed post-PR-A (#713/#714/#715) backfill are dead-letter messages to unregistered addresses — this PR correctly explains them, bringing `drift_unexplained ≈ 0`

## Background

After the BIP-322 backfill (#713/#714/#715) expanded D1 agents from 243 → 951, inbox reconcile reported `drift_unexplained=2517`. Investigation (finding artifact: `phases/05-invalid-agents-cleanup/2026-05-10T1600Z-orphan-recipient-finding.md`) showed these are messages whose `to_btc_address` has no KV `btc:` entry at all — dead-letter mail to addresses that never registered. Example: `bc1q9k70h3cwr3wxz2337wps29fyhhf8pamemkq0k2` received 1407+ messages but has no agent record in KV or D1.

The D1 schema FK (`to_btc_address → agents.btc_address`) correctly rejects these on INSERT. The reconcile route previously conflated two cases under `partial_cascade`:
1. Recipients with a KV `btc:` record (partial agents, correctly excluded from D1 by FK design)
2. Recipients with no KV record whatsoever (orphan addresses — dead-letter mail)

## Implementation

**Detection:** For each inbox message/reply whose `to_btc_address` is not in `fullAgents` (D1 agents), do a `kv.get("btc:{address}")` lookup. If the key doesn't exist → `orphan_recipient`. If it exists (partial/invalid agent) → `partial_cascade`.

**Cursor safety:** Per the #706 lesson on O(n) cursor growth, orphan addresses are NOT stored in the cursor. Instead, a per-invocation `btcExistenceCache` (similar to `stxResolutionCache`) deduplicates KV reads within each page call. Orphan addresses tend to be repeated recipients (same orphan gets 1000s of messages), so the cache keeps lookups to ~1–10 unique addresses per page.

**Subrequest impact:** Minimal. The cache prevents repeat KV reads for the same orphan address. Most pages process messages to 1–3 unique orphan addresses before seeing duplicates.

## Files Changed

- `lib/d1/reconcile.ts` — adds `orphan_recipient?: number` to `explained_categories` in both `DriftBreakdown` and `TableReconcileResult`
- `lib/d1/reconcile-cursor.ts` — adds `drift_explained_orphan_recipient: number` to `InboxPartialCounts` with cursor encode/decode validation
- `app/api/admin/reconcile/route.ts` — implements detection in both inbox reconcile paths, updates GET docs
- `app/api/admin/reconcile/__tests__/reconcile.test.ts` — 4 new orphan tests, updated 3 existing tests with correct partial-agent fixtures

## Test plan

- [ ] All 824 reconcile tests pass (`npm test`)
- [ ] TypeScript clean (no new errors introduced)
- [ ] New test suite `orphan_recipient explained category` covers: registered agent (no increment), inbound orphan, reply orphan, cross-page cursor accumulation
- [ ] Existing `Bug A` and `Bug C` tests updated to use actual partial-agent KV fixtures (correct distinction from orphan)
- [ ] Production reconcile post-merge: `drift_unexplained ≈ 0`, `explained_categories.orphan_recipient ≈ 2500`

## References

- Closes #718
- Phase 2.5 Step 3 inbox read flip gate: this PR clears the drift_unexplained gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)