### PR TITLE
feat(competition): allowlist Bitflow's 4 wrapper contracts

### DIFF
--- a/lib/competition/allowlist.ts
+++ b/lib/competition/allowlist.ts
@@ -203,6 +203,36 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
       "swap-helper-p",
     ],
   },
+
+  // -- Wrappers (4 contracts) --
+  // Bitflow-deployed adapters around external DEX protocols (Velar, ALEX,
+  // Arkadiko). All four expose top-level public `swap-*` entry points and
+  // can be called directly by the Bitflow SDK when it picks them over a
+  // router for a given route. Excluded from earlier seed lists by oversight
+  // (handoff text referenced "routers" only); legitimate Bitflow-routed
+  // swaps were being rejected with `contract_not_allowlisted` when the SDK
+  // chose this path.
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-v-1-1`,
+    functions: ["swap-helper-a", "swap-helper-b"],
+  },
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-multihop-v-1-1`,
+    functions: ["swap-3", "swap-4", "swap-5"],
+  },
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-alex-v-2-1`,
+    functions: [
+      "swap-helper",
+      "swap-helper-a",
+      "swap-helper-b",
+      "swap-helper-c",
+    ],
+  },
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-arkadiko-v-1-1`,
+    functions: ["swap-x-for-y", "swap-y-for-x"],
+  },
 ] as const;
 
 /** Convenience: all entries across protocols. Currently Bitflow-only. */


### PR DESCRIPTION
## Summary

Earlier PR #798 expanded the Bitflow allowlist to cover stableswap pools, XYK, DLMM, and the 13 cross-DEX routers, but missed the 4 `wrapper-*` contracts at the same deployer. Per their on-chain ABIs they're also top-level user-callable swap entry points (public `swap-*` functions, not internal trait helpers), and the Bitflow SDK can pick them over a router for a given route. When it does today, the swap is rejected with `contract_not_allowlisted` — wrong answer for a legitimate Bitflow swap.

## What's added

| Contract | Functions |
|---|---|
| `wrapper-velar-v-1-1` | `swap-helper-a`, `swap-helper-b` |
| `wrapper-velar-multihop-v-1-1` | `swap-3`, `swap-4`, `swap-5` |
| `wrapper-alex-v-2-1` | `swap-helper`, `swap-helper-a`, `swap-helper-b`, `swap-helper-c` |
| `wrapper-arkadiko-v-1-1` | `swap-x-for-y`, `swap-y-for-x` |

All four deployed at `SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M`. Function names pulled from each contract's on-chain ABI via Hiro `/v2/contracts/interface/{addr}/{name}` and cross-checked through the AIBTC MCP `get_contract_info` tool — no hand-typed names.

**New shape: 26 contracts / 92 (contract, function) tuples** (was 22 / 81 after PR #798).

## Why this is safe

The router-vs-wrapper distinction doesn't change the gaming surface — both are Bitflow-deployed swap contracts and both are reachable from the Bitflow SDK. Gaming concerns (e.g. deposit-and-trade inflation) live in the scoring layer (Phase 3.2), not in the allowlist. The allowlist's job is "did this tx call a swap?" and the wrappers unambiguously qualify.

## Test plan

- [ ] `npm test -- --run lib/competition` — 67 existing tests still pass (verified locally; no behavior change in `isAllowedSwap`, just more entries).
- [ ] `curl https://<preview>/api/competition/allowlist` returns `total_contracts: 26`, `total_functions: 92`, `protocols.bitflow: 26`.
- [ ] Submit a wrapper-routed swap via `POST /api/competition/trades` (e.g. a `wrapper-arkadiko-v-1-1` `swap-x-for-y` tx) — should now verify instead of being rejected.
- [ ] Submit an admin call to any of these wrappers — should still be rejected (we only add the public `swap-*` functions; if any wrapper added admin functions in the future they'd need explicit allowlisting).

## What is NOT in this PR

- The provider-attribution set (`PROVIDER_ATTRIBUTION_CONTRACTS`) is unchanged. The wrappers may or may not inject the `provider` clarity arg — we haven't confirmed at the Clarity source level. If they do and PR-E (provider extraction) wants to widen, that's a separate decision once Phase 3.1 PR-E lands.
- The underlying external DEX contracts (Velar pools, ALEX core, Arkadiko pools). Those swaps still wouldn't count unless they happen through a Bitflow contract.
- Scoring methodology. Trade-only P&L design discussion is separate from allowlist coverage.