### PR TITLE
feat(inbox): flip write-path KV auth reads to D1 (closes #736)

### DIFF
--- a/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
@@ -1,11 +1,15 @@
 /**
  * Tests for the mark-read PATCH D1 dual-write (Phase 2.5 Step 3 readiness).
  *
+ * Updated in Phase 2.5 Step 3.5 (#736): the PATCH auth read was flipped from
+ * KV (getMessage) to D1 (getInboxMessageFromD1). Tests updated to mock
+ * getInboxMessageFromD1 instead of getMessage.
+ *
  * Verifies:
- *  - After successful KV mark-read, ctx.waitUntil schedules D1 UPDATE
+ *  - After successful D1 read + KV mark-read, ctx.waitUntil schedules D1 UPDATE
  *  - D1 UPDATE is called with the correct messageId and { readAt: now }
  *  - D1 UPDATE failure is swallowed — response is still 200
- *  - When DB binding is absent, dual-write is skipped silently
+ *  - When DB binding is absent, response is 503 (D1 is now auth gate, not fallback)
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
@@ -26,13 +30,16 @@ vi.mock("@/lib/agent-lookup", () => ({
 }));
 
 vi.mock("@/lib/inbox", () => ({
-  getMessage: vi.fn(),
-  getReply: vi.fn(),
   updateMessage: vi.fn(),
   getAgentInbox: vi.fn(),
   validateMarkRead: vi.fn(),
   buildMarkReadMessage: vi.fn(() => "Mark as Read | msg_123"),
   decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  getInboxMessageFromD1: vi.fn(),
+  fetchRepliesForMessages: vi.fn(),
 }));
 
 vi.mock("@/lib/inbox/d1-dual-write", () => ({
@@ -60,11 +67,11 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
-  getMessage,
   validateMarkRead,
   updateMessage,
   decrementUnreadCount,
 } from "@/lib/inbox";
+import { getInboxMessageFromD1 } from "@/lib/inbox/d1-reads";
 import { updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
 import { PATCH } from "../route";
 
@@ -162,7 +169,8 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
     (validateMarkRead as Mock).mockReturnValue({
       data: { messageId: MESSAGE_ID, signature: "sig_abc123" },
     });
-    (getMessage as Mock).mockResolvedValue(INBOX_MESSAGE);
+    // Phase 2.5 Step 3.5: auth read is now D1, not KV
+    (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE);
     (verifyBitcoinSignature as Mock).mockReturnValue({
       valid: true,
       address: AGENT.btcAddress,
@@ -231,11 +239,14 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
       params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
     });
 
-    // Response must still be 200 — D1 failure must NOT propagate
+    // Response must still be 200 — D1 dual-write failure must NOT propagate
     expect(resp.status).toBe(200);
   });
 
-  it("skips D1 UPDATE when DB binding is absent", async () => {
+  it("returns 503 when DB binding is absent (D1 is now the auth gate, not a fallback)", async () => {
+    // Phase 2.5 Step 3.5: D1 is now the auth read source for PATCH.
+    // When env.DB is absent, the handler returns 503 (not 200) because
+    // it cannot perform the auth read without D1.
     const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const kv = createMockKV();
@@ -254,7 +265,13 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
       params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
     });
 
-    expect(resp.status).toBe(200);
+    // D1 is now required for auth read — no DB → 503 transient unavailable
+    expect(resp.status).toBe(503);
+    const body = await resp.json();
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(body.retry_after).toBe(5);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+    // ctx.waitUntil should NOT have been called — request rejected early
     expect(waitUntilFn).not.toHaveBeenCalled();
     expect(updateMessageStateD1).not.toHaveBeenCalled();
   });

--- a/app/api/inbox/[address]/[messageId]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/write-path-d1-flip.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Phase 2.5 Step 3.5 — PATCH /api/inbox/[address]/[messageId] write-path auth read D1 flip.
+ *
+ * Covers:
+ *  1. PATCH mark-read happy path — agent's own message, returns 200,
+ *       calls getInboxMessageFromD1 with correct args
+ *  2. PATCH tenant-discriminator — different agent's btcAddress in URL params → 404
+ *       (D1 query returns null because SQL gate filters out mismatched address)
+ *  3. PATCH D1-throws → 503 + Retry-After: 5 + structured body
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/736 (Step 3.5 spec)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be before route imports) ----------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  updateMessage: vi.fn(),
+  validateMarkRead: vi.fn(),
+  buildMarkReadMessage: vi.fn(() => "Mark as Read | msg_test"),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  getInboxMessageFromD1: vi.fn(),
+  fetchRepliesForMessages: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+vi.mock("@/lib/env", () => ({
+  shouldFailClosed: vi.fn(() => false),
+}));
+
+// ---- imports after mocks ---------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  validateMarkRead,
+  updateMessage,
+  decrementUnreadCount,
+} from "@/lib/inbox";
+import { getInboxMessageFromD1 } from "@/lib/inbox/d1-reads";
+import { PATCH } from "../route";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const ADDR_A = "bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h";
+const ADDR_B = "bc1qw0y4ant38zykzjqssgnujqmszruvhkwupvp6dn";
+const MSG_ID = "msg_1778221238475_test_write_path_d1";
+
+const AGENT_A = {
+  btcAddress: ADDR_A,
+  stxAddress: "SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E",
+  displayName: "Frosty Narwhal",
+};
+
+const AGENT_B = {
+  btcAddress: ADDR_B,
+  stxAddress: "SP3GXCKM4AB5EB1KJ8V5QSTR1XMTW3R142VQS2NVW",
+  displayName: "Amber Otter",
+};
+
+const INBOX_MESSAGE = {
+  messageId: MSG_ID,
+  fromAddress: "SP3GXCKM4AB5EB1KJ8V5QSTR1XMTW3R142VQS2NVW",
+  toBtcAddress: ADDR_A,
+  toStxAddress: "SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E",
+  content: "Hello from agent B to agent A",
+  paymentTxid: "abc123deadbeef",
+  paymentSatoshis: 100,
+  sentAt: "2026-05-08T06:20:38.665Z",
+  authenticated: false,
+  paymentStatus: "confirmed" as const,
+  // readAt absent — unread
+};
+
+// ---- helpers ----------------------------------------------------------------
+
+function makeMockDB(): D1Database {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn(),
+    all: vi.fn(),
+    run: vi.fn(),
+    raw: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+function buildPatchRequest(address: string, messageId: string): NextRequest {
+  return new NextRequest(
+    `https://aibtc.com/api/inbox/${address}/${messageId}`,
+    {
+      method: "PATCH",
+      headers: {
+        "content-type": "application/json",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId, signature: "sig_abc123" }),
+    }
+  );
+}
+
+function buildContext(address: string, messageId: string) {
+  return { params: Promise.resolve({ address, messageId }) };
+}
+
+function createRateLimitMock(success = true): RateLimit {
+  return {
+    limit: vi.fn().mockResolvedValue({ success }),
+  } as unknown as RateLimit;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (getCloudflareContext as Mock).mockReturnValue({
+    env: {
+      DB: makeMockDB(),
+      VERIFIED_AGENTS: {} as KVNamespace,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    },
+    ctx: { waitUntil: vi.fn() },
+  });
+
+  (lookupAgent as Mock).mockResolvedValue(AGENT_A);
+  (validateMarkRead as Mock).mockReturnValue({
+    data: { messageId: MSG_ID, signature: "sig_abc123" },
+  });
+  (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE);
+  (verifyBitcoinSignature as Mock).mockReturnValue({
+    valid: true,
+    address: ADDR_A,
+  });
+  (updateMessage as Mock).mockResolvedValue({ ...INBOX_MESSAGE, readAt: "2026-05-10T12:00:00.000Z" });
+  (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+});
+
+// ---- tests ------------------------------------------------------------------
+
+describe("Phase 2.5 Step 3.5 — PATCH mark-read write-path D1 flip", () => {
+  it("happy path: returns 200, calls getInboxMessageFromD1 with correct args", async () => {
+    const res = await PATCH(
+      buildPatchRequest(ADDR_A, MSG_ID),
+      buildContext(ADDR_A, MSG_ID)
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.messageId).toBe(MSG_ID);
+    expect(typeof body.readAt).toBe("string");
+
+    // Verify D1 was called with correct args (agent.btcAddress = ADDR_A, messageId)
+    expect(getInboxMessageFromD1).toHaveBeenCalledOnce();
+    const [, calledAddress, calledMessageId] = (getInboxMessageFromD1 as Mock).mock.calls[0];
+    expect(calledAddress).toBe(ADDR_A);
+    expect(calledMessageId).toBe(MSG_ID);
+  });
+
+  it("tenant-discriminator: different agent's btcAddress in URL → 404 (SQL gate returns null)", async () => {
+    // BLOCK-ON-MERGE: SQL gate in getInboxMessageFromD1 uses AND to_btc_address = ?
+    // When ADDR_B is in the URL, D1 returns null because the message belongs to ADDR_A.
+    // The route must return 404 (not 403 — avoids leaking existence to non-recipient).
+    (lookupAgent as Mock).mockResolvedValue(AGENT_B);
+    // D1 returns null — the SQL gate filters out messages not addressed to ADDR_B
+    (getInboxMessageFromD1 as Mock).mockResolvedValue(null);
+
+    const res = await PATCH(
+      buildPatchRequest(ADDR_B, MSG_ID),
+      buildContext(ADDR_B, MSG_ID)
+    );
+
+    // MUST be 404, not 403 — avoids leaking existence to non-recipient
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Message not found");
+    expect(body.messageId).toBe(MSG_ID);
+
+    // Verify D1 was queried with ADDR_B (not ADDR_A) — the gate is in SQL
+    expect(getInboxMessageFromD1).toHaveBeenCalledOnce();
+    const [, calledAddress] = (getInboxMessageFromD1 as Mock).mock.calls[0];
+    expect(calledAddress).toBe(ADDR_B);
+  });
+
+  it("D1-throws → 503 + Retry-After: 5 + structured body", async () => {
+    (getInboxMessageFromD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset")
+    );
+
+    const res = await PATCH(
+      buildPatchRequest(ADDR_A, MSG_ID),
+      buildContext(ADDR_A, MSG_ID)
+    );
+
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: "transient_d1_unavailable",
+      retry_after: 5,
+    });
+    expect(body.message).toMatch(/temporarily unavailable/i);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("DB binding absent → 503 with structured body (D1 is now auth gate)", async () => {
+    (getCloudflareContext as Mock).mockReturnValue({
+      env: {
+        // DB intentionally absent
+        VERIFIED_AGENTS: {} as KVNamespace,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const res = await PATCH(
+      buildPatchRequest(ADDR_A, MSG_ID),
+      buildContext(ADDR_A, MSG_ID)
+    );
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(body.retry_after).toBe(5);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+});

--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -8,7 +8,6 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
-  getMessage,
   updateMessage,
   validateMarkRead,
   buildMarkReadMessage,
@@ -104,9 +103,9 @@ export async function GET(
   );
 }
 
-// PATCH (mark-read) intentionally still writes to KV alongside the D1 dual-write
-// from #720. Phase 2.5 Step 4 (#730) removes the KV writes; until then, KV remains
-// authoritative for the write path so a Step 3.x rollback is bounded.
+// PATCH (mark-read) auth read flipped to D1 in Phase 2.5 Step 3.5 (#736).
+// KV writes (updateMessage, decrementUnreadCount) are NOT removed here — that
+// is Step 4 (#730). The D1 read is the new auth gate; KV write still mirrors it.
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ address: string; messageId: string }> }
@@ -199,8 +198,36 @@ export async function PATCH(
     );
   }
 
-  // Fetch message
-  const message = await getMessage(kv, messageId);
+  // Phase 2.5 Step 3.5 — fetch message from D1 instead of KV.
+  // Security gate: getInboxMessageFromD1 uses WHERE message_id = ? AND to_btc_address = ?
+  // AND is_reply = 0, so a mismatched address returns null → 404 (not 403 — avoids
+  // leaking message existence to a non-recipient).
+  // D1-throws fallback: 503 + Retry-After: 5 per Cycle 26 advisory (PR #732).
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  let message: InboxMessage | null;
+  try {
+    message = await getInboxMessageFromD1(db, agent.btcAddress, messageId);
+  } catch (e) {
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
 
   if (!message) {
     return NextResponse.json(
@@ -209,17 +236,6 @@ export async function PATCH(
         messageId,
       },
       { status: 404 }
-    );
-  }
-
-  // Verify message belongs to this agent (compare resolved BTC address)
-  if (message.toBtcAddress !== agent.btcAddress) {
-    return NextResponse.json(
-      {
-        error: "Message does not belong to this address",
-        messageId,
-      },
-      { status: 403 }
     );
   }
 

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -1,12 +1,16 @@
 /**
  * Regression tests for Phase 2.5 Step 1 — inbox/outbox dual-write to D1.
  *
+ * Updated in Phase 2.5 Step 3.5 (#736): the POST outbox auth reads were flipped
+ * from KV (getMessage, getReply) to D1 (getInboxMessageFromD1, getReplyForMessageFromD1).
+ * Tests updated to mock the D1 helpers instead of the KV helpers.
+ *
  * Key properties verified:
  *  - POST /api/inbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
  *  - D1 INSERT failure does NOT fail the 201 response (logged-and-swallowed)
  *  - POST /api/outbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
  *  - D1 INSERT for reply uses is_reply=1 and synthesized PK via deriveReplyD1Id
- *  - When DB binding is absent (env.DB falsy), dual-write is skipped silently
+ *  - When DB binding is absent, the outbox POST returns 503 (D1 is now the auth gate)
  *
  * These tests exercise the route handlers with mocked downstream functions.
  * They do NOT test the full payment flow — only the dual-write wiring.
@@ -41,8 +45,6 @@ vi.mock("@/lib/inbox", () => ({
   DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
   enqueueInboxReconciliation: vi.fn(),
   validateOutboxReply: vi.fn(),
-  getMessage: vi.fn(),
-  getReply: vi.fn(),
   storeReply: vi.fn(),
   updateMessage: vi.fn(),
   buildReplyMessage: vi.fn(),
@@ -58,6 +60,14 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
   insertReplyToD1: vi.fn().mockResolvedValue(undefined),
   updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+// Phase 2.5 Step 3.5: outbox POST auth reads now use D1 helpers
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  getInboxMessageFromD1: vi.fn(),
+  getReplyForMessageFromD1: vi.fn(),
+  listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
+  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock("@/lib/bitcoin-verify", () => ({
@@ -114,11 +124,13 @@ import {
   storeReply,
   updateMessage,
   validateOutboxReply,
-  getMessage,
-  getReply,
   buildReplyMessage,
   decrementUnreadCount,
 } from "@/lib/inbox";
+import {
+  getInboxMessageFromD1,
+  getReplyForMessageFromD1,
+} from "@/lib/inbox/d1-reads";
 import { insertInboundMessageToD1, insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { POST as inboxPOST } from "../route";
@@ -369,7 +381,9 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
     (storeReply as Mock).mockResolvedValue(undefined);
     (updateMessage as Mock).mockResolvedValue(undefined);
     (decrementUnreadCount as Mock).mockResolvedValue(undefined);
-    (getReply as Mock).mockResolvedValue(null); // no existing reply
+    // Phase 2.5 Step 3.5: auth reads now use D1 helpers
+    (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE); // original message
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(null); // no existing reply
     (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
   });
 
@@ -388,15 +402,6 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
 
     (validateOutboxReply as Mock).mockReturnValue({
       data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
-    });
-
-    (getMessage as Mock).mockResolvedValue({
-      messageId: MESSAGE_ID,
-      toBtcAddress: AGENT.btcAddress,
-      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
-      content: "Hello agent",
-      sentAt: "2026-02-18T02:26:42.598Z",
-      authenticated: false,
     });
 
     (verifyBitcoinSignature as Mock).mockReturnValue({
@@ -449,15 +454,6 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
       data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
     });
 
-    (getMessage as Mock).mockResolvedValue({
-      messageId: MESSAGE_ID,
-      toBtcAddress: AGENT.btcAddress,
-      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
-      content: "Hello agent",
-      sentAt: "2026-02-18T02:26:42.598Z",
-      authenticated: false,
-    });
-
     (verifyBitcoinSignature as Mock).mockReturnValue({
       valid: true,
       address: AGENT.btcAddress,
@@ -496,15 +492,6 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
       data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
     });
 
-    (getMessage as Mock).mockResolvedValue({
-      messageId: MESSAGE_ID,
-      toBtcAddress: AGENT.btcAddress,
-      fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
-      content: "Hello agent",
-      sentAt: "2026-02-18T02:26:42.598Z",
-      authenticated: false,
-    });
-
     (verifyBitcoinSignature as Mock).mockReturnValue({
       valid: true,
       address: AGENT.btcAddress,
@@ -541,7 +528,8 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     (storeReply as Mock).mockResolvedValue(undefined);
     (updateMessage as Mock).mockResolvedValue(undefined);
     (decrementUnreadCount as Mock).mockResolvedValue(undefined);
-    (getReply as Mock).mockResolvedValue(null); // no existing reply
+    // Phase 2.5 Step 3.5: auth reads now use D1 helpers
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(null); // no existing reply
     (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
   });
 
@@ -566,7 +554,7 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     });
 
     // Message is UNREAD (no readAt) — both readAt and repliedAt should be set
-    (getMessage as Mock).mockResolvedValue({
+    (getInboxMessageFromD1 as Mock).mockResolvedValue({
       messageId: MESSAGE_ID,
       toBtcAddress: AGENT.btcAddress,
       fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
@@ -632,7 +620,7 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     });
 
     // Message is ALREADY READ — only repliedAt should be set
-    (getMessage as Mock).mockResolvedValue({
+    (getInboxMessageFromD1 as Mock).mockResolvedValue({
       messageId: MESSAGE_ID,
       toBtcAddress: AGENT.btcAddress,
       fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
@@ -693,7 +681,7 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
       data: { messageId: MESSAGE_ID, reply: "hello", signature: "sig123" },
     });
 
-    (getMessage as Mock).mockResolvedValue({
+    (getInboxMessageFromD1 as Mock).mockResolvedValue({
       messageId: MESSAGE_ID,
       toBtcAddress: AGENT.btcAddress,
       fromAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",

--- a/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
@@ -1,0 +1,372 @@
+/**
+ * Phase 2.5 Step 3.5 — POST /api/outbox/[address] write-path auth read D1 flip.
+ *
+ * Covers:
+ *  4. POST happy path — reply to agent's own inbox message, returns 201, uses D1 reads
+ *  5. POST tenant-discriminator on original-message lookup — messageId belongs to
+ *       a different agent's inbox → 404 (not a leaked message)
+ *  6. POST duplicate-reply guard — second POST to same messageId returns 409,
+ *       uses new D1 duplicate-check helper (getReplyForMessageFromD1)
+ *  7. POST duplicate-check tenant-discriminator — if a different agent replied to
+ *       the same parent (theoretical edge), this agent can still reply (the new
+ *       helper's from_btc_address gate prevents false-409)
+ *  8. POST D1-throws on each of the three reads → 503 + Retry-After: 5
+ *  9. POST partial-write recovery path — verify freshMessage re-read is on D1
+ *       and handles null/throw correctly
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/736 (Step 3.5 spec)
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be before route imports) ----------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateOutboxReply: vi.fn(),
+  storeReply: vi.fn(),
+  updateMessage: vi.fn(),
+  buildReplyMessage: vi.fn(() => "Inbox Reply | msg_test | hello"),
+  decrementUnreadCount: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  getInboxMessageFromD1: vi.fn(),
+  getReplyForMessageFromD1: vi.fn(),
+  listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
+  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  insertReplyToD1: vi.fn().mockResolvedValue(undefined),
+  updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
+  isLogsRPC: () => false,
+}));
+
+vi.mock("@/lib/env", () => ({
+  shouldFailClosed: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/validation/address", () => ({
+  isStxAddress: vi.fn(() => false),
+}));
+
+// ---- imports after mocks ---------------------------------------------------
+
+import { POST } from "../route";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  validateOutboxReply,
+  storeReply,
+  updateMessage,
+  decrementUnreadCount,
+} from "@/lib/inbox";
+import {
+  getInboxMessageFromD1,
+  getReplyForMessageFromD1,
+} from "@/lib/inbox/d1-reads";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+
+// ---- shared fixtures --------------------------------------------------------
+
+const ADDR_A = "bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h"; // message recipient / replier
+const ADDR_B = "bc1qw0y4ant38zykzjqssgnujqmszruvhkwupvp6dn"; // message sender
+const MSG_ID = "msg_1778221238475_write_path_d1_test";
+
+const AGENT_A = {
+  btcAddress: ADDR_A,
+  stxAddress: "SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E",
+  displayName: "Frosty Narwhal",
+};
+
+// Message addressed to ADDR_A (they can reply)
+const INBOX_MESSAGE = {
+  messageId: MSG_ID,
+  fromAddress: "SP3GXCKM4AB5EB1KJ8V5QSTR1XMTW3R142VQS2NVW",
+  toBtcAddress: ADDR_A,
+  toStxAddress: "SP3JR7JXFT7ZM9JKSQPBQG1HPT0D365MA5TN0P12E",
+  content: "Hello from agent B to agent A",
+  paymentTxid: "abc123deadbeef",
+  paymentSatoshis: 100,
+  sentAt: "2026-05-08T06:20:38.665Z",
+  authenticated: false,
+  paymentStatus: "confirmed" as const,
+};
+
+const EXISTING_REPLY = {
+  messageId: MSG_ID,
+  fromAddress: ADDR_A,
+  toBtcAddress: ADDR_B,
+  reply: "Thanks for the message!",
+  signature: "sig_existing",
+  repliedAt: "2026-05-08T07:00:00.000Z",
+};
+
+// ---- helpers ----------------------------------------------------------------
+
+function makeMockDB(): D1Database {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    first: vi.fn(),
+    all: vi.fn(),
+    run: vi.fn(),
+    raw: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+function buildPostRequest(address: string): NextRequest {
+  return new NextRequest(
+    `https://aibtc.com/api/outbox/${address}`,
+    {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "content-length": "100",
+        "cf-connecting-ip": "1.2.3.4",
+      },
+      body: JSON.stringify({ messageId: MSG_ID, reply: "hello", signature: "sig123" }),
+    }
+  );
+}
+
+function buildContext(address: string) {
+  return { params: Promise.resolve({ address }) };
+}
+
+function createRateLimitMock(success = true): RateLimit {
+  return {
+    limit: vi.fn().mockResolvedValue({ success }),
+  } as unknown as RateLimit;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (getCloudflareContext as Mock).mockReturnValue({
+    env: {
+      DB: makeMockDB(),
+      VERIFIED_AGENTS: {} as KVNamespace,
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+      RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+    },
+    ctx: { waitUntil: vi.fn() },
+  });
+
+  (lookupAgent as Mock).mockResolvedValue(AGENT_A);
+  (validateOutboxReply as Mock).mockReturnValue({
+    data: { messageId: MSG_ID, reply: "hello", signature: "sig123" },
+  });
+  // Default: message exists in D1, no existing reply
+  (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE);
+  (getReplyForMessageFromD1 as Mock).mockResolvedValue(null);
+  // Default: signature verification passes (ADDR_A signed)
+  (verifyBitcoinSignature as Mock).mockReturnValue({
+    valid: true,
+    address: ADDR_A,
+  });
+
+  (storeReply as Mock).mockResolvedValue(undefined);
+  (updateMessage as Mock).mockResolvedValue(undefined);
+  (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+});
+
+// ---- tests ------------------------------------------------------------------
+
+describe("Phase 2.5 Step 3.5 — POST outbox write-path D1 flip", () => {
+  it("happy path (test 4): returns 201, uses D1 reads for auth", async () => {
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.message).toMatch(/reply sent/i);
+
+    // Verify D1 auth reads were called
+    expect(getInboxMessageFromD1).toHaveBeenCalled();
+    const [, calledAddress, calledMsgId] = (getInboxMessageFromD1 as Mock).mock.calls[0];
+    expect(calledAddress).toBe(ADDR_A); // agent.btcAddress as SQL gate
+    expect(calledMsgId).toBe(MSG_ID);
+
+    // Duplicate-check called with replier's BTC address
+    expect(getReplyForMessageFromD1).toHaveBeenCalledOnce();
+    const [, dupeParentId, dupeFromAddr] = (getReplyForMessageFromD1 as Mock).mock.calls[0];
+    expect(dupeParentId).toBe(MSG_ID);
+    expect(dupeFromAddr).toBe(ADDR_A); // btcResult.address
+  });
+
+  it("tenant-discriminator on original-message lookup (test 5): msgId not in this agent's inbox → 404", async () => {
+    // ADDR_A tries to reply to MSG_ID, but the message is not addressed to ADDR_A in D1.
+    // SQL gate: WHERE message_id = ? AND to_btc_address = ADDR_A → returns null → 404.
+    (getInboxMessageFromD1 as Mock).mockResolvedValue(null);
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("Message not found");
+    expect(body.messageId).toBe(MSG_ID);
+  });
+
+  it("duplicate-reply guard (test 6): existing D1 reply found → 409", async () => {
+    // ADDR_A already replied to MSG_ID.
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(EXISTING_REPLY);
+    // freshMessage re-read: repliedAt set → true duplicate (all writes completed)
+    (getInboxMessageFromD1 as Mock)
+      .mockResolvedValueOnce(INBOX_MESSAGE) // first call: original message fetch
+      .mockResolvedValueOnce({ ...INBOX_MESSAGE, repliedAt: "2026-05-08T07:00:00.000Z" }); // second: freshMessage
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("Reply already exists for this message");
+    expect(body.status).toBe("already_delivered");
+    expect(body.action).toBe("stop_polling");
+
+    // Verify duplicate-check used D1 helper with correct args
+    expect(getReplyForMessageFromD1).toHaveBeenCalledOnce();
+    const [, dupeParentId, dupeFromAddr] = (getReplyForMessageFromD1 as Mock).mock.calls[0];
+    expect(dupeParentId).toBe(MSG_ID);
+    expect(dupeFromAddr).toBe(ADDR_A);
+  });
+
+  it("duplicate-check tenant-discriminator (test 7): no prior reply from THIS agent allows reply", async () => {
+    // The SQL gate (from_btc_address = ADDR_A) means D1 returns null even if
+    // another agent theoretically replied to the same parent. ADDR_A can still reply.
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(null); // no reply from ADDR_A
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    // ADDR_A should be able to reply — no false-409
+    expect(res.status).toBe(201);
+    // Confirm duplicate check was queried with ADDR_A
+    expect(getReplyForMessageFromD1).toHaveBeenCalledOnce();
+    const [, , dupeFromAddr] = (getReplyForMessageFromD1 as Mock).mock.calls[0];
+    expect(dupeFromAddr).toBe(ADDR_A);
+  });
+
+  it("D1-throws on original-message fetch (test 8a): returns 503 + Retry-After: 5", async () => {
+    (getInboxMessageFromD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset")
+    );
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(503);
+    expect(res.status).not.toBe(500);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      error: "transient_d1_unavailable",
+      retry_after: 5,
+    });
+    expect(body.message).toMatch(/temporarily unavailable/i);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("D1-throws on duplicate-reply check (test 8b): returns 503 + Retry-After: 5", async () => {
+    // Original message fetch succeeds, but duplicate-check throws
+    (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE);
+    (getReplyForMessageFromD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: duplicate check failed")
+    );
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(body.retry_after).toBe(5);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("D1-throws on partial-write recovery re-read (test 8c): returns 503 + Retry-After: 5", async () => {
+    // existingReply found (triggers recovery path), but freshMessage re-read throws
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(EXISTING_REPLY);
+    // First call: original message. Second call (freshMessage re-read): throws
+    (getInboxMessageFromD1 as Mock)
+      .mockResolvedValueOnce(INBOX_MESSAGE)
+      .mockRejectedValueOnce(new Error("D1_ERROR: fresh-read failed"));
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(body.retry_after).toBe(5);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("partial-write recovery (test 9): freshMessage re-read is D1; null repliedAt means partial write → completes with 201", async () => {
+    // existingReply exists (from same agent), freshMessage.repliedAt is NOT set.
+    // Partial write: reply stored but parent message state not updated yet.
+    // The handler should complete the write (isRecovery = true) → 201 with recovered: true.
+    (getReplyForMessageFromD1 as Mock).mockResolvedValue(EXISTING_REPLY);
+    // First call: original message. Second call (freshMessage): repliedAt absent → partial write
+    (getInboxMessageFromD1 as Mock)
+      .mockResolvedValueOnce(INBOX_MESSAGE)
+      .mockResolvedValueOnce({ ...INBOX_MESSAGE, repliedAt: null }); // partial write detected
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    // Partial write detected → complete the operation → 201 with recovered=true
+    expect(res.status).toBe(201);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(body.recovered).toBe(true);
+
+    // Verify both D1 read calls happened (original + freshMessage)
+    expect(getInboxMessageFromD1).toHaveBeenCalledTimes(2);
+    // Both calls should use the same agent address and message ID
+    const [, firstAddr, firstMsg] = (getInboxMessageFromD1 as Mock).mock.calls[0];
+    expect(firstAddr).toBe(ADDR_A);
+    expect(firstMsg).toBe(MSG_ID);
+    const [, secondAddr, secondMsg] = (getInboxMessageFromD1 as Mock).mock.calls[1];
+    expect(secondAddr).toBe(ADDR_A);
+    expect(secondMsg).toBe(MSG_ID);
+  });
+
+  it("DB binding absent → 503 (D1 is now auth gate for POST outbox)", async () => {
+    (getCloudflareContext as Mock).mockReturnValue({
+      env: {
+        // DB intentionally absent
+        VERIFIED_AGENTS: {} as KVNamespace,
+        RATE_LIMIT_MUTATING: createRateLimitMock(true),
+        RATE_LIMIT_AUTHENTICATED: createRateLimitMock(true),
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+
+    // D1 is required for auth reads — no DB → 503
+    expect(res.status).toBe(503);
+    const body = await res.json();
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(body.retry_after).toBe(5);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+});

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -9,8 +9,6 @@ import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
   validateOutboxReply,
-  getMessage,
-  getReply,
   storeReply,
   updateMessage,
   buildReplyMessage,
@@ -19,7 +17,13 @@ import {
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
 import { insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
-import { listOutboxRepliesFromD1, countOutboxRepliesFromD1 } from "@/lib/inbox/d1-reads";
+import {
+  listOutboxRepliesFromD1,
+  countOutboxRepliesFromD1,
+  getInboxMessageFromD1,
+  getReplyForMessageFromD1,
+} from "@/lib/inbox/d1-reads";
+import type { InboxMessage, OutboxReply } from "@/lib/inbox/types";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -194,8 +198,40 @@ export async function POST(
 
   const { messageId, reply, signature } = validation.data;
 
-  // Fetch original message
-  const message = await getMessage(kv, messageId);
+  // Phase 2.5 Step 3.5 — fetch original message from D1 instead of KV.
+  // Security gate: getInboxMessageFromD1 uses WHERE message_id = ? AND to_btc_address = ?
+  // AND is_reply = 0, so messages addressed to a different agent return null → 404.
+  // This prevents a replier from replying to a message they are not the recipient of.
+  // D1-throws fallback: 503 + Retry-After: 5 per Cycle 26 advisory (PR #732).
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("D1 database binding unavailable", { messageId });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  // Note: agent.btcAddress is the URL path address (resolved from BTC or STX).
+  // The SQL gate ensures we only fetch messages addressed to this agent.
+  let message: InboxMessage | null;
+  try {
+    message = await getInboxMessageFromD1(db, agent.btcAddress, messageId);
+  } catch (e) {
+    logger.error("D1 message fetch failed", { messageId, error: String(e) });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
 
   if (!message) {
     logger.warn("Message not found", { messageId });
@@ -314,33 +350,56 @@ export async function POST(
     );
   }
 
-  // Check if reply already exists — with partial-write recovery
-  const existingReply = await getReply(kv, messageId);
+  // Phase 2.5 Step 3.5 — check for duplicate reply via D1 instead of KV.
+  // New helper: getReplyForMessageFromD1 uses WHERE reply_to_message_id = ? AND
+  // from_btc_address = ? AND is_reply = 1. The from_btc_address gate is the
+  // tenant-discriminator: only a prior reply by THIS agent blocks the duplicate
+  // check. A reply from a different agent to the same parent does NOT trigger 409.
+  // D1-throws fallback: 503 + Retry-After: 5 per Cycle 26 advisory.
+  let existingReply: OutboxReply | null;
+  try {
+    existingReply = await getReplyForMessageFromD1(db, messageId, btcResult.address);
+  } catch (e) {
+    logger.error("D1 duplicate-reply check failed", { messageId, error: String(e) });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
   let isRecovery = false;
 
   if (existingReply) {
-    // If the stored reply was from a different signer, reject immediately
-    if (existingReply.fromAddress !== btcResult.address) {
-      logger.warn("Reply exists from different address", {
+    // existingReply.fromAddress will always equal btcResult.address here because
+    // getReplyForMessageFromD1 already gates on from_btc_address = btcResult.address.
+    // The "different address" check from the KV path is now implicit in the SQL gate
+    // (a reply by a different agent simply won't be returned).
+
+    // Re-read the original message from D1 to check if the write completed.
+    // Preserves the partial-write recovery semantic from the KV path:
+    // if repliedAt is set on the message, the full write is confirmed (true duplicate).
+    // Phase 2.5 Step 3.5 — freshMessage re-read uses D1 instead of KV.
+    let freshMessage: InboxMessage | null;
+    try {
+      freshMessage = await getInboxMessageFromD1(db, agent.btcAddress, messageId);
+    } catch (e) {
+      logger.error("D1 fresh-message re-read failed (partial-write recovery)", {
         messageId,
-        existingFrom: existingReply.fromAddress,
-        requestFrom: btcResult.address,
+        error: String(e),
       });
       return NextResponse.json(
         {
-          error: "Reply already exists for this message from a different address",
-          messageId,
-          existingReply: {
-            repliedAt: existingReply.repliedAt,
-            reply: existingReply.reply,
-          },
+          error: "transient_d1_unavailable",
+          message: "Inbox database temporarily unavailable. Please retry shortly.",
+          retry_after: 5,
         },
-        { status: 409 }
+        { status: 503, headers: { "Retry-After": "5" } }
       );
     }
-
-    // Re-read the original message to check if the write completed
-    const freshMessage = await getMessage(kv, messageId);
 
     if (freshMessage?.repliedAt) {
       // All writes completed — true duplicate
@@ -567,7 +626,7 @@ export async function GET(
   // return 503 with a structured retry hint rather than an unstructured 500.
   // totalCount is queried in parallel with the page list so pagination metadata
   // reflects the full matching row count, not just the current page length.
-  let replies: import("@/lib/inbox/types").OutboxReply[];
+  let replies: OutboxReply[];
   let totalCount: number;
   try {
     [replies, totalCount] = await Promise.all([

--- a/lib/inbox/__tests__/d1-reads.test.ts
+++ b/lib/inbox/__tests__/d1-reads.test.ts
@@ -2,6 +2,7 @@
  * Tests for lib/inbox/d1-reads.ts
  *
  * Phase 2.5 Step 3.1 — D1 read flip for GET /api/inbox/[address].
+ * Phase 2.5 Step 3.5 — adds getReplyForMessageFromD1 for write-path auth reads.
  *
  * Verifies:
  *   - listInboxMessagesFromD1: correct SQL shape, status filter variants,
@@ -10,6 +11,7 @@
  *     SELECT COUNT(*) that closes aibtc-mcp-server#497
  *   - fetchRepliesForMessages: IN-clause construction, OutboxReply mapping,
  *     empty-input guard
+ *   - getReplyForMessageFromD1: tenant-discriminator gate, hit/miss, SQL shape
  *   - Cache-key invariant documentation (structural): ensures the public
  *     path does not set Cache-Control headers that would leak auth'd state
  *
@@ -18,6 +20,7 @@
  * make live network calls.
  *
  * See: https://github.com/aibtcdev/landing-page/issues/721
+ * See: https://github.com/aibtcdev/landing-page/issues/736 (Step 3.5)
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -27,6 +30,7 @@ import {
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
   countOutboxRepliesFromD1,
+  getReplyForMessageFromD1,
   type StatusFilter,
 } from "../d1-reads";
 
@@ -614,6 +618,103 @@ describe("countOutboxRepliesFromD1 (Phase 2.5 Step 3.3 — sentCount restoration
   });
 });
 
+// ── getReplyForMessageFromD1 ──────────────────────────────────────────────────
+
+describe("getReplyForMessageFromD1 (Phase 2.5 Step 3.5)", () => {
+  const PARENT_MSG_ID = "msg_1771381602504_30487f5e-1f3a-473a-8068-e040295a76bf";
+  const REPLIER_BTC = "bc1qp66jvxe765wgwpzqk8kcrmgh2mucyxg540mtzv";
+  const OTHER_REPLIER_BTC = "bc1qw0y4ant38zykzjqssgnujqmszruvhkwupvp6dn";
+
+  const REPLY_ROW = {
+    reply_to_message_id: PARENT_MSG_ID,
+    from_btc_address: REPLIER_BTC,
+    to_btc_address: BTC_ADDRESS,
+    content: "Great work — bookmarked.",
+    bitcoin_signature:
+      "Jx52I99dmnoFqmKkJXsLP4ELktANgZ6v1m1CFA7c5kz+Xr9W45m29QnabzGim5ubEzJP1eoynU/GjuRWMjRD9nQ=",
+    sent_at: "2026-02-19T22:14:43.426Z",
+  };
+
+  it("returns OutboxReply when a matching reply row exists", async () => {
+    const stmtMock = createPreparedStatement([], REPLY_ROW);
+    const db = {
+      prepare: vi.fn().mockReturnValue(stmtMock),
+      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
+    } as unknown as D1Database;
+
+    const result = await getReplyForMessageFromD1(db, PARENT_MSG_ID, REPLIER_BTC);
+
+    expect(result).not.toBeNull();
+    expect(result?.messageId).toBe(PARENT_MSG_ID);
+    expect(result?.fromAddress).toBe(REPLIER_BTC);
+    expect(result?.reply).toBe(REPLY_ROW.content);
+    expect(result?.signature).toBe(REPLY_ROW.bitcoin_signature);
+    expect(result?.repliedAt).toBe(REPLY_ROW.sent_at);
+  });
+
+  it("returns null when no reply row exists (no match)", async () => {
+    const stmtMock = createPreparedStatement([], null);
+    const db = {
+      prepare: vi.fn().mockReturnValue(stmtMock),
+      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
+    } as unknown as D1Database;
+
+    const result = await getReplyForMessageFromD1(db, PARENT_MSG_ID, REPLIER_BTC);
+
+    expect(result).toBeNull();
+  });
+
+  it("tenant-discriminator gate: reply from different from_btc_address is NOT returned", async () => {
+    // If REPLIER_BTC sent a reply, but we query with OTHER_REPLIER_BTC,
+    // D1 returns null (SQL gate: from_btc_address = OTHER_REPLIER_BTC doesn't match).
+    // This prevents false-409 duplicate-reply blocks for other agents replying to same parent.
+    const stmtMock = createPreparedStatement([], null); // D1 returns null — different address
+    const db = {
+      prepare: vi.fn().mockReturnValue(stmtMock),
+      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
+    } as unknown as D1Database;
+
+    const result = await getReplyForMessageFromD1(db, PARENT_MSG_ID, OTHER_REPLIER_BTC);
+
+    expect(result).toBeNull();
+    // Verify query was called with OTHER_REPLIER_BTC (the SQL gate enforces isolation)
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(PARENT_MSG_ID);
+    expect(bindArgs[1]).toBe(OTHER_REPLIER_BTC);
+  });
+
+  it("queries with correct SQL shape: WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1", async () => {
+    const stmtMock = createPreparedStatement([], null);
+    const db = {
+      prepare: vi.fn().mockReturnValue(stmtMock),
+      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
+    } as unknown as D1Database;
+
+    await getReplyForMessageFromD1(db, PARENT_MSG_ID, REPLIER_BTC);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("FROM inbox_messages");
+    expect(sql).toContain("reply_to_message_id = ?");
+    expect(sql).toContain("from_btc_address = ?");
+    expect(sql).toContain("is_reply = 1");
+    expect(sql).toContain("LIMIT 1");
+  });
+
+  it("binds parentMessageId first, then fromBtcAddress", async () => {
+    const stmtMock = createPreparedStatement([], null);
+    const db = {
+      prepare: vi.fn().mockReturnValue(stmtMock),
+      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
+    } as unknown as D1Database;
+
+    await getReplyForMessageFromD1(db, PARENT_MSG_ID, REPLIER_BTC);
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(PARENT_MSG_ID);
+    expect(bindArgs[1]).toBe(REPLIER_BTC);
+  });
+});
+
 // ── Cache-key invariant: structural verification ──────────────────────────────
 
 describe("cache-key invariants (structural verification)", () => {
@@ -630,6 +731,7 @@ describe("cache-key invariants (structural verification)", () => {
     expect(fetchRepliesForMessages.length).toBe(2);  // (db, parentMessageIds)
     expect(listOutboxRepliesFromD1.length).toBe(4);  // (db, btcAddress, limit, offset)
     expect(countOutboxRepliesFromD1.length).toBe(2); // (db, btcAddress)
+    expect(getReplyForMessageFromD1.length).toBe(3); // (db, parentMessageId, fromBtcAddress)
   });
 
   it("Invariant 3: read helpers are called with explicit inputs — no implicit cache-before-auth", async () => {

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -5,6 +5,9 @@
  * Phase 2.5 Step 3.2 — adds getInboxMessageFromD1 for the single-message GET.
  * Phase 2.5 Step 3.3 — adds listOutboxRepliesFromD1 + countOutboxRepliesFromD1
  *   for the outbox GET flip and sentCount/partners restoration in inbox-list.
+ * Phase 2.5 Step 3.5 — adds getReplyForMessageFromD1 for write-path auth reads
+ *   (POST outbox duplicate-check; PATCH mark-read message fetch now uses
+ *   getInboxMessageFromD1 directly).
  * KV writes are NOT removed here (that is Step 4).
  *
  * These helpers query the inbox_messages table that is being populated by
@@ -333,6 +336,53 @@ export async function countOutboxRepliesFromD1(
     .first<{ cnt: number }>();
 
   return row?.cnt ?? 0;
+}
+
+/**
+ * Fetch a single reply for a parent message, filtered by the replier's BTC address.
+ *
+ * Phase 2.5 Step 3.5 — used by POST /api/outbox/[address] to check for
+ * duplicate replies before storing a new one.
+ *
+ * The `from_btc_address` predicate is the tenant-discriminator gate: it ensures
+ * only a prior reply by THIS agent (identified via Bitcoin signature) blocks the
+ * duplicate check. A reply by a different agent to the same parent does not
+ * trigger a false-409.
+ *
+ * SQL shape:
+ *   SELECT message_id, reply_to_message_id, from_btc_address, to_btc_address,
+ *          content, bitcoin_signature, sent_at
+ *   FROM inbox_messages
+ *   WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1
+ *   LIMIT 1
+ *
+ * Returns null when:
+ *   - No reply exists for the given parentMessageId
+ *   - A reply exists but was sent by a different agent (from_btc_address mismatch)
+ *
+ * See: https://github.com/aibtcdev/landing-page/issues/736 (Step 3.5 spec)
+ */
+export async function getReplyForMessageFromD1(
+  db: D1Database,
+  parentMessageId: string,
+  fromBtcAddress: string
+): Promise<OutboxReply | null> {
+  const sql = `
+    SELECT
+      reply_to_message_id, from_btc_address, to_btc_address,
+      content, bitcoin_signature, sent_at
+    FROM inbox_messages
+    WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1
+    LIMIT 1
+  `;
+
+  const row = await db
+    .prepare(sql)
+    .bind(parentMessageId, fromBtcAddress)
+    .first<D1ReplyRow>();
+
+  if (!row) return null;
+  return replyRowToOutboxReply(row);
 }
 
 // Re-export the prefix so tests can verify synthesized IDs

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -350,7 +350,7 @@ export async function countOutboxRepliesFromD1(
  * trigger a false-409.
  *
  * SQL shape:
- *   SELECT message_id, reply_to_message_id, from_btc_address, to_btc_address,
+ *   SELECT reply_to_message_id, from_btc_address, to_btc_address,
  *          content, bitcoin_signature, sent_at
  *   FROM inbox_messages
  *   WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -61,15 +61,14 @@ function buildStagedPaymentKey(paymentId: string): string {
 /**
  * Get an inbox message by ID.
  *
+ * @deprecated Read-path usage removed in Phase 2.5 Step 3.5 (#736).
+ * All GET and write-path auth reads now use getInboxMessageFromD1 from d1-reads.ts.
+ * KV writes (updateMessage) still call this indirectly; Step 4 (#730) will remove
+ * those writes and this function once KV is fully sunset.
+ *
  * @param kv - Cloudflare KV namespace
  * @param messageId - Message ID
  * @returns InboxMessage or null if not found
- *
- * @example
- * const message = await getMessage(kv, "msg_123");
- * if (message) {
- *   console.log(`Message from: ${message.fromAddress}`);
- * }
  */
 export async function getMessage(
   kv: KVNamespace,
@@ -142,15 +141,15 @@ export async function updateMessage(
 /**
  * Get an outbox reply by message ID.
  *
+ * @deprecated Read-path usage removed in Phase 2.5 Step 3.5 (#736).
+ * The duplicate-reply check in POST /api/outbox/[address] now uses
+ * getReplyForMessageFromD1 from d1-reads.ts (with tenant-discriminator SQL gate).
+ * Step 4 (#730) will remove the KV writes (storeReply) and this function once
+ * KV is fully sunset.
+ *
  * @param kv - Cloudflare KV namespace
  * @param messageId - Message ID
  * @returns OutboxReply or null if not found
- *
- * @example
- * const reply = await getReply(kv, "msg_123");
- * if (reply) {
- *   console.log(`Reply: ${reply.reply}`);
- * }
  */
 export async function getReply(
   kv: KVNamespace,


### PR DESCRIPTION
## Summary

Phase 2.5 Step 3.5 — flips the 4 remaining KV authorization reads on write-path handlers to D1. Prerequisite for Step 4 (#730) which will remove KV writes entirely. D1 already has the data via dual-write from Step 1; flipping reads is reversible and does not touch writes.

## Call sites flipped (before → after)

| Handler | Line | Before | After |
|---------|------|--------|-------|
| POST `/api/outbox/[address]` | 198 | `getMessage(kv, messageId)` | `getInboxMessageFromD1(db, agent.btcAddress, messageId)` |
| POST `/api/outbox/[address]` | 318 | `getReply(kv, messageId)` | `getReplyForMessageFromD1(db, messageId, btcResult.address)` |
| POST `/api/outbox/[address]` | 343 | `getMessage(kv, messageId)` | `getInboxMessageFromD1(db, agent.btcAddress, messageId)` |
| PATCH `/api/inbox/[address]/[messageId]` | 203 | `getMessage(kv, messageId)` | `getInboxMessageFromD1(db, agent.btcAddress, messageId)` |

## New helper

`getReplyForMessageFromD1(db, parentMessageId, fromBtcAddress)` added to `lib/inbox/d1-reads.ts`:
```sql
SELECT ... FROM inbox_messages
WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1
LIMIT 1
```
The `from_btc_address` predicate is the tenant-discriminator gate: a reply by a different agent to the same parent does not trigger a false-409.

## Cutover template

- **pagination-equivalence**: N/A (single-row auth reads)
- **variant-additivity**: N/A (no read-variant changes)
- **security-gate-SQL**:
  - PATCH mark-read: `WHERE message_id = ? AND to_btc_address = ? AND is_reply = 0`
  - POST outbox original-msg fetch: `WHERE message_id = ? AND to_btc_address = ? AND is_reply = 0`
  - POST outbox duplicate-check: `WHERE reply_to_message_id = ? AND from_btc_address = ? AND is_reply = 1`

## Security improvements

The D1 SQL gates are STRONGER than the previous KV path:
- **PATCH**: Previous KV path did app-level `if (message.toBtcAddress !== agent.btcAddress) return 403`. D1 path moves this into SQL, returning null → 404 (avoids leaking existence to non-recipient).
- **POST outbox duplicate-check**: Previous `getReply(kv, messageId)` had no tenant gate. New helper adds `from_btc_address = ?` so only the replier's own prior reply blocks duplicate — prevents false-409 for other agents replying to same parent (theoretical edge).

## Behavior preservation

- Partial-write recovery path (POST outbox, formerly line 343) preserved with D1. If `getInboxMessageFromD1` returns null or throws on recovery re-read, same behavior as KV path (503 on throw; partial-write if no `repliedAt`).
- KV writes (`storeReply`, `updateMessage`, `decrementUnreadCount`) are NOT removed — that is Step 4 (#730).
- `getMessage` and `getReply` in `kv-helpers.ts` marked `@deprecated` with Step 4 pointer; not deleted in this PR (keeps diff focused on the flip).

## D1-throws fallback policy (Cycle 26 advisory, PR #732)

All 4 flipped call sites + DB-binding-absent check return **503 + Retry-After: 5** with `{error: "transient_d1_unavailable", message: "...", retry_after: 5}` on throw. For write-path, 503 = "transient unavailable, retry the write later."

## Empirical smoke targets

| Scenario | Pre-flip expectation | Post-flip expectation |
|----------|---------------------|----------------------|
| PATCH mark-read (own message) | 200 | 200 (no behavior change) |
| PATCH mark-read (different agent's message) | 403 | 404 (security improvement: no existence leak) |
| POST outbox (reply to own inbox msg) | 201 | 201 (no behavior change) |
| POST outbox (reply to different agent's inbox msg) | 404 | 404 (SQL gate same semantics) |
| POST outbox duplicate (same agent replies twice) | 409 | 409 (no behavior change) |
| D1 unavailable (any write-path) | 500 (unhandled) | 503 + Retry-After: 5 (structured) |

## Test coverage

- `app/api/inbox/[address]/[messageId]/__tests__/write-path-d1-flip.test.ts` — PATCH happy path, tenant-disc gate (404 not 403), D1-throws 503, DB-absent 503
- `app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts` — all 9 spec cases: happy path, tenant-disc on original-msg, duplicate-reply 409, duplicate-check tenant-gate, D1-throws on each of 3 reads, partial-write recovery, DB-absent 503
- `lib/inbox/__tests__/d1-reads.test.ts` — `getReplyForMessageFromD1` unit tests: hit, null, tenant gate, SQL shape, bind order
- `app/api/inbox/[address]/__tests__/dual-write.test.ts` — updated to mock D1 helpers instead of KV reads
- `app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts` — updated to mock `getInboxMessageFromD1`; DB-absent test expectation changed 200→503 (correct: D1 is now auth gate)

All existing tests pass (`npm test -- --run`; pre-existing `og-d1.test.ts` JSX failure ignored per spec).

@arc0btc @secret-mars for second-opinion review.

Closes #736

## Known transitional regression — heartbeat-only unread-count drift

Codex P1 review (resolved [here](https://github.com/aibtcdev/landing-page/pull/739#discussion_r3216457905) and [here](https://github.com/aibtcdev/landing-page/pull/739#discussion_r3216457908)) correctly identified that gating idempotency on D1 reads while KV is still the write source creates an eventual-consistency window: a hot retry inside the D1-propagation lag can observe stale state and double-call `decrementUnreadCount`.

**Impact:** bounded `inboxIndex.unreadCount` drift by ≤1 per concurrent retry, **visible only on the `/api/heartbeat` GET orientation** (the `/api/inbox/[address]` list response was already switched to D1 live `SELECT COUNT(*)` in #722 — KV counter no longer drives that response).

**Window:** closes when Step 4 (#730) removes the KV counter entirely and switches heartbeat to D1 live count. #730 is the immediate next step in the cutover series (chain: #729 → #736 → #730).

**Mitigation considered + rejected:** a split-read pattern (D1 for SQL ownership gate + KV for idempotency state) was prototyped but discarded — it carries bridge code that gets removed in #730 plus a transitional 1-extra-KV-read overhead. arc0btc + secret-mars APPROVED the unified-D1 approach with substantive review.

**Smoke plan:** the +30min smoke window will sample heartbeat `unreadCount` against the inbox-list D1 count to bound observed drift in production traffic. If drift is non-trivial before #730 lands, follow-up issue filed and bridge-code shipped.
