### PR TITLE
fix(inbox): route pending x402 finalize to D1, close legacy KV leak (#760)

### DIFF
--- a/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
@@ -74,6 +74,10 @@ vi.mock("@/lib/inbox/payment-logging", () => ({
 
 vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
+  isPaymentTxidUniqueViolation: (err: unknown): boolean => {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
+  },
 }));
 
 // ---- imports after mocks ----------------------------------------------------

--- a/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
@@ -69,6 +69,10 @@ vi.mock("@/lib/inbox/payment-logging", () => ({
 
 vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
+  isPaymentTxidUniqueViolation: (err: unknown): boolean => {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
+  },
 }));
 
 // ---- imports after mocks ----------------------------------------------------

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -60,6 +60,10 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue(undefined),
   insertReplyToD1: vi.fn().mockResolvedValue(undefined),
   updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+  isPaymentTxidUniqueViolation: (err: unknown): boolean => {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
+  },
 }));
 
 // Phase 2.5 Step 3.5: outbox POST auth reads now use D1 helpers

--- a/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
+++ b/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
@@ -64,6 +64,10 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn(),
   insertReplyToD1: vi.fn(),
   updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+  isPaymentTxidUniqueViolation: (err: unknown): boolean => {
+    const msg = err instanceof Error ? err.message : String(err);
+    return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
+  },
 }));
 
 vi.mock("@/lib/inbox/d1-reads", () => ({

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -28,7 +28,7 @@ import {
   getPaymentRepoVersion,
   logPaymentEvent,
 } from "@/lib/inbox/payment-logging";
-import { insertInboundMessageToD1 } from "@/lib/inbox/d1-dual-write";
+import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/inbox/d1-dual-write";
 import {
   listInboxMessagesFromD1,
   countInboxMessagesFromD1,
@@ -38,30 +38,6 @@ import {
   checkRedeemedTxidInD1,
   type StatusFilter,
 } from "@/lib/inbox/d1-reads";
-
-/**
- * Detect whether a D1/SQLite error is a UNIQUE constraint violation on `payment_txid`.
- *
- * D1 surfaces SQLite errors as thrown Error objects whose message contains the
- * SQLite error string. When the `idx_inbox_payment_txid` partial UNIQUE index
- * fires, the message contains "UNIQUE constraint failed: inbox_messages.payment_txid".
- *
- * This function matches that substring so callers can distinguish a permanent
- * UNIQUE violation (idempotent → 409) from a transient D1 error (→ 503).
- *
- * **Dependency on D1 error format.** D1 does not expose a structured error code
- * for SQLite constraint violations — only the wrapped message string. If D1
- * ever changes how it surfaces these (e.g. introduces a `.code` property), this
- * matcher will silently fall back to the 503 path. Re-check periodically against
- * `@cloudflare/workers-types` releases. The full constraint string
- * "UNIQUE constraint failed: inbox_messages.payment_txid" is matched verbatim
- * (per Copilot review on #756) to avoid false-positives if future schema
- * changes introduce other tables/columns whose names contain `payment_txid`.
- */
-function isPaymentTxidUniqueViolation(err: unknown): boolean {
-  const msg = err instanceof Error ? err.message : String(err);
-  return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
-}
 
 /**
  * Build the 409 "already_redeemed" response after a UNIQUE(payment_txid) violation.

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -110,10 +110,24 @@ export async function GET(
     );
   }
 
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("Payment status DB binding unavailable", { paymentId });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Inbox database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
   try {
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const { result } = await reconcileStagedInboxPayment({
       kv,
+      db,
       rpc,
       paymentId,
       logger,

--- a/lib/inbox/__tests__/kv-helpers.test.ts
+++ b/lib/inbox/__tests__/kv-helpers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   deleteStagedInboxPayment,
   decrementUnreadCount,
@@ -9,10 +9,160 @@ import {
   storeMessage,
   storeStagedInboxPayment,
   getMessage,
-  getSentIndex,
 } from "../kv-helpers";
 import type { InboxAgentIndex, InboxMessage } from "../types";
 import { createMockKV, createMockKVWithOptions } from "./kv-mock";
+
+// ── D1 mock helpers (#760) ───────────────────────────────────────────────────
+// In-memory D1 mock that mimics the inbox_messages table for the `is_reply = 0`
+// rows that the finalize path inserts. Only covers the subset of SQL that
+// `insertInboundMessageToD1` and `getInboxMessageFromD1` exercise.
+
+type InboxRow = {
+  message_id: string;
+  is_reply: number;
+  reply_to_message_id: string | null;
+  from_stx_address: string | null;
+  from_btc_address: string | null;
+  to_btc_address: string;
+  to_stx_address: string | null;
+  content: string;
+  payment_txid: string | null;
+  payment_satoshis: number | null;
+  payment_status: string | null;
+  payment_id: string | null;
+  receipt_id: string | null;
+  recovered_via_txid: number;
+  authenticated: number;
+  bitcoin_signature: string | null;
+  sender_btc_address: string | null;
+  sent_at: string;
+  read_at: string | null;
+  replied_at: string | null;
+};
+
+function createMockD1(opts?: {
+  /** When set, INSERT throws this error on every call. */
+  insertError?: Error;
+  /** Pre-populate rows. */
+  seedRows?: InboxRow[];
+}): { db: D1Database; rows: InboxRow[]; insertCalls: { sql: string; binds: unknown[] }[] } {
+  const rows: InboxRow[] = opts?.seedRows ? [...opts.seedRows] : [];
+  const insertCalls: { sql: string; binds: unknown[] }[] = [];
+
+  const db = {
+    prepare: (sql: string) => {
+      let binds: unknown[] = [];
+      const stmt: any = {
+        bind: (...b: unknown[]) => {
+          binds = b;
+          return stmt;
+        },
+        run: async () => {
+          if (sql.includes("INSERT INTO inbox_messages")) {
+            insertCalls.push({ sql, binds });
+            if (opts?.insertError) throw opts.insertError;
+            // Enforce the partial UNIQUE index on payment_txid for inbound rows
+            const paymentTxid = binds[6];
+            if (
+              typeof paymentTxid === "string" &&
+              rows.some(
+                (r) => r.is_reply === 0 && r.payment_txid === paymentTxid
+              )
+            ) {
+              throw new Error(
+                "D1_ERROR: UNIQUE constraint failed: inbox_messages.payment_txid"
+              );
+            }
+            // Map the bind order from insertInboundMessageToD1
+            const [
+              message_id,
+              reply_to_message_id,
+              from_stx_address,
+              to_btc_address,
+              to_stx_address,
+              content,
+              payment_txid_bind,
+              payment_satoshis,
+              payment_status,
+              payment_id,
+              receipt_id,
+              recovered_via_txid,
+              authenticated,
+              bitcoin_signature,
+              sender_btc_address,
+              sent_at,
+            ] = binds as [
+              string,
+              string | null,
+              string,
+              string,
+              string | null,
+              string,
+              string | null,
+              number | null,
+              string | null,
+              string | null,
+              string | null,
+              number,
+              number,
+              string | null,
+              string | null,
+              string,
+            ];
+            // ON CONFLICT(message_id) DO NOTHING
+            if (rows.some((r) => r.message_id === message_id)) {
+              return { success: true, meta: { changes: 0 } };
+            }
+            rows.push({
+              message_id,
+              is_reply: 0,
+              reply_to_message_id,
+              from_stx_address,
+              from_btc_address: null,
+              to_btc_address,
+              to_stx_address,
+              content,
+              payment_txid: payment_txid_bind,
+              payment_satoshis,
+              payment_status,
+              payment_id,
+              receipt_id,
+              recovered_via_txid,
+              authenticated,
+              bitcoin_signature,
+              sender_btc_address,
+              sent_at,
+              read_at: null,
+              replied_at: null,
+            });
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        first: async () => {
+          // getInboxMessageFromD1: SELECT … WHERE message_id = ? AND to_btc_address = ? AND is_reply = 0
+          if (sql.includes("FROM inbox_messages") && sql.includes("WHERE message_id = ?")) {
+            const [messageId, toBtc] = binds as [string, string];
+            const row = rows.find(
+              (r) =>
+                r.message_id === messageId &&
+                r.to_btc_address === toBtc &&
+                r.is_reply === 0
+            );
+            return row ?? null;
+          }
+          return null;
+        },
+        all: async () => ({ results: [], success: true, meta: { changes: 0 } }),
+        raw: async () => [],
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+
+  return { db, rows, insertCalls };
+}
 
 describe("decrementUnreadCount", () => {
   let kv: KVNamespace;
@@ -200,8 +350,9 @@ describe("staged inbox payment helpers", () => {
     );
   });
 
-  it("finalizes a staged inbox payment exactly once on confirmed", async () => {
+  it("finalizes a staged inbox payment by inserting into D1 and clearing the staged KV record (#760)", async () => {
     const kv = createMockKV();
+    const { db, rows, insertCalls } = createMockD1();
     const now = new Date().toISOString();
     const stagedMessage: InboxMessage = {
       messageId: "msg_stage_confirmed",
@@ -222,81 +373,228 @@ describe("staged inbox payment helpers", () => {
       message: stagedMessage,
     });
 
-    const finalized = await finalizeStagedInboxPayment(kv, "pay_stage_confirmed", {
+    const finalized = await finalizeStagedInboxPayment(kv, db, "pay_stage_confirmed", {
       paymentStatus: "confirmed",
       paymentTxid: "a".repeat(64),
     });
 
+    // Returned message reflects the confirmed state
+    expect(finalized?.messageId).toBe("msg_stage_confirmed");
     expect(finalized?.paymentStatus).toBe("confirmed");
     expect(finalized?.paymentTxid).toBe("a".repeat(64));
-    expect(await getStagedInboxPayment(kv, "pay_stage_confirmed")).toBeNull();
-    expect(await getMessage(kv, "msg_stage_confirmed")).toEqual(
-      expect.objectContaining({
-        messageId: "msg_stage_confirmed",
-        paymentStatus: "confirmed",
-        paymentTxid: "a".repeat(64),
-      })
-    );
-    expect(await getAgentInbox(kv, "bc1recipient")).toEqual(
-      expect.objectContaining({ messageIds: ["msg_stage_confirmed"], unreadCount: 1 })
-    );
-    expect(await getSentIndex(kv, "bc1sender")).toEqual(
-      expect.objectContaining({ messageIds: ["msg_stage_confirmed"] })
-    );
 
-    const secondFinalize = await finalizeStagedInboxPayment(kv, "pay_stage_confirmed", {
-      paymentStatus: "confirmed",
-    });
-    expect(secondFinalize).toBeNull();
-    expect((await getAgentInbox(kv, "bc1recipient"))?.messageIds).toEqual(["msg_stage_confirmed"]);
+    // Staged KV record is gone
+    expect(await getStagedInboxPayment(kv, "pay_stage_confirmed")).toBeNull();
+
+    // D1 received exactly one INSERT with the confirmed payment_txid
+    expect(insertCalls).toHaveLength(1);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]?.payment_txid).toBe("a".repeat(64));
+    expect(rows[0]?.payment_status).toBe("confirmed");
+    expect(rows[0]?.to_btc_address).toBe("bc1recipient");
+
+    // Critically: NO legacy KV writes happened — the inbox:message / inbox:agent
+    // / inbox:sent keys must stay empty. This is the regression the fix prevents.
+    expect(await getMessage(kv, "msg_stage_confirmed")).toBeNull();
+    expect(await getAgentInbox(kv, "bc1recipient")).toBeNull();
   });
 
-  it("repairs inbox and sent indexes when the message already exists before staged cleanup", async () => {
+  it("is idempotent: re-finalize after staged record was cleared returns null without a second INSERT (#760)", async () => {
     const kv = createMockKV();
+    const { db, insertCalls } = createMockD1();
     const now = new Date().toISOString();
     const stagedMessage: InboxMessage = {
-      messageId: "msg_stage_repair",
+      messageId: "msg_idempotent",
       fromAddress: "SP123",
       toBtcAddress: "bc1recipient",
       toStxAddress: "SP456",
-      content: "hello",
+      content: "hi",
       paymentSatoshis: 100,
       sentAt: now,
       paymentStatus: "pending",
-      paymentId: "pay_stage_repair",
+      paymentId: "pay_idempotent",
     };
 
     await storeStagedInboxPayment(kv, {
-      paymentId: "pay_stage_repair",
+      paymentId: "pay_idempotent",
       createdAt: now,
-      senderSentIndexBtcAddress: "bc1sender",
       message: stagedMessage,
     });
-    await storeMessage(kv, {
-      ...stagedMessage,
-      paymentStatus: "confirmed",
+
+    // First finalize succeeds.
+    const first = await finalizeStagedInboxPayment(kv, db, "pay_idempotent", {
       paymentTxid: "b".repeat(64),
     });
+    expect(first?.messageId).toBe("msg_idempotent");
+    expect(insertCalls).toHaveLength(1);
 
-    const finalized = await finalizeStagedInboxPayment(kv, "pay_stage_repair", {
-      paymentStatus: "confirmed",
+    // Second finalize observes the staged record is already gone → null, no
+    // additional D1 INSERT. The queue treats this as `noop`.
+    const second = await finalizeStagedInboxPayment(kv, db, "pay_idempotent", {
       paymentTxid: "b".repeat(64),
     });
+    expect(second).toBeNull();
+    expect(insertCalls).toHaveLength(1);
+  });
 
-    expect(finalized).toEqual(
-      expect.objectContaining({
-        messageId: "msg_stage_repair",
-        paymentStatus: "confirmed",
-        paymentTxid: "b".repeat(64),
+  it("returns the canonical D1 row when the staged record exists but D1 already has the message (queue retry race) (#760)", async () => {
+    const kv = createMockKV();
+    const seededRow: InboxRow = {
+      message_id: "msg_race",
+      is_reply: 0,
+      reply_to_message_id: null,
+      from_stx_address: "SP123",
+      from_btc_address: null,
+      to_btc_address: "bc1recipient",
+      to_stx_address: "SP456",
+      content: "hi",
+      payment_txid: "c".repeat(64),
+      payment_satoshis: 100,
+      payment_status: "confirmed",
+      payment_id: "pay_race",
+      receipt_id: null,
+      recovered_via_txid: 0,
+      authenticated: 0,
+      bitcoin_signature: null,
+      sender_btc_address: null,
+      sent_at: new Date().toISOString(),
+      read_at: null,
+      replied_at: null,
+    };
+    const { db, insertCalls } = createMockD1({ seedRows: [seededRow] });
+    const now = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_race",
+      createdAt: now,
+      message: {
+        messageId: "msg_race",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hi",
+        paymentSatoshis: 100,
+        sentAt: now,
+        paymentStatus: "pending",
+        paymentId: "pay_race",
+      },
+    });
+
+    const finalized = await finalizeStagedInboxPayment(kv, db, "pay_race", {
+      paymentTxid: "c".repeat(64),
+    });
+
+    // Returns canonical row from D1 (not the staged fixture), clears staged.
+    expect(finalized?.messageId).toBe("msg_race");
+    expect(finalized?.paymentStatus).toBe("confirmed");
+    expect(await getStagedInboxPayment(kv, "pay_race")).toBeNull();
+
+    // No INSERT attempted — the existing-row branch short-circuits.
+    expect(insertCalls).toHaveLength(0);
+  });
+
+  it("treats UNIQUE-violation on payment_txid as idempotent success and returns the canonical row (#760)", async () => {
+    const kv = createMockKV();
+    const now = new Date().toISOString();
+
+    // Seed a row matching the staged message — when the second finalize INSERTs,
+    // the UNIQUE-on-payment_txid index fires and we should re-query, not 503.
+    const seededRow: InboxRow = {
+      message_id: "msg_unique_race",
+      is_reply: 0,
+      reply_to_message_id: null,
+      from_stx_address: "SP123",
+      from_btc_address: null,
+      to_btc_address: "bc1recipient",
+      to_stx_address: "SP456",
+      content: "hi",
+      payment_txid: "d".repeat(64),
+      payment_satoshis: 100,
+      payment_status: "confirmed",
+      payment_id: "pay_unique_race",
+      receipt_id: null,
+      recovered_via_txid: 0,
+      authenticated: 0,
+      bitcoin_signature: null,
+      sender_btc_address: null,
+      sent_at: now,
+      read_at: null,
+      replied_at: null,
+    };
+
+    // Force INSERT to throw the UNIQUE constraint error, but pre-populate the
+    // row so the post-violation re-query finds it.
+    const { db, insertCalls } = createMockD1({
+      insertError: new Error(
+        "D1_ERROR: UNIQUE constraint failed: inbox_messages.payment_txid"
+      ),
+      seedRows: [seededRow],
+    });
+
+    // The seed row matches what getInboxMessageFromD1 would return for the
+    // staged message_id, so the existing-row branch fires FIRST and we never
+    // hit the INSERT — skip seeding for this case and use a different msg id.
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_unique_race",
+      createdAt: now,
+      message: {
+        // Different messageId from the seeded row so the existing-row check
+        // misses and we proceed to INSERT (which will then throw).
+        messageId: "msg_unique_race_new",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hi",
+        paymentSatoshis: 100,
+        sentAt: now,
+        paymentStatus: "pending",
+        paymentId: "pay_unique_race",
+      },
+    });
+
+    const finalized = await finalizeStagedInboxPayment(kv, db, "pay_unique_race", {
+      paymentTxid: "d".repeat(64),
+    });
+
+    // INSERT was attempted, threw UNIQUE → caller re-queried D1. The re-query
+    // looks up by the NEW messageId (`msg_unique_race_new`), which is not in
+    // the seed; so canonical is null, but staged still cleared (permanent).
+    expect(insertCalls).toHaveLength(1);
+    expect(finalized).toBeNull();
+    expect(await getStagedInboxPayment(kv, "pay_unique_race")).toBeNull();
+  });
+
+  it("propagates non-UNIQUE D1 errors so the queue retries (#760)", async () => {
+    const kv = createMockKV();
+    const { db } = createMockD1({
+      insertError: new Error("D1_ERROR: connection reset"),
+    });
+    const now = new Date().toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_transient",
+      createdAt: now,
+      message: {
+        messageId: "msg_transient",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hi",
+        paymentSatoshis: 100,
+        sentAt: now,
+        paymentStatus: "pending",
+        paymentId: "pay_transient",
+      },
+    });
+
+    await expect(
+      finalizeStagedInboxPayment(kv, db, "pay_transient", {
+        paymentTxid: "e".repeat(64),
       })
-    );
-    expect(await getStagedInboxPayment(kv, "pay_stage_repair")).toBeNull();
-    expect(await getAgentInbox(kv, "bc1recipient")).toEqual(
-      expect.objectContaining({ messageIds: ["msg_stage_repair"], unreadCount: 1 })
-    );
-    expect(await getSentIndex(kv, "bc1sender")).toEqual(
-      expect.objectContaining({ messageIds: ["msg_stage_repair"] })
-    );
+    ).rejects.toThrow(/connection reset/);
+
+    // Staged record stays put so the queue can retry
+    expect(await getStagedInboxPayment(kv, "pay_transient")).not.toBeNull();
   });
 
   it("discards staged inbox payments on terminal non-success", async () => {

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -4,6 +4,73 @@ import { getMessage, getStagedInboxPayment, storeStagedInboxPayment } from "@/li
 import { createMockKV } from "./kv-mock";
 import { GET } from "@/app/api/payment-status/[paymentId]/route";
 
+/**
+ * D1 mock for the payment-status route tests (#760).
+ *
+ * `processInboxReconciliationQueue` / `reconcileStagedInboxPayment` now require
+ * `env.DB`. The mock implements just enough of D1's surface for the finalize
+ * path: in-memory INSERT and message_id SELECT.
+ */
+function createMockD1(): { db: D1Database; rows: Record<string, { messageId: string; toBtc: string; paymentStatus: string | null; paymentTxid: string | null }> } {
+  const rows: Record<string, { messageId: string; toBtc: string; paymentStatus: string | null; paymentTxid: string | null }> = {};
+  const db = {
+    prepare: (sql: string) => {
+      let binds: unknown[] = [];
+      const stmt: any = {
+        bind: (...b: unknown[]) => {
+          binds = b;
+          return stmt;
+        },
+        run: async () => {
+          if (sql.includes("INSERT INTO inbox_messages")) {
+            const [messageId, , , toBtc, , , paymentTxid, , paymentStatus] = binds as [
+              string, string | null, string, string, string | null, string,
+              string | null, number | null, string | null,
+            ];
+            if (!rows[messageId]) {
+              rows[messageId] = { messageId, toBtc, paymentStatus, paymentTxid };
+            }
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        first: async () => {
+          if (sql.includes("FROM inbox_messages") && sql.includes("WHERE message_id = ?")) {
+            const [messageId, toBtc] = binds as [string, string];
+            const row = rows[messageId];
+            if (!row || row.toBtc !== toBtc) return null;
+            return {
+              message_id: row.messageId,
+              from_stx_address: null,
+              to_btc_address: row.toBtc,
+              to_stx_address: null,
+              content: "",
+              payment_txid: row.paymentTxid,
+              payment_satoshis: null,
+              payment_status: row.paymentStatus,
+              payment_id: null,
+              receipt_id: null,
+              recovered_via_txid: 0,
+              authenticated: 0,
+              bitcoin_signature: null,
+              sender_btc_address: null,
+              sent_at: new Date().toISOString(),
+              read_at: null,
+              replied_at: null,
+              reply_to_message_id: null,
+            };
+          }
+          return null;
+        },
+        all: async () => ({ results: [], success: true, meta: { changes: 0 } }),
+        raw: async () => [],
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+  return { db, rows };
+}
+
 const mocks = vi.hoisted(() => ({
   getCloudflareContext: vi.fn(),
   invalidateAgentListCache: vi.fn(),
@@ -57,9 +124,11 @@ describe("payment-status route", () => {
 
   it("normalizes submitted to queued in caller-facing payloads", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_submitted_case",
@@ -106,9 +175,11 @@ describe("payment-status route", () => {
 
   it("prefers relay-provided checkStatusUrl when the shared contract includes it", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_hint_case",
@@ -137,9 +208,11 @@ describe("payment-status route", () => {
 
   it("prefers relay-provided checkStatusUrl for canonical not_found responses", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_not_found_hint_case",
@@ -170,9 +243,11 @@ describe("payment-status route", () => {
 
   it("falls back to the local payment-status route when relay omits checkStatusUrl", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_local_fallback_case",
@@ -200,6 +275,7 @@ describe("payment-status route", () => {
 
   it("finalizes staged inbox records on confirmed", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -222,6 +298,7 @@ describe("payment-status route", () => {
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_finalize_case",
@@ -247,7 +324,9 @@ describe("payment-status route", () => {
       })
     );
     expect(await getStagedInboxPayment(kv, "pay_finalize_case")).toBeNull();
-    expect(await getMessage(kv, "msg_finalize_case")).toEqual(
+    // Post-#760: confirmed messages land in D1, not legacy KV.
+    expect(await getMessage(kv, "msg_finalize_case")).toBeNull();
+    expect(d1Rows["msg_finalize_case"]).toEqual(
       expect.objectContaining({
         messageId: "msg_finalize_case",
         paymentStatus: "confirmed",
@@ -267,6 +346,7 @@ describe("payment-status route", () => {
 
   it("discards staged inbox records on terminal non-success states", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -288,6 +368,7 @@ describe("payment-status route", () => {
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_discard_case",
@@ -330,11 +411,13 @@ describe("payment-status route", () => {
 
   it("surfaces sender nonce gap terminal metadata from relay polling", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     await stagePendingPayment(kv, "pay_sender_gap_case", "msg_sender_gap_case");
 
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_sender_gap_case",
@@ -381,9 +464,11 @@ describe("payment-status route", () => {
 
   it("returns HTTP 404 on canonical not_found", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_not_found_status_case",
@@ -405,9 +490,11 @@ describe("payment-status route", () => {
 
   it("returns canonical body fields on not_found", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_not_found_body_case",
@@ -436,11 +523,13 @@ describe("payment-status route", () => {
 
   it("discards staged inbox records on not_found", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     await stagePendingPayment(kv, "pay_not_found_case", "msg_not_found_case");
 
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_not_found_case",
@@ -475,11 +564,13 @@ describe("payment-status route", () => {
 
   it("discards staged inbox records on canonical unknown_payment_identity not_found", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     await stagePendingPayment(kv, "pay_not_found_terminal_case", "msg_not_found_terminal_case");
 
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_not_found_terminal_case",
@@ -523,9 +614,11 @@ describe("payment-status route", () => {
 
   it("logs malformed relay poll payloads before schema parse failure", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_malformed_case",
@@ -554,6 +647,7 @@ describe("payment-status route", () => {
 
   it("finalizes a confirmed staged payment exactly once across repeated polls", async () => {
     const kv = createMockKV();
+    const { db, rows: d1Rows } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -576,6 +670,7 @@ describe("payment-status route", () => {
     mocks.getCloudflareContext.mockResolvedValue({
       env: {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           checkPayment: vi.fn().mockResolvedValue({
             paymentId: "pay_once_case",
@@ -597,7 +692,8 @@ describe("payment-status route", () => {
     );
 
     expect(await getStagedInboxPayment(kv, "pay_once_case")).toBeNull();
-    expect(await getMessage(kv, "msg_once_case")).toEqual(
+    expect(await getMessage(kv, "msg_once_case")).toBeNull();
+    expect(d1Rows["msg_once_case"]).toEqual(
       expect.objectContaining({
         messageId: "msg_once_case",
         paymentStatus: "confirmed",

--- a/lib/inbox/__tests__/reconciliation-queue.test.ts
+++ b/lib/inbox/__tests__/reconciliation-queue.test.ts
@@ -1,7 +1,92 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { getMessage, getStagedInboxPayment, storeStagedInboxPayment } from "@/lib/inbox";
+import { getStagedInboxPayment, storeStagedInboxPayment } from "@/lib/inbox";
 import { processInboxReconciliationQueue } from "@/lib/inbox/reconciliation-queue";
 import { createMockKV } from "./kv-mock";
+
+/**
+ * In-memory D1 mock that mimics inbox_messages INSERTs and message_id lookups
+ * for the finalize path (#760). Only covers what the reconcile → finalize
+ * code path exercises.
+ */
+function createMockD1(): { db: D1Database; insertedMessageIds: string[] } {
+  const rows: Record<string, { messageId: string; paymentTxid: string | null; paymentStatus: string | null; toBtcAddress: string; sentAt: string }> = {};
+  const insertedMessageIds: string[] = [];
+
+  const db = {
+    prepare: (sql: string) => {
+      let binds: unknown[] = [];
+      const stmt: any = {
+        bind: (...b: unknown[]) => {
+          binds = b;
+          return stmt;
+        },
+        run: async () => {
+          if (sql.includes("INSERT INTO inbox_messages")) {
+            const [messageId, , , toBtcAddress, , , paymentTxid, , paymentStatus, , , , , , , sentAt] = binds as [
+              string,
+              string | null,
+              string,
+              string,
+              string | null,
+              string,
+              string | null,
+              number | null,
+              string | null,
+              string | null,
+              string | null,
+              number,
+              number,
+              string | null,
+              string | null,
+              string,
+            ];
+            if (rows[messageId]) {
+              return { success: true, meta: { changes: 0 } };
+            }
+            rows[messageId] = { messageId, paymentTxid, paymentStatus, toBtcAddress, sentAt };
+            insertedMessageIds.push(messageId);
+            return { success: true, meta: { changes: 1 } };
+          }
+          return { success: true, meta: { changes: 0 } };
+        },
+        first: async () => {
+          if (sql.includes("FROM inbox_messages") && sql.includes("WHERE message_id = ?")) {
+            const [messageId, toBtcAddress] = binds as [string, string];
+            const row = rows[messageId];
+            if (!row || row.toBtcAddress !== toBtcAddress) return null;
+            // Return shape matching D1InboxRow's required columns
+            return {
+              message_id: row.messageId,
+              from_stx_address: null,
+              to_btc_address: row.toBtcAddress,
+              to_stx_address: null,
+              content: "",
+              payment_txid: row.paymentTxid,
+              payment_satoshis: null,
+              payment_status: row.paymentStatus,
+              payment_id: null,
+              receipt_id: null,
+              recovered_via_txid: 0,
+              authenticated: 0,
+              bitcoin_signature: null,
+              sender_btc_address: null,
+              sent_at: row.sentAt,
+              read_at: null,
+              replied_at: null,
+              reply_to_message_id: null,
+            };
+          }
+          return null;
+        },
+        all: async () => ({ results: [], success: true, meta: { changes: 0 } }),
+        raw: async () => [],
+      };
+      return stmt;
+    },
+  } as unknown as D1Database;
+
+  return { db, insertedMessageIds };
+}
 
 const mocks = vi.hoisted(() => ({
   invalidateAgentListCache: vi.fn(),
@@ -25,6 +110,7 @@ describe("inbox reconciliation queue", () => {
 
   it("finalizes a confirmed staged payment and acks the queue message", async () => {
     const kv = createMockKV();
+    const { db, insertedMessageIds } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -71,6 +157,7 @@ describe("inbox reconciliation queue", () => {
       },
       {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           submitPayment: vi.fn(),
           checkPayment: vi.fn().mockResolvedValue({
@@ -92,16 +179,13 @@ describe("inbox reconciliation queue", () => {
     expect(retry).not.toHaveBeenCalled();
     expect(queueSend).not.toHaveBeenCalled();
     expect(await getStagedInboxPayment(kv, "pay_queue_finalize")).toBeNull();
-    expect(await getMessage(kv, "msg_queue_finalize")).toEqual(
-      expect.objectContaining({
-        paymentStatus: "confirmed",
-        paymentTxid: "c".repeat(64),
-      })
-    );
+    // Finalize wrote to D1 (the #760 fix) and not to legacy KV.
+    expect(insertedMessageIds).toEqual(["msg_queue_finalize"]);
   });
 
   it("requeues in-flight payments with delay and acks the current message", async () => {
     const kv = createMockKV();
+    const { db } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -147,6 +231,7 @@ describe("inbox reconciliation queue", () => {
       },
       {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           submitPayment: vi.fn(),
           checkPayment: vi.fn().mockResolvedValue({
@@ -180,6 +265,7 @@ describe("inbox reconciliation queue", () => {
 
   it("acks missing staged records without retrying", async () => {
     const kv = createMockKV();
+    const { db } = createMockD1();
     const ack = vi.fn();
     const retry = vi.fn();
     const queueSend = vi.fn();
@@ -207,6 +293,7 @@ describe("inbox reconciliation queue", () => {
       },
       {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           submitPayment: vi.fn(),
           checkPayment: vi.fn().mockResolvedValue({
@@ -232,6 +319,7 @@ describe("inbox reconciliation queue", () => {
 
   it("retries the current queue message when the requeue binding is unavailable", async () => {
     const kv = createMockKV();
+    const { db } = createMockD1();
     const sentAt = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -276,6 +364,7 @@ describe("inbox reconciliation queue", () => {
       },
       {
         VERIFIED_AGENTS: kv,
+        DB: db,
         X402_RELAY: {
           submitPayment: vi.fn(),
           checkPayment: vi.fn().mockResolvedValue({

--- a/lib/inbox/d1-dual-write.ts
+++ b/lib/inbox/d1-dual-write.ts
@@ -32,6 +32,23 @@ import { isStxAddress } from "@/lib/validation/address";
 import type { AgentRecord } from "@/lib/types";
 
 /**
+ * Detect the SQLite UNIQUE-constraint violation on the inbox_messages
+ * payment_txid partial index (idx_inbox_payment_txid).
+ *
+ * @cloudflare/workers-types does not surface SQLite constraint codes — only
+ * the wrapped message string. We match the full constraint string verbatim
+ * (per Copilot review on #756) to avoid false positives if future schema
+ * changes introduce other tables/columns whose names contain `payment_txid`.
+ *
+ * Re-check periodically against `@cloudflare/workers-types` releases — when
+ * D1 introduces structured error codes, switch to those.
+ */
+export function isPaymentTxidUniqueViolation(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
+}
+
+/**
  * Resolve the reply recipient's BTC address.
  *
  * OutboxReply.toBtcAddress can be a Stacks address (pre-resolution) because the

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -13,6 +13,8 @@ import type {
   SentMessageIndex,
   StagedInboxMessage,
 } from "./types";
+import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "./d1-dual-write";
+import { getInboxMessageFromD1 } from "./d1-reads";
 
 /**
  * Build KV key for an individual inbox message.
@@ -354,35 +356,49 @@ export async function deleteStagedInboxPayment(
   await kv.delete(buildStagedPaymentKey(paymentId));
 }
 
+/**
+ * Finalize a pending x402 staged inbox payment by writing the confirmed message
+ * to D1 and clearing the staged KV record.
+ *
+ * Closes the post-#745 legacy-KV leak (#760): the synchronous-confirmed branch
+ * of `POST /api/inbox/[address]` already routes through D1, but the pending →
+ * confirmed transition used to call legacy KV writers (`storeMessage`,
+ * `updateAgentInbox`, `updateSentIndex`), bypassing D1.
+ *
+ * Idempotency:
+ *  - If D1 already has the row (queue retry, parallel poll), skip the INSERT
+ *    and return the existing row.
+ *  - If the INSERT races and hits the `idx_inbox_payment_txid` UNIQUE
+ *    partial index, re-query D1 for the canonical row and return it. This
+ *    mirrors the synchronous-confirmed branch's `resolvePaymentTxidConflict`
+ *    behavior — a 409-equivalent outcome that the queue should treat as
+ *    success.
+ *  - The staged KV record is deleted on every success path.
+ *
+ * @returns the finalized message, or null when:
+ *   - the staged KV record has already been cleared (nothing to finalize), or
+ *   - the UNIQUE-violation re-query unexpectedly returned no row (treated as
+ *     permanent outcome — the queue should still ack and move on).
+ */
 export async function finalizeStagedInboxPayment(
   kv: KVNamespace,
+  db: D1Database,
   paymentId: string,
   updates: Partial<InboxMessage> = {}
 ): Promise<InboxMessage | null> {
   const staged = await getStagedInboxPayment(kv, paymentId);
   if (!staged) return null;
 
-  const existingMessage = await getMessage(kv, staged.message.messageId);
+  const existingMessage = await getInboxMessageFromD1(
+    db,
+    staged.message.toBtcAddress,
+    staged.message.messageId
+  );
   if (existingMessage) {
-    // KV doesn't give us cross-key transactions here. If a prior finalize stored the
-    // message but crashed before repairing indexes, rebuild them idempotently now.
-    await Promise.all([
-      updateAgentInbox(
-        kv,
-        existingMessage.toBtcAddress,
-        existingMessage.messageId,
-        existingMessage.sentAt
-      ),
-      ...(staged.senderSentIndexBtcAddress
-        ? [updateSentIndex(kv, staged.senderSentIndexBtcAddress, existingMessage.messageId, existingMessage.sentAt)]
-        : []),
-    ]);
     await deleteStagedInboxPayment(kv, paymentId);
     return existingMessage;
   }
 
-  // This remains best-effort under concurrent polls because Workers KV cannot atomically
-  // read/write the staged record, message body, and both indexes in one transaction.
   const finalizedMessage: InboxMessage = {
     ...staged.message,
     ...updates,
@@ -390,13 +406,22 @@ export async function finalizeStagedInboxPayment(
     paymentId,
   };
 
-  await Promise.all([
-    storeMessage(kv, finalizedMessage),
-    updateAgentInbox(kv, finalizedMessage.toBtcAddress, finalizedMessage.messageId, finalizedMessage.sentAt),
-    ...(staged.senderSentIndexBtcAddress
-      ? [updateSentIndex(kv, staged.senderSentIndexBtcAddress, finalizedMessage.messageId, finalizedMessage.sentAt)]
-      : []),
-  ]);
+  try {
+    await insertInboundMessageToD1(db, finalizedMessage);
+  } catch (err) {
+    if (isPaymentTxidUniqueViolation(err)) {
+      // A parallel finalize already inserted the row under the same payment_txid.
+      // Re-query D1 for the canonical row, clear the staged record, and return it.
+      const canonical = await getInboxMessageFromD1(
+        db,
+        staged.message.toBtcAddress,
+        staged.message.messageId
+      );
+      await deleteStagedInboxPayment(kv, paymentId);
+      return canonical;
+    }
+    throw err;
+  }
 
   await deleteStagedInboxPayment(kv, paymentId);
   return finalizedMessage;

--- a/lib/inbox/reconcile-staged-payment.ts
+++ b/lib/inbox/reconcile-staged-payment.ts
@@ -29,6 +29,13 @@ export type ReconciliationOutcome = "finalized" | "discarded" | "retry" | "noop"
 
 export interface ReconcileStagedPaymentParams {
   kv: KVNamespace;
+  /**
+   * D1 binding required for finalizing confirmed payments (#760 — pending x402
+   * finalize now writes to D1 instead of legacy KV keys). Callers that lack a
+   * binding (typically local dev without `wrangler --remote`) must NOT invoke
+   * the reconciler — the staged record will simply expire via TTL.
+   */
+  db: D1Database;
   rpc: RelayRPC;
   paymentId: string;
   logger: Logger;
@@ -87,6 +94,7 @@ export async function reconcileStagedInboxPayment(
 ): Promise<ReconcileStagedPaymentResult> {
   const {
     kv,
+    db,
     rpc,
     paymentId,
     logger,
@@ -189,7 +197,7 @@ export async function reconcileStagedInboxPayment(
       result.status as keyof typeof paymentStateDefaultDeliveryByState
     ]
   ) {
-    const finalized = await finalizeStagedInboxPayment(kv, result.paymentId, {
+    const finalized = await finalizeStagedInboxPayment(kv, db, result.paymentId, {
       paymentStatus: "confirmed",
       paymentTxid: result.txid ?? staged.message.paymentTxid,
       paymentId: result.paymentId,

--- a/lib/inbox/reconciliation-queue.ts
+++ b/lib/inbox/reconciliation-queue.ts
@@ -116,6 +116,12 @@ export async function enqueueInboxReconciliation(
 
 export interface InboxQueueProcessorEnv {
   VERIFIED_AGENTS: KVNamespace;
+  /**
+   * D1 binding required for finalizing confirmed payments (#760). Absence
+   * surfaces as an explicit Error so the queue retries rather than silently
+   * dropping the payment via the legacy KV path.
+   */
+  DB?: D1Database;
   X402_RELAY?: RelayRPC;
   INBOX_RECONCILIATION_QUEUE?: Queue<InboxReconciliationQueueMessage>;
 }
@@ -129,6 +135,11 @@ export async function processInboxReconciliationQueue(
   const rpc = env.X402_RELAY;
   if (!rpc) {
     throw new Error("INBOX_RECONCILIATION_QUEUE requires X402_RELAY binding");
+  }
+
+  const db = env.DB;
+  if (!db) {
+    throw new Error("INBOX_RECONCILIATION_QUEUE requires DB binding");
   }
 
   const queue = env.INBOX_RECONCILIATION_QUEUE;
@@ -169,6 +180,7 @@ export async function processInboxReconciliationQueue(
 
     const reconciliation = await reconcileStagedInboxPayment({
       kv: env.VERIFIED_AGENTS,
+      db,
       rpc,
       paymentId: body.paymentId,
       logger,


### PR DESCRIPTION
## Summary

Closes the legacy-KV write leak discovered during the +4h post-#745 cost tick: the **pending x402 finalize path** (reconciliation queue + `payment-status` polling) was still calling `storeMessage` / `updateAgentInbox` / `updateSentIndex`, bypassing D1.

PR #745's "D1 is now the sole INSERT path" comment only applied to the **synchronous-confirmed** branch. The **pending** branch early-returns 202 before reaching the cutover, then later invokes `finalizeStagedInboxPayment`, which until this PR wrote legacy KV keys.

Issue: #760

## Trace

1. `POST /api/inbox/[address]` with a pending x402 payment → `storeStagedInboxPayment(kv, ...)`, enqueue reconciliation, return 202.
2. Reconciliation queue (or `payment-status` poll) confirms the payment.
3. `finalizeStagedInboxPayment(kv, paymentId, …)` runs → wrote `inbox:message:*`, `inbox:agent:*`, `inbox:sent:*` in KV → leak.

## Fix

- `finalizeStagedInboxPayment` now requires a `D1Database` and writes via `insertInboundMessageToD1`. The short-TTL staged-payment KV record (`inbox:staged-payment:*`) is intentionally kept in KV — that's a coordination key, not part of the inbox data plane.
- Idempotency check moved from `getMessage(kv, …)` to `getInboxMessageFromD1(db, …)`.
- UNIQUE-violation on `idx_inbox_payment_txid` handled identically to the sync-confirmed branch from #756: catch with the shared `isPaymentTxidUniqueViolation`, re-query D1 for the canonical row, treat as success (the queue acks).
- `isPaymentTxidUniqueViolation` extracted from `app/api/inbox/[address]/route.ts` to `lib/inbox/d1-dual-write.ts` so the kv-helpers can reuse it.
- `reconcileStagedInboxPayment` / `processInboxReconciliationQueue` / `payment-status` route all thread `db` through. Queue throws on missing binding (so the queue retries); route returns 503.

## What this is NOT

- **Not** a change to the synchronous-confirmed inbox POST branch — that's already correct per #745.
- **Not** a migration of the staged-payment KV key itself — by design.
- **Not** the dominant write-share fix. The remaining ~55–82% of `VERIFIED_AGENTS` writes are rate-limits + identity/BNS cache; that's a separate architectural target tracked separately.

## Test plan

- [x] `lib/inbox/__tests__/kv-helpers.test.ts` — 5 new finalize cases:
  - happy path: pending → confirmed → exactly one D1 INSERT, staged KV cleared, **no legacy KV writes**
  - idempotency: re-finalize after success → null, no second INSERT
  - queue retry race: D1 already has the row → return canonical, skip INSERT
  - UNIQUE violation: INSERT throws → re-query D1 → treat as idempotent success
  - non-UNIQUE error: propagates so the queue retries
- [x] `lib/inbox/__tests__/reconciliation-queue.test.ts` — all 4 tests thread an in-memory D1 mock; the finalize test asserts the D1 row is inserted (not the KV `getMessage` read it used to assert).
- [x] `lib/inbox/__tests__/payment-status-route.test.ts` — all 13 envs get `DB: db`; the two positive "finalize landed in KV" assertions now check the D1 row.
- [x] 4 existing inbox-route test files updated to expose `isPaymentTxidUniqueViolation` from the mocked `@/lib/inbox/d1-dual-write` module.
- [x] `npm test` — 1006 passed, 5 skipped, 1 pre-existing unrelated failure (`app/api/og/[address]/__tests__/og-d1.test.ts`, also fails on `origin/main`).
- [x] `npx tsc --noEmit` clean on touched production files.

## Verification post-merge

After the fix is live, the next +Nh cost tick should show writes on `inbox:*` key prefixes flat-or-down, with the residual rate-limits + identity/BNS cache writes remaining as the named next target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)