### PR TITLE
fix(inbox): convert UNIQUE(payment_txid) violations from 503 to 409 idempotent (#748)

### DIFF
--- a/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
+++ b/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
@@ -1,0 +1,593 @@
+/**
+ * Regression tests for issue #748 — UNIQUE(payment_txid) violations return 409.
+ *
+ * Two code paths in POST /api/inbox/[address] can hit the UNIQUE partial index
+ * `idx_inbox_payment_txid` during concurrent retries:
+ *
+ *   1. txid-recovery path — SELECT guard + INSERT race produces UNIQUE violation
+ *   2. x402 confirmed-delivery path — client retries with same paymentTxid but
+ *      server generates a new messageId per attempt; INSERT hits UNIQUE constraint
+ *
+ * In both cases the route MUST:
+ *   - Detect the UNIQUE violation error string from D1
+ *   - Re-query via checkRedeemedTxidInD1 to obtain the canonical existingMessageId
+ *   - Return HTTP 409 with body { error: "already_redeemed", existingMessageId }
+ *   - NOT return 503 (503 is reserved for transient D1 failures, not permanent ones)
+ *
+ * The "retry storm" contract: 5 parallel INSERTs with same payment_txid must
+ * yield 1 × 201 and 4 × 409. This test simulates that by mocking D1 to allow
+ * the first insert and reject the subsequent ones with a UNIQUE constraint error.
+ *
+ * References:
+ *   - Issue #748 (this fix)
+ *   - PR #745 review threads PRRT_kwDOLbA8Ss6BGIID (txid-recovery) and
+ *     PRRT_kwDOLbA8Ss6BGIIY (x402 path)
+ *   - Umbrella #652
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be declared before route imports) -------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateInboxMessage: vi.fn(),
+  verifyInboxPayment: vi.fn(),
+  verifyTxidPayment: vi.fn(),
+  storeMessage: vi.fn(),
+  storeStagedInboxPayment: vi.fn(),
+  updateAgentInbox: vi.fn(),
+  updateSentIndex: vi.fn(),
+  INBOX_PRICE_SATS: 100,
+  REDEEMED_TXID_TTL_SECONDS: 7776000,
+  RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS: 300,
+  buildInboxPaymentRequirements: vi.fn().mockReturnValue({ scheme: "exact", network: "stacks:1" }),
+  buildSenderAuthMessage: vi.fn().mockReturnValue("Inbox Message | test content"),
+  DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
+  enqueueInboxReconciliation: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/payment-logging", () => ({
+  getPaymentRepoVersion: vi.fn().mockReturnValue("1.0.0"),
+  logPaymentEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  insertInboundMessageToD1: vi.fn(),
+  insertReplyToD1: vi.fn(),
+  updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  checkRedeemedTxidInD1: vi.fn(),
+  listInboxMessagesFromD1: vi.fn().mockResolvedValue([]),
+  countInboxMessagesFromD1: vi.fn().mockResolvedValue(0),
+  fetchRepliesForMessages: vi.fn().mockResolvedValue(new Map()),
+  listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
+  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+  createLogger: vi.fn(),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: vi.fn(),
+}));
+
+vi.mock("x402-stacks", () => ({
+  networkToCAIP2: vi.fn().mockReturnValue("stacks:1"),
+  X402_HEADERS: {
+    PAYMENT_SIGNATURE: "payment-signature",
+    PAYMENT_REQUIRED: "payment-required",
+    PAYMENT_RESPONSE: "payment-response",
+  },
+}));
+
+vi.mock("@aibtc/tx-schemas/http", () => ({
+  HttpPaymentPayloadSchema: {
+    safeParse: vi.fn().mockReturnValue({ success: true, data: {} }),
+  },
+}));
+
+vi.mock("@/lib/validation/address", () => ({
+  isStxAddress: vi.fn(() => false),
+}));
+
+vi.mock("@/lib/env", () => ({
+  shouldFailClosed: vi.fn(() => false),
+}));
+
+// ---- imports after mocks ----------------------------------------------------
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  validateInboxMessage,
+  verifyInboxPayment,
+  verifyTxidPayment,
+} from "@/lib/inbox";
+import { insertInboundMessageToD1 } from "@/lib/inbox/d1-dual-write";
+import { checkRedeemedTxidInD1 } from "@/lib/inbox/d1-reads";
+import { POST as inboxPOST } from "../route";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const AGENT = {
+  btcAddress: "bc1qyu22hyqr406pus0g9jmfytk4ss5z8qsje74l76",
+  stxAddress: "SPKH9AWG0ENZ87J1X0PBD4HETP22G8W22AFNVF8K",
+  displayName: "Test Agent",
+};
+
+const PAYMENT_TXID = "602f097b3de853e05546015af6ac9c32e858efcc9fd5ff92edb860d5cadc8c21";
+const EXISTING_MESSAGE_ID = "msg_1771381602504_existing_message_id";
+
+/** The UNIQUE constraint error string that D1/SQLite surfaces. */
+const UNIQUE_CONSTRAINT_ERROR = new Error(
+  "D1_ERROR: UNIQUE constraint failed: inbox_messages.payment_txid"
+);
+
+// ---- helpers ----------------------------------------------------------------
+
+function createMockDB(): D1Database {
+  const stmt = {
+    bind: vi.fn().mockReturnThis(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 1 } }),
+    first: vi.fn(),
+    all: vi.fn(),
+    raw: vi.fn(),
+  };
+  return {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+}
+
+function createMockKV(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+  } as unknown as KVNamespace;
+}
+
+function createRateLimitMock(success = true): RateLimit {
+  return {
+    limit: vi.fn().mockResolvedValue({ success }),
+  } as unknown as RateLimit;
+}
+
+function mockCloudflareContext(env: Partial<CloudflareEnv>) {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env,
+    ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
+  });
+}
+
+function buildTxidRecoveryRequest(): NextRequest {
+  return new NextRequest(`https://aibtc.com/api/inbox/${AGENT.btcAddress}`, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      content: "Hello agent",
+      paymentTxid: PAYMENT_TXID,
+      paymentSatoshis: 100,
+    }),
+  });
+}
+
+function buildX402Request(): NextRequest {
+  const paymentSigHeader = btoa(JSON.stringify({ scheme: "exact" }));
+  return new NextRequest(`https://aibtc.com/api/inbox/${AGENT.btcAddress}`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "payment-signature": paymentSigHeader,
+    },
+    body: JSON.stringify({ content: "Hello agent" }),
+  });
+}
+
+function routeParams() {
+  return { params: Promise.resolve({ address: AGENT.btcAddress }) };
+}
+
+// ---- txid-recovery path tests -----------------------------------------------
+
+describe("POST /api/inbox/[address] — txid-recovery UNIQUE violation → 409 (#748)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+
+    // Default: checkRedeemedTxidInD1 finds the existing message
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValue(EXISTING_MESSAGE_ID);
+
+    // Default: txid verification succeeds
+    (verifyTxidPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: PAYMENT_TXID,
+    });
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: PAYMENT_TXID,
+        paymentSatoshis: 100,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+  });
+
+  it("returns 409 with already_redeemed and existingMessageId when INSERT hits UNIQUE(payment_txid)", async () => {
+    // Simulate: first SELECT guard passes (no existing record), then INSERT hits UNIQUE violation.
+    // This is the txid-recovery race between SELECT and INSERT.
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+
+    // The route pre-checks via checkRedeemedTxidInD1 before INSERT —
+    // mock that to return null (no existing record at guard time),
+    // then the INSERT throws, then the re-check returns the existing ID.
+    // We control checkRedeemedTxidInD1 calls: first call (guard) returns null,
+    // second call (re-check after violation) returns the existing message ID.
+    (checkRedeemedTxidInD1 as Mock)
+      .mockResolvedValueOnce(null) // guard check: no existing record
+      .mockResolvedValueOnce(EXISTING_MESSAGE_ID); // re-check after violation
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildTxidRecoveryRequest(), routeParams());
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.error).toBe("already_redeemed");
+    expect(body.existingMessageId).toBe(EXISTING_MESSAGE_ID);
+  });
+
+  it("does NOT return 503 on UNIQUE violation — 503 is reserved for transient errors", async () => {
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+    (checkRedeemedTxidInD1 as Mock)
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce(EXISTING_MESSAGE_ID);
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildTxidRecoveryRequest(), routeParams());
+
+    expect(resp.status).not.toBe(503);
+    expect(resp.status).toBe(409);
+  });
+
+  it("returns 409 with null existingMessageId when re-check also fails", async () => {
+    // Edge case: UNIQUE violation fires, but re-check query also fails.
+    // Still return 409 (not 503), existingMessageId is null.
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+    (checkRedeemedTxidInD1 as Mock)
+      .mockResolvedValueOnce(null) // guard
+      .mockRejectedValueOnce(new Error("D1 transient error")); // re-check fails
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildTxidRecoveryRequest(), routeParams());
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.error).toBe("already_redeemed");
+    expect(body.existingMessageId).toBeNull();
+  });
+
+  it("returns 503 on non-UNIQUE D1 errors (transient-503 path unchanged)", async () => {
+    // A transient D1 error (not a UNIQUE violation) must still return 503.
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset by peer")
+    );
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValueOnce(null); // guard: no existing record
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildTxidRecoveryRequest(), routeParams());
+
+    expect(resp.status).toBe(503);
+    const body = await resp.json();
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfter).toBe(5);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+  });
+});
+
+// ---- x402 confirmed-delivery path tests -------------------------------------
+
+describe("POST /api/inbox/[address] — x402 delivery UNIQUE violation → 409 (#748)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+
+    // Default: checkRedeemedTxidInD1 finds the existing message
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValue(EXISTING_MESSAGE_ID);
+
+    // Default: payment verification succeeds with a confirmed payment
+    (verifyInboxPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: PAYMENT_TXID,
+      paymentStatus: "confirmed",
+    });
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: undefined,
+        paymentSatoshis: undefined,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+  });
+
+  it("returns 409 with already_redeemed and existingMessageId when x402 INSERT hits UNIQUE(payment_txid)", async () => {
+    // x402 client retries with the same paymentTxid; server generates a new messageId
+    // per attempt. The INSERT hits the UNIQUE index.
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValue(EXISTING_MESSAGE_ID);
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildX402Request(), routeParams());
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.error).toBe("already_redeemed");
+    expect(body.existingMessageId).toBe(EXISTING_MESSAGE_ID);
+  });
+
+  it("does NOT return 503 on x402 UNIQUE violation", async () => {
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValue(EXISTING_MESSAGE_ID);
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildX402Request(), routeParams());
+
+    expect(resp.status).not.toBe(503);
+    expect(resp.status).toBe(409);
+  });
+
+  it("returns 409 with null existingMessageId when x402 re-check fails", async () => {
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(UNIQUE_CONSTRAINT_ERROR);
+    (checkRedeemedTxidInD1 as Mock).mockRejectedValue(new Error("D1 transient error"));
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildX402Request(), routeParams());
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    expect(body.error).toBe("already_redeemed");
+    expect(body.existingMessageId).toBeNull();
+  });
+
+  it("returns 503 on non-UNIQUE D1 errors in x402 path (transient-503 path unchanged)", async () => {
+    (insertInboundMessageToD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: database is locked")
+    );
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildX402Request(), routeParams());
+
+    expect(resp.status).toBe(503);
+    const body = await resp.json();
+    expect(body.retryable).toBe(true);
+    expect(body.retryAfter).toBe(5);
+    expect(resp.headers.get("Retry-After")).toBe("5");
+  });
+});
+
+// ---- retry-storm simulation -------------------------------------------------
+
+describe("retry-storm simulation — 5 concurrent requests with same payment_txid (#748)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (lookupAgent as Mock).mockResolvedValue(AGENT);
+
+    (verifyTxidPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: PAYMENT_TXID,
+    });
+
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: PAYMENT_TXID,
+        paymentSatoshis: 100,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+  });
+
+  it("txid-recovery: 5 parallel requests yield 1×201 + 4×409 with deterministic existingMessageId", async () => {
+    // Simulate: first call succeeds, the next 4 hit UNIQUE constraint.
+    // checkRedeemedTxidInD1 behavior:
+    //   - For the guard check (pre-INSERT): all 5 return null (race condition — no record yet)
+    //   - For the re-check (post-violation): returns EXISTING_MESSAGE_ID
+    let insertCallCount = 0;
+    (insertInboundMessageToD1 as Mock).mockImplementation(async () => {
+      insertCallCount++;
+      if (insertCallCount === 1) {
+        // First insert succeeds
+        return undefined;
+      }
+      // Subsequent inserts hit UNIQUE constraint
+      throw UNIQUE_CONSTRAINT_ERROR;
+    });
+
+    // checkRedeemedTxidInD1: all guard checks return null, re-checks return the existing ID
+    (checkRedeemedTxidInD1 as Mock).mockImplementation(async () => {
+      // After the first successful insert, re-checks see the existing record.
+      // Guard checks (before INSERT) also see null since we simulate a race.
+      // In practice the guard check on the pre-existing 4 requests all pass null
+      // because the SELECT runs before any INSERT commits. Post-violation re-checks
+      // all return the existing message ID.
+      if (insertCallCount > 1) {
+        // Post-first-insert: re-checks see the existing record
+        return EXISTING_MESSAGE_ID;
+      }
+      return null;
+    });
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    // Fire 5 concurrent requests
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        inboxPOST(buildTxidRecoveryRequest(), routeParams())
+      )
+    );
+
+    const statuses = responses.map((r) => r.status);
+    const successCount = statuses.filter((s) => s === 201).length;
+    const conflictCount = statuses.filter((s) => s === 409).length;
+
+    expect(successCount).toBe(1);
+    expect(conflictCount).toBe(4);
+
+    // All 409 responses must have a deterministic existingMessageId
+    const conflictResponses = await Promise.all(
+      responses
+        .filter((r) => r.status === 409)
+        .map((r) => r.json())
+    );
+    for (const body of conflictResponses) {
+      expect(body.error).toBe("already_redeemed");
+      expect(body.existingMessageId).toBe(EXISTING_MESSAGE_ID);
+    }
+  });
+
+  it("x402: 5 parallel requests yield 1×201 + 4×409 with deterministic existingMessageId", async () => {
+    (validateInboxMessage as Mock).mockReturnValue({
+      data: {
+        toBtcAddress: AGENT.btcAddress,
+        toStxAddress: AGENT.stxAddress,
+        content: "Hello agent",
+        paymentTxid: undefined,
+        paymentSatoshis: undefined,
+        signature: undefined,
+        replyTo: undefined,
+      },
+    });
+
+    (verifyInboxPayment as Mock).mockResolvedValue({
+      success: true,
+      payerStxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      paymentTxid: PAYMENT_TXID,
+      paymentStatus: "confirmed",
+    });
+
+    let insertCallCount = 0;
+    (insertInboundMessageToD1 as Mock).mockImplementation(async () => {
+      insertCallCount++;
+      if (insertCallCount === 1) {
+        return undefined;
+      }
+      throw UNIQUE_CONSTRAINT_ERROR;
+    });
+
+    (checkRedeemedTxidInD1 as Mock).mockResolvedValue(EXISTING_MESSAGE_ID);
+
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const responses = await Promise.all(
+      Array.from({ length: 5 }, () =>
+        inboxPOST(buildX402Request(), routeParams())
+      )
+    );
+
+    const statuses = responses.map((r) => r.status);
+    const successCount = statuses.filter((s) => s === 201).length;
+    const conflictCount = statuses.filter((s) => s === 409).length;
+
+    expect(successCount).toBe(1);
+    expect(conflictCount).toBe(4);
+
+    const conflictBodies = await Promise.all(
+      responses
+        .filter((r) => r.status === 409)
+        .map((r) => r.json())
+    );
+    for (const body of conflictBodies) {
+      expect(body.error).toBe("already_redeemed");
+      expect(body.existingMessageId).toBe(EXISTING_MESSAGE_ID);
+    }
+  });
+});

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -39,6 +39,21 @@ import {
   type StatusFilter,
 } from "@/lib/inbox/d1-reads";
 
+/**
+ * Detect whether a D1/SQLite error is a UNIQUE constraint violation on `payment_txid`.
+ *
+ * D1 surfaces SQLite errors as thrown Error objects whose message contains the
+ * SQLite error string. When the `idx_inbox_payment_txid` partial UNIQUE index
+ * fires, the message contains "UNIQUE constraint failed: inbox_messages.payment_txid".
+ *
+ * This function matches that substring so callers can distinguish a permanent
+ * UNIQUE violation (idempotent → 409) from a transient D1 error (→ 503).
+ */
+function isPaymentTxidUniqueViolation(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("UNIQUE constraint failed") && msg.includes("payment_txid");
+}
+
 /** Maps nonce-related error codes to structured action strings for agents and operators. */
 const NONCE_ACTION_MAP: Record<string, string> = {
   SENDER_NONCE_STALE: "refetch_nonce_and_resign",
@@ -1039,9 +1054,40 @@ export async function POST(
     // The payment_txid UNIQUE index (idx_inbox_payment_txid) provides permanent
     // double-redemption prevention — ON CONFLICT on message_id is belt-and-
     // suspenders for the race where two concurrent requests share the same ID.
+    //
+    // UNIQUE-violation handling (#748): concurrent retries racing between the
+    // SELECT guard and the INSERT can hit idx_inbox_payment_txid. When detected,
+    // re-query the canonical existingMessageId and return 409 (not 503) — this
+    // is a permanent idempotent outcome, not a transient D1 failure.
     try {
       await insertInboundMessageToD1(db, message);
     } catch (err) {
+      if (isPaymentTxidUniqueViolation(err)) {
+        // Race between SELECT guard and INSERT — txid was redeemed concurrently.
+        // Re-query to get the canonical existingMessageId and return 409.
+        logger.warn("inbox.payment_txid_unique_violation", {
+          messageId: message.messageId,
+          path: "txid_recovery",
+          paymentTxid: message.paymentTxid,
+          error: String(err),
+        });
+        let existingMsgId: string | null = null;
+        try {
+          existingMsgId = await checkRedeemedTxidInD1(db, message.paymentTxid!);
+        } catch (reCheckErr) {
+          logger.error("inbox.already_redeemed_recheck_failed", {
+            paymentTxid: message.paymentTxid,
+            error: String(reCheckErr),
+          });
+        }
+        return NextResponse.json(
+          {
+            error: "already_redeemed",
+            existingMessageId: existingMsgId ?? null,
+          },
+          { status: 409 }
+        );
+      }
       logger.error("inbox.d1_insert_failed", {
         messageId: message.messageId,
         path: "txid_recovery",
@@ -1549,6 +1595,10 @@ export async function POST(
   // D1 is now the sole INSERT path (Phase 2.5 Step 4 — KV writes removed).
   // D1 INSERT is synchronous and failure-propagating: on D1 failure return 503
   // + Retry-After: 5 so the sender retries rather than seeing a phantom 200.
+  //
+  // UNIQUE-violation handling (#748): x402 client retries with the same paymentTxid
+  // but the server generates a new messageId per attempt. The INSERT hits
+  // idx_inbox_payment_txid. Re-query and return 409 (not 503) — permanent outcome.
   if (!db) {
     logger.error("D1 binding unavailable on x402 delivery path", { messageId });
     return NextResponse.json(
@@ -1563,6 +1613,33 @@ export async function POST(
   try {
     await insertInboundMessageToD1(db, message);
   } catch (err) {
+    if (isPaymentTxidUniqueViolation(err)) {
+      // x402 client retry with same paymentTxid — look up canonical existingMessageId.
+      logger.warn("inbox.payment_txid_unique_violation", {
+        messageId: message.messageId,
+        path: "x402_payment",
+        paymentTxid: message.paymentTxid,
+        error: String(err),
+      });
+      let existingMsgId: string | null = null;
+      try {
+        existingMsgId = message.paymentTxid
+          ? await checkRedeemedTxidInD1(db, message.paymentTxid)
+          : null;
+      } catch (reCheckErr) {
+        logger.error("inbox.already_redeemed_recheck_failed", {
+          paymentTxid: message.paymentTxid,
+          error: String(reCheckErr),
+        });
+      }
+      return NextResponse.json(
+        {
+          error: "already_redeemed",
+          existingMessageId: existingMsgId ?? null,
+        },
+        { status: 409 }
+      );
+    }
     logger.error("inbox.d1_insert_failed", {
       messageId: message.messageId,
       path: "x402_payment",

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -53,13 +53,14 @@ import {
  * for SQLite constraint violations — only the wrapped message string. If D1
  * ever changes how it surfaces these (e.g. introduces a `.code` property), this
  * matcher will silently fall back to the 503 path. Re-check periodically against
- * `@cloudflare/workers-types` releases. Matching both substrings ("UNIQUE
- * constraint failed" AND "payment_txid") avoids false-matching other UNIQUE
- * indexes in the schema.
+ * `@cloudflare/workers-types` releases. The full constraint string
+ * "UNIQUE constraint failed: inbox_messages.payment_txid" is matched verbatim
+ * (per Copilot review on #756) to avoid false-positives if future schema
+ * changes introduce other tables/columns whose names contain `payment_txid`.
  */
 function isPaymentTxidUniqueViolation(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
-  return msg.includes("UNIQUE constraint failed") && msg.includes("payment_txid");
+  return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
 }
 
 /**

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -48,10 +48,56 @@ import {
  *
  * This function matches that substring so callers can distinguish a permanent
  * UNIQUE violation (idempotent → 409) from a transient D1 error (→ 503).
+ *
+ * **Dependency on D1 error format.** D1 does not expose a structured error code
+ * for SQLite constraint violations — only the wrapped message string. If D1
+ * ever changes how it surfaces these (e.g. introduces a `.code` property), this
+ * matcher will silently fall back to the 503 path. Re-check periodically against
+ * `@cloudflare/workers-types` releases. Matching both substrings ("UNIQUE
+ * constraint failed" AND "payment_txid") avoids false-matching other UNIQUE
+ * indexes in the schema.
  */
 function isPaymentTxidUniqueViolation(err: unknown): boolean {
   const msg = err instanceof Error ? err.message : String(err);
   return msg.includes("UNIQUE constraint failed") && msg.includes("payment_txid");
+}
+
+/**
+ * Build the 409 "already_redeemed" response after a UNIQUE(payment_txid) violation.
+ *
+ * Re-queries `checkRedeemedTxidInD1` to surface the canonical existingMessageId.
+ * If the re-check itself fails, still returns 409 with `existingMessageId: null`
+ * — the UNIQUE violation is permanent; only the surfaced id is best-effort.
+ */
+async function resolvePaymentTxidConflict(
+  db: D1Database,
+  paymentTxid: string | undefined,
+  path: "txid_recovery" | "x402_payment",
+  logger: Logger,
+  messageId: string,
+  err: unknown
+): Promise<NextResponse> {
+  logger.warn("inbox.payment_txid_unique_violation", {
+    messageId,
+    path,
+    paymentTxid,
+    error: String(err),
+  });
+  let existingMsgId: string | null = null;
+  try {
+    existingMsgId = paymentTxid
+      ? await checkRedeemedTxidInD1(db, paymentTxid)
+      : null;
+  } catch (reCheckErr) {
+    logger.error("inbox.already_redeemed_recheck_failed", {
+      paymentTxid,
+      error: String(reCheckErr),
+    });
+  }
+  return NextResponse.json(
+    { error: "already_redeemed", existingMessageId: existingMsgId ?? null },
+    { status: 409 }
+  );
 }
 
 /** Maps nonce-related error codes to structured action strings for agents and operators. */
@@ -1063,29 +1109,13 @@ export async function POST(
       await insertInboundMessageToD1(db, message);
     } catch (err) {
       if (isPaymentTxidUniqueViolation(err)) {
-        // Race between SELECT guard and INSERT — txid was redeemed concurrently.
-        // Re-query to get the canonical existingMessageId and return 409.
-        logger.warn("inbox.payment_txid_unique_violation", {
-          messageId: message.messageId,
-          path: "txid_recovery",
-          paymentTxid: message.paymentTxid,
-          error: String(err),
-        });
-        let existingMsgId: string | null = null;
-        try {
-          existingMsgId = await checkRedeemedTxidInD1(db, message.paymentTxid!);
-        } catch (reCheckErr) {
-          logger.error("inbox.already_redeemed_recheck_failed", {
-            paymentTxid: message.paymentTxid,
-            error: String(reCheckErr),
-          });
-        }
-        return NextResponse.json(
-          {
-            error: "already_redeemed",
-            existingMessageId: existingMsgId ?? null,
-          },
-          { status: 409 }
+        return resolvePaymentTxidConflict(
+          db,
+          message.paymentTxid,
+          "txid_recovery",
+          logger,
+          message.messageId,
+          err
         );
       }
       logger.error("inbox.d1_insert_failed", {
@@ -1614,30 +1644,13 @@ export async function POST(
     await insertInboundMessageToD1(db, message);
   } catch (err) {
     if (isPaymentTxidUniqueViolation(err)) {
-      // x402 client retry with same paymentTxid — look up canonical existingMessageId.
-      logger.warn("inbox.payment_txid_unique_violation", {
-        messageId: message.messageId,
-        path: "x402_payment",
-        paymentTxid: message.paymentTxid,
-        error: String(err),
-      });
-      let existingMsgId: string | null = null;
-      try {
-        existingMsgId = message.paymentTxid
-          ? await checkRedeemedTxidInD1(db, message.paymentTxid)
-          : null;
-      } catch (reCheckErr) {
-        logger.error("inbox.already_redeemed_recheck_failed", {
-          paymentTxid: message.paymentTxid,
-          error: String(reCheckErr),
-        });
-      }
-      return NextResponse.json(
-        {
-          error: "already_redeemed",
-          existingMessageId: existingMsgId ?? null,
-        },
-        { status: 409 }
+      return resolvePaymentTxidConflict(
+        db,
+        message.paymentTxid,
+        "x402_payment",
+        logger,
+        message.messageId,
+        err
       );
     }
     logger.error("inbox.d1_insert_failed", {


### PR DESCRIPTION
## Summary

- Detects `idx_inbox_payment_txid` UNIQUE constraint violations in both INSERT paths and returns HTTP 409 `{ error: "already_redeemed", existingMessageId }` instead of 503
- Adds `isPaymentTxidUniqueViolation()` helper that matches the SQLite error string to distinguish permanent idempotent outcomes from transient D1 failures
- Re-queries via `checkRedeemedTxidInD1` on violation to return a deterministic `existingMessageId`
- Non-UNIQUE D1 failures continue to return 503 (transient-503 path unchanged)
- 10 new unit tests including retry-storm simulation (5 concurrent requests → 1×201 + 4×409)

Closes #748
References umbrella #652
Addresses Copilot review threads on PR #745: PRRT_kwDOLbA8Ss6BGIID (txid-recovery path) and PRRT_kwDOLbA8Ss6BGIIY (x402 path)

## Test plan

- [x] `npx vitest run uniq-violation-409` — 10 new tests pass
- [x] `npx vitest run` — 54/55 test files pass (1 pre-existing JSX failure in `og-d1.test.ts`, unrelated)
- [x] txid-recovery path: UNIQUE violation → 409 with `existingMessageId`
- [x] x402 path: UNIQUE violation → 409 with `existingMessageId`
- [x] Both paths: non-UNIQUE D1 error → 503 unchanged
- [x] Re-check failure → 409 with `existingMessageId: null` (graceful degradation)
- [x] Retry-storm: 5 concurrent requests → 1×201 + 4×409

🤖 Generated with [Claude Code](https://claude.com/claude-code)