### PR TITLE
fix(wrangler): v2 deleted_classes migration — remove SchedulerDO from landing-page worker

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -82,6 +82,20 @@
     ]
   },
 
+  // Durable Object migration history.
+  //
+  // v1 was applied to the `landing-page` worker out-of-band during PR
+  // #743 experimentation (2026-05-12). Main does not reference the
+  // SchedulerDO class — so v2 deletes it, restoring the worker to a
+  // clean no-DO state. Both tags must be declared so wrangler can
+  // diff against CF's current migration history. Once v2 lands, do
+  // not remove these entries: future deploys still need to see the
+  // full history to deploy successfully.
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
+    { "tag": "v2", "deleted_classes": ["SchedulerDO"] }
+  ],
+
   /**
    * Named environments — Wrangler does NOT merge top-level config into named envs.
    * Every binding that the Worker needs must be re-declared in each env block.
@@ -165,7 +179,12 @@
             "max_retries": 5
           }
         ]
-      }
+      },
+
+      "migrations": [
+        { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
+        { "tag": "v2", "deleted_classes": ["SchedulerDO"] }
+      ]
     },
 
     "preview": {
@@ -245,7 +264,12 @@
             "max_retries": 5
           }
         ]
-      }
+      },
+
+      "migrations": [
+        { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
+        { "tag": "v2", "deleted_classes": ["SchedulerDO"] }
+      ]
     }
   }
 }


### PR DESCRIPTION
## What

Adds a `v2` Durable Object migration to `wrangler.jsonc` (all three blocks: top-level, `env.production`, `env.preview`) that deletes the `SchedulerDO` class:

```jsonc
"migrations": [
  { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
  { "tag": "v2", "deleted_classes": ["SchedulerDO"] }
]
```

## Why

During PR #743 experimentation on 2026-05-12, the non-production branch deploy command was temporarily flipped from `npx wrangler versions upload` to `npx wrangler deploy --env preview`. Cloudflare Workers Builds overrode the `--env preview` worker name from `landing-page-preview` back to `landing-page` (production), which meant the v1 SchedulerDO migration was applied to the **production** worker, not the intended preview worker.

Production `aibtc.com` is currently serving the experimental branch's bundle and has the `landing-page_SchedulerDO` namespace registered.

Attempted dashboard rollback to a pre-experiment version failed with:

> Invalid deployment: The version "5229218f-..." cannot be deployed because it has a resource that was modified: the version depends on Durable Object migration "", but the current deployment is using migration "v1"

This is CF's safety net — rolling back to a version that doesn't know about an applied migration would orphan the DO data.

The fix is a **forward** migration (v2) that deletes the class, restoring the worker to a clean no-DO state. Once this merges, CI's `wrangler deploy` applies v2, the SchedulerDO namespace is removed, and `aibtc.com` runs main's code with no DO baggage.

## Test plan

- [x] Local `npm run build` passes
- [ ] After merge, CI's `wrangler deploy` runs cleanly
- [ ] `aibtc.com/` returns 200 from main's code (`45e70f9` + this commit)
- [ ] `aibtc.com/leaderboard` shows main's pre-PR-#743 leaderboard (browser-side Tenero, no SSR volume)
- [ ] CF dashboard → Workers → `landing-page` → Durable Objects: `landing-page_SchedulerDO` namespace is gone
- [ ] No errors in `logs.aibtc.com` post-deploy

## Notes

- Keep both migration entries declared after this lands; removing v1 would break the next deploy with a similar history mismatch.
- The actual `SchedulerDO` class definition + binding never landed on main, so no source-tree cleanup needed here.
- PR #743 remains open; its scheduler work needs to be revisited as a clean follow-up (likely with the class definition inline at the entry point, plus a fresh migration v3 reintroducing it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)