### PR TITLE
fix(scheduler): move to v2 instance with admin controls

### DIFF
--- a/app/api/admin/scheduler/__tests__/route.test.ts
+++ b/app/api/admin/scheduler/__tests__/route.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/admin/auth", () => ({
+  requireAdmin: vi.fn().mockResolvedValue(null),
+}));
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import { GET, POST } from "../route";
+
+const schedulerStub = {
+  status: vi.fn().mockResolvedValue({ now: 123 }),
+  refreshNow: vi.fn().mockResolvedValue({ tenero: { succeeded: 1 } }),
+  pauseUntil: vi.fn().mockResolvedValue(undefined),
+  resume: vi.fn().mockResolvedValue(undefined),
+};
+
+const schedulerNamespace = {
+  idFromName: vi.fn((name: string) => `id:${name}`),
+  get: vi.fn(() => schedulerStub),
+};
+
+function request(path: string, method = "GET") {
+  return new NextRequest(`https://aibtc.com${path}`, { method });
+}
+
+function mockCloudflareContext() {
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: { SCHEDULER: schedulerNamespace },
+    ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
+  });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (requireAdmin as Mock).mockResolvedValue(null);
+  mockCloudflareContext();
+});
+
+describe("GET /api/admin/scheduler", () => {
+  it("requires admin auth", async () => {
+    (requireAdmin as Mock).mockResolvedValueOnce(
+      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
+    );
+
+    const response = await GET(request("/api/admin/scheduler"));
+
+    expect(response.status).toBe(401);
+    expect(getCloudflareContext).not.toHaveBeenCalled();
+  });
+
+  it("returns scheduler status with no-store/noindex headers", async () => {
+    const response = await GET(request("/api/admin/scheduler"));
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("cache-control")).toBe("no-store");
+    expect(response.headers.get("x-robots-tag")).toBe("noindex");
+    expect(schedulerNamespace.idFromName).toHaveBeenCalledWith("v2");
+    expect(body).toEqual({ name: "v2", status: { now: 123 } });
+  });
+
+  it("rejects unknown scheduler names before touching a stub", async () => {
+    const response = await GET(request("/api/admin/scheduler?name=typo"));
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Unsupported scheduler name");
+    expect(schedulerNamespace.idFromName).not.toHaveBeenCalled();
+  });
+});
+
+describe("POST /api/admin/scheduler", () => {
+  it("rejects pause without until", async () => {
+    const response = await POST(
+      request("/api/admin/scheduler?action=pause", "POST")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Missing `until`");
+    expect(schedulerStub.pauseUntil).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid refresh tasks", async () => {
+    const response = await POST(
+      request("/api/admin/scheduler?action=refresh&task=prices", "POST")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Unsupported task");
+    expect(schedulerStub.refreshNow).not.toHaveBeenCalled();
+  });
+
+  it("refreshes an allowlisted scheduler task", async () => {
+    const response = await POST(
+      request("/api/admin/scheduler?name=v3&action=refresh&task=all", "POST")
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(schedulerNamespace.idFromName).toHaveBeenCalledWith("v3");
+    expect(schedulerStub.refreshNow).toHaveBeenCalledWith("all");
+    expect(body).toEqual({
+      name: "v3",
+      task: "all",
+      result: { tenero: { succeeded: 1 } },
+    });
+  });
+});

--- a/app/api/admin/scheduler/route.ts
+++ b/app/api/admin/scheduler/route.ts
@@ -1,20 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
+import type { SchedulerRpc, SchedulerTask } from "@/lib/scheduler/rpc-types";
 
-type SchedulerStub = {
-  status(): Promise<unknown>;
-  refreshNow(task: "tenero" | "all"): Promise<unknown>;
-  pauseUntil(timestamp: number): Promise<void>;
-  resume(): Promise<void>;
-};
+const DEFAULT_SCHEDULER_INSTANCE = "v2";
+const ALLOWED_SCHEDULER_INSTANCES = new Set(["v1", "v2", "v3"]);
+const ALLOWED_TASKS = new Set<SchedulerTask>(["tenero", "all"]);
 
-function schedulerStub(env: CloudflareEnv, name: string): SchedulerStub {
-  const ns = env.SCHEDULER as unknown as {
-    idFromName(name: string): DurableObjectId;
-    get(id: DurableObjectId): SchedulerStub;
-  };
-  return ns.get(ns.idFromName(name));
+function json(body: unknown, init: ResponseInit = {}) {
+  const headers = new Headers(init.headers);
+  headers.set("Cache-Control", "no-store");
+  headers.set("X-Robots-Tag", "noindex");
+  return NextResponse.json(body, { ...init, headers });
+}
+
+function schedulerName(url: URL): string | NextResponse {
+  const name = url.searchParams.get("name") || DEFAULT_SCHEDULER_INSTANCE;
+  if (!ALLOWED_SCHEDULER_INSTANCES.has(name)) {
+    return json(
+      { error: "Unsupported scheduler name. Use v1, v2, or v3." },
+      { status: 400 }
+    );
+  }
+  return name;
+}
+
+function schedulerStub(env: CloudflareEnv, name: string): SchedulerRpc {
+  return env.SCHEDULER.get(env.SCHEDULER.idFromName(name));
+}
+
+function schedulerTask(url: URL): SchedulerTask | NextResponse {
+  const task = url.searchParams.get("task") || "tenero";
+  if (!ALLOWED_TASKS.has(task as SchedulerTask)) {
+    return json(
+      { error: "Unsupported task. Use tenero or all." },
+      { status: 400 }
+    );
+  }
+  return task as SchedulerTask;
 }
 
 export async function GET(request: NextRequest) {
@@ -23,9 +46,11 @@ export async function GET(request: NextRequest) {
 
   const { env } = await getCloudflareContext();
   const url = new URL(request.url);
-  const name = url.searchParams.get("name") || "v2";
+  const name = schedulerName(url);
+  if (typeof name !== "string") return name;
+
   const status = await schedulerStub(env, name).status();
-  return NextResponse.json({ name, status });
+  return json({ name, status });
 }
 
 export async function POST(request: NextRequest) {
@@ -34,34 +59,46 @@ export async function POST(request: NextRequest) {
 
   const { env } = await getCloudflareContext();
   const url = new URL(request.url);
-  const name = url.searchParams.get("name") || "v2";
+  const name = schedulerName(url);
+  if (typeof name !== "string") return name;
+
   const action = url.searchParams.get("action");
   const stub = schedulerStub(env, name);
 
   if (action === "pause") {
-    const until = Number(url.searchParams.get("until") || 0);
+    const rawUntil = url.searchParams.get("until");
+    if (!rawUntil) {
+      return json(
+        { error: "Missing `until`; provide a future unix-millis value." },
+        { status: 400 }
+      );
+    }
+
+    const until = Number(rawUntil);
     if (!Number.isFinite(until) || until <= Date.now()) {
-      return NextResponse.json(
+      return json(
         { error: "Provide a future unix-millis `until` value." },
         { status: 400 }
       );
     }
     await stub.pauseUntil(until);
-    return NextResponse.json({ name, pausedUntil: until });
+    return json({ name, pausedUntil: until });
   }
 
   if (action === "resume") {
     await stub.resume();
-    return NextResponse.json({ name, resumed: true });
+    return json({ name, resumed: true });
   }
 
   if (action === "refresh") {
-    const task = url.searchParams.get("task") === "all" ? "all" : "tenero";
+    const task = schedulerTask(url);
+    if (typeof task !== "string") return task;
+
     const result = await stub.refreshNow(task);
-    return NextResponse.json({ name, task, result });
+    return json({ name, task, result });
   }
 
-  return NextResponse.json(
+  return json(
     { error: "Unsupported action. Use pause, resume, or refresh." },
     { status: 400 }
   );

--- a/app/api/admin/scheduler/route.ts
+++ b/app/api/admin/scheduler/route.ts
@@ -1,0 +1,68 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+
+type SchedulerStub = {
+  status(): Promise<unknown>;
+  refreshNow(task: "tenero" | "all"): Promise<unknown>;
+  pauseUntil(timestamp: number): Promise<void>;
+  resume(): Promise<void>;
+};
+
+function schedulerStub(env: CloudflareEnv, name: string): SchedulerStub {
+  const ns = env.SCHEDULER as unknown as {
+    idFromName(name: string): DurableObjectId;
+    get(id: DurableObjectId): SchedulerStub;
+  };
+  return ns.get(ns.idFromName(name));
+}
+
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  const { env } = await getCloudflareContext();
+  const url = new URL(request.url);
+  const name = url.searchParams.get("name") || "v2";
+  const status = await schedulerStub(env, name).status();
+  return NextResponse.json({ name, status });
+}
+
+export async function POST(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  const { env } = await getCloudflareContext();
+  const url = new URL(request.url);
+  const name = url.searchParams.get("name") || "v2";
+  const action = url.searchParams.get("action");
+  const stub = schedulerStub(env, name);
+
+  if (action === "pause") {
+    const until = Number(url.searchParams.get("until") || 0);
+    if (!Number.isFinite(until) || until <= Date.now()) {
+      return NextResponse.json(
+        { error: "Provide a future unix-millis `until` value." },
+        { status: 400 }
+      );
+    }
+    await stub.pauseUntil(until);
+    return NextResponse.json({ name, pausedUntil: until });
+  }
+
+  if (action === "resume") {
+    await stub.resume();
+    return NextResponse.json({ name, resumed: true });
+  }
+
+  if (action === "refresh") {
+    const task = url.searchParams.get("task") === "all" ? "all" : "tenero";
+    const result = await stub.refreshNow(task);
+    return NextResponse.json({ name, task, result });
+  }
+
+  return NextResponse.json(
+    { error: "Unsupported action. Use pause, resume, or refresh." },
+    { status: 400 }
+  );
+}

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -9,6 +9,8 @@ import { getCachedTokenPrices } from "@/lib/external/tenero/kv-cache";
 // Next's build-time prerender never needs a Wrangler platform proxy.
 export const dynamic = "force-dynamic";
 
+const SCHEDULER_INSTANCE_NAME = "v2";
+
 export const metadata: Metadata = {
   title: "Trading Leaderboard - AIBTC",
   description:
@@ -101,7 +103,7 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   try {
     if (env.SCHEDULER) {
       ctx.waitUntil(
-        env.SCHEDULER.get(env.SCHEDULER.idFromName("v1"))
+        env.SCHEDULER.get(env.SCHEDULER.idFromName(SCHEDULER_INSTANCE_NAME))
           .status()
           .then(() => undefined)
           .catch(() => undefined)

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -29,20 +29,10 @@ interface CloudflareEnv {
   // only expands T's methods when T is branded). Without it, callers
   // see `.fetch()` / `.connect()` only, never `.status()` / etc.
   //
-  // Keep these method signatures in sync with the SchedulerDO class in
-  // worker.ts.
-  // Returns are typed as `Promise<void>` not `Promise<unknown>` because the
-  // RPC `Result<R>` type only accepts Serializable returns — `unknown`
-  // falls through to `never` and the call site can't even chain `.then()`.
-  // Callers that need richer return types should tighten these here when
-  // they wire up real consumers.
+  // Keep these method signatures in sync with SchedulerRpc in
+  // lib/scheduler/rpc-types.ts and SchedulerDO in worker.ts.
   SCHEDULER: DurableObjectNamespace<
-    Rpc.DurableObjectBranded & {
-      status(): Promise<void>;
-      refreshNow(task: "tenero" | "all"): Promise<void>;
-      pauseUntil(timestamp: number): Promise<void>;
-      resume(): Promise<void>;
-    }
+    Rpc.DurableObjectBranded & import("./lib/scheduler/rpc-types").SchedulerRpc
   >;
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
 }

--- a/lib/scheduler/rpc-types.ts
+++ b/lib/scheduler/rpc-types.ts
@@ -1,0 +1,24 @@
+import type { TeneroRunResult } from "./tenero-task";
+
+export type SchedulerTask = "tenero" | "all";
+
+export interface SchedulerStatus {
+  now: number;
+  pausedUntil: number | null;
+  lastTeneroRunAt: number | null;
+  lastTeneroResult: TeneroRunResult | null;
+  consecutiveFailures: { tenero: number };
+  nextRunAfter: { tenero: number | null };
+  nextAlarmAt: number | null;
+}
+
+export interface SchedulerRefreshResult {
+  tenero?: TeneroRunResult;
+}
+
+export interface SchedulerRpc {
+  status(): Promise<SchedulerStatus>;
+  refreshNow(task: SchedulerTask): Promise<SchedulerRefreshResult>;
+  pauseUntil(timestamp: number): Promise<void>;
+  resume(): Promise<void>;
+}

--- a/worker.ts
+++ b/worker.ts
@@ -18,6 +18,11 @@ import {
   type TeneroRunResult,
   TENERO_MINUTE_QUOTA_BACKOFF_MS,
 } from "./lib/scheduler/tenero-task";
+import type {
+  SchedulerRefreshResult,
+  SchedulerStatus,
+  SchedulerTask,
+} from "./lib/scheduler/rpc-types";
 
 // ─────────────────────────── SchedulerDO ───────────────────────────
 //
@@ -43,16 +48,6 @@ import {
 
 const TENERO_INTERVAL_MS = 5 * 60 * 1000;
 const ALARM_TICK_MS = TENERO_INTERVAL_MS;
-
-export interface SchedulerStatus {
-  now: number;
-  pausedUntil: number | null;
-  lastTeneroRunAt: number | null;
-  lastTeneroResult: TeneroRunResult | null;
-  consecutiveFailures: { tenero: number };
-  nextRunAfter: { tenero: number | null };
-  nextAlarmAt: number | null;
-}
 
 type StoredScheduler = {
   lastTeneroRunAt?: number;
@@ -89,7 +84,7 @@ export class SchedulerDO extends DurableObject<CloudflareEnv> {
     };
   }
 
-  async refreshNow(task: "tenero" | "all"): Promise<{ tenero?: TeneroRunResult }> {
+  async refreshNow(task: SchedulerTask): Promise<SchedulerRefreshResult> {
     const logger = this.makeLogger({ trigger: "refreshNow", task });
     const out: { tenero?: TeneroRunResult } = {};
     if (task === "tenero" || task === "all") {


### PR DESCRIPTION
## Summary

Production verification showed the original `v1` SchedulerDO instance stayed warm after deploys and continued firing the older token set (`tokenCount=4`, including `unknown`). This moves the active scheduler singleton to `v2` and adds an admin-only control route so operators can inspect/pause/resume/refresh named scheduler instances.

## What changed

- `/leaderboard` now kicks `SCHEDULER.idFromName("v2")` instead of `v1`.
- Adds `GET /api/admin/scheduler?name=v2` for status.
- Adds `POST /api/admin/scheduler?name={name}&action=pause|resume|refresh` protected by `X-Admin-Key`.

## Operational actions already performed

- Deployed this patch directly to production to recover the scheduler.
- Paused old `v1` until a far-future timestamp via the new admin route.
- Forced `v2`/`v3` refreshes to verify current behavior.

## Verification

- `npm run lint` passes (existing image warnings only)
- `npm run test -- lib/scheduler/__tests__/tenero-task.test.ts` passes
- `npm run build` passes
- `npx opennextjs-cloudflare build` passes
- Production route `/api/admin/scheduler` is live and authenticated

## Note on Tenero key

`TENERO_API_KEY` is present as a Worker secret, but the supplied value does not raise Worker-side Tenero quota. Local tests without a key also return quota, so the earlier local key test was a false positive. Worker requests still return `x-ratelimit-month-remaining: 0`. Prices will remain empty until we get a Tenero key/header combination that works from Cloudflare Workers.