### PR TITLE
fix(#750): restore @deprecated markers on KV inbox readers post-Step 4

### DIFF
--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -183,6 +183,11 @@ export async function storeReply(
 /**
  * Get the agent inbox index.
  *
+ * @deprecated reads stale data after #730 Step 4 — KV inbox writes were
+ *   removed in PR #745, so this returns frozen-at-cutover data for newly
+ *   delivered messages. Migrate callers to lib/inbox/d1-reads.ts equivalents
+ *   (`listInboxMessagesFromD1` / `countInboxMessagesFromD1`). Tracked in #746.
+ *
  * @param kv - Cloudflare KV namespace
  * @param btcAddress - Bitcoin address
  * @returns InboxAgentIndex or null if not found
@@ -255,6 +260,11 @@ export async function updateAgentInbox(
 
 /**
  * Get the agent sent message index.
+ *
+ * @deprecated reads stale data after #730 Step 4 — KV sent-index writes were
+ *   removed in PR #745, so this returns frozen-at-cutover data for newly
+ *   sent messages. Migrate callers to lib/inbox/d1-reads.ts equivalents
+ *   (`listOutboxRepliesFromD1` / `countOutboxRepliesFromD1`). Tracked in #746.
  *
  * @param kv - Cloudflare KV namespace
  * @param btcAddress - Bitcoin address


### PR DESCRIPTION
## Summary

Closes #750.

After PR #745 (Phase 2.5 Step 4) dropped KV writes for inbox/sent indexes, `getAgentInbox` and `getSentIndex` in `lib/inbox/kv-helpers.ts` still have active callers in `lib/agent-enrichment.ts` (and indirectly via `lib/activity.ts` KV reads). They now read **frozen-at-cutover data** for newly delivered messages. Removing the `@deprecated` JSDoc in #745 sent the wrong contributor signal.

This PR re-adds `@deprecated` JSDoc to both functions, updated to reflect the post-Step-4 context:

```ts
/**
 * @deprecated reads stale data after #730 Step 4 — KV inbox writes were
 *   removed in PR #745, so this returns frozen-at-cutover data for newly
 *   delivered messages. Migrate callers to lib/inbox/d1-reads.ts equivalents
 *   (`listInboxMessagesFromD1` / `countInboxMessagesFromD1`). Tracked in #746.
 */
```

Same pattern for `getSentIndex` pointing at `listOutboxRepliesFromD1` / `countOutboxRepliesFromD1`.

## Scope boundary

This PR only restores deprecation signals on the read helpers. The asymmetry vs the write-side helpers (`updateAgentInbox` / `updateSentIndex`, which are now fully orphaned) is intentional — those can be deleted in the same Phase 4.x cleanup that lands #746. Marking them `@deprecated` adds noise for callers that no longer exist.

## Test plan

- [x] `kv-helpers.ts` compiles (JSDoc-only change; zero runtime/type-surface impact)
- [x] No callers added/removed
- [x] CI on this PR (lint + tsc + tests) should be untouched

## References

- Closes #750
- Tracks #746 (caller migration to D1 reads — the @deprecated marker stays until #746 lands)
- Originating discussion: PR #745 review thread (arc0btc nit + secret-mars APPROVE comment)