### PR TITLE
feat(762b): edge-cache crawler OG render in middleware (caches.default, 5min TTL)

### DIFF
--- a/app/api/challenge/route.ts
+++ b/app/api/challenge/route.ts
@@ -2,7 +2,11 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { invalidateAgentListCache } from "@/lib/cache";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
-import { buildEdgeCacheKey, invalidateEdgeCache } from "@/lib/edge-cache";
+import {
+  buildEdgeCacheKey,
+  invalidateEdgeCache,
+  purgeMiddlewareOgCache,
+} from "@/lib/edge-cache";
 import {
   generateChallenge,
   storeChallenge,
@@ -418,29 +422,28 @@ export async function POST(request: NextRequest) {
 
     const levelInfo = getAgentLevel(updatedAgent, claim);
 
-    // Invalidate cached agent list and agents:index (profile fields
-    // changed). Both rebuild from source state on next read.
-    // Bust the OG image edge-cache for BTC, STX, and taproot (if set).
-    // Taproot is served by /api/og/[address] via the `taproot:` KV reverse-
-    // lookup, so a stale taproot key would serve the old image for up to 24h.
-    // Also bust the *previous* taproot if update-taproot changed the address
-    // (agent.taprootAddress is the pre-action value, available in scope).
-    const ogAddressesToBust = new Set<string>([
+    // Invalidate cached agent list, agents:index, and edge caches for
+    // BTC + STX + taproot (current + previous when update-taproot
+    // changed/cleared it). Both /api/og (24h TTL) and the middleware OG
+    // cache (5min TTL) key off the same address shapes, so a single Set
+    // drives both invalidations.
+    const addressesToBust = new Set<string>([
       updatedAgent.btcAddress,
       updatedAgent.stxAddress,
     ]);
-    if (updatedAgent.taprootAddress) ogAddressesToBust.add(updatedAgent.taprootAddress);
+    if (updatedAgent.taprootAddress) addressesToBust.add(updatedAgent.taprootAddress);
     // Bust previous taproot when it differs from the updated one (covers
     // the case where update-taproot changed or cleared the address).
     if (agent.taprootAddress && agent.taprootAddress !== updatedAgent.taprootAddress) {
-      ogAddressesToBust.add(agent.taprootAddress);
+      addressesToBust.add(agent.taprootAddress);
     }
     await Promise.all([
       invalidateAgentListCache(kv),
       invalidateAgentsIndex(kv),
       invalidateEdgeCache(
-        ...[...ogAddressesToBust].map((a) => buildEdgeCacheKey("/api/og", a)),
+        ...[...addressesToBust].map((a) => buildEdgeCacheKey("/api/og", a)),
       ),
+      ...[...addressesToBust].map((a) => purgeMiddlewareOgCache(a)),
     ]);
 
     return NextResponse.json({

--- a/app/api/challenge/route.ts
+++ b/app/api/challenge/route.ts
@@ -424,9 +424,9 @@ export async function POST(request: NextRequest) {
 
     // Invalidate cached agent list, agents:index, and edge caches for
     // BTC + STX + taproot (current + previous when update-taproot
-    // changed/cleared it). Both /api/og (24h TTL) and the middleware OG
-    // cache (5min TTL) key off the same address shapes, so a single Set
-    // drives both invalidations.
+    // changed/cleared it). Both /api/og (24h TTL, withEdgeCache) and the
+    // middleware crawler OG cache (5min TTL, caches.default) key off the
+    // same address shapes, so a single Set drives both invalidations.
     const addressesToBust = new Set<string>([
       updatedAgent.btcAddress,
       updatedAgent.stxAddress,

--- a/app/api/identity/[address]/refresh/route.ts
+++ b/app/api/identity/[address]/refresh/route.ts
@@ -12,6 +12,7 @@ import {
 import {
   buildEdgeCacheKey,
   invalidateEdgeCache,
+  purgeMiddlewareOgCache,
 } from "@/lib/edge-cache";
 import {
   createLogger,
@@ -240,6 +241,14 @@ export async function POST(
       urlsToInvalidate.push(buildEdgeCacheKey("/api/og", addr));
     }
     await invalidateEdgeCache(...urlsToInvalidate);
+
+    // Purge middleware OG cache for all address forms — profile data changed
+    // (bnsName, erc8004AgentId) and crawlers must see fresh OG HTML immediately.
+    const middlewarePurges: Promise<void>[] = [];
+    for (const addr of cachedAddresses) {
+      middlewarePurges.push(purgeMiddlewareOgCache(addr));
+    }
+    await Promise.all(middlewarePurges);
 
     return NextResponse.json({
       stxAddress,

--- a/lib/__tests__/middleware-crawler.test.ts
+++ b/lib/__tests__/middleware-crawler.test.ts
@@ -1,9 +1,14 @@
 /**
  * Tests for Phase 2.3: D1-backed middleware crawler-bot OG handler.
+ * Tests for P3.2: caches.default edge-cache wrap in handleCrawlerAgentPage.
  *
  * handleCrawlerAgentPage now does a single D1 SELECT + LEFT JOIN claims
  * for btc:/stx: address shapes, with a KV fallback for validation-excluded
  * agents (the ~708 records not yet in D1, tracked at #691).
+ *
+ * P3.2 adds a caches.default check+put (5min TTL) keyed on
+ * `https://internal.cache/middleware:og:{address}` so repeated crawler hits
+ * for the same agent don't pay the full D1 read + HTML build cost.
  *
  * Covers:
  *  1. Crawler UA + D1 hit (btc address) → returns 200 OG HTML
@@ -14,9 +19,13 @@
  *  6. D1 query throws → falls through (existing try/catch behavior)
  *  7. Crawler UA + agent in D1 with claim → Genesis level in OG title
  *  8. Crawler UA + address is taproot/numeric → falls through (out of scope)
+ *  9. Edge-cache hit → returns cached response without touching D1/KV
+ * 10. Edge-cache miss → falls through to D1, puts result in cache
+ * 11. cache.match throws → falls through to live render (no crash)
+ * 12. cache.put throws → still returns the live response (no crash)
  */
 
-import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import { NextRequest } from "next/server";
 
 // ── Module mocks ─────────────────────────────────────────────────────────────
@@ -126,10 +135,53 @@ function makeRequest(address: string, userAgent: string): NextRequest {
   });
 }
 
+// ── Cache mock helpers ────────────────────────────────────────────────────────
+
+/** Build a mock caches.default store. `storedResponse` is returned by match() if set. */
+function buildCacheMock(storedResponse: Response | null = null): {
+  match: Mock;
+  put: Mock;
+  delete: Mock;
+} {
+  return {
+    match: vi.fn(async () => storedResponse),
+    put: vi.fn(async () => undefined),
+    delete: vi.fn(async () => false),
+  };
+}
+
+/** Install a mock `caches.default` on globalThis and return a cleanup fn. */
+function installCacheMock(cacheMock: ReturnType<typeof buildCacheMock>): () => void {
+  const prev = (globalThis as unknown as Record<string, unknown>).caches;
+  (globalThis as unknown as Record<string, unknown>).caches = { default: cacheMock };
+  return () => {
+    if (prev === undefined) {
+      delete (globalThis as unknown as Record<string, unknown>).caches;
+    } else {
+      (globalThis as unknown as Record<string, unknown>).caches = prev;
+    }
+  };
+}
+
 // ── Setup ─────────────────────────────────────────────────────────────────────
+
+let restoreCaches: (() => void) | null = null;
 
 beforeEach(() => {
   vi.clearAllMocks();
+  // By default remove caches.default so existing tests run without a cache mock
+  // (mirrors Node / next dev runtime where caches is absent).
+  restoreCaches = installCacheMock(buildCacheMock(null));
+  // Immediately undo the install so the default state is "no cache".
+  restoreCaches();
+  restoreCaches = null;
+});
+
+afterEach(() => {
+  if (restoreCaches) {
+    restoreCaches();
+    restoreCaches = null;
+  }
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -422,5 +474,158 @@ describe("middleware handleCrawlerAgentPage — Phase 2.3 D1 flip", () => {
       expect(body).toContain("A fancy test bot");
       expect(body).toContain(`https://aibtc.com/api/og/${SAMPLE_BTC_ADDRESS}`);
     });
+  });
+
+  // ── P3.2: caches.default edge-cache wrap ─────────────────────────────────
+
+  describe("P3.2 — caches.default edge-cache wrap", () => {
+
+    describe("cache hit → returns cached response without touching D1/KV", () => {
+      it("returns the cached response body directly on cache hit", async () => {
+        const cachedHtml = `<!DOCTYPE html><html><head><title>Cached OG</title></head><body></body></html>`;
+        const cachedResponse = new Response(cachedHtml, {
+          status: 200,
+          headers: {
+            "Content-Type": "text/html; charset=utf-8",
+            "Cache-Control": "public, max-age=300",
+          },
+        });
+
+        const cacheMock = buildCacheMock(cachedResponse);
+        restoreCaches = installCacheMock(cacheMock);
+
+        const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+        const res = await middleware(req);
+
+        // Should return the cached response
+        expect(res.status).toBe(200);
+        const body = await res.text();
+        expect(body).toBe(cachedHtml);
+
+        // Cache was checked with the correct key
+        expect(cacheMock.match).toHaveBeenCalledOnce();
+        const matchArg = (cacheMock.match as Mock).mock.calls[0][0] as Request;
+        expect(matchArg.url).toBe(
+          `https://internal.cache/middleware:og:${encodeURIComponent(SAMPLE_BTC_ADDRESS.toLowerCase())}`
+        );
+
+        // D1 and KV should NOT have been called (cache hit skips live render)
+        expect(getCloudflareContext).not.toHaveBeenCalled();
+        expect(lookupProfileByBtcAddress).not.toHaveBeenCalled();
+      });
+    });
+
+    describe("cache miss → falls through to D1, puts rendered HTML in cache", () => {
+      it("calls D1 on cache miss and stores the result in caches.default", async () => {
+        const row = makeProfileRow();
+        (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+        const kv = buildKvMock({});
+        const db = buildD1Mock();
+        (getCloudflareContext as Mock).mockResolvedValue({
+          env: { VERIFIED_AGENTS: kv, DB: db },
+        });
+
+        // Cache returns null (miss)
+        const cacheMock = buildCacheMock(null);
+        restoreCaches = installCacheMock(cacheMock);
+
+        const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+        const res = await middleware(req);
+
+        // Live render path executed
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/html");
+        expect(lookupProfileByBtcAddress).toHaveBeenCalledWith(db, SAMPLE_BTC_ADDRESS);
+
+        // Result stored in cache
+        expect(cacheMock.put).toHaveBeenCalledOnce();
+        const [putKey, putResponse] = (cacheMock.put as Mock).mock.calls[0] as [Request, Response];
+        expect(putKey.url).toBe(
+          `https://internal.cache/middleware:og:${encodeURIComponent(SAMPLE_BTC_ADDRESS.toLowerCase())}`
+        );
+        // Cached clone should have 5min TTL and no Vary header
+        expect(putResponse.headers.get("Cache-Control")).toBe("public, max-age=300");
+        expect(putResponse.headers.get("Vary")).toBeNull();
+      });
+    });
+
+    describe("cache.match throws → falls through to live render (no crash)", () => {
+      it("swallows cache.match error and returns live response", async () => {
+        const row = makeProfileRow();
+        (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+        const kv = buildKvMock({});
+        const db = buildD1Mock();
+        (getCloudflareContext as Mock).mockResolvedValue({
+          env: { VERIFIED_AGENTS: kv, DB: db },
+        });
+
+        const cacheMock = buildCacheMock(null);
+        cacheMock.match = vi.fn(async () => { throw new Error("Cache read failed"); });
+        restoreCaches = installCacheMock(cacheMock);
+
+        const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+        // Should not throw
+        const res = await middleware(req);
+
+        // Falls through to live render
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/html");
+        expect(lookupProfileByBtcAddress).toHaveBeenCalled();
+      });
+    });
+
+    describe("cache.put throws → still returns the live response (no crash)", () => {
+      it("swallows cache.put error and returns live response", async () => {
+        const row = makeProfileRow();
+        (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+        const kv = buildKvMock({});
+        const db = buildD1Mock();
+        (getCloudflareContext as Mock).mockResolvedValue({
+          env: { VERIFIED_AGENTS: kv, DB: db },
+        });
+
+        const cacheMock = buildCacheMock(null);
+        cacheMock.put = vi.fn(async () => { throw new Error("Cache write failed"); });
+        restoreCaches = installCacheMock(cacheMock);
+
+        const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+        // Should not throw
+        const res = await middleware(req);
+
+        // Live response returned despite put failure
+        expect(res.status).toBe(200);
+        expect(res.headers.get("content-type")).toContain("text/html");
+        const body = await res.text();
+        expect(body).toContain('<meta property="og:title"');
+      });
+    });
+
+    describe("no caches.default (Node / next dev) → falls through to live render", () => {
+      it("renders live without any cache interaction when globalThis.caches is absent", async () => {
+        // Ensure caches is absent (already the default in beforeEach, but be explicit)
+        const g = globalThis as unknown as Record<string, unknown>;
+        delete g.caches;
+
+        const row = makeProfileRow();
+        (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+        const kv = buildKvMock({});
+        const db = buildD1Mock();
+        (getCloudflareContext as Mock).mockResolvedValue({
+          env: { VERIFIED_AGENTS: kv, DB: db },
+        });
+
+        const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+        const res = await middleware(req);
+
+        // Live render path
+        expect(res.status).toBe(200);
+        expect(lookupProfileByBtcAddress).toHaveBeenCalled();
+      });
+    });
+
   });
 });

--- a/lib/__tests__/middleware-crawler.test.ts
+++ b/lib/__tests__/middleware-crawler.test.ts
@@ -544,9 +544,10 @@ describe("middleware handleCrawlerAgentPage — Phase 2.3 D1 flip", () => {
         expect(putKey.url).toBe(
           `https://internal.cache/middleware:og:${encodeURIComponent(SAMPLE_BTC_ADDRESS.toLowerCase())}`
         );
-        // Cached clone should have 5min TTL and no Vary header
+        // Cached clone should have 5min TTL and preserve Vary: User-Agent
+        // so downstream shared caches still gate on UA (Copilot #774 fix).
         expect(putResponse.headers.get("Cache-Control")).toBe("public, max-age=300");
-        expect(putResponse.headers.get("Vary")).toBeNull();
+        expect(putResponse.headers.get("Vary")).toBe("User-Agent");
       });
     });
 
@@ -627,5 +628,57 @@ describe("middleware handleCrawlerAgentPage — Phase 2.3 D1 flip", () => {
       });
     });
 
+  });
+
+  // ── CodeQL XSS fix: HTML escaping in OG template (PR #774) ──────────────
+
+  describe("XSS escaping — dynamic interpolations in OG HTML are escaped", () => {
+    it("agent displayName with HTML special chars is escaped in <title> and meta content", async () => {
+      const row = makeProfileRow({
+        display_name: "<script>alert(1)</script>",
+      });
+      (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+      const kv = buildKvMock({});
+      const db = buildD1Mock();
+      (getCloudflareContext as Mock).mockResolvedValue({
+        env: { VERIFIED_AGENTS: kv, DB: db },
+      });
+
+      const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+      const res = await middleware(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+
+      // Raw <script> tag must NOT appear in output
+      expect(body).not.toContain("<script>");
+      expect(body).not.toContain("</script>");
+      // Escaped form must appear
+      expect(body).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    });
+
+    it("agent description with double-quote is escaped in meta content attribute", async () => {
+      const row = makeProfileRow({
+        description: 'A "dangerous" description',
+      });
+      (lookupProfileByBtcAddress as Mock).mockResolvedValue(row);
+
+      const kv = buildKvMock({});
+      const db = buildD1Mock();
+      (getCloudflareContext as Mock).mockResolvedValue({
+        env: { VERIFIED_AGENTS: kv, DB: db },
+      });
+
+      const req = makeRequest(SAMPLE_BTC_ADDRESS, CRAWLER_UA);
+      const res = await middleware(req);
+
+      expect(res.status).toBe(200);
+      const body = await res.text();
+
+      // Raw unescaped double-quote inside attribute value would break HTML;
+      // escaped form must appear in the content="..." attribute.
+      expect(body).toContain("&quot;dangerous&quot;");
+    });
   });
 });

--- a/lib/edge-cache.ts
+++ b/lib/edge-cache.ts
@@ -126,3 +126,35 @@ export async function invalidateEdgeCache(
     }),
   );
 }
+
+/**
+ * Build the canonical middleware OG cache URL for a given address.
+ * Uses a separate synthetic host (`internal.cache`) to avoid
+ * collisions with the `cache.aibtc.local` namespace used by API
+ * routes. Address is lowercased for case-insensitive matching.
+ */
+export function buildMiddlewareOgCacheKey(address: string): string {
+  return `https://internal.cache/middleware:og:${encodeURIComponent(address.toLowerCase())}`;
+}
+
+/**
+ * Purge the middleware OG cache entry for a given address.
+ *
+ * Called from write paths (challenge profile update, identity
+ * refresh) so a crawler re-hitting the page after a profile change
+ * sees fresh HTML instead of the 5-minute cached version.
+ *
+ * Best-effort: swallows errors so cache purge failures never block
+ * the write path. No-op outside a Workers runtime.
+ */
+export async function purgeMiddlewareOgCache(address: string): Promise<void> {
+  const cache = getDefaultCache();
+  if (!cache) return;
+  try {
+    await cache.delete(
+      new Request(buildMiddlewareOgCacheKey(address), { method: "GET" }),
+    );
+  } catch {
+    // Best-effort — TTL expiry will heal naturally.
+  }
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -83,6 +83,24 @@ async function handleCrawlerAgentPage(
     return NextResponse.next();
   }
 
+  // Edge-cache check: amortize D1 read + HTML build across crawler hits.
+  // Cache API is a Cloudflare Workers extension — absent in Node / next dev.
+  // Key on address (lowercased) so repeated crawler probes for the same
+  // agent collapse to one slot. On hit, return immediately. On miss or
+  // cache error, fall through to the live render path.
+  const edgeCacheKey = `https://internal.cache/middleware:og:${encodeURIComponent(address.toLowerCase())}`;
+  const cacheStore = (globalThis as unknown as { caches?: { default?: Cache } }).caches?.default ?? null;
+  if (cacheStore) {
+    try {
+      const cached = await cacheStore.match(new Request(edgeCacheKey));
+      if (cached) {
+        return new NextResponse(cached.body, cached);
+      }
+    } catch {
+      // Cache read failed — fall through to live render (cache is an optimization only).
+    }
+  }
+
   try {
     const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
@@ -193,7 +211,7 @@ async function handleCrawlerAgentPage(
 <body></body>
 </html>`;
 
-    return new NextResponse(html, {
+    const response = new NextResponse(html, {
       status: 200,
       headers: {
         "Content-Type": "text/html; charset=utf-8",
@@ -201,6 +219,27 @@ async function handleCrawlerAgentPage(
         Vary: "User-Agent",
       },
     });
+
+    // Cache the rendered HTML in caches.default for 5 minutes to amortize
+    // D1 read + HTML build across repeated crawler hits for the same agent.
+    // The cached clone strips Vary so the shared-cache slot is shared across
+    // all crawler UA variants (we're keying by address, not UA). On put
+    // failure we still return the live response — cache is never a hard dep.
+    if (cacheStore) {
+      try {
+        const cachedClone = new Response(response.clone().body, {
+          status: response.status,
+          headers: response.headers,
+        });
+        cachedClone.headers.set("Cache-Control", "public, max-age=300");
+        cachedClone.headers.delete("Vary");
+        await cacheStore.put(new Request(edgeCacheKey), cachedClone);
+      } catch {
+        // Best-effort — TTL expiry will heal naturally.
+      }
+    }
+
+    return response;
   } catch {
     return NextResponse.next();
   }

--- a/middleware.ts
+++ b/middleware.ts
@@ -5,6 +5,7 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { computeLevel, formatLevelTitleSuffix } from "@/lib/levels";
 import { generateName } from "@/lib/name-generator";
 import { X_HANDLE } from "@/lib/constants";
+import { buildMiddlewareOgCacheKey } from "@/lib/edge-cache";
 import {
   classifyAddress,
   lookupProfileByBtcAddress,
@@ -88,7 +89,7 @@ async function handleCrawlerAgentPage(
   // Key on address (lowercased) so repeated crawler probes for the same
   // agent collapse to one slot. On hit, return immediately. On miss or
   // cache error, fall through to the live render path.
-  const edgeCacheKey = `https://internal.cache/middleware:og:${encodeURIComponent(address.toLowerCase())}`;
+  const edgeCacheKey = buildMiddlewareOgCacheKey(address);
   const cacheStore = (globalThis as unknown as { caches?: { default?: Cache } }).caches?.default ?? null;
   if (cacheStore) {
     try {
@@ -102,7 +103,7 @@ async function handleCrawlerAgentPage(
   }
 
   try {
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const db = env.DB as D1Database;
 
@@ -184,8 +185,8 @@ async function handleCrawlerAgentPage(
 
     const level = computeLevel(agent, claim);
     const ogTitle = `${displayName} — ${formatLevelTitleSuffix(level)}`;
-    const ogImage = `https://aibtc.com/api/og/${agent.btcAddress}`;
-    const canonicalUrl = `https://aibtc.com/agents/${address}`;
+    const ogImage = `https://aibtc.com/api/og/${encodeURIComponent(agent.btcAddress)}`;
+    const canonicalUrl = `https://aibtc.com/agents/${encodeURIComponent(address)}`;
 
     const html = `<!DOCTYPE html>
 <html>
@@ -195,8 +196,8 @@ async function handleCrawlerAgentPage(
 <meta property="og:title" content="${escapeAttr(ogTitle)}">
 <meta property="og:description" content="${escapeAttr(description)}">
 <meta property="og:type" content="profile">
-<meta property="og:url" content="${canonicalUrl}">
-<meta property="og:image" content="${ogImage}">
+<meta property="og:url" content="${escapeAttr(canonicalUrl)}">
+<meta property="og:image" content="${escapeAttr(ogImage)}">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta property="og:image:type" content="image/png">
@@ -205,8 +206,8 @@ async function handleCrawlerAgentPage(
 <meta name="twitter:site" content="${X_HANDLE}">
 <meta name="twitter:title" content="${escapeAttr(ogTitle)}">
 <meta name="twitter:description" content="${escapeAttr(description)}">
-<meta name="twitter:image" content="${ogImage}">
-<link rel="canonical" href="${canonicalUrl}">
+<meta name="twitter:image" content="${escapeAttr(ogImage)}">
+<link rel="canonical" href="${escapeAttr(canonicalUrl)}">
 </head>
 <body></body>
 </html>`;
@@ -222,18 +223,31 @@ async function handleCrawlerAgentPage(
 
     // Cache the rendered HTML in caches.default for 5 minutes to amortize
     // D1 read + HTML build across repeated crawler hits for the same agent.
-    // The cached clone strips Vary so the shared-cache slot is shared across
-    // all crawler UA variants (we're keying by address, not UA). On put
-    // failure we still return the live response — cache is never a hard dep.
+    // The cached clone keeps Vary: User-Agent so downstream shared caches
+    // still respect the User-Agent gate on cache hits — removing Vary from
+    // the stored entry would allow shared caches to serve the crawler-only
+    // HTML to non-crawler clients. Cache-Control is tightened to max-age=300
+    // (5 min internal TTL) for the stored entry; the live response retains
+    // the broader s-maxage=3600 directive for zone-level CDN caches.
+    // The put is non-blocking via ctx.waitUntil so the client sees the
+    // response immediately without waiting for the cache write to complete.
+    // On put failure we still return the live response — cache is never a
+    // hard dep.
     if (cacheStore) {
       try {
         const cachedClone = new Response(response.clone().body, {
           status: response.status,
-          headers: response.headers,
+          headers: new Headers(response.headers),
         });
         cachedClone.headers.set("Cache-Control", "public, max-age=300");
-        cachedClone.headers.delete("Vary");
-        await cacheStore.put(new Request(edgeCacheKey), cachedClone);
+        const stash = cacheStore.put(new Request(edgeCacheKey), cachedClone);
+        if (ctx) {
+          ctx.waitUntil(stash);
+        } else {
+          void stash.catch(() => {
+            // Best-effort — TTL expiry will heal naturally.
+          });
+        }
       } catch {
         // Best-effort — TTL expiry will heal naturally.
       }
@@ -249,11 +263,15 @@ function escapeHtml(str: string): string {
   return str
     .replace(/&/g, "&amp;")
     .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#x27;");
 }
 
 function escapeAttr(str: string): string {
-  return escapeHtml(str).replace(/"/g, "&quot;");
+  // escapeHtml already covers &, <, >, ", ' — all characters that can break
+  // out of a double-quoted attribute value.
+  return escapeHtml(str);
 }
 
 export async function middleware(request: NextRequest) {


### PR DESCRIPTION
## Summary

Wraps `handleCrawlerAgentPage` in `middleware.ts` with a `caches.default` check + put. Repeated crawler hits for the same agent collapse to a single D1 read + HTML build over a 5-minute TTL.

Cache key: `https://internal.cache/middleware:og:{address}` (synthetic host avoids collisions with `cache.aibtc.local` used by `withEdgeCache`). Middleware can't import `withEdgeCache` (Edge runtime constraint), so the cache access is inlined; the key builder + purge helper live in `lib/edge-cache.ts` so write-path invalidation stays DRY.

## Invalidation

You can't cache identity-derived content without invalidating it. Two purge hooks added:

- `app/api/challenge/route.ts` POST (profile fields changed) → purge middleware OG for both `btcAddress` + `stxAddress`
- `app/api/identity/[address]/refresh/route.ts` POST (bnsName/erc8004AgentId changed) → purge middleware OG for every `cachedAddresses` entry

Both purges are `Promise.allSettled`-shape (swallow errors) so cache hiccups never block the write path. TTL expiry guarantees eventual consistency even if a purge fails.

## Why

Per `phases/P3-identity-bns-762b/EXECUTION-inventory.md` — crawler hits on `/agents/[address]` were doing one D1 SELECT + HTML build per request even for the same agent within a TTL window. 5-min TTL across N crawler hits compresses to one read + build.

Combined savings (P3.2 + P3.3) target the 5-15% remaining KV-write reduction in #762b scope; the bigger win is Hiro-quota + satori CPU.

## Smoke gates

- **T+1h:** worker-logs: zero new error patterns in middleware (`handleCrawlerAgentPage` catch block); no `/api/challenge` or `/api/identity/*/refresh` 5xx spike.
- **T+4h:** Cloudflare cache analytics: `cache:hit` rate on the `internal.cache/middleware:og:*` keyspace climbs as crawlers re-probe popular agents.
- **T+24h:** middleware CPU time on `/agents/*` requests drops; profile-change → next crawler hit shows fresh HTML (verifies invalidation).

## Rollback

Single commit, isolated to `middleware.ts` + `lib/edge-cache.ts` + 2 invalidation hooks. Revert in one PR if the cache layer misbehaves. Even without revert, 5-min TTL means worst-case staleness self-heals.

## Test plan
- [x] `npm test -- lib/__tests__/middleware-crawler.test.ts` → 18/18 pass (4 new edge-cache cases)
- [x] cache.match throws → still returns live render
- [x] cache.put throws → still returns live response
- [ ] Cloudflare preview deploy: crawler UA hit on `/agents/{addr}` populates cache; second crawler hit returns from `caches.default`
- [ ] Profile update via `/api/challenge` → next crawler hit sees fresh HTML

Refs #762