### PR TITLE
feat(762c): resolve/[identifier] stx → D1 (fail-closed)

### DIFF
--- a/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
+++ b/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
@@ -275,7 +275,7 @@ describe("Path A — direct STX address lookup: D1 throws → fail-closed → 40
 // ============================================================================
 
 describe("Path B — agent-id lookup: D1 returns row → 200 with erc8004AgentId set", () => {
-  it("returns 200 with mapped identity body and erc8004AgentId filled in", async () => {
+  it("fills in erc8004AgentId and passes the enriched agent to enrichAgentProfile", async () => {
     const mockDb = buildMockD1();
     const mockKv = buildMockKv();
 
@@ -293,6 +293,15 @@ describe("Path B — agent-id lookup: D1 returns row → 200 with erc8004AgentId
     const record = makeAgentRecord({ erc8004AgentId: null });
     (mapRowToAgentRecord as Mock).mockReturnValue(record);
 
+    // Capture the agent arg passed to enrichAgentProfile so we can assert fill-in
+    let capturedAgent: AgentRecord | undefined;
+    (enrichAgentProfile as Mock).mockImplementation(
+      async (agent: AgentRecord, ...rest: unknown[]) => {
+        capturedAgent = { ...agent };
+        return makeEnrichmentResult();
+      }
+    );
+
     const res = await GET(
       buildAgentIdRequest(TEST_AGENT_ID),
       { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
@@ -303,6 +312,51 @@ describe("Path B — agent-id lookup: D1 returns row → 200 with erc8004AgentId
     expect(body.found).toBe(true);
     expect(body.identifierType).toBe("agent-id");
     expect(lookupProfileByStxAddress as Mock).toHaveBeenCalledWith(mockDb, TEST_STX_ADDRESS);
+    // Assert that the agent passed to enrichAgentProfile has erc8004AgentId set to the on-chain value
+    expect(capturedAgent).toBeDefined();
+    expect(capturedAgent!.erc8004AgentId).toBe(TEST_AGENT_ID);
+  });
+
+  it("overrides a stale stored erc8004AgentId with the authoritative on-chain value", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    // On-chain resolution: agentId → stxAddress
+    (callReadOnly as Mock).mockResolvedValue({ result: "0x00" });
+    (parseClarityValue as Mock).mockReturnValue(TEST_STX_ADDRESS);
+
+    const STALE_AGENT_ID = 999; // incorrect stored value
+    const row = makeProfileRow({ erc8004_agent_id: STALE_AGENT_ID });
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(row);
+    // mapRowToAgentRecord returns the stale value as stored in D1
+    const record = makeAgentRecord({ erc8004AgentId: STALE_AGENT_ID });
+    (mapRowToAgentRecord as Mock).mockReturnValue(record);
+
+    let capturedAgent: AgentRecord | undefined;
+    (enrichAgentProfile as Mock).mockImplementation(
+      async (agent: AgentRecord, ...rest: unknown[]) => {
+        capturedAgent = { ...agent };
+        return makeEnrichmentResult();
+      }
+    );
+
+    const res = await GET(
+      buildAgentIdRequest(TEST_AGENT_ID),
+      { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(true);
+    // The on-chain TEST_AGENT_ID must override the stale stored STALE_AGENT_ID
+    expect(capturedAgent).toBeDefined();
+    expect(capturedAgent!.erc8004AgentId).toBe(TEST_AGENT_ID);
+    expect(capturedAgent!.erc8004AgentId).not.toBe(STALE_AGENT_ID);
   });
 });
 

--- a/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
+++ b/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Phase 4.0c — STX lookup via D1 in resolve/[identifier] (replaces kv.get('stx:...')).
+ *
+ * Two code paths are tested:
+ *
+ * Path A — identifierType === "stx" (direct STX address lookup, ~L384):
+ *   (a1) D1 returns a row → 200 with mapped identity body
+ *   (a2) D1 returns null  → 404 not found (same as prior KV null path)
+ *   (a3) D1 throws        → fail-closed → 404 not found
+ *   (a4) DB binding undefined → fail-closed → 404 not found
+ *
+ * Path B — identifierType === "agent-id" (on-chain ID → STX → D1, ~L295):
+ *   (b1) D1 returns a row → 200 with mapped identity body (erc8004AgentId set)
+ *   (b2) D1 returns null  → 404 not registered on platform
+ *   (b3) D1 throws        → fail-closed → 404 not registered on platform
+ *   (b4) DB binding undefined → fail-closed → 404 not registered on platform
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (declared before route import) ----------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/identity", () => ({
+  callReadOnly: vi.fn(),
+  parseClarityValue: vi.fn(),
+  IDENTITY_REGISTRY_CONTRACT: "SP2PABAF9FTAJYNFZH93XENAJ8FVY99RRM50D2JG9.identity-registry-v2",
+}));
+
+vi.mock("@/lib/agent-enrichment", () => ({
+  enrichAgentProfile: vi.fn(),
+}));
+
+vi.mock("@/lib/agents-index", () => ({
+  getAgentsIndex: vi.fn(),
+}));
+
+vi.mock("@/lib/bns-reverse-index", () => ({
+  lookupBtcAddressByBnsName: vi.fn(),
+  syncBnsLookup: vi.fn(),
+}));
+
+vi.mock("@/lib/cache/agent-profile", () => ({
+  lookupProfileByStxAddress: vi.fn(),
+  mapRowToAgentRecord: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  isLogsRPC: () => false,
+}));
+
+// ---- imports after mocks ----------------------------------------------------
+
+import { GET } from "../route";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { callReadOnly, parseClarityValue } from "@/lib/identity";
+import { enrichAgentProfile } from "@/lib/agent-enrichment";
+import { lookupProfileByStxAddress, mapRowToAgentRecord } from "@/lib/cache/agent-profile";
+import type { AgentProfileRow } from "@/lib/cache/agent-profile";
+import type { AgentRecord } from "@/lib/types";
+
+// ---- fixtures ---------------------------------------------------------------
+
+const TEST_STX_ADDRESS = "SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE";
+const TEST_BTC_ADDRESS = "bc1qar0srrr7xfkvy5l643lydnw9re59gtzzwf5mdq";
+const TEST_AGENT_ID = 42;
+
+function makeProfileRow(overrides: Partial<AgentProfileRow> = {}): AgentProfileRow {
+  return {
+    btc_address: TEST_BTC_ADDRESS,
+    stx_address: TEST_STX_ADDRESS,
+    stx_public_key: "02mock_stx_pubkey",
+    btc_public_key: "03mock_btc_pubkey",
+    taproot_address: null,
+    display_name: "Mock Agent",
+    description: null,
+    bns_name: null,
+    owner: null,
+    verified_at: "2026-01-01T00:00:00.000Z",
+    last_active_at: null,
+    erc8004_agent_id: null,
+    nostr_public_key: null,
+    capabilities_json: null,
+    last_identity_check: null,
+    referred_by_btc: null,
+    referral_code: "ABCDEF",
+    github_username: null,
+    claim_status: null,
+    tweet_url: null,
+    tweet_author: null,
+    claimed_at: null,
+    reward_satoshis: null,
+    reward_txid: null,
+    ...overrides,
+  };
+}
+
+function makeAgentRecord(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    btcAddress: TEST_BTC_ADDRESS,
+    stxAddress: TEST_STX_ADDRESS,
+    stxPublicKey: "02mock_stx_pubkey",
+    btcPublicKey: "03mock_btc_pubkey",
+    taprootAddress: null,
+    displayName: "Mock Agent",
+    description: null,
+    bnsName: null,
+    owner: null,
+    verifiedAt: "2026-01-01T00:00:00.000Z",
+    lastActiveAt: undefined,
+    erc8004AgentId: null,
+    nostrPublicKey: null,
+    capabilities: null,
+    lastIdentityCheck: undefined,
+    referredBy: undefined,
+    githubUsername: null,
+    ...overrides,
+  };
+}
+
+function makeEnrichmentResult() {
+  return {
+    levelInfo: { level: 1, levelName: "Registered", nextLevel: null },
+    claim: null,
+    identity: null,
+    reputation: null,
+    checkIn: null,
+    trust: { level: 1, levelName: "Registered", onChainIdentity: false, reputationScore: null, reputationCount: 0 },
+    activity: { lastActiveAt: null, hasCheckedIn: false, hasInboxMessages: false, unreadInboxCount: 0, sentCount: 0 },
+    capabilities: [],
+    resolvedAgentId: null,
+    caip19: null,
+  };
+}
+
+function buildMockD1(): D1Database {
+  return { prepare: vi.fn() } as unknown as D1Database;
+}
+
+function buildMockKv(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ keys: [] }),
+    getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+function buildStxRequest(identifier: string) {
+  return new NextRequest(`https://aibtc.com/api/resolve/${identifier}`, { method: "GET" });
+}
+
+function buildAgentIdRequest(agentId: number) {
+  return new NextRequest(`https://aibtc.com/api/resolve/${agentId}`, { method: "GET" });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  // Default enrichAgentProfile mock — returns minimal valid enrichment
+  (enrichAgentProfile as Mock).mockResolvedValue(makeEnrichmentResult());
+
+  // Default mapRowToAgentRecord — returns a real AgentRecord from a row
+  (mapRowToAgentRecord as Mock).mockImplementation(makeAgentRecord);
+});
+
+// ============================================================================
+// Path A: identifierType === "stx" (direct STX address lookup)
+// ============================================================================
+
+describe("Path A — direct STX address lookup: D1 returns row → 200", () => {
+  it("returns 200 with mapped identity body when D1 finds the agent", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const row = makeProfileRow();
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(row);
+    (mapRowToAgentRecord as Mock).mockReturnValue(makeAgentRecord());
+
+    const res = await GET(
+      buildStxRequest(TEST_STX_ADDRESS),
+      { params: Promise.resolve({ identifier: TEST_STX_ADDRESS }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(true);
+    expect(body.identifierType).toBe("stx");
+    expect((body.identity as Record<string, unknown>).stxAddress).toBe(TEST_STX_ADDRESS);
+    expect(lookupProfileByStxAddress as Mock).toHaveBeenCalledWith(mockDb, TEST_STX_ADDRESS);
+    expect(mapRowToAgentRecord as Mock).toHaveBeenCalledWith(row);
+  });
+});
+
+describe("Path A — direct STX address lookup: D1 returns null → 404", () => {
+  it("returns 404 not found when D1 has no row for the STX address", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(null);
+
+    const res = await GET(
+      buildStxRequest(TEST_STX_ADDRESS),
+      { params: Promise.resolve({ identifier: TEST_STX_ADDRESS }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+  });
+});
+
+describe("Path A — direct STX address lookup: D1 throws → fail-closed → 404", () => {
+  it("returns 404 when D1 throws a transient error (fail-closed)", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (lookupProfileByStxAddress as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset")
+    );
+
+    const res = await GET(
+      buildStxRequest(TEST_STX_ADDRESS),
+      { params: Promise.resolve({ identifier: TEST_STX_ADDRESS }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+  });
+
+  it("returns 404 when DB binding is undefined (fail-closed)", async () => {
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: undefined, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const res = await GET(
+      buildStxRequest(TEST_STX_ADDRESS),
+      { params: Promise.resolve({ identifier: TEST_STX_ADDRESS }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+  });
+});
+
+// ============================================================================
+// Path B: identifierType === "agent-id" (on-chain ID → STX → D1 lookup)
+// ============================================================================
+
+describe("Path B — agent-id lookup: D1 returns row → 200 with erc8004AgentId set", () => {
+  it("returns 200 with mapped identity body and erc8004AgentId filled in", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    // On-chain resolution: agentId → stxAddress
+    (callReadOnly as Mock).mockResolvedValue({ result: "0x00" });
+    (parseClarityValue as Mock).mockReturnValue(TEST_STX_ADDRESS);
+
+    const row = makeProfileRow({ erc8004_agent_id: null }); // null to exercise the fill-in
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(row);
+    const record = makeAgentRecord({ erc8004AgentId: null });
+    (mapRowToAgentRecord as Mock).mockReturnValue(record);
+
+    const res = await GET(
+      buildAgentIdRequest(TEST_AGENT_ID),
+      { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(true);
+    expect(body.identifierType).toBe("agent-id");
+    expect(lookupProfileByStxAddress as Mock).toHaveBeenCalledWith(mockDb, TEST_STX_ADDRESS);
+  });
+});
+
+describe("Path B — agent-id lookup: D1 returns null → 404 not registered", () => {
+  it("returns 404 when D1 has no row for the resolved STX address", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (callReadOnly as Mock).mockResolvedValue({ result: "0x00" });
+    (parseClarityValue as Mock).mockReturnValue(TEST_STX_ADDRESS);
+    (lookupProfileByStxAddress as Mock).mockResolvedValue(null);
+
+    const res = await GET(
+      buildAgentIdRequest(TEST_AGENT_ID),
+      { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+    expect(String(body.error)).toContain("not registered on the AIBTC platform");
+  });
+});
+
+describe("Path B — agent-id lookup: D1 throws → fail-closed → 404", () => {
+  it("returns 404 when D1 throws a transient error (fail-closed)", async () => {
+    const mockDb = buildMockD1();
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: mockDb, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (callReadOnly as Mock).mockResolvedValue({ result: "0x00" });
+    (parseClarityValue as Mock).mockReturnValue(TEST_STX_ADDRESS);
+    (lookupProfileByStxAddress as Mock).mockRejectedValue(
+      new Error("D1_ERROR: timeout")
+    );
+
+    const res = await GET(
+      buildAgentIdRequest(TEST_AGENT_ID),
+      { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+  });
+
+  it("returns 404 when DB binding is undefined (fail-closed)", async () => {
+    const mockKv = buildMockKv();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { DB: undefined, VERIFIED_AGENTS: mockKv, HIRO_API_KEY: undefined, LOGS: undefined },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    (callReadOnly as Mock).mockResolvedValue({ result: "0x00" });
+    (parseClarityValue as Mock).mockReturnValue(TEST_STX_ADDRESS);
+
+    const res = await GET(
+      buildAgentIdRequest(TEST_AGENT_ID),
+      { params: Promise.resolve({ identifier: String(TEST_AGENT_ID) }) }
+    );
+
+    expect(res.status).toBe(404);
+    const body = await res.json() as Record<string, unknown>;
+    expect(body.found).toBe(false);
+  });
+});

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -33,6 +33,11 @@ import {
   syncBnsLookup,
 } from "@/lib/bns-reverse-index";
 import {
+  lookupProfileByStxAddress,
+  mapRowToAgentRecord,
+  type AgentProfileRow,
+} from "@/lib/cache/agent-profile";
+import {
   createLogger,
   createConsoleLogger,
   isLogsRPC,
@@ -287,20 +292,50 @@ export async function GET(
         );
       }
 
-      // Look up agent record by STX address
-      const data = await kv.get(`stx:${stxAddress}`);
-      if (data) {
-        try {
-          agent = JSON.parse(data) as AgentRecord;
-          // Ensure the stored erc8004AgentId matches what we found on-chain
-          if (agent.erc8004AgentId == null) {
-            agent.erc8004AgentId = agentId;
-          }
-        } catch {
+      // Look up agent record by STX address via D1 (fail-closed).
+      // D1 is the authoritative store; KV stx: was a secondary index.
+      let stxRow: AgentProfileRow | null = null;
+      try {
+        if (!db) {
+          logger.error("resolve.agent_id_d1_unavailable", { stxAddress, agentId });
           return NextResponse.json(
-            { error: "Failed to parse agent record." },
-            { status: 500 }
+            {
+              found: false,
+              identifier,
+              identifierType,
+              error: `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is not registered on the AIBTC platform.`,
+              nextSteps: {
+                action: "Register as a new agent",
+                endpoint: "POST /api/register",
+                documentation: "https://aibtc.com/llms-full.txt",
+              },
+            },
+            { status: 404 }
           );
+        }
+        stxRow = await lookupProfileByStxAddress(db, stxAddress);
+      } catch (d1Err) {
+        logger.error("resolve.agent_id_d1_failed", { stxAddress, agentId, error: String(d1Err) });
+        return NextResponse.json(
+          {
+            found: false,
+            identifier,
+            identifierType,
+            error: `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is not registered on the AIBTC platform.`,
+            nextSteps: {
+              action: "Register as a new agent",
+              endpoint: "POST /api/register",
+              documentation: "https://aibtc.com/llms-full.txt",
+            },
+          },
+          { status: 404 }
+        );
+      }
+      if (stxRow) {
+        agent = mapRowToAgentRecord(stxRow);
+        // Ensure the erc8004AgentId matches what we found on-chain
+        if (agent.erc8004AgentId == null) {
+          agent.erc8004AgentId = agentId;
         }
       } else {
         // On-chain identity exists but agent not registered on platform
@@ -348,16 +383,22 @@ export async function GET(
         }
       }
     } else if (identifierType === "stx") {
-      const data = await kv.get(`stx:${identifier}`);
-      if (data) {
-        try {
-          agent = JSON.parse(data) as AgentRecord;
-        } catch {
-          return NextResponse.json(
-            { error: "Failed to parse agent record." },
-            { status: 500 }
-          );
+      // Direct STX address lookup via D1 (fail-closed).
+      // D1 is the authoritative store; KV stx: was a secondary index.
+      try {
+        if (!db) {
+          logger.error("resolve.stx_d1_unavailable", { identifier });
+          // agent stays null → falls through to 404 below (same as prior KV null path)
+        } else {
+          const stxRow = await lookupProfileByStxAddress(db, identifier);
+          if (stxRow) {
+            agent = mapRowToAgentRecord(stxRow);
+          }
+          // stxRow === null → agent stays null → falls through to 404 below
         }
+      } catch (d1Err) {
+        logger.error("resolve.stx_d1_failed", { identifier, error: String(d1Err) });
+        // agent stays null → falls through to 404 below (fail-closed)
       }
     } else if (identifierType === "bns") {
       // BNS routes hit the dedicated reverse index — 2 KV reads

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -7,7 +7,8 @@
  * - Numeric agent-id (e.g. "42") — looks up ERC-8004 NFT owner on-chain
  * - Taproot address (bc1p...) — resolves via taproot: reverse index
  * - Bitcoin address (bc1q..., 1..., 3...) — direct KV lookup
- * - Stacks address (SP..., SM...) — direct KV lookup
+ * - Stacks address (SP..., SM...) — resolved via D1 (lookupProfileByStxAddress);
+ *   the legacy stx: KV secondary index was removed in PR #787 / phase P4.0c.
  * - BNS name (*.btc) — scans agents and matches bnsName field
  * - Display name (any other string) — scans agents and matches displayName field
  *
@@ -229,6 +230,37 @@ function buildUsageResponse() {
 }
 
 // ---------------------------------------------------------------------------
+// Shared 404 response for STX-addressed agents that have an on-chain identity
+// but are not registered on the AIBTC platform.
+// ---------------------------------------------------------------------------
+
+function buildStxNotRegisteredResponse(
+  identifier: string,
+  identifierType: string,
+  stxAddress: string,
+  agentId?: number
+): NextResponse {
+  const qualifier =
+    agentId !== undefined
+      ? `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is`
+      : `${stxAddress} is`;
+  return NextResponse.json(
+    {
+      found: false,
+      identifier,
+      identifierType,
+      error: `${qualifier} not registered on the AIBTC platform.`,
+      nextSteps: {
+        action: "Register as a new agent",
+        endpoint: "POST /api/register",
+        documentation: "https://aibtc.com/llms-full.txt",
+      },
+    },
+    { status: 404 }
+  );
+}
+
+// ---------------------------------------------------------------------------
 // Main handler
 // ---------------------------------------------------------------------------
 
@@ -298,61 +330,22 @@ export async function GET(
       try {
         if (!db) {
           logger.error("resolve.agent_id_d1_unavailable", { stxAddress, agentId });
-          return NextResponse.json(
-            {
-              found: false,
-              identifier,
-              identifierType,
-              error: `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is not registered on the AIBTC platform.`,
-              nextSteps: {
-                action: "Register as a new agent",
-                endpoint: "POST /api/register",
-                documentation: "https://aibtc.com/llms-full.txt",
-              },
-            },
-            { status: 404 }
-          );
+          return buildStxNotRegisteredResponse(identifier, identifierType, stxAddress, agentId);
         }
         stxRow = await lookupProfileByStxAddress(db, stxAddress);
       } catch (d1Err) {
         logger.error("resolve.agent_id_d1_failed", { stxAddress, agentId, error: String(d1Err) });
-        return NextResponse.json(
-          {
-            found: false,
-            identifier,
-            identifierType,
-            error: `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is not registered on the AIBTC platform.`,
-            nextSteps: {
-              action: "Register as a new agent",
-              endpoint: "POST /api/register",
-              documentation: "https://aibtc.com/llms-full.txt",
-            },
-          },
-          { status: 404 }
-        );
+        return buildStxNotRegisteredResponse(identifier, identifierType, stxAddress, agentId);
       }
       if (stxRow) {
         agent = mapRowToAgentRecord(stxRow);
-        // Ensure the erc8004AgentId matches what we found on-chain
-        if (agent.erc8004AgentId == null) {
-          agent.erc8004AgentId = agentId;
-        }
+        // Always set erc8004AgentId to the authoritative on-chain value, overriding
+        // any stale non-null value that may have been stored in D1. The on-chain
+        // agentId is the source of truth in the agent-id lookup path.
+        agent.erc8004AgentId = agentId;
       } else {
         // On-chain identity exists but agent not registered on platform
-        return NextResponse.json(
-          {
-            found: false,
-            identifier,
-            identifierType,
-            error: `Agent ID ${agentId} is minted on-chain (owner: ${stxAddress}) but this address is not registered on the AIBTC platform.`,
-            nextSteps: {
-              action: "Register as a new agent",
-              endpoint: "POST /api/register",
-              documentation: "https://aibtc.com/llms-full.txt",
-            },
-          },
-          { status: 404 }
-        );
+        return buildStxNotRegisteredResponse(identifier, identifierType, stxAddress, agentId);
       }
     } else if (identifierType === "taproot") {
       // Taproot: resolve via taproot: reverse index


### PR DESCRIPTION
## Summary
- Migrate `app/api/resolve/[identifier]/route.ts` two `kv.get(\`stx:…\`)` sites (~L295, ~L384) to `lookupProfileByStxAddress(db, …)`.
- Fail-closed on D1 error/missing binding. No KV fallback.
- Last pre-req before P4.2 heartbeat dual-write removal.

## Changes

**Path A** (`identifierType === "stx"`, ~L384): Direct STX address lookup.
D1 null → agent stays null → existing 404 "not found" path.
D1 throw or missing `db` binding → same 404 path (fail-closed).

**Path B** (`identifierType === "agent-id"`, ~L295): On-chain ID resolved to STX address via `get-owner`, then D1 lookup.
D1 null/throw/missing `db` → 404 "not registered on platform" (identical shape to prior KV null path).

## Test plan
- [x] New unit tests (8 total): D1-success / D1-null / D1-throw / DB-undefined on both code paths
- [x] `npx tsc --noEmit` — 0 new errors (baseline 127, post 127)
- [x] Matches #776 fail-closed pattern exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)