### PR TITLE
feat(762c): replace KV stx: dupcheck with D1 query, fail-closed

### DIFF
--- a/app/api/register/__tests__/stx-d1-dupcheck.test.ts
+++ b/app/api/register/__tests__/stx-d1-dupcheck.test.ts
@@ -1,0 +1,290 @@
+/**
+ * Phase 4.0b — STX duplicate check via D1 (replaces kv.get('stx:...')).
+ *
+ * Covers three cases:
+ *  (a) D1 returns a row → address exists → 409 STX_ADDRESS_TAKEN
+ *  (b) D1 returns null  → address free  → registration proceeds past the check
+ *  (c) D1 throws        → fail-closed   → 409 STX_ADDRESS_TAKEN
+ *
+ * The test hooks in at the POST handler level, mocking every layer that runs
+ * before the D1 check so the three interesting D1 outcomes can be isolated.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (declared before route import) ----------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+  bip322VerifyP2TR: vi.fn(),
+}));
+
+// @stacks/transactions: publicKeyFromSignatureRsv + getAddressFromPublicKey
+vi.mock("@stacks/transactions", () => ({
+  publicKeyFromSignatureRsv: vi.fn().mockReturnValue("02mock_stx_pubkey"),
+  getAddressFromPublicKey: vi.fn().mockReturnValue("SP1TESTADDRESS1234"),
+}));
+
+// @stacks/encryption: verifyMessageSignatureRsv + hashMessage
+vi.mock("@stacks/encryption", () => ({
+  verifyMessageSignatureRsv: vi.fn().mockReturnValue(true),
+  hashMessage: vi.fn().mockReturnValue(new Uint8Array(32)),
+}));
+
+// @stacks/common: bytesToHex
+vi.mock("@stacks/common", () => ({
+  bytesToHex: vi.fn().mockReturnValue("aabbccddeeff00112233445566778899aabbccddeeff00112233445566778899"),
+}));
+
+vi.mock("@/lib/cache/agent-profile", () => ({
+  lookupProfileByStxAddress: vi.fn(),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: vi.fn(),
+}));
+
+vi.mock("@/lib/agents-index", () => ({
+  invalidateAgentsIndex: vi.fn(),
+}));
+
+vi.mock("@/lib/bns-reverse-index", () => ({
+  syncBnsLookup: vi.fn(),
+}));
+
+vi.mock("@/lib/bns", () => ({
+  lookupBnsName: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/sponsor", () => ({
+  provisionSponsorKey: vi.fn().mockResolvedValue({ success: true, apiKey: "test-api-key" }),
+  DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
+}));
+
+vi.mock("@/lib/vouch", () => ({
+  MIN_REFERRER_LEVEL: 2,
+  MAX_REFERRALS: 10,
+  storeVouch: vi.fn(),
+  getVouchIndex: vi.fn().mockResolvedValue([]),
+  generateAndStoreReferralCode: vi.fn().mockResolvedValue("NEWCOD"),
+  lookupReferralCode: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  isLogsRPC: () => false,
+}));
+
+vi.mock("@/lib/name-generator", () => ({
+  generateName: vi.fn().mockReturnValue("MockAgent"),
+}));
+
+vi.mock("@/lib/levels", () => ({
+  computeLevel: vi.fn().mockReturnValue(1),
+  getNextLevel: vi.fn().mockReturnValue(null),
+}));
+
+vi.mock("@/lib/claim-code", () => ({
+  generateClaimCode: vi.fn().mockReturnValue("CLAIMCODE1"),
+}));
+
+vi.mock("@/lib/challenge", () => ({
+  validateTaprootAddress: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/lib/nostr", () => ({
+  validateNostrPubkey: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/lib/constants", () => ({
+  X_HANDLE: "@aibtcdev",
+}));
+
+// ---- imports after mocks ----------------------------------------------------
+
+import { POST } from "../route";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { lookupProfileByStxAddress } from "@/lib/cache/agent-profile";
+import type { AgentProfileRow } from "@/lib/cache/agent-profile";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const TEST_STX_ADDRESS = "SP1TESTADDRESS1234";
+const TEST_BTC_ADDRESS = "bc1qtest1address1mock1";
+
+/** Minimal AgentProfileRow that satisfies the type for a "row exists" scenario. */
+function makeProfileRow(overrides: Partial<AgentProfileRow> = {}): AgentProfileRow {
+  return {
+    btc_address: TEST_BTC_ADDRESS,
+    stx_address: TEST_STX_ADDRESS,
+    stx_public_key: "02mock_stx_pubkey",
+    btc_public_key: "03mock_btc_pubkey",
+    taproot_address: null,
+    display_name: null,
+    description: null,
+    bns_name: null,
+    owner: null,
+    verified_at: "2026-01-01T00:00:00.000Z",
+    last_active_at: null,
+    erc8004_agent_id: null,
+    nostr_public_key: null,
+    capabilities_json: null,
+    last_identity_check: null,
+    referred_by_btc: null,
+    referral_code: "ABCDEF",
+    github_username: null,
+    claim_status: null,
+    tweet_url: null,
+    tweet_author: null,
+    claimed_at: null,
+    reward_satoshis: null,
+    reward_txid: null,
+    ...overrides,
+  };
+}
+
+function buildRequest() {
+  return new NextRequest("https://aibtc.com/api/register", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      bitcoinSignature: "mock_btc_sig",
+      stacksSignature: "mock_stx_sig",
+      btcAddress: TEST_BTC_ADDRESS,
+      stxAddress: TEST_STX_ADDRESS,
+    }),
+  });
+}
+
+function buildMockD1(): D1Database {
+  return { prepare: vi.fn() } as unknown as D1Database;
+}
+
+function buildMockKv(btcValue: string | null = null): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(btcValue),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ keys: [] }),
+    getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default: verifyBitcoinSignature succeeds, returns TEST_BTC_ADDRESS
+  (verifyBitcoinSignature as Mock).mockReturnValue({
+    valid: true,
+    address: TEST_BTC_ADDRESS,
+    publicKey: "03mock_btc_pubkey",
+  });
+});
+
+// ---- test cases -------------------------------------------------------------
+
+describe("STX duplicate-check: D1 hit → 409 STX_ADDRESS_TAKEN", () => {
+  it("returns 409 when D1 finds an existing row for the STX address", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv(null); // BTC not taken
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        DB: mockDb,
+        VERIFIED_AGENTS: mockKv,
+        X402_RELAY_URL: "https://x402-relay.aibtc.com",
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(makeProfileRow());
+
+    const res = await POST(buildRequest());
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { code: string };
+    expect(body.code).toBe("STX_ADDRESS_TAKEN");
+    expect(lookupProfileByStxAddress as Mock).toHaveBeenCalledWith(mockDb, TEST_STX_ADDRESS);
+  });
+});
+
+describe("STX duplicate-check: D1 miss → registration proceeds past check", () => {
+  it("does NOT return 409 STX_ADDRESS_TAKEN when D1 returns null", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv(null); // BTC not taken either
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        DB: mockDb,
+        VERIFIED_AGENTS: mockKv,
+        X402_RELAY_URL: "https://x402-relay.aibtc.com",
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    // D1 returns null → address is free
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(null);
+
+    const res = await POST(buildRequest());
+
+    // Should NOT be 409 STX_ADDRESS_TAKEN — registration proceeds further.
+    // (It may still fail for other reasons, e.g. sponsor provisioning errors
+    // in the mock environment — but the STX duplicate check must pass.)
+    expect(res.status).not.toBe(409);
+    const body = await res.json() as { code: string };
+    expect(body.code).not.toBe("STX_ADDRESS_TAKEN");
+  });
+});
+
+describe("STX duplicate-check: D1 throws → fail-closed → 409 STX_ADDRESS_TAKEN", () => {
+  it("returns 409 STX_ADDRESS_TAKEN when D1 throws a transient error", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv(null);
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        DB: mockDb,
+        VERIFIED_AGENTS: mockKv,
+        X402_RELAY_URL: "https://x402-relay.aibtc.com",
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    // Simulate D1 transient failure
+    (lookupProfileByStxAddress as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset")
+    );
+
+    const res = await POST(buildRequest());
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { code: string };
+    expect(body.code).toBe("STX_ADDRESS_TAKEN");
+  });
+
+  it("returns 409 STX_ADDRESS_TAKEN when DB binding is undefined (fail-closed)", async () => {
+    const mockKv = buildMockKv(null);
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        DB: undefined, // binding not present
+        VERIFIED_AGENTS: mockKv,
+        X402_RELAY_URL: "https://x402-relay.aibtc.com",
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const res = await POST(buildRequest());
+
+    expect(res.status).toBe(409);
+    const body = await res.json() as { code: string };
+    expect(body.code).toBe("STX_ADDRESS_TAKEN");
+  });
+});

--- a/app/api/register/__tests__/stx-d1-dupcheck.test.ts
+++ b/app/api/register/__tests__/stx-d1-dupcheck.test.ts
@@ -1,13 +1,14 @@
 /**
  * Phase 4.0b — STX duplicate check via D1 (replaces kv.get('stx:...')).
  *
- * Covers three cases:
+ * Covers four cases:
  *  (a) D1 returns a row → address exists → 409 STX_ADDRESS_TAKEN
  *  (b) D1 returns null  → address free  → registration proceeds past the check
  *  (c) D1 throws        → fail-closed   → 409 STX_ADDRESS_TAKEN
+ *  (d) DB binding undefined → fail-closed → 409 STX_ADDRESS_TAKEN
  *
  * The test hooks in at the POST handler level, mocking every layer that runs
- * before the D1 check so the three interesting D1 outcomes can be isolated.
+ * before the D1 check so the four interesting D1 outcomes can be isolated.
  */
 
 import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -16,6 +16,7 @@ import { generateName } from "@/lib/name-generator";
 import { computeLevel, getNextLevel } from "@/lib/levels";
 import { verifyBitcoinSignature, bip322VerifyP2TR } from "@/lib/bitcoin-verify";
 import { lookupBnsName } from "@/lib/bns";
+import { lookupProfileByStxAddress } from "@/lib/cache/agent-profile";
 import { generateClaimCode } from "@/lib/claim-code";
 import { isPartialAgentRecord } from "@/lib/types";
 import { X_HANDLE } from "@/lib/constants";
@@ -734,14 +735,29 @@ export async function POST(request: NextRequest) {
     }
 
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database | undefined;
 
-    // Phase 1: KV duplicate check (fast, avoids unnecessary relay calls on 409)
-    const [existingStx, existingBtc] = await Promise.all([
-      kv.get(`stx:${stxResult.address}`),
-      kv.get(`btc:${btcResult.address}`),
-    ]);
+    // STX duplicate check via D1 (fail-closed: D1 error or missing binding → treat as taken).
+    // This replaces the previous kv.get(`stx:${addr}`) lookup; D1 is the authoritative store.
+    // Fail-closed rationale: D1 UNIQUE constraint would reject the INSERT anyway, but surfacing
+    // a clear 409 here gives better UX and avoids a wasted relay call.
+    let stxAlreadyExists: boolean;
+    try {
+      if (!db) {
+        // D1 binding unavailable (local dev without wrangler) — fail closed.
+        log.error("D1 binding (DB) unavailable for STX duplicate check; treating as taken (fail-closed)");
+        stxAlreadyExists = true;
+      } else {
+        const existingStxRow = await lookupProfileByStxAddress(db, stxResult.address);
+        stxAlreadyExists = existingStxRow !== null;
+      }
+    } catch (d1Err) {
+      // D1 error (transient unavailability, schema mismatch, etc.) — fail closed.
+      log.error(`D1 STX duplicate check failed for ${stxResult.address}: ${d1Err}; treating as taken (fail-closed)`);
+      stxAlreadyExists = true;
+    }
 
-    if (existingStx) {
+    if (stxAlreadyExists) {
       return registrationError(
         "Stacks address already registered. Each address can only be registered once.",
         "STX_ADDRESS_TAKEN",
@@ -749,6 +765,9 @@ export async function POST(request: NextRequest) {
         409
       );
     }
+
+    // BTC duplicate check: KV (btc: key) remains unchanged pending P4.3 migration.
+    const existingBtc = await kv.get(`btc:${btcResult.address}`);
 
     if (existingBtc) {
       let existingRecord;

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -753,7 +753,7 @@ export async function POST(request: NextRequest) {
       }
     } catch (d1Err) {
       // D1 error (transient unavailability, schema mismatch, etc.) — fail closed.
-      log.error(`D1 STX duplicate check failed for ${stxResult.address}: ${d1Err}; treating as taken (fail-closed)`);
+      log.error("D1 STX duplicate check failed; treating as taken (fail-closed)", { stxAddress: stxResult.address, error: String(d1Err) });
       stxAlreadyExists = true;
     }
 


### PR DESCRIPTION
## Summary

- Replaces `kv.get('stx:<addr>')` duplicate check in `POST /api/register` with `lookupProfileByStxAddress(db, addr)` — a D1 `WHERE stx_address = ?` query
- D1 is the authoritative store; this eliminates an unneeded KV read on every registration attempt
- BTC address check (`btc:` KV key) is unchanged (tracked as P4.3)

## Fail-closed semantics

Per campaign brief, D1 errors must not bypass the duplicate check:

| Scenario | Behaviour |
|---|---|
| D1 returns row | 409 `STX_ADDRESS_TAKEN` |
| D1 returns null | Registration proceeds |
| D1 throws | 409 `STX_ADDRESS_TAKEN` + error logged |
| `DB` binding undefined | 409 `STX_ADDRESS_TAKEN` + error logged |

The D1 UNIQUE constraint would reject a duplicate INSERT downstream anyway, but the early 409 avoids the relay call cost and gives clearer UX.

## Files changed

- `app/api/register/route.ts` — imports `lookupProfileByStxAddress`, replaces KV check
- `app/api/register/__tests__/stx-d1-dupcheck.test.ts` — 4 new tests (D1 hit / miss / throw / DB undefined)

## Test plan

- [x] `npx vitest run app/api/register/__tests__/` → 4/4 passing
- [x] `npm run typecheck` → 124 errors (no new errors in touched files; pre-existing baseline was 128)

## Smoke gates

- **T+1h:** Register 5xx rate at baseline (no regression from D1 path error)
- **T+4h:** D1 query error log rate near 0 (check `logs.aibtc.com` for `D1 STX duplicate check failed`)
- **T+24h:** No spike in 409 `STX_ADDRESS_TAKEN` (legitimate new registrations not blocked)
- **T+24h tracker writeback:** Update P4.2-blocker status in `EXECUTION-inventory.md`

## Context

- Campaign: `landing-page-cost-finish` phase P4-dual-write-cleanup-762c
- Sister PR: #773 (migrates `buildIndexFromScan` to D1)
- Inventory doc: `.planning/active/2026-05-11-landing-page-cost-finish/phases/P4-dual-write-cleanup-762c/EXECUTION-inventory.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)