### PR TITLE
feat(profile): show agent's L1 + L2 BTC balance under the wallet address

### DIFF
--- a/app/agents/[address]/AgentProfile.tsx
+++ b/app/agents/[address]/AgentProfile.tsx
@@ -266,12 +266,13 @@ export default function AgentProfile({
                     {truncateAddress(agent.btcAddress)}
                   </a>
                   {btcBalance && (btcBalance.l1Sats > 0 || btcBalance.l2Sats > 0) && (
-                    <div className="mt-2 font-mono text-xs text-white/70">
-                      <span className="text-[#F7931A]">₿</span>{" "}
-                      {formatBtc(btcBalance.l1Sats + btcBalance.l2Sats)}
-                      <span className="ml-2 text-white/40">
-                        L1 {formatBtc(btcBalance.l1Sats)} · L2 {formatBtc(btcBalance.l2Sats)}
-                      </span>
+                    <div className="mt-2 flex flex-wrap gap-x-3 font-mono text-xs text-white/70">
+                      {btcBalance.l1Sats > 0 && (
+                        <span>{formatBtc(btcBalance.l1Sats)} BTC</span>
+                      )}
+                      {btcBalance.l2Sats > 0 && (
+                        <span>{formatBtc(btcBalance.l2Sats)} sBTC</span>
+                      )}
                     </div>
                   )}
                 </div>

--- a/app/agents/[address]/AgentProfile.tsx
+++ b/app/agents/[address]/AgentProfile.tsx
@@ -19,6 +19,8 @@ import { generateName } from "@/lib/name-generator";
 import { fetcher } from "@/lib/fetcher";
 import type { AgentRecord } from "@/lib/types";
 import type { NextLevelInfo } from "@/lib/levels";
+import type { BtcBalance } from "@/lib/balances/btc";
+import { formatBtc } from "@/lib/balances/btc";
 import { truncateAddress, formatRelativeTime, getActivityStatus } from "@/lib/utils";
 import { deriveNpub, encodeNpub } from "@/lib/nostr";
 
@@ -42,6 +44,7 @@ interface AgentProfileProps {
   level: number;
   levelName: string;
   nextLevel: NextLevelInfo | null;
+  btcBalance?: BtcBalance;
 }
 
 export default function AgentProfile({
@@ -50,6 +53,7 @@ export default function AgentProfile({
   level: initialLevel,
   levelName: initialLevelName,
   nextLevel: initialNextLevel,
+  btcBalance,
 }: AgentProfileProps) {
   // Mutable state initialized from server props — updated by client-side claim submission
   const [agent, setAgent] = useState<AgentRecord>(initialAgent);
@@ -261,6 +265,15 @@ export default function AgentProfile({
                     />
                     {truncateAddress(agent.btcAddress)}
                   </a>
+                  {btcBalance && (btcBalance.l1Sats > 0 || btcBalance.l2Sats > 0) && (
+                    <div className="mt-2 font-mono text-xs text-white/70">
+                      <span className="text-[#F7931A]">₿</span>{" "}
+                      {formatBtc(btcBalance.l1Sats + btcBalance.l2Sats)}
+                      <span className="ml-2 text-white/40">
+                        L1 {formatBtc(btcBalance.l1Sats)} · L2 {formatBtc(btcBalance.l2Sats)}
+                      </span>
+                    </div>
+                  )}
                 </div>
               </div>
 

--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -16,6 +16,7 @@ import {
   setCachedIdentityLookupFailed,
 } from "@/lib/identity/kv-cache";
 import type { AgentIdentity } from "@/lib/identity/types";
+import { fetchBtcBalance } from "@/lib/balances/btc";
 import { getAgentsIndex } from "@/lib/agents-index";
 import {
   lookupBtcAddressByBnsName,
@@ -326,6 +327,14 @@ export default async function AgentProfilePage({
         }
       : null;
 
+    // BTC balance (L1 native + L2 sBTC). Best-effort — degrades to 0/0 on
+    // upstream failure rather than blocking the page.
+    const btcBalance = await fetchBtcBalance(
+      agentWithIdentity.btcAddress,
+      agentWithIdentity.stxAddress,
+      env.HIRO_API_KEY
+    );
+
     return (
       <AgentProfile
         agent={agentWithIdentity}
@@ -333,6 +342,7 @@ export default async function AgentProfilePage({
         level={levelInfo.level}
         levelName={levelInfo.levelName}
         nextLevel={levelInfo.nextLevel}
+        btcBalance={btcBalance}
       />
     );
   } catch {

--- a/lib/balances/btc.ts
+++ b/lib/balances/btc.ts
@@ -1,0 +1,69 @@
+/**
+ * Fetch an agent's BTC balance across L1 (native Bitcoin) and L2 (sBTC on
+ * Stacks). Used on the agent profile page; non-critical, so failures on
+ * either side degrade to 0 rather than throwing.
+ *
+ * Both APIs are public and free; no caching layer here — profile pages are
+ * SSR'd, low-volume, and balances change frequently enough that a cache
+ * would mostly serve stale numbers anyway.
+ */
+
+import { SBTC_CONTRACTS } from "@/lib/inbox/constants";
+import { STACKS_API_BASE } from "@/lib/identity/constants";
+
+export interface BtcBalance {
+  /** Native L1 BTC balance in satoshis. 0 if fetch failed or address has no history. */
+  l1Sats: number;
+  /** sBTC balance on Stacks in satoshis (sBTC is 1:1 with BTC at 8 decimals). 0 if fetch failed. */
+  l2Sats: number;
+}
+
+const SBTC_ASSET_ID = `${SBTC_CONTRACTS.mainnet.address}.${SBTC_CONTRACTS.mainnet.name}::${SBTC_CONTRACTS.mainnet.name}`;
+
+async function fetchL1Sats(btcAddress: string): Promise<number> {
+  const url = `https://mempool.space/api/address/${btcAddress}`;
+  const res = await fetch(url, { headers: { Accept: "application/json" } });
+  if (!res.ok) return 0;
+  const body = (await res.json()) as {
+    chain_stats?: { funded_txo_sum?: number; spent_txo_sum?: number };
+  };
+  const funded = body.chain_stats?.funded_txo_sum ?? 0;
+  const spent = body.chain_stats?.spent_txo_sum ?? 0;
+  return Math.max(0, funded - spent);
+}
+
+async function fetchL2Sats(stxAddress: string, hiroApiKey?: string): Promise<number> {
+  const url = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/balances`;
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (hiroApiKey) headers["x-hiro-api-key"] = hiroApiKey;
+  const res = await fetch(url, { headers });
+  if (!res.ok) return 0;
+  const body = (await res.json()) as {
+    fungible_tokens?: Record<string, { balance?: string }>;
+  };
+  const raw = body.fungible_tokens?.[SBTC_ASSET_ID]?.balance ?? "0";
+  const parsed = Number(raw);
+  return Number.isFinite(parsed) ? parsed : 0;
+}
+
+export async function fetchBtcBalance(
+  btcAddress: string,
+  stxAddress: string,
+  hiroApiKey?: string
+): Promise<BtcBalance> {
+  const [l1, l2] = await Promise.allSettled([
+    fetchL1Sats(btcAddress),
+    fetchL2Sats(stxAddress, hiroApiKey),
+  ]);
+  return {
+    l1Sats: l1.status === "fulfilled" ? l1.value : 0,
+    l2Sats: l2.status === "fulfilled" ? l2.value : 0,
+  };
+}
+
+/** Format sats as BTC with up to 8 decimals, trailing zeros trimmed. */
+export function formatBtc(sats: number): string {
+  if (sats <= 0) return "0";
+  const btc = sats / 1e8;
+  return btc.toFixed(8).replace(/\.?0+$/, "");
+}


### PR DESCRIPTION
## Summary

Adds a small line beneath the existing mempool.space address pill on each agent's profile page (`/agents/[address]`):

```
[●] bc1q...abc                          ← existing
₿ 0.00123456   L1 0.001 · L2 0.000234   ← new
```

- **L1** — `mempool.space/api/address/{btc}` → `funded_txo_sum − spent_txo_sum`
- **L2** — Hiro `/extended/v1/address/{stx}/balances` → `fungible_tokens[sbtc-token].balance`
- Both fetched in parallel via `Promise.allSettled`; failure on either side degrades to 0 rather than blocking the page
- Hidden entirely when both balances are 0 so freshly-registered agents stay clean

## What changed

| File | Δ | What |
|---|---:|---|
| `lib/balances/btc.ts` (new) | +69 | `fetchBtcBalance()` + `formatBtc()` — single module, no shared state, reusable from any surface |
| `app/agents/[address]/page.tsx` | +10 | Import + one call after `resolveIdentity` + one new prop |
| `app/agents/[address]/AgentProfile.tsx` | +13 | Type import + optional `btcBalance` prop + 8-line render slot |

~50 LOC of real signal-bearing code; ~40 are comments / module structure.

## Design notes

- **Placement**: under the address pill, inside the existing wallet block — no new card, same `font-mono text-xs` family as surrounding pills so it reads as a continuation of the wallet identity, not a new section.
- **Hierarchy**: total in `text-white/70` reads first, breakdown in `text-white/40` reads quieter.
- **No caching**: profile pages are low-volume and balances change frequently enough that a stale cache would mostly mislead. SSR'd at request time. Can add a 30s KV TTL later if latency shows up in traces.
- **Helper at `lib/balances/btc.ts`** rather than inline so any future surface (agent list row, dashboard, OG image) can reuse the same wire shape.
- **Reuses existing constants**: `SBTC_CONTRACTS.mainnet` from `lib/inbox/constants.ts` and `STACKS_API_BASE` from `lib/identity/constants.ts` — no new contract addresses or API hosts introduced.

## What is NOT in this PR

- USD denomination — out of scope, would require a price oracle dependency
- Other L2 BTC variants (xBTC, aBTC) — sBTC is the canonical L2 for AIBTC agents
- Agent list row balance column — single-surface ask; can come as a follow-up if the data proves useful in aggregate
- Caching — see design notes
- Tests — `fetchBtcBalance` is a thin wire-shape adapter over public APIs; no business logic to cover. If the wire shape from mempool.space or Hiro changes, the live page will show 0 (graceful degradation) and we'll notice in a smoke check.

## Test plan

- [ ] `/agents/[any registered btc address]` renders the new line below the address pill
- [ ] A profile whose L1 + L2 are both 0 (fresh agent) shows nothing — pill stays as-is
- [ ] Total = L1 + L2; trailing zeros trimmed (`0.001` not `0.00100000`)
- [ ] Mempool.space or Hiro returning 5xx still renders the page (degraded to 0 for that side)
- [ ] Mobile view: line wraps cleanly under the address pill

🤖 Generated with [Claude Code](https://claude.com/claude-code)