### PR TITLE
feat(762c): rebuild agents:index from D1 SELECT (retain KV scan fallback)

### DIFF
--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -93,7 +93,7 @@ async function resolveAgentAndClaim(
     const target = address.toLowerCase();
     let btcAddress = await lookupBtcAddressByBnsName(kv, target);
     if (!btcAddress) {
-      const index = await getAgentsIndex(kv);
+      const index = await getAgentsIndex(kv, db);
       const entry = index.agents.find(
         (a) => a.bnsName && a.bnsName.toLowerCase() === target,
       );

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -197,7 +197,7 @@ export async function GET(
           if (!btcAddress) {
             // Cold-start fallback: pre-B6.2 agents without a reverse-index entry.
             // Find via agents:index and self-heal.
-            const index = await getAgentsIndex(kv);
+            const index = await getAgentsIndex(kv, db);
             const entry = index.agents.find(
               (a) => a.bnsName && a.bnsName.toLowerCase() === target
             );

--- a/app/api/capabilities/route.ts
+++ b/app/api/capabilities/route.ts
@@ -33,6 +33,7 @@ export async function GET(request: NextRequest) {
   try {
     const { env } = await getCloudflareContext({ async: true });
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database;
 
     const capability = searchParams.get("capability");
     const limit = Math.min(parseInt(searchParams.get("limit") || "50", 10), 100);
@@ -41,7 +42,7 @@ export async function GET(request: NextRequest) {
     // Source capabilities + addresses from the maintained agents:index
     // (single KV read), then only fetch full AgentRecords for the
     // paginated slice that's actually returned.
-    const index = await getAgentsIndex(kv);
+    const index = await getAgentsIndex(kv, db);
     const indexed: AgentIndexEntry[] = index.agents.filter(
       (e) => Array.isArray(e.capabilities) && e.capabilities.length > 0,
     );

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -128,10 +128,11 @@ async function resolveAgentIdToStxAddress(
  */
 async function findAgentByIndex(
   kv: KVNamespace,
+  db: D1Database | undefined,
   predicate: (entry: AgentIndexEntry) => boolean,
   validate: (record: AgentRecord) => boolean
 ): Promise<AgentRecord | null> {
-  const index = await getAgentsIndex(kv);
+  const index = await getAgentsIndex(kv, db);
   const entry = index.agents.find(predicate);
   if (!entry) return null;
 
@@ -368,7 +369,7 @@ export async function GET(
       const target = identifier.toLowerCase();
       let btcAddress = await lookupBtcAddressByBnsName(kv, target);
       if (!btcAddress) {
-        const index = await getAgentsIndex(kv);
+        const index = await getAgentsIndex(kv, db);
         const entry = index.agents.find(
           (a) => a.bnsName && a.bnsName.toLowerCase() === target,
         );
@@ -400,6 +401,7 @@ export async function GET(
       const target = identifier.toLowerCase();
       agent = await findAgentByIndex(
         kv,
+        db,
         (e) => !!e.displayName && e.displayName.toLowerCase() === target,
         (r) => !!r.displayName && r.displayName.toLowerCase() === target,
       );

--- a/lib/__tests__/agents-index.test.ts
+++ b/lib/__tests__/agents-index.test.ts
@@ -232,6 +232,123 @@ describe("invalidateAgentsIndex", () => {
   });
 });
 
+// ---------------------------------------------------------------------------
+// D1 path
+// ---------------------------------------------------------------------------
+
+interface MockD1Row {
+  btc_address: string;
+  stx_address: string;
+  taproot_address: string | null;
+  bns_name: string | null;
+  display_name: string | null;
+  capabilities_json: string | null;
+  verified_at: string;
+}
+
+function makeD1Row(seed: string, overrides: Partial<MockD1Row> = {}): MockD1Row {
+  return {
+    btc_address: `bc1q${seed}`,
+    stx_address: `SP${seed.toUpperCase()}`,
+    taproot_address: null,
+    bns_name: `${seed}.btc`,
+    display_name: `Agent ${seed}`,
+    capabilities_json: null,
+    verified_at: "2026-05-05T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeD1(rows: MockD1Row[]): D1Database {
+  return {
+    prepare: () => ({
+      all: async () => ({ results: rows }),
+    }),
+  } as unknown as D1Database;
+}
+
+function make100D1Rows(): MockD1Row[] {
+  return Array.from({ length: 100 }, (_, i) => makeD1Row(`row${i}`));
+}
+
+describe("getAgentsIndex — D1 path", () => {
+  let kv: MockKV;
+
+  beforeEach(() => {
+    kv = createMockKv();
+  });
+
+  it("builds index from D1 when SELECT returns >= 100 rows", async () => {
+    const rows = make100D1Rows();
+    const db = makeD1(rows);
+
+    const index = await getAgentsIndex(kv.asKv(), db);
+
+    expect(index.v).toBe(1);
+    expect(index.agents).toHaveLength(100);
+    expect(index.agents[0].btcAddress).toBe("bc1qrow0");
+    // Index was cached in KV
+    expect(kv.store.has("agents:index")).toBe(true);
+    // KV scan list should NOT have been called (D1 path used)
+    expect(kv.stats.lists).toBe(0);
+  });
+
+  it("falls back to KV scan when D1 returns fewer than 100 rows", async () => {
+    // Seed 3 agents in KV so the fallback scan produces a real index.
+    seedAgents(kv, [makeAgent("a"), makeAgent("b"), makeAgent("c")]);
+
+    const db = makeD1([makeD1Row("only1"), makeD1Row("only2")]);
+
+    const index = await getAgentsIndex(kv.asKv(), db);
+
+    // Should have fallen back to KV scan (3 agents).
+    expect(index.agents).toHaveLength(3);
+    // KV list must have fired (scan path active).
+    expect(kv.stats.lists).toBeGreaterThan(0);
+  });
+
+  it("falls back to KV scan when D1 throws", async () => {
+    seedAgents(kv, [makeAgent("x")]);
+
+    const db = {
+      prepare: () => ({
+        all: async () => {
+          throw new Error("D1 unavailable");
+        },
+      }),
+    } as unknown as D1Database;
+
+    const index = await getAgentsIndex(kv.asKv(), db);
+
+    expect(index.agents).toHaveLength(1);
+    expect(index.agents[0].btcAddress).toBe("bc1qx");
+    expect(kv.stats.lists).toBeGreaterThan(0);
+  });
+
+  it("sets capabilities to null when capabilities_json is malformed", async () => {
+    const rows = [
+      ...make100D1Rows().slice(0, 99),
+      makeD1Row("bad", { capabilities_json: "{ not valid json" }),
+    ];
+    const db = makeD1(rows);
+
+    const index = await getAgentsIndex(kv.asKv(), db);
+
+    const badEntry = index.agents.find((e) => e.btcAddress === "bc1qbad");
+    expect(badEntry).toBeDefined();
+    expect(badEntry!.capabilities).toBeNull();
+  });
+
+  it("uses KV scan path when db is undefined (no D1 binding)", async () => {
+    seedAgents(kv, [makeAgent("a")]);
+
+    const index = await getAgentsIndex(kv.asKv(), undefined);
+
+    expect(index.agents).toHaveLength(1);
+    expect(kv.stats.lists).toBeGreaterThan(0);
+  });
+});
+
 describe("AgentsIndex schema (round-trip)", () => {
   it("stable JSON round-trip preserves the schema", async () => {
     const kv = createMockKv();

--- a/lib/agents-index.ts
+++ b/lib/agents-index.ts
@@ -110,10 +110,82 @@ async function writeIndex(
 }
 
 /**
- * Rebuild the index by scanning all `stx:` keys. One-shot recovery
- * path used on cold miss; this is the SAME work the hot paths used
- * to do every request, so we want it to fire at most once per
- * deployment / index-loss event.
+ * D1 row shape for the agents SELECT used in buildIndexFromScan.
+ * Only the columns needed for AgentIndexEntry are selected.
+ */
+interface AgentIndexRow {
+  btc_address: string;
+  stx_address: string;
+  taproot_address: string | null;
+  bns_name: string | null;
+  display_name: string | null;
+  capabilities_json: string | null;
+  verified_at: string;
+}
+
+/**
+ * Rebuild the index from D1 via a single SELECT. Returns all rows
+ * as AgentIndexEntry[].
+ *
+ * Returns null if the D1 query fails (caller falls back to KV scan).
+ * Logs a warning if fewer than MIN_EXPECTED_D1_ROWS rows are returned
+ * as a signal that D1 may not yet be fully backfilled (see #691).
+ */
+const MIN_EXPECTED_D1_ROWS = 100;
+
+async function buildIndexFromD1(
+  db: D1Database,
+  logger?: Logger,
+): Promise<AgentIndexEntry[] | null> {
+  try {
+    const result = await db
+      .prepare(
+        `SELECT btc_address, stx_address, taproot_address, bns_name,
+                display_name, capabilities_json, verified_at
+         FROM agents
+         ORDER BY verified_at ASC`,
+      )
+      .all<AgentIndexRow>();
+
+    const entries: AgentIndexEntry[] = result.results.map((row) => ({
+      btcAddress: row.btc_address,
+      stxAddress: row.stx_address,
+      taprootAddress: row.taproot_address ?? null,
+      bnsName: row.bns_name ?? null,
+      displayName: row.display_name ?? null,
+      capabilities: row.capabilities_json
+        ? (() => {
+            try {
+              return JSON.parse(row.capabilities_json!) as string[];
+            } catch {
+              return null;
+            }
+          })()
+        : null,
+      verifiedAt: row.verified_at,
+    }));
+
+    if (entries.length < MIN_EXPECTED_D1_ROWS) {
+      // D1 backfill (#691) may be incomplete. Log so operators can track.
+      logger?.warn("agents_index.d1_low_row_count", {
+        count: entries.length,
+        threshold: MIN_EXPECTED_D1_ROWS,
+        note: "D1 backfill (#691) may be in progress",
+      });
+    }
+
+    return entries;
+  } catch (e) {
+    logger?.warn("agents_index.d1_query_error", { error: String(e) });
+    return null;
+  }
+}
+
+/**
+ * Rebuild the index by scanning all `stx:` keys. Fallback path used
+ * when D1 is unavailable or returns an unexpected result. This is the
+ * same work hot paths used to do on every request before B6 — kept as
+ * a safety net while D1 backfill (#691) is in progress.
  */
 async function buildIndexFromScan(
   kv: KVNamespace,
@@ -157,14 +229,19 @@ async function buildIndexFromScan(
 }
 
 /**
- * Get the agents index. On cold miss, performs a one-shot scan-
- * based backfill, gating concurrent rebuilds with a 60s sentinel.
- * Loser requests poll briefly for the winner's result before
- * falling through to their own scan (so a stuck sentinel never
- * blocks the read).
+ * Get the agents index. On cold miss, rebuilds from D1 (single SELECT)
+ * when a D1Database is provided, falling back to the KV scan if D1 is
+ * unavailable or returns null. Concurrent rebuilds are gated with a
+ * 60s sentinel; loser requests poll briefly before falling through.
+ *
+ * @param kv - KV namespace for index storage and fallback scan.
+ * @param db - Optional D1 binding (env.DB). When provided, cold-miss
+ *   rebuilds use a single D1 SELECT instead of kv.list + N kv.get.
+ * @param logger - Optional structured logger.
  */
 export async function getAgentsIndex(
   kv: KVNamespace,
+  db?: D1Database,
   logger?: Logger,
 ): Promise<AgentsIndex> {
   const cached = await readIndex(kv);
@@ -192,9 +269,30 @@ export async function getAgentsIndex(
   }
 
   try {
-    const entries = await buildIndexFromScan(kv, logger);
+    // Prefer D1 SELECT (single query, ~5 ms) over KV scan (~431 reads).
+    // Falls back to KV scan if db is absent or the query fails — ensures
+    // the index is always populated even if D1 backfill (#691) is
+    // incomplete.
+    let entries: AgentIndexEntry[] | null = null;
+    if (db) {
+      entries = await buildIndexFromD1(db, logger);
+      if (entries !== null) {
+        logger?.info("agents_index.backfilled_from_d1", {
+          count: entries.length,
+        });
+      }
+    }
+    if (entries === null) {
+      logger?.warn("agents_index.falling_back_to_kv_scan", {
+        reason: db ? "d1_query_failed" : "no_d1_binding",
+      });
+      entries = await buildIndexFromScan(kv, logger);
+      logger?.info("agents_index.backfilled_from_kv", {
+        count: entries.length,
+      });
+    }
+
     const index = await writeIndex(kv, entries);
-    logger?.info("agents_index.backfilled", { count: entries.length });
     return index;
   } finally {
     await kv.delete(BACKFILL_LOCK_KEY).catch(() => {});

--- a/lib/agents-index.ts
+++ b/lib/agents-index.ts
@@ -110,7 +110,7 @@ async function writeIndex(
 }
 
 /**
- * D1 row shape for the agents SELECT used in buildIndexFromScan.
+ * D1 row shape for the agents SELECT used in buildIndexFromD1.
  * Only the columns needed for AgentIndexEntry are selected.
  */
 interface AgentIndexRow {
@@ -166,12 +166,16 @@ async function buildIndexFromD1(
     }));
 
     if (entries.length < MIN_EXPECTED_D1_ROWS) {
-      // D1 backfill (#691) may be incomplete. Log so operators can track.
+      // D1 backfill (#691) may be incomplete. Treat as "not ready" and
+      // return null so the caller falls back to the KV-scan safety net.
+      // A partial index must never be cached — callers would serve stale
+      // incomplete results until the next cold-miss rebuild.
       logger?.warn("agents_index.d1_low_row_count", {
         count: entries.length,
         threshold: MIN_EXPECTED_D1_ROWS,
-        note: "D1 backfill (#691) may be in progress",
+        note: "D1 backfill (#691) may be in progress — falling back to KV scan",
       });
+      return null;
     }
 
     return entries;


### PR DESCRIPTION
## Summary

Replaces the cold-miss `kv.list({prefix:'stx:'})` + N `kv.get` fanout (~431 KV reads on a cold-cache rebuild) in `getAgentsIndex` with a single D1 SELECT against the `agents` table. Falls back to the existing KV scan if D1 is unavailable or returns null, so the index still populates if the #691 backfill is incomplete. Concurrent-rebuild sentinel (60 s) gating is preserved.

`env.DB` is threaded through `getAgentsIndex()` at all four production call-sites:

- `app/api/resolve/[identifier]/route.ts` (both index-lookup paths)
- `app/api/agents/[address]/route.ts`
- `app/api/capabilities/route.ts`
- `app/agents/[address]/page.tsx` (SSR)

The new `db?` parameter is optional, so any future call-site that lacks a D1 binding still gets the old KV-scan path automatically.

## Why

Pre-requisite for **P4.2** (#762, heartbeat dual-write removal). Once `btc:`+`stx:`+`checkin:` triple-writes are dropped, the cold-miss `kv.list({prefix:'stx:'})` rebuild is the last consumer that depended on those keys existing. This change retires that dependency.

P4.1 inventory: `~/.planning/active/2026-05-11-landing-page-cost-finish/phases/P4-dual-write-cleanup-762c/EXECUTION-inventory.md`

## Smoke gates

This change only fires on cold-miss (sentinel-gated). Verification post-merge:

- **T+1h:** worker-logs `agents_index.backfilled_from_d1` shows ≥1 hit when an index rebuild fires; no `agents_index.d1_query_error` spike.
- **T+4h:** `agents_index.falling_back_to_kv_scan` rate stays ~0 (D1 query healthy).
- **T+24h:** KV writes on `VERIFIED_AGENTS` show a small reduction on cold-miss days (~430 reads per rebuild → 1 D1 query); main signal arrives downstream when P4.2 lands.

## Rollback

Single commit, isolated to `lib/agents-index.ts` + 4 call-sites. Revert is one `git revert` if the D1 path misbehaves; KV-scan fallback keeps the index serving even without revert.

## Test plan
- [x] `npm run test -- lib/__tests__/agents-index.test.ts` → 11/11 pass
- [x] Existing fallback path covered (D1 absent → KV scan)
- [x] No new type errors in touched files (`getAgentsIndex` signature change propagated to all 4 call-sites)
- [ ] Cloudflare preview deploy: cold-miss `/api/capabilities` should log `backfilled_from_d1`

Refs #762