### PR TITLE
chore(inbox): drop KV writes from inbox/outbox POST/PATCH — D1 sole source of truth (#730)

### DIFF
--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -7,7 +7,7 @@ import { X_HANDLE } from "@/lib/constants";
 import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { generateName } from "@/lib/name-generator";
-import type { InboxAgentIndex } from "@/lib/inbox/types";
+import { countInboxMessagesFromD1 } from "@/lib/inbox/d1-reads";
 import {
   CHECK_IN_MESSAGE_FORMAT,
   buildCheckInMessage,
@@ -103,13 +103,20 @@ function getNextAction(
 }
 
 /**
- * Parse inbox index data to extract unread count.
+ * Fetch live unread count from D1.
+ *
+ * Phase 2.5 Step 4 — replaces the KV inbox:agent:{btcAddress} read that served
+ * the cached unreadCount. The D1 live SELECT COUNT(*) WHERE read_at IS NULL is
+ * served by idx_inbox_unread and closes the +1 stale-counter drift tracked in
+ * aibtc-mcp-server#497.
+ *
+ * Fails open (returns 0) on D1 unavailability so heartbeat orientation is never
+ * blocked by a transient D1 error.
  */
-function parseUnreadCount(inboxIndexData: string | null): number {
-  if (!inboxIndexData) return 0;
+async function fetchUnreadCount(db: D1Database | undefined, btcAddress: string): Promise<number> {
+  if (!db) return 0;
   try {
-    const inboxIndex = JSON.parse(inboxIndexData) as InboxAgentIndex;
-    return inboxIndex.unreadCount || 0;
+    return await countInboxMessagesFromD1(db, btcAddress, "unread");
   } catch {
     return 0;
   }
@@ -134,9 +141,11 @@ export async function GET(request: NextRequest) {
 
     const { agent, claim } = result;
 
-    // Fetch inbox index in parallel (claim already fetched by lookupAgent)
-    const inboxIndexData = await kv.get(`inbox:agent:${agent.btcAddress}`);
-    const unreadCount = parseUnreadCount(inboxIndexData);
+    // Phase 2.5 Step 4 — unreadCount now served from D1 live SELECT COUNT(*).
+    // Replaces the KV inbox:agent:{btcAddress} read that served a stale cached
+    // counter. Closes aibtc-mcp-server#497 for the heartbeat orientation path.
+    const db = env.DB as D1Database | undefined;
+    const unreadCount = await fetchUnreadCount(db, agent.btcAddress);
 
     const orientation = getOrientation(agent, claim, unreadCount);
 
@@ -368,17 +377,17 @@ export async function POST(request: NextRequest) {
       lastActiveAt: timestamp,
     };
 
-    // Write updates to both btc: and stx: keys, fetch inbox in parallel.
+    // Write updates to both btc: and stx: keys in parallel; fetch D1 unread count.
     // Pure timestamp updates are tolerated as stale for up to the 2-min cache
     // TTL — no need to invalidate the cached agent list on every check-in.
-    const [, , inboxIndexData] = await Promise.all([
+    // Phase 2.5 Step 4 — unreadCount now served from D1 live SELECT COUNT(*);
+    // KV inbox:agent:{btcAddress} read removed.
+    const db = env.DB as D1Database | undefined;
+    const [, , unreadCount] = await Promise.all([
       kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent)),
       kv.put(`stx:${agent.stxAddress}`, JSON.stringify(updatedAgent)),
-      kv.get(`inbox:agent:${btcAddress}`),
+      fetchUnreadCount(db, btcAddress),
     ]);
-
-    // Build orientation and level info (single getAgentLevel call inside getOrientation)
-    const unreadCount = parseUnreadCount(inboxIndexData);
     const orientation = getOrientation(updatedAgent, claim, unreadCount);
     const nextLevel = getNextLevel(orientation.level);
 

--- a/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
@@ -1,15 +1,18 @@
 /**
- * Tests for the mark-read PATCH D1 dual-write (Phase 2.5 Step 3 readiness).
+ * Tests for the mark-read PATCH D1 sole-source-of-truth (Phase 2.5 Step 4).
  *
- * Updated in Phase 2.5 Step 3.5 (#736): the PATCH auth read was flipped from
- * KV (getMessage) to D1 (getInboxMessageFromD1). Tests updated to mock
- * getInboxMessageFromD1 instead of getMessage.
+ * Updated in Phase 2.5 Step 4 (#730): KV writes (updateMessage,
+ * decrementUnreadCount) are removed; D1 is now the sole write path.
+ * The D1 UPDATE is synchronous and failure-propagating.
  *
- * Verifies:
- *  - After successful D1 read + KV mark-read, ctx.waitUntil schedules D1 UPDATE
- *  - D1 UPDATE is called with the correct messageId and { readAt: now }
- *  - D1 UPDATE failure is swallowed — response is still 200
- *  - When DB binding is absent, response is 503 (D1 is now auth gate, not fallback)
+ * Previously (Steps 1-3): D1 UPDATE was scheduled via ctx.waitUntil (best-effort)
+ * and failure did NOT fail the 200 response. That contract is REVERSED in Step 4.
+ *
+ * Verifies (Step 4 contract):
+ *  - After D1 auth read succeeds, updateMessageStateD1 is called synchronously
+ *  - D1 UPDATE success → 200 response with readAt
+ *  - D1 UPDATE failure → 503 + Retry-After: 5 (failure propagates)
+ *  - When DB binding is absent → 503 (D1 is required auth gate, not a fallback)
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
@@ -162,7 +165,7 @@ function buildPatchRequest(address: string, messageId: string) {
 
 // ---- tests ------------------------------------------------------------------
 
-describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 Step 3 readiness)", () => {
+describe("PATCH /api/inbox/[address]/[messageId] — D1 sole-source-of-truth (Phase 2.5 Step 4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (lookupAgent as Mock).mockResolvedValue(AGENT);
@@ -177,10 +180,14 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
     });
     (updateMessage as Mock).mockResolvedValue({ ...INBOX_MESSAGE, readAt: "2026-05-10T12:00:00.000Z" });
     (decrementUnreadCount as Mock).mockResolvedValue(undefined);
+    // Re-apply resolved values cleared by clearAllMocks
+    (updateMessageStateD1 as Mock).mockResolvedValue(undefined);
   });
 
-  it("schedules D1 UPDATE via ctx.waitUntil after successful KV mark-read", async () => {
-    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+  it("D1 UPDATE is synchronous — returns 200 and updateMessageStateD1 was called directly", async () => {
+    // Step 4 contract: updateMessageStateD1 is called synchronously (not via
+    // ctx.waitUntil). Success → 200 with readAt in the response.
+    const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
     const kv = createMockKV();
@@ -200,8 +207,10 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
     });
 
     expect(resp.status).toBe(200);
-    expect(waitUntilFn).toHaveBeenCalled();
+    // D1 UPDATE must have been called synchronously
     expect(updateMessageStateD1).toHaveBeenCalledOnce();
+    // ctx.waitUntil must NOT have been called — D1 UPDATE is no longer fire-and-forget
+    expect(waitUntilFn).not.toHaveBeenCalled();
 
     // Verify called with correct messageId and readAt field
     const [calledDb, calledMessageId, calledUpdates] = (
@@ -214,13 +223,14 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
     expect(calledUpdates).not.toHaveProperty("repliedAt");
   });
 
-  it("D1 UPDATE failure does NOT fail the 200 response", async () => {
+  it("D1 UPDATE failure returns 503 with Retry-After: 5 (Step 4 reversed contract)", async () => {
+    // Step 4 contract: D1 UPDATE failure PROPAGATES — 503 + Retry-After: 5.
+    // The old Step-1/2 contract ("D1 UPDATE failure does NOT fail the 200 response")
+    // is REVERSED: D1 is now the sole write path, so failure must propagate.
     const d1Error = new Error("D1 constraint violation");
     (updateMessageStateD1 as Mock).mockRejectedValue(d1Error);
 
-    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
-      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
-    });
+    const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
     const kv = createMockKV();
@@ -239,8 +249,12 @@ describe("PATCH /api/inbox/[address]/[messageId] — D1 dual-write (Phase 2.5 St
       params: Promise.resolve({ address: AGENT.btcAddress, messageId: MESSAGE_ID }),
     });
 
-    // Response must still be 200 — D1 dual-write failure must NOT propagate
-    expect(resp.status).toBe(200);
+    // D1 failure must propagate — caller retries rather than getting a phantom 200
+    expect(resp.status).toBe(503);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+    const body = await resp.json();
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfter).toBe(5);
   });
 
   it("returns 503 when DB binding is absent (D1 is now the auth gate, not a fallback)", async () => {

--- a/app/api/inbox/[address]/[messageId]/route.ts
+++ b/app/api/inbox/[address]/[messageId]/route.ts
@@ -8,10 +8,8 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
-  updateMessage,
   validateMarkRead,
   buildMarkReadMessage,
-  decrementUnreadCount,
 } from "@/lib/inbox";
 import { shouldFailClosed } from "@/lib/env";
 import { updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
@@ -104,8 +102,8 @@ export async function GET(
 }
 
 // PATCH (mark-read) auth read flipped to D1 in Phase 2.5 Step 3.5 (#736).
-// KV writes (updateMessage, decrementUnreadCount) are NOT removed here — that
-// is Step 4 (#730). The D1 read is the new auth gate; KV write still mirrors it.
+// KV writes (updateMessage, decrementUnreadCount) removed in Phase 2.5 Step 4 (#730).
+// D1 is now the sole write path; unreadCount served by live SELECT COUNT(*).
 export async function PATCH(
   request: NextRequest,
   { params }: { params: Promise<{ address: string; messageId: string }> }
@@ -293,32 +291,27 @@ export async function PATCH(
     );
   }
 
-  // Update message with readAt timestamp
+  // D1 is now the sole write path (Phase 2.5 Step 4 — KV writes removed).
+  // unreadCount is now a live SELECT COUNT(*) so no KV decrement is needed.
+  //
+  // D1 UPDATE is synchronous and failure-propagating: failure returns 503
+  // + Retry-After: 5 so the caller can retry rather than seeing a phantom 200.
   const now = new Date().toISOString();
-  const updatedMessage = await updateMessage(kv, messageId, { readAt: now });
-
-  if (!updatedMessage) {
+  try {
+    await updateMessageStateD1(db, messageId, { readAt: now });
+  } catch (err) {
+    logger.error("mark_read.d1_update_failed", {
+      messageId,
+      path: "mark_read",
+      error: String(err),
+    });
     return NextResponse.json(
-      { error: "Failed to update message" },
-      { status: 500 }
-    );
-  }
-
-  // Decrement unreadCount on the agent inbox index (clamped to 0)
-  await decrementUnreadCount(kv, message.toBtcAddress);
-
-  // D1 dual-write (Phase 2.5 Step 3 readiness).
-  // KV is still the source of truth; D1 UPDATE is fire-and-forget.
-  // D1 failure is logged-and-swallowed — it must NOT fail the response.
-  if (env.DB) {
-    ctx.waitUntil(
-      updateMessageStateD1(env.DB as D1Database, messageId, { readAt: now }).catch((err) =>
-        logger.error("mark_read.dual_write_d1_failed", {
-          messageId,
-          path: "mark_read",
-          error: String(err),
-        })
-      )
+      {
+        error: "Mark-read failed. Please retry shortly.",
+        retryable: true,
+        retryAfter: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
     );
   }
 

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -1,19 +1,19 @@
 /**
- * Regression tests for Phase 2.5 Step 1 — inbox/outbox dual-write to D1.
+ * Regression tests for Phase 2.5 Step 4 — D1 as sole source of truth.
  *
- * Updated in Phase 2.5 Step 3.5 (#736): the POST outbox auth reads were flipped
- * from KV (getMessage, getReply) to D1 (getInboxMessageFromD1, getReplyForMessageFromD1).
- * Tests updated to mock the D1 helpers instead of the KV helpers.
+ * Updated in Phase 2.5 Step 4 (#730): KV writes removed; D1 is now the
+ * authoritative and only write path. Tests updated to match the new contract:
  *
- * Key properties verified:
- *  - POST /api/inbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
- *  - D1 INSERT failure does NOT fail the 201 response (logged-and-swallowed)
- *  - POST /api/outbox/[address]: after KV write succeeds, ctx.waitUntil schedules D1 INSERT
- *  - D1 INSERT for reply uses is_reply=1 and synthesized PK via deriveReplyD1Id
- *  - When DB binding is absent, the outbox POST returns 503 (D1 is now the auth gate)
+ *  - POST /api/inbox/[address]: D1 INSERT is synchronous (not fire-and-forget).
+ *    D1 failure propagates → 503 + Retry-After: 5.
+ *    Missing DB binding → 503 + Retry-After: 5.
+ *  - POST /api/outbox/[address]: same — D1 INSERT is synchronous.
+ *    D1 failure propagates → 503 + Retry-After: 5.
+ *    Parent message state update (replied_at / read_at) is still best-effort
+ *    via ctx.waitUntil — failure there does NOT fail the 201.
  *
  * These tests exercise the route handlers with mocked downstream functions.
- * They do NOT test the full payment flow — only the dual-write wiring.
+ * They do NOT test the full payment flow — only the D1 write-path wiring.
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
@@ -117,7 +117,6 @@ vi.mock("@/lib/env", () => ({
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
-  storeMessage,
   updateAgentInbox,
   validateInboxMessage,
   verifyInboxPayment,
@@ -208,18 +207,21 @@ function createRateLimitMock(success = true): RateLimit {
   } as unknown as RateLimit;
 }
 
-// ---- inbox POST dual-write tests -------------------------------------------
+// ---- inbox POST D1 sole-source-of-truth tests (Phase 2.5 Step 4) -----------
 
-describe("POST /api/inbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () => {
+describe("POST /api/inbox/[address] — D1 sole-source-of-truth (Phase 2.5 Step 4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (lookupAgent as Mock).mockResolvedValue(AGENT);
-    (storeMessage as Mock).mockResolvedValue(undefined);
     (updateAgentInbox as Mock).mockResolvedValue(undefined);
+    // Re-apply resolved values cleared by clearAllMocks
+    (insertInboundMessageToD1 as Mock).mockResolvedValue(undefined);
   });
 
-  it("schedules D1 INSERT via ctx.waitUntil after successful x402 KV write", async () => {
-    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
+  it("D1 INSERT is synchronous — returns 201 and insertInboundMessageToD1 was called directly", async () => {
+    // Step 4 contract: insertInboundMessageToD1 is called synchronously (not
+    // fire-and-forget). A successful insert returns 201.
+    const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
     const kv = createMockKV();
@@ -262,22 +264,20 @@ describe("POST /api/inbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =>
     const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
     expect(resp.status).toBe(201);
-    // ctx.waitUntil must have been called (D1 INSERT scheduled)
-    expect(waitUntilFn).toHaveBeenCalled();
-    // insertInboundMessageToD1 must have been called (inside waitUntil promise)
+    // D1 INSERT must have been called (synchronous, not in waitUntil)
     expect(insertInboundMessageToD1).toHaveBeenCalledOnce();
-    // Verify DB is passed
+    // Verify DB is passed as first arg
     const [calledDb] = (insertInboundMessageToD1 as Mock).mock.calls[0];
     expect(calledDb).toBe(db);
   });
 
-  it("D1 INSERT failure does NOT fail the 201 response", async () => {
+  it("D1 INSERT failure returns 503 with Retry-After: 5 (Step 4 reversed contract)", async () => {
+    // Step 4 contract: D1 failure PROPAGATES — 503 + Retry-After: 5.
+    // The old Step-1/2 contract (best-effort, swallow errors) is reversed here.
     const d1Error = new Error("D1 unavailable");
     (insertInboundMessageToD1 as Mock).mockRejectedValue(d1Error);
 
-    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
-      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
-    });
+    const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
     const kv = createMockKV();
@@ -319,18 +319,24 @@ describe("POST /api/inbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =>
 
     const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
-    // Response must still be 201 — D1 failure must NOT propagate
-    expect(resp.status).toBe(201);
+    // D1 failure must propagate — sender retries rather than losing the message
+    expect(resp.status).toBe(503);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+    const body = await resp.json();
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfter).toBe(5);
   });
 
-  it("skips D1 INSERT when DB binding is absent (no env.DB)", async () => {
+  it("missing DB binding returns 503 (D1 is required — no fallback)", async () => {
+    // Step 4 contract: DB binding is required for delivery. Missing binding → 503.
+    // Old Step-1 behavior (skip D1, return 201 anyway) is reversed.
     const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const kv = createMockKV();
 
     mockCloudflareContext({
       VERIFIED_AGENTS: kv,
-      // DB is intentionally absent
+      // DB intentionally absent
       RATE_LIMIT_MUTATING: createRateLimitMock(true),
     }, ctx);
 
@@ -365,16 +371,17 @@ describe("POST /api/inbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =>
 
     const resp = await inboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
-    expect(resp.status).toBe(201);
-    // ctx.waitUntil should NOT have been called — no DB binding
-    expect(waitUntilFn).not.toHaveBeenCalled();
+    // D1 is required — no DB → 503 (not 201 as in the old skip-D1 behavior)
+    expect(resp.status).toBe(503);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+    // D1 insert must NOT have been called — rejected before reaching insert
     expect(insertInboundMessageToD1).not.toHaveBeenCalled();
   });
 });
 
-// ---- outbox POST dual-write tests ------------------------------------------
+// ---- outbox POST D1 sole-source-of-truth tests (Phase 2.5 Step 4) ----------
 
-describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () => {
+describe("POST /api/outbox/[address] — D1 sole-source-of-truth (Phase 2.5 Step 4)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (lookupAgent as Mock).mockResolvedValue(AGENT);
@@ -385,9 +392,14 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
     (getInboxMessageFromD1 as Mock).mockResolvedValue(INBOX_MESSAGE); // original message
     (getReplyForMessageFromD1 as Mock).mockResolvedValue(null); // no existing reply
     (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
+    // Re-apply resolved values cleared by clearAllMocks
+    (insertReplyToD1 as Mock).mockResolvedValue(undefined);
+    (updateMessageStateD1 as Mock).mockResolvedValue(undefined);
   });
 
-  it("schedules D1 INSERT via ctx.waitUntil after successful KV reply write", async () => {
+  it("D1 INSERT is synchronous — returns 201 and insertReplyToD1 was called directly", async () => {
+    // Step 4: insertReplyToD1 is called synchronously; success → 201.
+    // ctx.waitUntil is called only for the best-effort parent state update.
     const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
@@ -422,9 +434,7 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
     const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
     expect(resp.status).toBe(201);
-    // ctx.waitUntil must have been called (D1 INSERT scheduled)
-    expect(waitUntilFn).toHaveBeenCalled();
-    // insertReplyToD1 must have been called
+    // insertReplyToD1 must have been called synchronously
     expect(insertReplyToD1).toHaveBeenCalledOnce();
     // Verify DB and KV are passed
     const [calledDb, calledKv] = (insertReplyToD1 as Mock).mock.calls[0];
@@ -432,13 +442,13 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
     expect(calledKv).toBe(kv);
   });
 
-  it("D1 INSERT failure does NOT fail the 201 response", async () => {
+  it("D1 INSERT failure returns 503 with Retry-After: 5 (Step 4 reversed contract)", async () => {
+    // Step 4 contract: D1 INSERT failure PROPAGATES — 503 + Retry-After: 5.
+    // The old best-effort / swallow-errors contract is reversed.
     const d1Error = new Error("D1 constraint violation");
     (insertReplyToD1 as Mock).mockRejectedValue(d1Error);
 
-    const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
-      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
-    });
+    const waitUntilFn = vi.fn();
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
     const kv = createMockKV();
@@ -471,11 +481,15 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
 
     const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
-    // Response must still be 201 — D1 failure must NOT propagate
-    expect(resp.status).toBe(201);
+    // D1 failure must propagate — replier retries rather than losing the reply
+    expect(resp.status).toBe(503);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+    const body = await resp.json();
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfter).toBe(5);
   });
 
-  it("D1 INSERT is called with is_reply=1 semantics (reply shape with synthesized PK)", async () => {
+  it("D1 INSERT is called with correct reply shape (messageId = parent message ID)", async () => {
     const waitUntilFn = vi.fn(async (p: Promise<unknown>) => { await p; });
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
@@ -519,9 +533,9 @@ describe("POST /api/outbox/[address] — D1 dual-write (Phase 2.5 Step 1)", () =
   });
 });
 
-// ── outbox POST parent-state dual-write tests ─────────────────────────────
+// ── outbox POST parent-state D1 tests (still best-effort via ctx.waitUntil) ──
 
-describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2.5 Step 3 readiness)", () => {
+describe("POST /api/outbox/[address] — parent message D1 state update (still best-effort)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (lookupAgent as Mock).mockResolvedValue(AGENT);
@@ -531,6 +545,9 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     // Phase 2.5 Step 3.5: auth reads now use D1 helpers
     (getReplyForMessageFromD1 as Mock).mockResolvedValue(null); // no existing reply
     (buildReplyMessage as Mock).mockReturnValue("Inbox Reply | msg_123 | hello");
+    // Re-apply resolved values cleared by clearAllMocks
+    (insertReplyToD1 as Mock).mockResolvedValue(undefined);
+    (updateMessageStateD1 as Mock).mockResolvedValue(undefined);
   });
 
   it("schedules D1 parent-state UPDATE via ctx.waitUntil after reply write (unread message)", async () => {
@@ -582,8 +599,8 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
     expect(resp.status).toBe(201);
-    // waitUntil called at least twice: once for insertReplyToD1, once for updateMessageStateD1
-    expect(waitUntilFn).toHaveBeenCalledTimes(2);
+    // waitUntil called once: for the best-effort parent-state updateMessageStateD1
+    expect(waitUntilFn).toHaveBeenCalledTimes(1);
     expect(updateMessageStateD1).toHaveBeenCalledOnce();
 
     const [calledDb, calledMessageId, calledUpdates] = (
@@ -656,12 +673,15 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
     expect(calledUpdates).not.toHaveProperty("readAt");
   });
 
-  it("D1 parent-state UPDATE failure does NOT fail the 201 response", async () => {
+  it("D1 parent-state UPDATE failure does NOT fail the 201 response (best-effort path)", async () => {
+    // The parent-state update (replied_at / read_at on the parent message row)
+    // is best-effort via ctx.waitUntil. Its failure must NOT propagate to the
+    // caller — the reply row itself is already committed.
     const d1Error = new Error("D1 update failed");
     (updateMessageStateD1 as Mock).mockRejectedValue(d1Error);
 
     const waitUntilFn = vi.fn(async (p: Promise<unknown>) => {
-      try { await p; } catch { /* swallow */ }
+      try { await p; } catch { /* swallow — simulates Worker swallowing the error */ }
     });
     const ctx = createCtxWithWaitUntil(waitUntilFn);
     const db = createMockDB();
@@ -707,7 +727,7 @@ describe("POST /api/outbox/[address] — parent message D1 state update (Phase 2
 
     const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
-    // D1 failure must NOT propagate to the user response
+    // Parent-state update failure must NOT propagate — reply is already stored
     expect(resp.status).toBe(201);
   });
 });

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -12,12 +12,8 @@ import {
   validateInboxMessage,
   verifyInboxPayment,
   verifyTxidPayment,
-  storeMessage,
   storeStagedInboxPayment,
-  updateAgentInbox,
-  updateSentIndex,
   INBOX_PRICE_SATS,
-  REDEEMED_TXID_TTL_SECONDS,
   RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS,
   buildInboxPaymentRequirements,
   buildSenderAuthMessage,
@@ -39,6 +35,7 @@ import {
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
   countOutboxRepliesFromD1,
+  checkRedeemedTxidInD1,
   type StatusFilter,
 } from "@/lib/inbox/d1-reads";
 
@@ -246,10 +243,9 @@ export async function GET(
   // D1-throws fallback policy (declared per #722 dev-council Cycle 26 advisory):
   // If the D1 query layer throws — transient unavailability, network error,
   // schema mismatch — return 503 with a structured retry hint rather than
-  // letting Next.js produce an unstructured 500. Step 3.2/3.3/3.4 will follow
-  // this same pattern so the cutover series has a uniform fallback contract.
-  // KV remains the source of truth (writes still go there per #720); a 503
-  // here means "D1 read transiently unavailable — retry."
+  // letting Next.js produce an unstructured 500.
+  // Phase 2.5 Step 4 (#730): D1 is now the sole source of truth for reads
+  // and writes on this path. A 503 here means "D1 transiently unavailable."
   let receivedMessages: import("@/lib/inbox/types").InboxMessage[];
   let unreadCount: number;
   let totalCount: number;
@@ -563,6 +559,7 @@ export async function POST(
   const { address } = await params;
   const { env, ctx } = await getCloudflareContext();
   const kv = env.VERIFIED_AGENTS as KVNamespace;
+  const db = env.DB as D1Database | undefined;
   const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
   const logger = isLogsRPC(env.LOGS)
     ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
@@ -833,7 +830,7 @@ export async function POST(
     });
 
     // Rate limit: up to 20 recovery attempts per txid per 60 seconds (RATE_LIMIT_MUTATING window).
-    // Double-redemption is prevented by the inbox:redeemed-txid:{txid} key below regardless of retry count.
+    // Double-redemption is prevented by the D1 idx_inbox_payment_txid UNIQUE index regardless of retry count.
     let txidRecoveryLimited = false;
     try {
       const result = await env.RATE_LIMIT_MUTATING.limit({ key: `txid-recovery:${paymentTxid}` });
@@ -856,16 +853,40 @@ export async function POST(
       );
     }
 
-    // Prevent double-redemption
-    const redeemedKey = `inbox:redeemed-txid:${paymentTxid}`;
-    const existingRedemption = await kv.get(redeemedKey);
-    if (existingRedemption) {
+    // Prevent double-redemption — D1 is now the authoritative idempotency store.
+    // idx_inbox_payment_txid (UNIQUE partial index on payment_txid) makes this
+    // index-only. Replaces the former KV inbox:redeemed-txid:{txid} check.
+    if (!db) {
+      return NextResponse.json(
+        {
+          error: "Database unavailable. Please try again shortly.",
+          retryable: true,
+          retryAfter: 5,
+        },
+        { status: 503, headers: { "Retry-After": "5" } }
+      );
+    }
+    let existingRedemptionMessageId: string | null;
+    try {
+      existingRedemptionMessageId = await checkRedeemedTxidInD1(db, paymentTxid);
+    } catch (e) {
+      logger.error("D1 redeemed-txid check failed", { txid: paymentTxid, error: String(e) });
+      return NextResponse.json(
+        {
+          error: "Database unavailable. Please try again shortly.",
+          retryable: true,
+          retryAfter: 5,
+        },
+        { status: 503, headers: { "Retry-After": "5" } }
+      );
+    }
+    if (existingRedemptionMessageId) {
       logger.warn("Txid already redeemed", { txid: paymentTxid });
       return NextResponse.json(
         {
           error: "This transaction has already been used for a message",
           txid: paymentTxid,
-          existingMessageId: existingRedemption,
+          existingMessageId: existingRedemptionMessageId,
         },
         { status: 409 }
       );
@@ -989,17 +1010,7 @@ export async function POST(
     const fromAddress = txidResult.payerStxAddress || "unknown";
     const messageId = `msg_${Date.now()}_${crypto.randomUUID()}`;
 
-    // Guard against (extremely unlikely) server-generated ID collision
-    const existingMessage = await kv.get(`inbox:message:${messageId}`);
-    if (existingMessage) {
-      logger.warn("Duplicate message ID", { messageId });
-      return NextResponse.json(
-        { error: "Message already exists", messageId },
-        { status: 409 }
-      );
-    }
-
-    // Look up sender agent for BIP-322 verification and sent-index update
+    // Look up sender agent for BIP-322 verification
     const senderAgent = fromAddress !== "unknown" ? await lookupAgent(kv, fromAddress) : null;
     const sigResult = verifySenderSignature(senderSignatureInput, content, logger, senderAgent?.btcAddress);
     if (sigResult instanceof NextResponse) return sigResult;
@@ -1022,28 +1033,27 @@ export async function POST(
       ...(replyTo && { replyTo }),
     };
 
-    // Store message, update indexes, and mark txid as redeemed (with TTL)
-    await Promise.all([
-      storeMessage(kv, message),
-      updateAgentInbox(kv, toBtcAddress, messageId, now),
-      kv.put(redeemedKey, messageId, { expirationTtl: REDEEMED_TXID_TTL_SECONDS }),
-      ...(senderAgent
-        ? [updateSentIndex(kv, senderAgent.btcAddress, messageId, now)]
-        : []),
-    ]);
-
-    // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
-    // KV is still the source of truth; D1 INSERT is fire-and-forget.
-    // D1 failure is logged-and-swallowed — it must NOT fail the response.
-    if (env.DB) {
-      ctx.waitUntil(
-        insertInboundMessageToD1(env.DB as D1Database, message).catch((err) =>
-          logger.error("inbox.dual_write_d1_failed", {
-            messageId: message.messageId,
-            path: "txid_recovery",
-            error: String(err),
-          })
-        )
+    // D1 is now the sole INSERT path (Phase 2.5 Step 4 — KV writes removed).
+    // D1 INSERT is synchronous and failure-propagating: failure returns 503 +
+    // Retry-After: 5 so the sender retries rather than seeing a phantom 200.
+    // The payment_txid UNIQUE index (idx_inbox_payment_txid) provides permanent
+    // double-redemption prevention — ON CONFLICT on message_id is belt-and-
+    // suspenders for the race where two concurrent requests share the same ID.
+    try {
+      await insertInboundMessageToD1(db, message);
+    } catch (err) {
+      logger.error("inbox.d1_insert_failed", {
+        messageId: message.messageId,
+        path: "txid_recovery",
+        error: String(err),
+      });
+      return NextResponse.json(
+        {
+          error: "Message delivery failed. Please retry shortly.",
+          retryable: true,
+          retryAfter: 5,
+        },
+        { status: 503, headers: { "Retry-After": "5" } }
       );
     }
 
@@ -1417,20 +1427,7 @@ export async function POST(
   const fromAddress = paymentResult.payerStxAddress || "unknown";
   const messageId = `msg_${Date.now()}_${crypto.randomUUID()}`;
 
-  // Guard against (extremely unlikely) server-generated ID collision
-  const existingMessage = await kv.get(`inbox:message:${messageId}`);
-  if (existingMessage) {
-    logger.warn("Duplicate message ID", { messageId });
-    return NextResponse.json(
-      {
-        error: "Message already exists",
-        messageId,
-      },
-      { status: 409 }
-    );
-  }
-
-  // Look up sender agent for BIP-322 verification and sent-index update
+  // Look up sender agent for BIP-322 verification
   const senderAgent = fromAddress !== "unknown" ? await lookupAgent(kv, fromAddress) : null;
   const sigResult = verifySenderSignature(senderSignatureInput, content, logger, senderAgent?.btcAddress);
   if (sigResult instanceof NextResponse) return sigResult;
@@ -1549,26 +1546,35 @@ export async function POST(
     }
   }
 
-  await Promise.all([
-    storeMessage(kv, message),
-    updateAgentInbox(kv, toBtcAddress, messageId, now),
-    ...(senderAgent
-      ? [updateSentIndex(kv, senderAgent.btcAddress, messageId, now)]
-      : []),
-  ]);
-
-  // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
-  // KV is still the source of truth; D1 INSERT is fire-and-forget.
-  // D1 failure is logged-and-swallowed — it must NOT fail the response.
-  if (env.DB) {
-    ctx.waitUntil(
-      insertInboundMessageToD1(env.DB as D1Database, message).catch((err) =>
-        logger.error("inbox.dual_write_d1_failed", {
-          messageId: message.messageId,
-          path: "x402_payment",
-          error: String(err),
-        })
-      )
+  // D1 is now the sole INSERT path (Phase 2.5 Step 4 — KV writes removed).
+  // D1 INSERT is synchronous and failure-propagating: on D1 failure return 503
+  // + Retry-After: 5 so the sender retries rather than seeing a phantom 200.
+  if (!db) {
+    logger.error("D1 binding unavailable on x402 delivery path", { messageId });
+    return NextResponse.json(
+      {
+        error: "Message delivery failed. Please retry shortly.",
+        retryable: true,
+        retryAfter: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+  try {
+    await insertInboundMessageToD1(db, message);
+  } catch (err) {
+    logger.error("inbox.d1_insert_failed", {
+      messageId: message.messageId,
+      path: "x402_payment",
+      error: String(err),
+    });
+    return NextResponse.json(
+      {
+        error: "Message delivery failed. Please retry shortly.",
+        retryable: true,
+        retryAfter: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
     );
   }
 

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -9,10 +9,7 @@ import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
   validateOutboxReply,
-  storeReply,
-  updateMessage,
   buildReplyMessage,
-  decrementUnreadCount,
 } from "@/lib/inbox";
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
@@ -439,60 +436,52 @@ export async function POST(
     repliedAt: now,
   };
 
-  // Check if message is already read (to know if we need to decrement unread)
-  const wasUnread = !message.readAt;
-
-  // Store reply and update message (also mark as read) in parallel
-  // On recovery, storeReply overwrites the existing partial record with a fresh timestamp
-  await Promise.all([
-    storeReply(kv, outboxReply),
-    updateMessage(kv, messageId, {
-      repliedAt: now,
-      ...(!message.readAt && { readAt: now }),
-    }),
-  ]);
-
-  // Decrement unreadCount if message was unread
-  if (wasUnread) {
-    await decrementUnreadCount(kv, message.toBtcAddress);
-  }
-
-  // D1 dual-write (Phase 2.5 Step 1 — reversible scaffolding).
-  // KV is still the source of truth; D1 INSERT is fire-and-forget.
-  // D1 failure is logged-and-swallowed — it must NOT fail the response.
+  // D1 is now the sole write path (Phase 2.5 Step 4 — KV writes removed).
+  // unreadCount is now a live SELECT COUNT(*) so no KV decrement is needed.
+  //
+  // insertReplyToD1 is synchronous + failure-propagating: failure returns 503
+  // + Retry-After: 5 so the sender retries rather than losing the reply.
   // Note: insertReplyToD1 resolves outboxReply.toBtcAddress (may be STX) to BTC
-  // via KV lookup before inserting. If resolution fails, it throws and the catch
-  // logs it as a dual-write failure.
-  if (env.DB) {
-    ctx.waitUntil(
-      insertReplyToD1(env.DB as D1Database, kv, outboxReply).catch((err) =>
-        logger.error("outbox.dual_write_d1_failed", {
-          messageId: outboxReply.messageId,
-          path: "kv_reply",
-          error: String(err),
-        })
-      )
-    );
-
-    // D1 dual-write for the PARENT message's read_at / replied_at state
-    // (Phase 2.5 Step 3 readiness — closes the updateMessage dual-write gap).
-    // The outbox POST updates the parent message in KV (sets repliedAt + possibly readAt).
-    // We mirror that here. Target is the parent's message_id directly — no derivation.
-    // wasUnread reflects whether readAt is being set for the first time.
-    const parentUpdates: { readAt?: string; repliedAt?: string } = {
-      repliedAt: now,
-      ...(wasUnread && { readAt: now }),
-    };
-    ctx.waitUntil(
-      updateMessageStateD1(env.DB as D1Database, messageId, parentUpdates).catch((err) =>
-        logger.error("outbox.dual_write_d1_parent_state_failed", {
-          messageId,
-          path: "kv_reply_parent_state",
-          error: String(err),
-        })
-      )
+  // via KV lookup before inserting.
+  //
+  // updateMessageStateD1 sets replied_at (and read_at if unread) on the parent
+  // message row. Failure here is logged-and-swallowed: the reply row already
+  // committed, so the parent state update is best-effort metadata (the reply
+  // content itself is durable). This matches the prior fire-and-forget pattern
+  // for the parent state update.
+  try {
+    await insertReplyToD1(db, kv, outboxReply);
+  } catch (err) {
+    logger.error("outbox.d1_insert_failed", {
+      messageId: outboxReply.messageId,
+      error: String(err),
+    });
+    return NextResponse.json(
+      {
+        error: "Reply delivery failed. Please retry shortly.",
+        retryable: true,
+        retryAfter: 5,
+        messageId,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
     );
   }
+
+  // Best-effort: update parent message's replied_at (and read_at if unread).
+  // The reply row is already committed; this is metadata only.
+  const wasUnread = !message.readAt;
+  const parentUpdates: { readAt?: string; repliedAt?: string } = {
+    repliedAt: now,
+    ...(wasUnread && { readAt: now }),
+  };
+  ctx.waitUntil(
+    updateMessageStateD1(db, messageId, parentUpdates).catch((err) =>
+      logger.error("outbox.d1_parent_state_failed", {
+        messageId,
+        error: String(err),
+      })
+    )
+  );
 
   // Generate reputationPayload (ERC-8004 feedbackHash) using Web Crypto API
   const hashData = new TextEncoder().encode(`${messageId}${reply}${signature}`);

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -385,5 +385,39 @@ export async function getReplyForMessageFromD1(
   return replyRowToOutboxReply(row);
 }
 
+/**
+ * Check whether a payment txid has already been redeemed (double-redemption guard).
+ *
+ * Phase 2.5 Step 4 — replaces the KV `inbox:redeemed-txid:{txid}` read in the
+ * txid-recovery path. The D1 unique partial index `idx_inbox_payment_txid` on
+ * `payment_txid WHERE payment_txid IS NOT NULL` makes this query index-only.
+ *
+ * Returns the messageId of the existing row on redemption, or null if the txid
+ * has not been used. Callers return 409 on a non-null result.
+ *
+ * SQL shape:
+ *   SELECT message_id FROM inbox_messages
+ *   WHERE payment_txid = ? AND payment_txid IS NOT NULL
+ *   LIMIT 1
+ */
+export async function checkRedeemedTxidInD1(
+  db: D1Database,
+  paymentTxid: string
+): Promise<string | null> {
+  const sql = `
+    SELECT message_id
+    FROM inbox_messages
+    WHERE payment_txid = ? AND payment_txid IS NOT NULL
+    LIMIT 1
+  `;
+
+  const row = await db
+    .prepare(sql)
+    .bind(paymentTxid)
+    .first<{ message_id: string }>();
+
+  return row?.message_id ?? null;
+}
+
 // Re-export the prefix so tests can verify synthesized IDs
 export { REPLY_D1_PK_PREFIX };

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -61,11 +61,6 @@ function buildStagedPaymentKey(paymentId: string): string {
 /**
  * Get an inbox message by ID.
  *
- * @deprecated Read-path usage removed in Phase 2.5 Step 3.5 (#736).
- * All GET and write-path auth reads now use getInboxMessageFromD1 from d1-reads.ts.
- * KV writes (updateMessage) still call this indirectly; Step 4 (#730) will remove
- * those writes and this function once KV is fully sunset.
- *
  * @param kv - Cloudflare KV namespace
  * @param messageId - Message ID
  * @returns InboxMessage or null if not found
@@ -140,12 +135,6 @@ export async function updateMessage(
 
 /**
  * Get an outbox reply by message ID.
- *
- * @deprecated Read-path usage removed in Phase 2.5 Step 3.5 (#736).
- * The duplicate-reply check in POST /api/outbox/[address] now uses
- * getReplyForMessageFromD1 from d1-reads.ts (with tenant-discriminator SQL gate).
- * Step 4 (#730) will remove the KV writes (storeReply) and this function once
- * KV is fully sunset.
  *
  * @param kv - Cloudflare KV namespace
  * @param messageId - Message ID


### PR DESCRIPTION
## Summary

Phase 2.5 Step 4 — the final, irreversible cutover PR in the inbox D1 migration series. Removes all KV INSERT/UPDATE calls from the inbox/outbox POST and PATCH write handlers. D1 is now the sole source of truth for all new inbox/outbox writes.

**Closes:** #730
**References:** Umbrella Phase 2.5 series #697, cost umbrella #652

## Sign-off chain

- Umbrella series authorized by whoabuddy: **2026-05-11T01:40Z**
- Irreversible-cutover checkpoint go-confirmation: **2026-05-11T06:09Z**
- Step 3.5 (#739) smoke closed clean at 2026-05-11T06:08Z before this spawn

## What changed

### inbox POST (`app/api/inbox/[address]/route.ts`)
- Drop `storeMessage`, `updateAgentInbox`, `updateSentIndex` KV calls (both x402 and txid-recovery paths)
- Replace `inbox:redeemed-txid:{txid}` KV write + read with D1 `SELECT` on `idx_inbox_payment_txid` (UNIQUE partial index — now **permanent** instead of 90-day TTL, matching schema intent)
- `insertInboundMessageToD1` is now **synchronous + failure-propagating**: 503 + `Retry-After: 5` on D1 INSERT failure

### outbox POST (`app/api/outbox/[address]/route.ts`)
- Drop `storeReply`, `updateMessage` (mark-replied), `decrementUnreadCount` KV calls
- `insertReplyToD1` is now **synchronous + failure-propagating**: 503 + `Retry-After: 5` on D1 INSERT failure
- `updateMessageStateD1` for parent message (replied_at + read_at) remains `ctx.waitUntil` — best-effort metadata; the reply row itself is synchronous

### inbox PATCH mark-read (`app/api/inbox/[address]/[messageId]/route.ts`)
- Drop `updateMessage`, `decrementUnreadCount` KV calls
- `updateMessageStateD1` is now **synchronous + failure-propagating**: 503 + `Retry-After: 5` on D1 UPDATE failure

### heartbeat unreadCount (`app/api/heartbeat/route.ts`)
- Switch from KV `inbox:agent:{btcAddress}` stale counter to D1 live `SELECT COUNT(*) WHERE read_at IS NULL`
- Closes the +1 stale-counter drift tracked in aibtc-mcp-server#497
- Fails open (returns 0) on D1 unavailability so heartbeat orientation is never blocked

### lib/inbox/d1-reads.ts
- Add `checkRedeemedTxidInD1` helper: served by the `idx_inbox_payment_txid` UNIQUE partial index; replaces KV `inbox:redeemed-txid` read

### lib/inbox/kv-helpers.ts
- Remove `@deprecated` markers from `getMessage` + `getReply` (now orphaned; Phase 4.x deletes the helper functions when KV namespace is archived)

## Pre-merge checklist

- [x] `storeMessage`, `storeReply`, `updateAgentInbox`, `updateMessage`, `updateSentIndex`, `decrementUnreadCount` removed from all three POST/PATCH handlers
- [x] D1 INSERT is `await`-ed synchronously (not `ctx.waitUntil`) on all write paths
- [x] 503 + `Retry-After: 5` on D1 INSERT/UPDATE failure in all three handlers
- [x] heartbeat `unreadCount` switched to D1 live `SELECT COUNT(*)`
- [x] No TypeScript errors (`tsc --noEmit` passes on relevant files)

## Post-merge smoke (≥60min window)

- [ ] Send a test message via x402, verify D1 row exists, verify GET /api/inbox returns it
- [ ] Verify no `inbox:message:*` KV writes via worker-logs
- [ ] 60min worker-logs window: 0 ERROR / 0 WARN / 0 D1-503s on write paths
- [ ] Cost: ~43K writes/day should drop to near-zero for inbox/outbox events

## Rollback plan

If Step 4 smoke surfaces write failures: `wrangler workers deployments revert` to prior deployment. All messages written between merge and revert are in D1 (post-Step-3.x reads serve them); the dual-write from #705/#720 does not auto-resume (those KV writes are now gone). The operational stance per project memory is forward-fix, not rollback — D1 reads are live and correct.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)