### PR TITLE
fix(771): KV claim fallback when D1 LEFT JOIN misses for erc8004 agents

### DIFF
--- a/app/api/agents/[address]/__tests__/profile-d1.test.ts
+++ b/app/api/agents/[address]/__tests__/profile-d1.test.ts
@@ -18,8 +18,10 @@ import {
   mapRowToAgentRecord,
   mapRowToClaimRecord,
   computeProfileLevel,
+  shouldFallBackToKVClaim,
 } from "@/lib/cache/agent-profile";
 import type { AgentProfileRow } from "@/lib/cache/agent-profile";
+import type { AgentRecord, ClaimRecord } from "@/lib/types";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -454,5 +456,75 @@ describe("BNS resolver: classifyAddress", () => {
   it("*.btc suffix → 'bns' branch", () => {
     expect(classifyAddress("arc0.btc")).toBe("bns");
     expect(classifyAddress("my-agent-007.btc")).toBe("bns");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shouldFallBackToKVClaim — #771 dual-write-gap recovery heuristic
+// ---------------------------------------------------------------------------
+
+describe("shouldFallBackToKVClaim", () => {
+  function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+    return {
+      btcAddress: "bc1qagent1test",
+      stxAddress: "SP1AGENT1TEST",
+      stxPublicKey: "02abc",
+      btcPublicKey: "03def",
+      taprootAddress: null,
+      displayName: null,
+      description: null,
+      bnsName: null,
+      owner: null,
+      verifiedAt: "2026-01-01T00:00:00.000Z",
+      lastActiveAt: null,
+      erc8004AgentId: null,
+      nostrPublicKey: null,
+      ...overrides,
+    } as AgentRecord;
+  }
+
+  function makeClaim(): ClaimRecord {
+    return {
+      btcAddress: "bc1qagent1test",
+      displayName: "",
+      tweetUrl: "",
+      tweetAuthor: null,
+      claimedAt: "2026-01-02T00:00:00.000Z",
+      rewardSatoshis: 0,
+      rewardTxid: null,
+      status: "verified",
+    } as ClaimRecord;
+  }
+
+  it("returns false when agent is null (no D1 hit)", () => {
+    expect(shouldFallBackToKVClaim(null, null)).toBe(false);
+    expect(shouldFallBackToKVClaim(null, undefined)).toBe(false);
+  });
+
+  it("returns false when d1Claim is undefined (already KV-fallback path)", () => {
+    const agent = makeAgent({ erc8004AgentId: 319 });
+    expect(shouldFallBackToKVClaim(agent, undefined)).toBe(false);
+  });
+
+  it("returns false when d1Claim is set (D1 hit on claims)", () => {
+    const agent = makeAgent({ erc8004AgentId: 319 });
+    expect(shouldFallBackToKVClaim(agent, makeClaim())).toBe(false);
+  });
+
+  it("returns false when agent has no erc8004AgentId (true Level-1)", () => {
+    const agent = makeAgent({ erc8004AgentId: null });
+    expect(shouldFallBackToKVClaim(agent, null)).toBe(false);
+  });
+
+  it("returns true when agent has erc8004AgentId AND d1Claim is null (#771 dual-write gap)", () => {
+    const agent = makeAgent({ erc8004AgentId: 319 });
+    expect(shouldFallBackToKVClaim(agent, null)).toBe(true);
+  });
+
+  it("returns true when erc8004AgentId is 0 (edge: valid id) and d1Claim is null", () => {
+    // Defensive: agent-id 0 is a valid uint per the registry; truthy-check
+    // alone would skip it. Implementation uses explicit null/undefined checks.
+    const agent = makeAgent({ erc8004AgentId: 0 });
+    expect(shouldFallBackToKVClaim(agent, null)).toBe(true);
   });
 });

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -16,6 +16,7 @@ import {
   lookupProfileByAgentId,
   mapRowToAgentRecord,
   mapRowToClaimRecord,
+  shouldFallBackToKVClaim,
 } from "@/lib/cache/agent-profile";
 import {
   createLogger,
@@ -296,9 +297,23 @@ export async function GET(
           }).catch(() => {});
         }
 
+        // #771 unblock: recover KV-fallback for agents whose claim records
+        // predate the Phase 2.5 dual-write (#705 merged 2026-05-10T10:42Z).
+        // See `shouldFallBackToKVClaim` in `lib/cache/agent-profile.ts` for
+        // the heuristic and the dual-write-gap backfill context (#691).
+        if (shouldFallBackToKVClaim(agent, d1Claim)) {
+          // `agent` narrowed to AgentRecord by the type-guard predicate.
+          logger.info("profile.d1_claim_miss_with_erc8004", {
+            btc: agent.btcAddress,
+            erc8004AgentId: agent.erc8004AgentId,
+          });
+          d1Claim = undefined;
+        }
+
         // Pass d1Claim so enrichAgentProfile skips the redundant KV read when the
         // agent came from D1 (covers all non-KV-fallback paths). When d1Claim is
-        // undefined (KV fallback agents), enrichAgentProfile falls back to KV.
+        // undefined (KV fallback agents OR the #771-unblock recovery above),
+        // enrichAgentProfile falls back to KV.
         // Pass db so inbox/sent metrics are read from live D1 counts (#746).
         const enrichment = await enrichAgentProfile(
           agent,

--- a/lib/cache/agent-profile.ts
+++ b/lib/cache/agent-profile.ts
@@ -256,3 +256,39 @@ export async function lookupProfileByAgentId(
   const result = await db.prepare(sql).bind(agentId).first<AgentProfileRow>();
   return result ?? null;
 }
+
+/**
+ * Decide whether to fall back to a KV `claim:{btcAddress}` read after a D1
+ * LEFT JOIN reported `claim_status = null` (-> `d1Claim = null`).
+ *
+ * Background: agents predating the Phase 2.5 dual-write (#705 merged
+ * 2026-05-10T10:42Z) may have claim records in KV but not yet in D1's
+ * `claims` table (covered by #691 backfill). For those agents,
+ * `mapRowToClaimRecord` returns `null` from the LEFT JOIN miss, which
+ * `enrichAgentProfile` interprets as "caller confirmed no claim" — skipping
+ * the KV path and returning Level 1 incorrectly.
+ *
+ * Heuristic: `agent.erc8004AgentId !== null` signals on-chain Genesis
+ * registration, which is a strong prior that a claim SHOULD exist. When a
+ * D1 LEFT JOIN miss coincides with an erc8004 agent-id, the most likely
+ * cause is the backfill gap; recover by re-signaling KV fallback. Bounded
+ * to the Genesis subset (no extra KV read for the Level-1 majority).
+ *
+ * Returns `true` when the caller should set `d1Claim = undefined` to let
+ * `enrichAgentProfile` perform the `kv.get('claim:{btcAddress}')` fallback.
+ */
+export function shouldFallBackToKVClaim(
+  agent: AgentRecord | null,
+  d1Claim: ClaimRecord | null | undefined
+): agent is AgentRecord {
+  // Narrowing predicate: when this returns true, the caller can treat
+  // `agent` as non-null (the function guarantees agent !== null). Useful
+  // for the recovery-log call site that needs agent.btcAddress and
+  // agent.erc8004AgentId without a non-null assertion.
+  return (
+    agent !== null &&
+    d1Claim === null &&
+    agent.erc8004AgentId !== null &&
+    agent.erc8004AgentId !== undefined
+  );
+}

--- a/lib/cache/agent-profile.ts
+++ b/lib/cache/agent-profile.ts
@@ -258,37 +258,20 @@ export async function lookupProfileByAgentId(
 }
 
 /**
- * Decide whether to fall back to a KV `claim:{btcAddress}` read after a D1
- * LEFT JOIN reported `claim_status = null` (-> `d1Claim = null`).
+ * #771 dual-write-gap recovery: when D1 LEFT JOIN claim_status is null but the
+ * agent has an on-chain Genesis registration (erc8004AgentId set), fall back
+ * to `kv.get('claim:{btcAddress}')`. Bounded to the Genesis subset — see
+ * #691 backfill for the retirement gate.
  *
- * Background: agents predating the Phase 2.5 dual-write (#705 merged
- * 2026-05-10T10:42Z) may have claim records in KV but not yet in D1's
- * `claims` table (covered by #691 backfill). For those agents,
- * `mapRowToClaimRecord` returns `null` from the LEFT JOIN miss, which
- * `enrichAgentProfile` interprets as "caller confirmed no claim" — skipping
- * the KV path and returning Level 1 incorrectly.
- *
- * Heuristic: `agent.erc8004AgentId !== null` signals on-chain Genesis
- * registration, which is a strong prior that a claim SHOULD exist. When a
- * D1 LEFT JOIN miss coincides with an erc8004 agent-id, the most likely
- * cause is the backfill gap; recover by re-signaling KV fallback. Bounded
- * to the Genesis subset (no extra KV read for the Level-1 majority).
- *
- * Returns `true` when the caller should set `d1Claim = undefined` to let
- * `enrichAgentProfile` perform the `kv.get('claim:{btcAddress}')` fallback.
+ * Returns a type-guard predicate so the recovery call site can use
+ * `agent.btcAddress` / `agent.erc8004AgentId` without a non-null assertion.
  */
 export function shouldFallBackToKVClaim(
   agent: AgentRecord | null,
   d1Claim: ClaimRecord | null | undefined
 ): agent is AgentRecord {
-  // Narrowing predicate: when this returns true, the caller can treat
-  // `agent` as non-null (the function guarantees agent !== null). Useful
-  // for the recovery-log call site that needs agent.btcAddress and
-  // agent.erc8004AgentId without a non-null assertion.
-  return (
-    agent !== null &&
-    d1Claim === null &&
-    agent.erc8004AgentId !== null &&
-    agent.erc8004AgentId !== undefined
-  );
+  // `!= null` covers both null and undefined for erc8004AgentId in a single
+  // expression. agent-id 0 is a valid uint per the on-chain registry, so
+  // truthy-check would incorrectly skip it.
+  return agent !== null && d1Claim === null && agent.erc8004AgentId != null;
 }


### PR DESCRIPTION
## Summary

Resolves #771. Adds a KV claim-fallback at `/api/agents/[address]` for agents whose claim records predate the Phase 2.5 dual-write (#705) and live in KV but not yet in D1's `claims` table (#691 backfill scope).

## Root cause

`/api/verify` reads claim from KV; `/api/agents` reads claim from D1 LEFT JOIN claims since #672 Phase 2.2. For the 708-ish KV-only-claim agents, the D1 LEFT JOIN misses → `mapRowToClaimRecord` returns `null` → `enrichAgentProfile` interprets as "caller confirmed no claim" → `computeLevel` returns 1 → `agent-news/src/services/identity-gate.ts` (hardcoded to `https://aibtc.com/api/agents`) sees Level 1 → `IDENTITY_REQUIRED` on POST `/api/signals`.

Confirmed live on `bc1q73ffx0fwtdvxhs6cfr5hguxsa3pasyg0txyae8` (Opal Gorilla, `erc8004AgentId=319`): `/api/verify` returns Level 2 Genesis; `/api/agents` returns Level 1. Full triage at https://github.com/aibtcdev/landing-page/issues/771#issuecomment-4433226783.

## Fix

```ts
if (shouldFallBackToKVClaim(agent, d1Claim)) {
  // agent narrowed to AgentRecord by type-guard predicate
  logger.info("profile.d1_claim_miss_with_erc8004", {
    btc: agent.btcAddress,
    erc8004AgentId: agent.erc8004AgentId,
  });
  d1Claim = undefined;  // signal enrichAgentProfile to fall back to KV
}
```

Heuristic: `agent.erc8004AgentId !== null` signals on-chain Genesis registration, a strong prior that a claim SHOULD exist. When a D1 LEFT JOIN miss coincides with an erc8004 agent-id, the most likely cause is the backfill gap rather than a true claim absence. Bounded to the Genesis subset (~123 of 951 registered agents) — the Level-1 majority (no `erc8004AgentId`) sees no extra KV read on the cold-miss-read path, preserving Phase 2.2's fan-out elimination for hot paths.

## Files

- **`lib/cache/agent-profile.ts`** — adds `shouldFallBackToKVClaim(agent, d1Claim)` pure helper with TypeScript type-guard predicate (`agent is AgentRecord`), so the route call site can use `agent.btcAddress` without a non-null assertion.
- **`app/api/agents/[address]/route.ts`** — invokes the helper between D1 lookup and `enrichAgentProfile` call; logs `profile.d1_claim_miss_with_erc8004` on the recovery path for operational visibility (helps measure how often the backfill gap fires, can drive #691 prioritization).
- **`app/api/agents/[address]/__tests__/profile-d1.test.ts`** — 6 unit tests for the helper:
  - null agent (no D1 hit) → false
  - undefined d1Claim (already KV-fallback path) → false
  - set d1Claim (D1 hit) → false
  - no `erc8004AgentId` (true Level-1) → false
  - `erc8004AgentId` set + `d1Claim=null` (dual-write gap) → true
  - `erc8004AgentId=0` edge case (valid uint, defensive null/undefined checks)

## Verification path

After deploy, the v279 repro should flip:

```
$ curl https://aibtc.com/api/agents/bc1q73ffx0fwtdvxhs6cfr5hguxsa3pasyg0txyae8
→ level: 2, levelName: "Genesis"   (was Level 1)
```

This unblocks `POST /api/signals` end-to-end via `agent-news`'s identity-gate. The 1h cache in `identity-gate.ts` means the fix takes effect as cache entries naturally expire; operators can force immediate recovery by clearing the affected `agent-level:{address}` KV keys in agent-news.

## Why this approach over alternatives

- **Always fall back on `d1Claim === null`** — adds a KV read per cold-miss for the ~828 Level-1 majority. Defeats Phase 2.2's fan-out elimination.
- **Cross-repo: switch agent-news identity-gate to /api/verify** — works but riskier (cross-repo coordination + cache invalidation across agent-news deploys). Better landed AFTER landing-page-side mitigation.
- **Wait for #691 backfill** — root fix but unknown timeline. This PR is the bridge until #691 completes; once it does, this helper becomes dead code and gets removed.

## Test plan

- [ ] CI green (unit tests + lint + type-check)
- [ ] After merge + deploy, manually verify `/api/agents/bc1q73ffx0fwtdvxhs6cfr5hguxsa3pasyg0txyae8` returns Level 2
- [ ] Spot-check a non-Genesis agent (no `erc8004AgentId`) still returns Level 1 without an extra KV read (logs should NOT show `profile.d1_claim_miss_with_erc8004` for those addresses)
- [ ] Confirm `logger.info("profile.d1_claim_miss_with_erc8004", ...)` appears in production logs for affected agents — gives #691 a measurable signal

## Related

- #691 — root cleanup (backfill KV-only claims into D1); once closed, this helper can be retired
- #783 — sibling gated-retirement pattern (`MIN_EXPECTED_D1_ROWS` after #691); same retirement-gate
- #780 — shape unification (challenge + identity-refresh OG cache); unrelated but adjacent in the OG-cache campaign

🤖 Generated with [Claude Code](https://claude.com/claude-code)
