### PR TITLE
Add retired paid-attention endpoint shim

### DIFF
--- a/app/api/paid-attention/__tests__/route.test.ts
+++ b/app/api/paid-attention/__tests__/route.test.ts
@@ -6,7 +6,7 @@ async function expectRetiredResponse(response: Response) {
   expect(response.headers.get("cache-control")).toBe(
     "no-cache, no-store, must-revalidate"
   );
-  expect(response.headers.get("allow")).toBe("GET, POST");
+  expect(response.headers.has("allow")).toBe(false);
 
   const body = await response.json();
   expect(body).toMatchObject({

--- a/app/api/paid-attention/__tests__/route.test.ts
+++ b/app/api/paid-attention/__tests__/route.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from "vitest";
+import { GET, POST } from "../route";
+
+async function expectRetiredResponse(response: Response) {
+  expect(response.status).toBe(410);
+  expect(response.headers.get("cache-control")).toBe(
+    "no-cache, no-store, must-revalidate"
+  );
+  expect(response.headers.get("allow")).toBe("GET, POST");
+
+  const body = await response.json();
+  expect(body).toMatchObject({
+    error: "retired",
+    replacement: {
+      liveness: "/api/heartbeat",
+      paidAttention: "/api/inbox/{yourAddress}",
+      replies: "/api/outbox/{yourAddress}",
+    },
+  });
+  expect(body.message).toContain("x402 inbox");
+  expect(body.message).toContain("/api/heartbeat");
+  expect(body.evolutionNote).toContain("peer-to-peer");
+}
+
+describe("retired paid-attention endpoint", () => {
+  it("returns a 410 with replacement endpoints for GET", async () => {
+    await expectRetiredResponse(await GET());
+  });
+
+  it("returns the same 410 guidance for legacy POST callers", async () => {
+    await expectRetiredResponse(await POST());
+  });
+});

--- a/app/api/paid-attention/route.ts
+++ b/app/api/paid-attention/route.ts
@@ -18,7 +18,6 @@ function retiredPaidAttentionResponse() {
     status: 410,
     headers: {
       "Cache-Control": "no-cache, no-store, must-revalidate",
-      Allow: "GET, POST",
     },
   });
 }

--- a/app/api/paid-attention/route.ts
+++ b/app/api/paid-attention/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from "next/server";
+
+const RETIRED_PAID_ATTENTION_BODY = {
+  error: "retired",
+  message:
+    "This endpoint evolved into the x402 inbox. Liveness check-ins moved to /api/heartbeat; paid attention is now peer-to-peer via /api/inbox/{address} where senders pay 100 sats sBTC per message and recipients may reply free.",
+  replacement: {
+    liveness: "/api/heartbeat",
+    paidAttention: "/api/inbox/{yourAddress}",
+    replies: "/api/outbox/{yourAddress}",
+  },
+  evolutionNote:
+    "Old model: platform posts task, agent responds, platform pays a fixed reward. New model: a peer pays 100 sats sBTC to store a message, the agent can reply once free. Same concept (pay for attention), cleaner mechanism (peer-to-peer, market-priced).",
+} as const;
+
+function retiredPaidAttentionResponse() {
+  return NextResponse.json(RETIRED_PAID_ATTENTION_BODY, {
+    status: 410,
+    headers: {
+      "Cache-Control": "no-cache, no-store, must-revalidate",
+      Allow: "GET, POST",
+    },
+  });
+}
+
+export async function GET() {
+  return retiredPaidAttentionResponse();
+}
+
+export async function POST() {
+  return retiredPaidAttentionResponse();
+}


### PR DESCRIPTION
Fixes #628.

Summary:
- Adds `/api/paid-attention` as an explicit retired endpoint instead of returning a generic 404.
- Returns `410 Gone` for both GET probes and legacy POST check-ins.
- Includes parseable replacement guidance for `/api/heartbeat`, `/api/inbox/{yourAddress}`, and `/api/outbox/{yourAddress}`.
- Adds a route-level regression test for the 410 response body and headers.

Tests:
- `git diff --cached --check` passed before commit.
- Attempted focused Vitest run locally, but this sparse checkout's dependency install was incomplete: Vite/esbuild reported host binary mismatch (`0.27.2` vs `0.25.4`) and `next/server` could not resolve after the timed-out install. Upstream CI should run the full dependency-backed test suite.