### PR TITLE
fix(#746): flip agent-enrichment + activity KV inbox readers to D1

### DIFF
--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -92,6 +92,7 @@ export async function GET(request: NextRequest) {
   try {
     const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database | undefined;
 
     // Check cache first
     const cached = await kv.get<CachedActivity>(CACHE_KEY, "json");
@@ -143,7 +144,7 @@ export async function GET(request: NextRequest) {
 
     let response: ActivityResponse;
     try {
-      response = await buildActivityData(kv);
+      response = await buildActivityData(kv, db);
 
       // Cache the response
       const cacheData: CachedActivity = {

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -299,9 +299,12 @@ export async function GET(
         // Pass d1Claim so enrichAgentProfile skips the redundant KV read when the
         // agent came from D1 (covers all non-KV-fallback paths). When d1Claim is
         // undefined (KV fallback agents), enrichAgentProfile falls back to KV.
+        //
+        // `db` threads through for inbox/sent count reads from D1 (post-#730 Step 4).
         const enrichment = await enrichAgentProfile(
           agent,
           kv,
+          db,
           hiroApiKey,
           `agents/${agent.btcAddress}`,
           logger,

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -300,7 +300,8 @@ export async function GET(
         // agent came from D1 (covers all non-KV-fallback paths). When d1Claim is
         // undefined (KV fallback agents), enrichAgentProfile falls back to KV.
         //
-        // `db` threads through for inbox/sent count reads from D1 (post-#730 Step 4).
+        // `db` threads through for inbox/sent count reads from D1 (Phase 2.5
+        // Step 4 cutover landed in PR #745; umbrella quest #697).
         const enrichment = await enrichAgentProfile(
           agent,
           kv,

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -242,6 +242,7 @@ export async function GET(
 
     const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database | undefined;
     const hiroApiKey = env.HIRO_API_KEY;
 
     const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
@@ -432,6 +433,7 @@ export async function GET(
     const enrichment = await enrichAgentProfile(
       agent,
       kv,
+      db,
       hiroApiKey,
       `resolve/${agent.btcAddress}`,
       logger

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -93,6 +93,7 @@ async function fetchHomeData() {
   try {
     const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database | undefined;
     const { agents, stats } = await getCachedAgentList(kv, (p) =>
       ctx.waitUntil(p)
     );
@@ -115,7 +116,7 @@ async function fetchHomeData() {
     // top-agent events, not an O(N) scan.
     let activityData: ActivityResponse | undefined;
     try {
-      activityData = await buildActivityData(kv);
+      activityData = await buildActivityData(kv, db);
     } catch {
       // Graceful degradation: ActivityFeed will fall back to client-side fetch
     }

--- a/lib/__tests__/agent-enrichment.test.ts
+++ b/lib/__tests__/agent-enrichment.test.ts
@@ -6,6 +6,10 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { enrichAgentProfile } from "../agent-enrichment";
+import {
+  countInboxMessagesFromD1,
+  countOutboxRepliesFromD1,
+} from "../inbox/d1-reads";
 import type { AgentRecord, ClaimRecord, ClaimStatus } from "../types";
 
 // ---------------------------------------------------------------------------
@@ -24,9 +28,9 @@ vi.mock("@/lib/heartbeat", () => ({
   getCheckInRecord: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@/lib/inbox/kv-helpers", () => ({
-  getAgentInbox: vi.fn().mockResolvedValue(null),
-  getSentIndex: vi.fn().mockResolvedValue(null),
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  countInboxMessagesFromD1: vi.fn().mockResolvedValue(0),
+  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock("@/lib/caip19", () => ({
@@ -113,6 +117,7 @@ describe("enrichAgentProfile", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         claim
       );
 
@@ -128,6 +133,7 @@ describe("enrichAgentProfile", () => {
       await enrichAgentProfile(
         agent,
         kv as unknown as KVNamespace,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -150,6 +156,7 @@ describe("enrichAgentProfile", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         claim
       );
 
@@ -166,6 +173,7 @@ describe("enrichAgentProfile", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         null
       );
 
@@ -179,6 +187,7 @@ describe("enrichAgentProfile", () => {
       const result = await enrichAgentProfile(
         agent,
         kv as unknown as KVNamespace,
+        undefined,
         undefined,
         undefined,
         undefined,
@@ -199,6 +208,7 @@ describe("enrichAgentProfile", () => {
         undefined,
         undefined,
         undefined,
+        undefined,
         claim
       );
 
@@ -213,7 +223,8 @@ describe("enrichAgentProfile", () => {
 
       await enrichAgentProfile(
         agent,
-        kv as unknown as KVNamespace
+        kv as unknown as KVNamespace,
+        undefined
       );
 
       const claimKvReads = kv._getCallKeys.filter((k) =>
@@ -246,7 +257,8 @@ describe("enrichAgentProfile", () => {
 
       const result = await enrichAgentProfile(
         agent,
-        kv as unknown as KVNamespace
+        kv as unknown as KVNamespace,
+        undefined
       );
 
       expect(result.claim).toBeNull();
@@ -263,11 +275,92 @@ describe("enrichAgentProfile", () => {
 
       const result = await enrichAgentProfile(
         agent,
-        kv as unknown as KVNamespace
+        kv as unknown as KVNamespace,
+        undefined
       );
 
       expect(result.claim).not.toBeNull();
       expect(result.claim?.status).toBe("rewarded");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Inbox/sent counts post-#730 Step 4 (PR #745) — D1 reads, not KV
+  // -------------------------------------------------------------------------
+  describe("inbox/sent counts from D1 (post-Step-4)", () => {
+    function makeMockDb(): D1Database {
+      // enrichAgentProfile only calls countInboxMessagesFromD1 + countOutboxRepliesFromD1,
+      // which are vi.mock()ed at the top of the file. The D1Database object
+      // itself is opaque to enrichAgentProfile (only passed through), so a
+      // sentinel is sufficient.
+      return { __mock: true } as unknown as D1Database;
+    }
+
+    it("returns zero counts when db is undefined (no stale KV fallback)", async () => {
+      const agent = makeAgent();
+
+      const result = await enrichAgentProfile(
+        agent,
+        kv as unknown as KVNamespace,
+        undefined // db undefined → skip D1 reads, return zeros
+      );
+
+      expect(result.activity.unreadInboxCount).toBe(0);
+      expect(result.activity.sentCount).toBe(0);
+      expect(result.activity.hasInboxMessages).toBe(false);
+      expect(countInboxMessagesFromD1).not.toHaveBeenCalled();
+      expect(countOutboxRepliesFromD1).not.toHaveBeenCalled();
+    });
+
+    it("reads inbox unread + total counts from D1 when db is provided", async () => {
+      const agent = makeAgent();
+      const db = makeMockDb();
+
+      vi.mocked(countInboxMessagesFromD1)
+        .mockResolvedValueOnce(7) // total
+        .mockResolvedValueOnce(3); // unread
+      vi.mocked(countOutboxRepliesFromD1).mockResolvedValueOnce(5);
+
+      const result = await enrichAgentProfile(
+        agent,
+        kv as unknown as KVNamespace,
+        db
+      );
+
+      expect(result.activity.unreadInboxCount).toBe(3);
+      expect(result.activity.sentCount).toBe(5);
+      expect(result.activity.hasInboxMessages).toBe(true);
+      expect(countInboxMessagesFromD1).toHaveBeenCalledWith(
+        db,
+        agent.btcAddress,
+        "all"
+      );
+      expect(countInboxMessagesFromD1).toHaveBeenCalledWith(
+        db,
+        agent.btcAddress,
+        "unread"
+      );
+      expect(countOutboxRepliesFromD1).toHaveBeenCalledWith(db, agent.btcAddress);
+    });
+
+    it("hasInboxMessages=false when D1 returns zero total", async () => {
+      const agent = makeAgent();
+      const db = makeMockDb();
+
+      vi.mocked(countInboxMessagesFromD1)
+        .mockResolvedValueOnce(0) // total
+        .mockResolvedValueOnce(0); // unread
+      vi.mocked(countOutboxRepliesFromD1).mockResolvedValueOnce(0);
+
+      const result = await enrichAgentProfile(
+        agent,
+        kv as unknown as KVNamespace,
+        db
+      );
+
+      expect(result.activity.hasInboxMessages).toBe(false);
+      expect(result.activity.unreadInboxCount).toBe(0);
+      expect(result.activity.sentCount).toBe(0);
     });
   });
 });

--- a/lib/__tests__/agent-enrichment.test.ts
+++ b/lib/__tests__/agent-enrichment.test.ts
@@ -316,9 +316,12 @@ describe("enrichAgentProfile", () => {
       const agent = makeAgent();
       const db = makeMockDb();
 
-      vi.mocked(countInboxMessagesFromD1)
-        .mockResolvedValueOnce(7) // total
-        .mockResolvedValueOnce(3); // unread
+      // Argument-matched mock (not call-order-dependent) — if the Promise.all
+      // array order ever changes, this assertion still maps "all" → total and
+      // "unread" → unread correctly.
+      vi.mocked(countInboxMessagesFromD1).mockImplementation(
+        async (_db, _btc, status) => (status === "unread" ? 3 : 7)
+      );
       vi.mocked(countOutboxRepliesFromD1).mockResolvedValueOnce(5);
 
       const result = await enrichAgentProfile(
@@ -347,9 +350,7 @@ describe("enrichAgentProfile", () => {
       const agent = makeAgent();
       const db = makeMockDb();
 
-      vi.mocked(countInboxMessagesFromD1)
-        .mockResolvedValueOnce(0) // total
-        .mockResolvedValueOnce(0); // unread
+      vi.mocked(countInboxMessagesFromD1).mockResolvedValue(0);
       vi.mocked(countOutboxRepliesFromD1).mockResolvedValueOnce(0);
 
       const result = await enrichAgentProfile(

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -65,6 +65,14 @@ export async function buildActivityData(
   // --- 4. Collect events from top active agents ---
   // One D1 query/agent (LIMIT 3 ORDER BY sent_at DESC) replaces the prior
   // 4 KV reads/agent (inbox:agent index + 3 inbox:message lookups).
+  if (!db) {
+    // Surface configuration drift in CF preview deploys before it reaches prod.
+    // Without the D1 binding the activity feed silently drops all message
+    // events — registration events still surface but the feed is half-empty.
+    console.warn(
+      "activity.build_data: D1 binding missing — message events skipped, registration events only"
+    );
+  }
   const eventPromises = sortedAgents.map(async (agent) => {
     const agentEvents: ActivityEvent[] = [];
 

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -6,8 +6,8 @@
  * route handler module.
  */
 
-import type { InboxMessage, InboxAgentIndex } from "@/lib/inbox/types";
 import { INBOX_PRICE_SATS } from "@/lib/inbox/constants";
+import { listInboxMessagesFromD1 } from "@/lib/inbox/d1-reads";
 import { getCachedAgentList } from "@/lib/cache";
 import type { ActivityEvent, ActivityResponse } from "@/app/components/activity-shared";
 
@@ -19,11 +19,19 @@ const ACTIVE_DAYS_THRESHOLD = 7;
  * Assemble activity data using the shared agent-list cache.
  *
  * Uses getCachedAgentList() (single KV read on cache hit) instead of
- * an independent O(N) KV scan. Only the per-agent event detail fetches
- * (recent messages for top 20 active agents) remain as
- * targeted KV reads — O(20 * 3) rather than O(N).
+ * an independent O(N) KV scan. Per-agent recent-message fetches now read
+ * from D1 via `listInboxMessagesFromD1` (one query/agent, ordered by
+ * sent_at DESC LIMIT 3) — collapses the previous 4 KV reads/agent
+ * (inbox:agent index + 3 inbox:message lookups) to a single SELECT.
+ *
+ * When `db` is undefined (legacy / test paths), message events are
+ * skipped rather than reading stale KV indexes (KV inbox writes were
+ * removed in #730 Step 4 / PR #745). Registration events still surface.
  */
-export async function buildActivityData(kv: KVNamespace): Promise<ActivityResponse> {
+export async function buildActivityData(
+  kv: KVNamespace,
+  db: D1Database | undefined
+): Promise<ActivityResponse> {
   // --- 1. Get agent data from the shared cache (single KV read on hit) ---
   const { agents: cachedAgents, stats: agentStats } = await getCachedAgentList(kv);
 
@@ -55,53 +63,42 @@ export async function buildActivityData(kv: KVNamespace): Promise<ActivityRespon
   const agentByStx = new Map(cachedAgents.map((a) => [a.stxAddress, a]));
 
   // --- 4. Collect events from top active agents ---
-  // O(TOP_ACTIVE_AGENTS * 3) KV reads: 3 messages per agent
+  // One D1 query/agent (LIMIT 3 ORDER BY sent_at DESC) replaces the prior
+  // 4 KV reads/agent (inbox:agent index + 3 inbox:message lookups).
   const eventPromises = sortedAgents.map(async (agent) => {
     const agentEvents: ActivityEvent[] = [];
 
-    // Fetch inbox index for this agent
-    const inboxIndex = await kv.get<InboxAgentIndex>(
-      `inbox:agent:${agent.btcAddress}`,
-      "json"
-    );
-
-    if (inboxIndex && inboxIndex.messageIds.length > 0) {
-      // Fetch most recent 3 messages for the event feed
-      const recentMessageIds = inboxIndex.messageIds.slice(-3).reverse();
-      const messages = await Promise.all(
-        recentMessageIds.map(async (messageId) => {
-          const message = await kv.get<InboxMessage>(
-            `inbox:message:${messageId}`,
-            "json"
-          );
-          return message;
-        })
+    if (db) {
+      // listInboxMessagesFromD1 returns most-recent first (ORDER BY sent_at DESC)
+      const messages = await listInboxMessagesFromD1(
+        db,
+        agent.btcAddress,
+        3,
+        0,
+        "all"
       );
 
-      // Add message events
       for (const message of messages) {
-        if (message) {
-          // Find sender agent for display name (O(1) Map lookup)
-          const senderAgent = agentByStx.get(message.fromAddress);
+        // Find sender agent for display name (O(1) Map lookup)
+        const senderAgent = agentByStx.get(message.fromAddress);
 
-          agentEvents.push({
-            type: "message",
-            timestamp: message.sentAt,
-            agent: {
-              btcAddress: senderAgent?.btcAddress || message.fromAddress,
-              displayName: senderAgent?.displayName || "Unknown Agent",
-            },
-            recipient: {
-              btcAddress: agent.btcAddress,
-              displayName: agent.displayName || agent.btcAddress,
-            },
-            paymentSatoshis: message.paymentSatoshis,
-            messagePreview: message.content.length > 80
-              ? message.content.slice(0, 80) + "…"
-              : message.content,
-            messageId: message.messageId,
-          });
-        }
+        agentEvents.push({
+          type: "message",
+          timestamp: message.sentAt,
+          agent: {
+            btcAddress: senderAgent?.btcAddress || message.fromAddress,
+            displayName: senderAgent?.displayName || "Unknown Agent",
+          },
+          recipient: {
+            btcAddress: agent.btcAddress,
+            displayName: agent.displayName || agent.btcAddress,
+          },
+          paymentSatoshis: message.paymentSatoshis,
+          messagePreview: message.content.length > 80
+            ? message.content.slice(0, 80) + "…"
+            : message.content,
+          messageId: message.messageId,
+        });
       }
     }
 

--- a/lib/agent-enrichment.ts
+++ b/lib/agent-enrichment.ts
@@ -13,7 +13,10 @@ import type { AgentIdentity, ReputationSummary } from "@/lib/identity/types";
 import { getAgentLevel, type AgentLevelInfo } from "@/lib/levels";
 import { getCheckInRecord, type CheckInRecord } from "@/lib/heartbeat";
 import { detectAgentIdentity, getReputationSummary } from "@/lib/identity";
-import { getAgentInbox, getSentIndex } from "@/lib/inbox/kv-helpers";
+import {
+  countInboxMessagesFromD1,
+  countOutboxRepliesFromD1,
+} from "@/lib/inbox/d1-reads";
 import { getCAIP19AgentId } from "@/lib/caip19";
 import type { Logger } from "@/lib/logging";
 
@@ -60,7 +63,11 @@ export interface EnrichmentResult {
  * guard so a slow Hiro API does not block the response.
  *
  * @param agent - The agent record to enrich
- * @param kv - Cloudflare KV namespace
+ * @param kv - Cloudflare KV namespace (still used for claim, check-in, identity)
+ * @param db - D1 binding for live inbox/sent counts. Required post-#730 Step 4
+ *   for accurate `unreadInboxCount` / `sentCount` / `hasInboxMessages`. When
+ *   undefined (e.g. legacy KV-fallback test paths), inbox metrics return zero
+ *   rather than reading stale KV data.
  * @param hiroApiKey - Optional Hiro API key for authenticated Stacks API requests
  * @param logPrefix - Prefix for timeout warning logs (e.g. "agents/bc1q...")
  * @param logger - Optional logger for telemetry
@@ -73,6 +80,7 @@ export interface EnrichmentResult {
 export async function enrichAgentProfile(
   agent: AgentRecord,
   kv: KVNamespace,
+  db: D1Database | undefined,
   hiroApiKey?: string,
   logPrefix?: string,
   logger?: Logger,
@@ -95,17 +103,22 @@ export async function enrichAgentProfile(
   // null means "caller confirmed no claim" (same as a KV miss).
   const hasPrefetchedClaim = prefetchedClaim !== undefined;
 
-  // Fetch check-in, identity+reputation, inbox, and sent index in parallel.
+  // Fetch check-in, identity+reputation, inbox count, and sent count in parallel.
   // Claim is either passed in (skips KV) or fetched from KV alongside the others.
   // Identity and reputation are combined into a single slot so reputation starts immediately
   // after identity resolves, without blocking the other parallel fetches.
+  //
+  // Inbox/sent counts read from D1 post-#730 Step 4 (PR #745) — KV inbox writes
+  // were dropped, so reading via getAgentInbox/getSentIndex would return frozen
+  // data. When `db` is undefined, return zeros rather than stale KV reads.
   const enrichmentResult = await Promise.race([
     Promise.all([
       hasPrefetchedClaim ? Promise.resolve(null) : kv.get(`claim:${agent.btcAddress}`),
       getCheckInRecord(kv, agent.btcAddress),
       fetchIdentityAndReputation(agent, hiroApiKey, kv, logger),
-      getAgentInbox(kv, agent.btcAddress),
-      getSentIndex(kv, agent.btcAddress),
+      db ? countInboxMessagesFromD1(db, agent.btcAddress, "all") : Promise.resolve(0),
+      db ? countInboxMessagesFromD1(db, agent.btcAddress, "unread") : Promise.resolve(0),
+      db ? countOutboxRepliesFromD1(db, agent.btcAddress) : Promise.resolve(0),
     ]).finally(() => clearTimeout(timeoutId)),
     enrichmentTimeout,
   ]);
@@ -115,14 +128,16 @@ export async function enrichAgentProfile(
     claimData,
     checkInRecord,
     identityAndReputation,
-    inboxIndex,
-    sentIndex,
+    inboxTotal,
+    inboxUnread,
+    sentTotal,
   ] = enrichmentResult ?? [
     null,
     null,
     { identity: null, reputation: null },
-    null,
-    null,
+    0,
+    0,
+    0,
   ];
 
   const identity = identityAndReputation?.identity ?? null;
@@ -160,9 +175,9 @@ export async function enrichAgentProfile(
   const activity: ActivityMetrics = {
     lastActiveAt: agent.lastActiveAt ?? null,
     hasCheckedIn: !!checkInRecord,
-    hasInboxMessages: !!inboxIndex,
-    unreadInboxCount: inboxIndex?.unreadCount ?? 0,
-    sentCount: sentIndex?.messageIds.length ?? 0,
+    hasInboxMessages: inboxTotal > 0,
+    unreadInboxCount: inboxUnread,
+    sentCount: sentTotal,
   };
 
   const capabilities = deriveCapabilities(levelInfo.level, agent, identity);


### PR DESCRIPTION
## Summary

Closes #746, **#740**, **#741**.

After PR #745 (Phase 2.5 Step 4) dropped KV writes for inbox/sent indexes, `lib/agent-enrichment.ts:107-108` and `lib/activity.ts:63-77` were still reading from those KV stores. Without corresponding writers, those reads served **frozen-at-merge-time data** for newly delivered messages — exactly the data-freshness regression #740 and #741 were tracking.

This PR threads `D1Database` through both call paths and replaces the KV inbox/sent reads with their `lib/inbox/d1-reads.ts` equivalents.

## Changes

### `lib/agent-enrichment.ts`
- Signature: add `db: D1Database | undefined` as a required positional (between `kv` and `hiroApiKey`)
- `getAgentInbox(kv, btc)` → `countInboxMessagesFromD1(db, btc, "all"/"unread")` for `unreadInboxCount` + `hasInboxMessages`
- `getSentIndex(kv, btc)` → `countOutboxRepliesFromD1(db, btc)` for `sentCount`
- `hasInboxMessages` derives from `inboxTotal > 0` (not `!!inboxIndex`)
- When `db` is undefined: returns zeros (no stale KV fallback). Documented in JSDoc.

### `lib/activity.ts`
- Signature: add `db: D1Database | undefined`
- Replace 4 KV reads/agent (`inbox:agent:${btc}` index + 3 `inbox:message:${id}` lookups) with **one D1 query/agent**: `listInboxMessagesFromD1(db, btc, 3, 0, "all")` (ORDER BY sent_at DESC LIMIT 3)
- Latency win on top of the freshness fix: O(TOP_ACTIVE_AGENTS * 4) → O(TOP_ACTIVE_AGENTS * 1) external reads
- When `db` is undefined: skips message events (registration events still surface)
- Drops the now-unused `InboxMessage` and `InboxAgentIndex` type imports

### Callers updated to pass `db`
- `app/api/agents/[address]/route.ts:302` — `db` already declared at L128
- `app/api/resolve/[identifier]/route.ts:432` — declared `const db = env.DB as D1Database | undefined;` next to `kv` at L244
- `app/api/activity/route.ts:146` — declared `db` next to `kv` at L94
- `app/page.tsx:118` — declared `db` next to `kv` at L95

### Tests (`lib/__tests__/agent-enrichment.test.ts`)
- Obsolete `vi.mock(\"@/lib/inbox/kv-helpers\")` replaced with `vi.mock(\"@/lib/inbox/d1-reads\")` to match new imports
- Existing 10 claim-passthrough / KV-fetch tests updated for the new 7-arg signature (db inserted at position 3)
- **3 new tests** for the D1 inbox/sent count path:
  - \`returns zero counts when db is undefined (no stale KV fallback)\` — confirms no D1 helpers called and result is zeros
  - \`reads inbox unread + total counts from D1 when db is provided\` — asserts `countInboxMessagesFromD1` called twice (\"all\" + \"unread\") and `countOutboxRepliesFromD1` called once with expected args
  - \`hasInboxMessages=false when D1 returns zero total\` — derivation correctness

## Test plan

- [x] \`npx vitest run lib/__tests__/agent-enrichment.test.ts\` → **13/13 pass** (10 existing + 3 new)
- [x] \`npx vitest run\` (full suite) → **989 pass, 5 skipped, 0 fail**
- [x] \`npx tsc --noEmit\` on touched files → clean (pre-existing test-file errors on unrelated files unchanged from main)
- [x] \`npx next lint\` on touched files → clean (only pre-existing \`<img>\` warning at \`app/page.tsx:185\` unrelated to this PR)
- [ ] Cloudflare Workers preview deploy → ready for review
- [ ] Smoke: after deploy, \`/api/agents\` listing shows live unread/sent counts for newly delivered messages (the #740/#741 regression test)

## Scope boundary

This PR migrates the **inbox/sent readers** in `agent-enrichment.ts` and `activity.ts`. The write-side helpers (`updateAgentInbox` / `updateSentIndex` in `kv-helpers.ts`) are now fully orphaned post-#745 + this PR — Phase 4.x cleanup can delete them in a follow-up. The `@deprecated` markers on `getAgentInbox` / `getSentIndex` from PR #751 stay until that cleanup lands.

## Sequencing

- PR #751 (restore `@deprecated` markers) is a clean prerequisite — already arc-APPROVED.
- This PR can land independently. When both merge, #746 + #740 + #741 close together.

## References

- Closes #746, #740, #741
- Tracks #697 (Phase 2.5 umbrella)
- Originating discussion: [PR #745 review thread](https://github.com/aibtcdev/landing-page/pull/745#pullrequestreview-...)