### PR TITLE
feat(d1): dual-write for updateMessage + backfill read_at/replied_at

### DIFF
--- a/app/api/admin/backfill-message-state/__tests__/route.test.ts
+++ b/app/api/admin/backfill-message-state/__tests__/route.test.ts
@@ -1,0 +1,460 @@
+/**
+ * Tests for POST /api/admin/backfill-message-state
+ *
+ * Verifies:
+ *  - Admin key required (401 without X-Admin-Key)
+ *  - Scans KV inbox:message: prefix, calls D1 UPDATE with COALESCE
+ *  - Counts: updated_read_at, updated_replied_at, skipped_already_set,
+ *    skipped_no_timestamps, not_in_d1, failed
+ *  - Idempotency: running twice on the same records does not double-update
+ *  - Cursor pagination: respects cursor, returns next cursor when page not complete
+ *  - Orphan handling: KV record with no D1 row counts as not_in_d1, no error
+ *  - 503 when DB binding is absent
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- types ------------------------------------------------------------------
+
+interface BackfillMessageStateResponse {
+  cursor: string | null;
+  batchSize: number;
+  scanned: number;
+  updated_read_at: number;
+  updated_replied_at: number;
+  skipped_already_set: number;
+  skipped_no_timestamps: number;
+  not_in_d1: number;
+  failed: { key: string; reason: string }[];
+  duration_ms: number;
+  // self-doc fields (GET response)
+  endpoint?: string;
+  method?: string;
+  error?: string;
+}
+
+// ---- module mocks -----------------------------------------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  requireAdmin: vi.fn().mockResolvedValue(null), // null = auth passed
+}));
+
+// ---- imports after mocks ---------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import { POST, GET } from "../route";
+
+// ---- helpers ----------------------------------------------------------------
+
+const ADMIN_KEY = "test-admin-key";
+
+function buildRequest(
+  body: Record<string, unknown> = {},
+  withAdminKey = true
+): NextRequest {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (withAdminKey) headers["X-Admin-Key"] = ADMIN_KEY;
+  return new NextRequest(
+    "https://aibtc.com/api/admin/backfill-message-state",
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify(body),
+    }
+  );
+}
+
+/** Build a D1 PreparedStatement mock. */
+function createPreparedStatement({
+  firstResult = null,
+  runResult = { meta: { changes: 1 } },
+}: {
+  firstResult?: unknown;
+  runResult?: { meta: { changes: number } };
+} = {}) {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue(runResult),
+    first: vi.fn().mockResolvedValue(firstResult),
+    all: vi.fn(),
+    raw: vi.fn(),
+  };
+  return stmt;
+}
+
+/** Build a mock D1 database where prepare() returns the given stmt. */
+function createMockDB(stmt = createPreparedStatement()) {
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+/** Build KV mock with controllable list + get behavior. */
+function createMockKV(
+  keys: string[],
+  data: Record<string, string>,
+  cursor: string | null = null
+) {
+  const kv = {
+    list: vi.fn().mockResolvedValue({
+      keys: keys.map((name) => ({ name })),
+      list_complete: cursor === null,
+      cursor: cursor ?? undefined,
+    }),
+    get: vi.fn((key: string) => Promise.resolve(data[key] ?? null)),
+    put: vi.fn(),
+    delete: vi.fn(),
+    getWithMetadata: vi.fn(),
+  };
+  return kv as unknown as KVNamespace;
+}
+
+function mockCloudflareContext(env: Partial<CloudflareEnv>) {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env,
+    ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
+  });
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const MSG_ID_READ = "msg_read_001";
+const MSG_ID_REPLIED = "msg_replied_001";
+const MSG_ID_BOTH = "msg_both_001";
+const MSG_ID_UNREAD_UNREPLIED = "msg_none_001";
+
+function makeKvMessage(
+  messageId: string,
+  readAt: string | null = null,
+  repliedAt: string | null = null
+): string {
+  return JSON.stringify({
+    messageId,
+    fromAddress: "SP_SENDER",
+    toBtcAddress: "bc1q_recipient",
+    toStxAddress: "SP_RECIPIENT",
+    content: "test message",
+    paymentSatoshis: 100,
+    sentAt: "2026-05-01T00:00:00.000Z",
+    authenticated: false,
+    ...(readAt && { readAt }),
+    ...(repliedAt && { repliedAt }),
+  });
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("GET /api/admin/backfill-message-state", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 401 when admin key is missing", async () => {
+    (requireAdmin as Mock).mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: "Missing X-Admin-Key header" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+    const req = new NextRequest(
+      "https://aibtc.com/api/admin/backfill-message-state",
+      { method: "GET" }
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(401);
+  });
+
+  it("returns self-doc JSON when admin key is valid", async () => {
+    mockCloudflareContext({});
+    const req = new NextRequest(
+      "https://aibtc.com/api/admin/backfill-message-state",
+      { method: "GET", headers: { "X-Admin-Key": ADMIN_KEY } }
+    );
+    const resp = await GET(req);
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body).toHaveProperty("endpoint");
+    expect(body).toHaveProperty("method", "POST");
+  });
+});
+
+describe("POST /api/admin/backfill-message-state", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns 503 when DB binding is absent", async () => {
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV([], {}),
+      // DB intentionally absent
+    });
+    const req = buildRequest();
+    const resp = await POST(req);
+    expect(resp.status).toBe(503);
+  });
+
+  it("counts updated_read_at for KV record with readAt set and D1 has NULL read_at", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_READ}`],
+      {
+        [`inbox:message:${MSG_ID_READ}`]: makeKvMessage(
+          MSG_ID_READ,
+          "2026-05-10T12:00:00.000Z",
+          null
+        ),
+      }
+    );
+
+    // D1 SELECT returns row with read_at = NULL
+    const selectStmt = createPreparedStatement({
+      firstResult: { read_at: null, replied_at: null },
+    });
+    const updateStmt = createPreparedStatement();
+    const db = {
+      prepare: vi
+        .fn()
+        .mockReturnValueOnce(selectStmt) // first call: SELECT
+        .mockReturnValueOnce(updateStmt), // second call: UPDATE
+      batch: vi.fn(),
+      dump: vi.fn(),
+      exec: vi.fn(),
+    } as unknown as D1Database;
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    expect(resp.status).toBe(200);
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.scanned).toBe(1);
+    expect(body.updated_read_at).toBe(1);
+    expect(body.updated_replied_at).toBe(0);
+  });
+
+  it("counts updated_replied_at for KV record with repliedAt set and D1 has NULL replied_at", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_REPLIED}`],
+      {
+        [`inbox:message:${MSG_ID_REPLIED}`]: makeKvMessage(
+          MSG_ID_REPLIED,
+          null,
+          "2026-05-10T13:00:00.000Z"
+        ),
+      }
+    );
+
+    const selectStmt = createPreparedStatement({
+      firstResult: { read_at: null, replied_at: null },
+    });
+    const updateStmt = createPreparedStatement();
+    const db = {
+      prepare: vi
+        .fn()
+        .mockReturnValueOnce(selectStmt)
+        .mockReturnValueOnce(updateStmt),
+      batch: vi.fn(),
+      dump: vi.fn(),
+      exec: vi.fn(),
+    } as unknown as D1Database;
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.updated_replied_at).toBe(1);
+    expect(body.updated_read_at).toBe(0);
+  });
+
+  it("counts skipped_already_set when D1 already has both read_at and replied_at set", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_BOTH}`],
+      {
+        [`inbox:message:${MSG_ID_BOTH}`]: makeKvMessage(
+          MSG_ID_BOTH,
+          "2026-05-10T12:00:00.000Z",
+          "2026-05-10T13:00:00.000Z"
+        ),
+      }
+    );
+
+    // D1 already has both values — nothing to update
+    const selectStmt = createPreparedStatement({
+      firstResult: {
+        read_at: "2026-05-10T12:00:00.000Z",
+        replied_at: "2026-05-10T13:00:00.000Z",
+      },
+    });
+    const db = createMockDB(selectStmt);
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.skipped_already_set).toBe(1);
+    expect(body.updated_read_at).toBe(0);
+    expect(body.updated_replied_at).toBe(0);
+  });
+
+  it("counts skipped_no_timestamps for KV records with neither readAt nor repliedAt", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_UNREAD_UNREPLIED}`],
+      {
+        [`inbox:message:${MSG_ID_UNREAD_UNREPLIED}`]: makeKvMessage(
+          MSG_ID_UNREAD_UNREPLIED,
+          null,
+          null
+        ),
+      }
+    );
+
+    const db = createMockDB();
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.skipped_no_timestamps).toBe(1);
+    expect(body.scanned).toBe(1);
+    // D1 should not have been queried — no timestamps means nothing to do
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  it("counts not_in_d1 for orphan-recipient messages with no D1 row", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_READ}`],
+      {
+        [`inbox:message:${MSG_ID_READ}`]: makeKvMessage(
+          MSG_ID_READ,
+          "2026-05-10T12:00:00.000Z",
+          null
+        ),
+      }
+    );
+
+    // D1 SELECT returns null — no row exists (orphan-recipient)
+    const selectStmt = createPreparedStatement({ firstResult: null });
+    const db = createMockDB(selectStmt);
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.not_in_d1).toBe(1);
+    expect(body.updated_read_at).toBe(0);
+    // Verify UPDATE was NOT called — we return early for orphans
+    // prepare() was called once (for SELECT), not twice (SELECT + UPDATE)
+    expect(db.prepare).toHaveBeenCalledTimes(1);
+  });
+
+  it("is idempotent: running twice on the same data does not double-update", async () => {
+    // Simulate second run: D1 now has read_at set (from first run)
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_READ}`],
+      {
+        [`inbox:message:${MSG_ID_READ}`]: makeKvMessage(
+          MSG_ID_READ,
+          "2026-05-10T12:00:00.000Z",
+          null
+        ),
+      }
+    );
+
+    // Second run: D1 already has read_at set
+    const selectStmt = createPreparedStatement({
+      firstResult: {
+        read_at: "2026-05-10T12:00:00.000Z",
+        replied_at: null,
+      },
+    });
+    const db = createMockDB(selectStmt);
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    // Both read_at already set → skipped_already_set (because needsReadAt is false,
+    // needsRepliedAt is false since repliedAt is null in KV too)
+    // Actually: repliedAt is null in KV → skipped_no_timestamps? No — readAt IS set in KV.
+    // Logic: needsReadAt = kvReadAt(set) && d1.read_at(set) → false
+    //        needsRepliedAt = kvRepliedAt(null) && d1.replied_at(null) → false (kvRepliedAt is null)
+    // → skipped_already_set
+    expect(body.skipped_already_set).toBe(1);
+    expect(body.updated_read_at).toBe(0);
+    expect(body.updated_replied_at).toBe(0);
+  });
+
+  it("respects cursor pagination — passes cursor to KV list", async () => {
+    const kv = createMockKV([], {});
+    const db = createMockDB();
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest({ cursor: "cursor_abc123" }));
+    expect(resp.status).toBe(200);
+
+    // Verify KV was called with the cursor
+    const listCall = (kv.list as Mock).mock.calls[0][0];
+    expect(listCall.cursor).toBe("cursor_abc123");
+  });
+
+  it("returns next cursor when KV page is not complete", async () => {
+    const kv = createMockKV([], {}, "next_cursor_xyz");
+    const db = createMockDB();
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.cursor).toBe("next_cursor_xyz");
+  });
+
+  it("returns null cursor when KV page is complete", async () => {
+    const kv = createMockKV([], {}, null);
+    const db = createMockDB();
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.cursor).toBeNull();
+  });
+
+  it("counts failed when D1 SELECT throws", async () => {
+    const kv = createMockKV(
+      [`inbox:message:${MSG_ID_READ}`],
+      {
+        [`inbox:message:${MSG_ID_READ}`]: makeKvMessage(
+          MSG_ID_READ,
+          "2026-05-10T12:00:00.000Z",
+          null
+        ),
+      }
+    );
+
+    const selectStmt = createPreparedStatement();
+    selectStmt.first.mockRejectedValue(new Error("D1 timeout"));
+    const db = createMockDB(selectStmt);
+
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(body.failed).toHaveLength(1);
+    expect(body.failed[0].key).toBe(`inbox:message:${MSG_ID_READ}`);
+    expect(body.failed[0].reason).toContain("D1 SELECT failed");
+    expect(body.updated_read_at).toBe(0);
+  });
+
+  it("includes duration_ms in response", async () => {
+    const kv = createMockKV([], {});
+    const db = createMockDB();
+    mockCloudflareContext({ VERIFIED_AGENTS: kv, DB: db });
+
+    const resp = await POST(buildRequest());
+    const body = await resp.json() as BackfillMessageStateResponse;
+    expect(typeof body.duration_ms).toBe("number");
+    expect(body.duration_ms).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/app/api/admin/backfill-message-state/route.ts
+++ b/app/api/admin/backfill-message-state/route.ts
@@ -1,0 +1,206 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import type { InboxMessage } from "@/lib/inbox/types";
+
+/**
+ * GET /api/admin/backfill-message-state — Self-documenting endpoint.
+ */
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  return NextResponse.json({
+    endpoint: "/api/admin/backfill-message-state",
+    description:
+      "Backfill read_at and replied_at columns for existing D1 inbox_messages rows. " +
+      "Iterates KV inbox:message: prefix and, for each record that has readAt and/or repliedAt set, " +
+      "UPDATEs the D1 row using COALESCE (only sets if D1 currently has NULL). " +
+      "Safe to run multiple times — idempotent by design.",
+    method: "POST",
+    headers: { "X-Admin-Key": "required" },
+    parameters: {
+      cursor: "string | null — resume from a previous run cursor (optional)",
+      batchSize: "number — KV keys per call (default 100, max 500)",
+    },
+    counters: {
+      scanned: "Total KV inbox:message: keys examined",
+      updated_read_at: "D1 rows updated with read_at (was NULL in D1, set in KV)",
+      updated_replied_at: "D1 rows updated with replied_at (was NULL in D1, set in KV)",
+      skipped_already_set: "KV records where D1 already had all the non-NULL fields",
+      skipped_no_timestamps: "KV records with no readAt and no repliedAt (nothing to backfill)",
+      not_in_d1: "KV records with no matching D1 row (orphan-recipients, expected ~600)",
+      failed: "Records that raised an error during backfill",
+    },
+  });
+}
+
+// ── Types ──────────────────────────────────────────────────────────────────
+
+interface BackfillMessageStateResult {
+  cursor: string | null;
+  batchSize: number;
+  scanned: number;
+  updated_read_at: number;
+  updated_replied_at: number;
+  skipped_already_set: number;
+  skipped_no_timestamps: number;
+  not_in_d1: number;
+  failed: { key: string; reason: string }[];
+  duration_ms: number;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function parseBatchSize(raw: string | null): number {
+  if (!raw) return 100;
+  const n = parseInt(raw, 10);
+  if (!Number.isFinite(n)) return 100;
+  return Math.max(10, Math.min(500, n));
+}
+
+/**
+ * POST /api/admin/backfill-message-state
+ *
+ * Cursor-paginated backfill of read_at / replied_at for existing D1 inbox_messages
+ * rows. Uses COALESCE to avoid overwriting values that already exist in D1.
+ *
+ * Safe to run multiple times — COALESCE makes it idempotent. Loop externally
+ * until the returned cursor is null.
+ */
+export async function POST(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  const start = Date.now();
+  const { env } = await getCloudflareContext();
+  const kv = env.VERIFIED_AGENTS as KVNamespace;
+  const db = env.DB as D1Database | undefined;
+
+  if (!db) {
+    return NextResponse.json(
+      { error: "D1 database binding (DB) is not configured" },
+      { status: 503 }
+    );
+  }
+
+  // Parse body
+  let cursor: string | null = null;
+  let batchSize = 100;
+  try {
+    const body = (await request.json()) as {
+      cursor?: string | null;
+      batchSize?: number;
+    };
+    cursor = body?.cursor ?? null;
+    batchSize = parseBatchSize(String(body?.batchSize ?? ""));
+  } catch {
+    // no body / invalid JSON — use defaults
+  }
+
+  const result: BackfillMessageStateResult = {
+    cursor: null,
+    batchSize,
+    scanned: 0,
+    updated_read_at: 0,
+    updated_replied_at: 0,
+    skipped_already_set: 0,
+    skipped_no_timestamps: 0,
+    not_in_d1: 0,
+    failed: [],
+    duration_ms: 0,
+  };
+
+  // Scan KV inbox:message: prefix (cursor-paginated)
+  const listOpts: KVNamespaceListOptions = {
+    prefix: "inbox:message:",
+    limit: batchSize,
+  };
+  if (cursor) listOpts.cursor = cursor;
+
+  const page = await kv.list(listOpts);
+  result.cursor = page.list_complete ? null : page.cursor;
+
+  for (const kvKey of page.keys) {
+    result.scanned++;
+
+    // Read KV record
+    const raw = await kv.get(kvKey.name);
+    if (!raw) continue;
+
+    let msg: InboxMessage;
+    try {
+      msg = JSON.parse(raw) as InboxMessage;
+    } catch {
+      result.failed.push({ key: kvKey.name, reason: "JSON parse error" });
+      continue;
+    }
+
+    const kvReadAt = msg.readAt ?? null;
+    const kvRepliedAt = msg.repliedAt ?? null;
+
+    // Nothing to backfill if both are unset in KV
+    if (!kvReadAt && !kvRepliedAt) {
+      result.skipped_no_timestamps++;
+      continue;
+    }
+
+    // Query D1 for the current state of these two columns
+    let d1Row: { read_at: string | null; replied_at: string | null } | null = null;
+    try {
+      d1Row = await db
+        .prepare(
+          "SELECT read_at, replied_at FROM inbox_messages WHERE message_id = ?"
+        )
+        .bind(msg.messageId)
+        .first<{ read_at: string | null; replied_at: string | null }>();
+    } catch (err) {
+      result.failed.push({
+        key: kvKey.name,
+        reason: `D1 SELECT failed: ${String(err)}`,
+      });
+      continue;
+    }
+
+    // No D1 row — orphan-recipient or cascade gap (not an error)
+    if (!d1Row) {
+      result.not_in_d1++;
+      continue;
+    }
+
+    // Determine which columns actually need updating (D1 currently NULL)
+    const needsReadAt = kvReadAt !== null && d1Row.read_at === null;
+    const needsRepliedAt = kvRepliedAt !== null && d1Row.replied_at === null;
+
+    if (!needsReadAt && !needsRepliedAt) {
+      result.skipped_already_set++;
+      continue;
+    }
+
+    // UPDATE using COALESCE — safe even if D1 somehow became non-NULL between
+    // our SELECT and the UPDATE (COALESCE will leave the existing value alone).
+    try {
+      await db
+        .prepare(
+          `UPDATE inbox_messages
+           SET read_at    = COALESCE(read_at, ?),
+               replied_at = COALESCE(replied_at, ?)
+           WHERE message_id = ?`
+        )
+        .bind(kvReadAt, kvRepliedAt, msg.messageId)
+        .run();
+    } catch (err) {
+      result.failed.push({
+        key: kvKey.name,
+        reason: `D1 UPDATE failed: ${String(err)}`,
+      });
+      continue;
+    }
+
+    if (needsReadAt) result.updated_read_at++;
+    if (needsRepliedAt) result.updated_replied_at++;
+  }
+
+  result.duration_ms = Date.now() - start;
+  return NextResponse.json(result);
+}

--- a/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Tests for the mark-read PATCH D1 dual-write (Phase 2.5 Step 3 readiness).
+ *
+ * Verifies:
+ *  - After successful KV mark-read, ctx.waitUntil schedules D1 UPDATE
+ *  - D1 UPDATE is called with the correct messageId and { readAt: now }
+ *  - D1 UPDATE failure is swallowed — response is still 200
+ *  - When DB binding is absent, dual-write is skipped silently
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be before route imports) ----------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  getMessage: vi.fn(),
+  getReply: vi.fn(),
+  updateMessage: vi.fn(),
+  getAgentInbox: vi.fn(),
+  validateMarkRead: vi.fn(),
+  buildMarkReadMessage: vi.fn(() => "Mark as Read | msg_123"),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+  shouldFailClosed: vi.fn(() => false),
+}));
+
+// ---- imports after mocks ---------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  getMessage,
+  validateMarkRead,
+  updateMessage,
+  decrementUnreadCount,
+} from "@/lib/inbox";
+import { updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
+import { PATCH } from "../route";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const AGENT = {
+  btcAddress: "bc1qyu22hyqr406pus0g9jmfytk4ss5z8qsje74l76",
+  stxAddress: "SPKH9AWG0ENZ87J1X0PBD4HETP22G8W22AFNVF8K",
+  displayName: "Test Agent",
+};
+
+const MESSAGE_ID = "msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf";
+
+const INBOX_MESSAGE = {
+  messageId: MESSAGE_ID,
+  fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+  toBtcAddress: AGENT.btcAddress,
+  toStxAddress: AGENT.stxAddress,
+  content: "Hello agent",
+  paymentTxid: "abc123",
+  paymentSatoshis: 100,
+  sentAt: "2026-02-18T02:26:42.598Z",
+  authenticated: false,
+  // readAt intentionally absent — message is unread
+};
+
+// ---- helpers ----------------------------------------------------------------
+
+function createMockDB(): D1Database {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    first: vi.fn(),
+    all: vi.fn(),
+    raw: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+function createMockKV(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+}
+
+function createCtxWithWaitUntil(waitUntilFn: Mock = vi.fn()) {
+  return {
+    waitUntil: waitUntilFn,
+    passThroughOnException: vi.fn(),
+  };
+}
+
+function mockCloudflareContext(
+  env: Partial<CloudflareEnv>,
+  ctx = createCtxWithWaitUntil()
+) {
+  (getCloudflareContext as Mock).mockResolvedValue({ env, ctx });
+}
+
+function createRateLimitMock(success = true): RateLimit {
+  return {
+    limit: vi.fn().mockResolvedValue({ success }),
+  } as unknown as RateLimit;
+}
+
+function buildPatchRequest(address: string, messageId: string) {
+  return new NextRequest(
+    `https://aibtc.com/api/inbox/${address}/${messageId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId, signature: "sig_abc123" }),
+    }
+  );
+}
+
+// ---- tests ------------------------------------------------------------------
+
+describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 Step 3 readiness)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+    (validateMarkRead as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, signature: "sig_abc123" },
+    });
+    (getMessage as Mock).mockResolvedValue(INBOX_MESSAGE);
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+    (updateMessage as Mock).mockResolvedValue({ ...INBOX_MESSAGE, readAt: "2026-05-10T12:00:00.000Z" });
+    (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+  });
+
+  it("schedules D1 UPDATE via ctx.waitUntil after successful KV mark-read", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    const req = buildPatchRequest(AGENT.btcAddress, MESSAGE_ID);
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(waitUntilFn).toHaveBeenCalled();
+    expect(updateMessageStateD1).toHaveBeenCalledOnce();
+
+    // Verify called with correct messageId and readAt field
+    const [calledDb, calledMessageId, calledUpdates] = (
+      updateMessageStateD1 as Mock
+    ).mock.calls[0];
+    expect(calledDb).toBe(db);
+    expect(calledMessageId).toBe(MESSAGE_ID);
+    expect(calledUpdates).toHaveProperty("readAt");
+    expect(typeof calledUpdates.readAt).toBe("string");
+    expect(calledUpdates).not.toHaveProperty("repliedAt");
+  });
+
+  it("D1 UPDATE failure does NOT fail the 200 response", async () => {
+    const d1Error = new Error("D1 constraint violation");
+    (updateMessageStateD1 as Mock).mockRejectedValue(d1Error);
+
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
+      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
+    });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    const req = buildPatchRequest(AGENT.btcAddress, MESSAGE_ID);
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
+    });
+
+    // Response must still be 200 — D1 failure must NOT propagate
+    expect(resp.status).toBe(200);
+  });
+
+  it("skips D1 UPDATE when DB binding is absent", async () => {
+    const waitUntilFn = vi.fn();
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        // DB intentionally absent
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    const req = buildPatchRequest(AGENT.btcAddress, MESSAGE_ID);
+    const resp = await PATCH(req, {
+      params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
+    });
+
+    expect(resp.status).toBe(200);
+    expect(waitUntilFn).not.toHaveBeenCalled();
+    expect(updateMessageStateD1).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -13,6 +13,7 @@ import {
   decrementUnreadCount,
 } from "@/lib/inbox";
 import { shouldFailClosed } from "@/lib/env";
+import { updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -279,6 +280,21 @@ export async function PATCH(
 
   // Decrement unreadCount on the agent inbox index (clamped to 0)
   await decrementUnreadCount(kv, message.toBtcAddress);
+
+  // D1 dual-write (Phase 2.5 Step 3 readiness).
+  // KV is still the source of truth; D1 UPDATE is fire-and-forget.
+  // D1 failure is logged-and-swallowed — it must NOT fail the response.
+  if (env.DB) {
+    ctx.waitUntil(
+      updateMessageStateD1(env.DB as D1Database, messageId, { readAt: now }).catch((err) =>
+        logger.error("mark_read.dual_write_d1_failed", {
+          messageId,
+          path: "mark_read",
+          error: String(err),
+        })
+      )
+    );
+  }
 
   return NextResponse.json({
     success: true,

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -59,6 +59,7 @@ vi.mock("@/lib/inbox/payment-logging", () => ({
 vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
   insertReplyToD1: vi.fn().mockResolvedValue(undefined),
+  updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/bitcoin-verify", () => ({
@@ -120,7 +121,7 @@ import {
   buildReplyMessage,
   decrementUnreadCount,
 } from "@/lib/inbox";
-import { insertInboundMessageToD1, insertReplyToD1 } from "@/lib/inbox/d1-dual-write";
+import { insertInboundMessageToD1, insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { POST as inboxPOST } from "../route";
 import { POST as outboxPOST } from "../.././../outbox/[address]/route";
@@ -530,5 +531,197 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
     // deriveReplyD1Id is called INSIDE insertReplyToD1, not in the route
     expect(outboxReplyArg.messageId).toBe(MESSAGE_ID);
     expect(outboxReplyArg.fromAddress).toBe(AGENT.btcAddress);
+  });
+});
+
+// ── outbox POST parent-state dual-write tests ─────────────────────────────
+
+describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2.5 Step 3 readiness)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+    (storeReply as Mock).mockResolvedValue(undefined);
+    (updateMessage as Mock).mockResolvedValue(undefined);
+    (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+    (getReply as Mock).mockResolvedValue(null); // no existing reply
+    (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
+  });
+
+  it("schedules D1 parent-state UPDATE via ctx.waitUntil after reply write (unread message)", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+        RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    // Message is UNREAD (no readAt) — both readAt and repliedAt should be set
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+      // readAt absent — unread
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    expect(resp.status).toBe(201);
+    // waitUntil called at least twice: once for insertReplyToD1, once for updateMessageStateD1
+    expect(waitUntilFn).toHaveBeenCalledTimes(2);
+    expect(updateMessageStateD1).toHaveBeenCalledOnce();
+
+    const [calledDb, calledMessageId, calledUpdates] = (
+      updateMessageStateD1 as Mock
+    ).mock.calls[0];
+    expect(calledDb).toBe(db);
+    // Must target the PARENT message_id directly (not the derived reply PK)
+    expect(calledMessageId).toBe(MESSAGE_ID);
+    // Message was unread → both fields should be set
+    expect(calledUpdates).toHaveProperty("repliedAt");
+    expect(calledUpdates).toHaveProperty("readAt");
+    expect(typeof calledUpdates.repliedAt).toBe("string");
+    expect(typeof calledUpdates.readAt).toBe("string");
+  });
+
+  it("sets only repliedAt (not readAt) when parent message was already read", async () => {
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+        RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    // Message is ALREADY READ — only repliedAt should be set
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+      readAt: "2026-05-10T10:00:00.000Z", // already read
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    expect(resp.status).toBe(201);
+    expect(updateMessageStateD1).toHaveBeenCalledOnce();
+
+    const [, , calledUpdates] = (updateMessageStateD1 as Mock).mock.calls[0];
+    // Message was already read → only repliedAt set, no readAt override
+    expect(calledUpdates).toHaveProperty("repliedAt");
+    expect(calledUpdates).not.toHaveProperty("readAt");
+  });
+
+  it("D1 parent-state UPDATE failure does NOT fail the 201 response", async () => {
+    const d1Error = new Error("D1 update failed");
+    (updateMessageStateD1 as Mock).mockRejectedValue(d1Error);
+
+    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
+      try { await p; } catch { /* swallow */ }
+    });
+    const ctx = createCtxWithWaitUntil(waitUntilFn);
+    const db = createMockDB();
+    const kv = createMockKV();
+
+    mockCloudflareContext(
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+        RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+      },
+      ctx
+    );
+
+    (validateOutboxReply as Mock).mockReturnValue({
+      data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
+    });
+
+    (getMessage as Mock).mockResolvedValue({
+      messageId: MESSAGE_ID,
+      toBtcAddress: AGENT.btcAddress,
+      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      content: "Hello agent",
+      sentAt: "2026-02-18T02:26:42.598Z",
+      authenticated: false,
+    });
+
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: AGENT.btcAddress,
+    });
+
+    const req = new NextRequest(`https://aibtc.com/api/outbox/${AGENT.btcAddress}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "50",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MESSAGE_ID, reply: "hello", signature: "sig123" }),
+    });
+
+    const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
+
+    // D1 failure must NOT propagate to the user response
+    expect(resp.status).toBe(201);
   });
 });

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -15,7 +15,7 @@ import {
 } from "@/lib/inbox";
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
-import { insertReplyToD1 } from "@/lib/inbox/d1-dual-write";
+import { insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -406,6 +406,25 @@ export async function POST(
         logger.error("outbox.dual_write_d1_failed", {
           messageId: outboxReply.messageId,
           path: "kv_reply",
+          error: String(err),
+        })
+      )
+    );
+
+    // D1 dual-write for the PARENT message's read_at / replied_at state
+    // (Phase 2.5 Step 3 readiness — closes the updateMessage dual-write gap).
+    // The outbox POST updates the parent message in KV (sets repliedAt + possibly readAt).
+    // We mirror that here. Target is the parent's message_id directly — no derivation.
+    // wasUnread reflects whether readAt is being set for the first time.
+    const parentUpdates: { readAt?: string; repliedAt?: string } = {
+      repliedAt: now,
+      ...(wasUnread && { readAt: now }),
+    };
+    ctx.waitUntil(
+      updateMessageStateD1(env.DB as D1Database, messageId, parentUpdates).catch((err) =>
+        logger.error("outbox.dual_write_d1_parent_state_failed", {
+          messageId,
+          path: "kv_reply_parent_state",
           error: String(err),
         })
       )

--- a/lib/inbox/__tests__/d1-dual-write.test.ts
+++ b/lib/inbox/__tests__/d1-dual-write.test.ts
@@ -16,6 +16,7 @@ import {
   insertInboundMessageToD1,
   insertReplyToD1,
   resolveReplyRecipientBtcAddress,
+  updateMessageStateD1,
 } from "../d1-dual-write";
 import { deriveReplyD1Id } from "../d1-pk";
 import type { InboxMessage, OutboxReply } from "../types";
@@ -358,5 +359,117 @@ describe("insertReplyToD1", () => {
     // to_btc_address = the BTC address passed through unchanged
     expect(bindArgs[3]).toBe(replyWithBtcRecipient.toBtcAddress);
     expect(kv.get).not.toHaveBeenCalled();
+  });
+});
+
+// ── updateMessageStateD1 ──────────────────────────────────────────────────────
+
+describe("updateMessageStateD1", () => {
+  const MSG_ID = "msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf";
+  const READ_AT = "2026-05-10T12:00:00.000Z";
+  const REPLIED_AT = "2026-05-10T12:05:00.000Z";
+
+  it("is a noop when updates object is empty — does not call D1", async () => {
+    const db = createMockD1();
+    await updateMessageStateD1(db, MSG_ID, {});
+    expect(db.prepare).not.toHaveBeenCalled();
+  });
+
+  it("builds a single-clause UPDATE when only readAt is provided", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { readAt: READ_AT });
+
+    expect(db.prepare).toHaveBeenCalledOnce();
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("UPDATE inbox_messages SET");
+    expect(sql).toContain("read_at = ?");
+    expect(sql).not.toContain("replied_at");
+  });
+
+  it("binds readAt and messageId in correct order for single-field update", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { readAt: READ_AT });
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(READ_AT);    // first SET value
+    expect(bindArgs[1]).toBe(MSG_ID);     // WHERE message_id = ?
+  });
+
+  it("builds a single-clause UPDATE when only repliedAt is provided", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { repliedAt: REPLIED_AT });
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("replied_at = ?");
+    expect(sql).not.toContain("read_at");
+  });
+
+  it("binds repliedAt and messageId in correct order for single-field update", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { repliedAt: REPLIED_AT });
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(REPLIED_AT);
+    expect(bindArgs[1]).toBe(MSG_ID);
+  });
+
+  it("builds a two-clause UPDATE when both readAt and repliedAt are provided", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { readAt: READ_AT, repliedAt: REPLIED_AT });
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("read_at = ?");
+    expect(sql).toContain("replied_at = ?");
+  });
+
+  it("binds readAt, repliedAt, and messageId in correct order for two-field update", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { readAt: READ_AT, repliedAt: REPLIED_AT });
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(READ_AT);     // first SET value
+    expect(bindArgs[1]).toBe(REPLIED_AT);  // second SET value
+    expect(bindArgs[2]).toBe(MSG_ID);      // WHERE message_id = ?
+  });
+
+  it("calls .run() on the prepared statement", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await updateMessageStateD1(db, MSG_ID, { readAt: READ_AT });
+
+    expect(stmtMock.run).toHaveBeenCalledOnce();
+  });
+
+  it("targets the correct row via WHERE message_id = ?", async () => {
+    const db = createMockD1();
+    const stmtMock = createPreparedStatement();
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    const customMsgId = "msg_custom_id_for_test";
+    await updateMessageStateD1(db, customMsgId, { readAt: READ_AT });
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    // Last bind param must be the messageId (WHERE clause)
+    expect(bindArgs[bindArgs.length - 1]).toBe(customMsgId);
   });
 });

--- a/lib/inbox/d1-dual-write.ts
+++ b/lib/inbox/d1-dual-write.ts
@@ -139,6 +139,47 @@ export async function insertInboundMessageToD1(
 }
 
 /**
+ * UPDATE read_at and/or replied_at on an existing D1 inbox_messages row.
+ *
+ * Called from the mark-read PATCH and the outbox-reply POST to keep D1 in
+ * sync with KV state updates. Builds a dynamic SET clause so callers only
+ * pass the fields they actually changed.
+ *
+ * Safety contract:
+ *  - Noop when updates is empty (no fields → no SQL executed).
+ *  - Caller is expressing "set this to this value now"; we do NOT coalesce
+ *    here — the caller already checked KV state before deciding what to send.
+ *  - If the D1 row doesn't exist (orphan-recipient messages), the UPDATE
+ *    simply affects 0 rows; no error is raised.
+ *  - Callers wrap this in ctx.waitUntil(...).catch(logger.error) so a D1
+ *    failure is logged-and-swallowed and never blocks the response.
+ */
+export async function updateMessageStateD1(
+  db: D1Database,
+  messageId: string,
+  updates: { readAt?: string; repliedAt?: string }
+): Promise<void> {
+  const setClauses: string[] = [];
+  const values: unknown[] = [];
+  if (updates.readAt !== undefined) {
+    setClauses.push("read_at = ?");
+    values.push(updates.readAt);
+  }
+  if (updates.repliedAt !== undefined) {
+    setClauses.push("replied_at = ?");
+    values.push(updates.repliedAt);
+  }
+  if (setClauses.length === 0) return; // noop guard — nothing to update
+  values.push(messageId);
+  await db
+    .prepare(
+      `UPDATE inbox_messages SET ${setClauses.join(", ")} WHERE message_id = ?`
+    )
+    .bind(...(values as Parameters<D1PreparedStatement["bind"]>))
+    .run();
+}
+
+/**
  * INSERT a reply (is_reply=1) into D1.
  *
  * Column mapping (verified against migrations/003_inbox_messages.sql):


### PR DESCRIPTION
## Summary

- **Closes the dual-write gap** from Phase 2.5 Step 1 (PR #705): `storeMessage`/`storeReply` were wired to D1, but `updateMessage` calls were not. This PR wires them.
- **Adds `updateMessageStateD1` helper** in `lib/inbox/d1-dual-write.ts` — dynamic SET clause builder, noop guard, same log-and-swallow contract as existing helpers.
- **Wires D1 UPDATE at two call sites** via `ctx.waitUntil`:
  - Mark-read PATCH (`/api/inbox/[address]/[messageId]`): sets `read_at` on the D1 row
  - Outbox-reply POST (`/api/outbox/[address]`): sets `replied_at` + `read_at` (when parent was unread) on the parent message row — targets parent `message_id` directly, no `deriveReplyD1Id` needed
- **New admin route** `POST /api/admin/backfill-message-state`: cursor-paginated KV scan using `COALESCE(read_at, ?)` to safely backfill existing 5227 D1 rows whose `read_at`/`replied_at` are NULL from before this PR. Idempotent. ~600 `not_in_d1` expected (orphan-recipients without D1 rows).

## Why this gates Step 3

Without this fix, after the Step 3 read flip (separate PR), D1-backed UI would show messages as **UNREAD** even when KV has them marked read. All historical read/reply state lives in KV only; the backfill admin route syncs it to D1 before the flip.

See: `phases/06-phase-2.5-step-3-readiness/2026-05-10-callsite-survey-correction.md`

## Test plan

- [x] `npm test` — 849 pass, 0 new failures (pre-existing JSX parse failure in `og-d1.test.ts` unrelated)
- [x] `npx tsc --noEmit` — no errors in changed files
- [x] `updateMessageStateD1` unit tests: noop, single-field, two-field, bind order, row targeting
- [x] Mark-read PATCH dual-write tests: D1 UPDATE scheduled, failure swallowed, no-DB skip
- [x] Outbox reply parent-state tests: correct fields for unread vs already-read parent, failure swallowed
- [x] Backfill route tests: all counters, idempotency, cursor pagination, orphan handling, D1 SELECT failure
- [ ] Post-merge deploy: run backfill loop `POST /api/admin/backfill-message-state` until `cursor: null`
- [ ] Post-backfill: reconcile spot-check — `drift_unexplained` should match orphan count only

## Backfill plan (post-merge)

```python
# /tmp/loop-backfill-state.py
import requests, os, json

KEY = open("/tmp/.arc_admin_key").read().strip()
URL = "https://aibtc.com/api/admin/backfill-message-state"
cursor = None
totals = {}

while True:
    r = requests.post(URL, headers={"X-Admin-Key": KEY}, json={"cursor": cursor, "batchSize": 500})
    body = r.json()
    for k, v in body.items():
        if isinstance(v, int):
            totals[k] = totals.get(k, 0) + v
    print(json.dumps(body, indent=2))
    cursor = body.get("cursor")
    if not cursor:
        break

print("TOTALS:", totals)
```

Expected counts: `scanned` ~5837, `not_in_d1` ~600, bulk of historical reads in `updated_read_at`.

## Security note

This PR touches the inbox write path (paid surface). Changes are additive fire-and-forget only — D1 failures never surface to callers. No read paths modified.

Refs #697

🤖 Generated with [Claude Code](https://claude.com/claude-code)