### PR TITLE
feat(tenero): derive scheduler refresh set from D1 swaps table

### DIFF
--- a/app/api/competition/tracked-tokens/route.ts
+++ b/app/api/competition/tracked-tokens/route.ts
@@ -1,0 +1,87 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// Public read of the dynamic token set the SchedulerDO refreshes Tenero
+// prices for. Derived from the `swaps` table on each request — see
+// `lib/external/tenero/tokens.ts:getActiveTokenIds`. Read-only, no auth.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import {
+  STATIC_TOKEN_IDS,
+  MAX_TRACKED_TOKENS,
+  getActiveTokenIds,
+} from "@/lib/external/tenero";
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/competition/tracked-tokens",
+      method: "GET",
+      description:
+        "The Tenero refresh set the SchedulerDO uses on each tick. Union of the always-include static core and distinct token_in / token_out from successful agent/cron swaps in D1, junk-filtered for shape, ranked by trade count, capped at MAX_TRACKED_TOKENS. Falls back to the static core on D1 query failure.",
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseFormat: {
+        tokens: "string[] — the active set (static core ∪ dynamic discovery)",
+        count: "number — length of tokens",
+        source:
+          "'dynamic' when D1 derivation succeeded, 'static-fallback' on failure or missing binding",
+        staticCore: "string[] — the always-include core that backs the fallback",
+        maxTracked: "number — upper bound on dynamic discovery per tick (MAX_TRACKED_TOKENS)",
+      },
+      relatedEndpoints: {
+        allowlist:
+          "GET /api/competition/allowlist — contracts + functions the verifier will accept",
+        prices: "GET /api/prices — cached USD prices for the static core only",
+      },
+      notes: [
+        "Dynamic discovery falls back to STATIC_TOKEN_IDS when there's no DB binding or the query throws.",
+        "Tokens are ordered with the static core first, then dynamic entries by descending trade count.",
+        "The set is recomputed on each SchedulerDO tick (5 min cadence); this endpoint reports what the *next* tick would use.",
+      ],
+    },
+    {
+      headers: {
+        // 1 min browser, 1 min shared — the set can shift as agents trade.
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+      },
+    }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") return selfDocResponse();
+
+  const { env } = await getCloudflareContext({ async: true });
+  const db = env.DB as D1Database | undefined;
+  const tokens = await getActiveTokenIds(db);
+
+  // `getActiveTokenIds` falls back to STATIC_TOKEN_IDS on any failure; we
+  // can't distinguish "fallback" from "static core happened to win" without
+  // a side-channel, so the heuristic is: if the result has more tokens than
+  // the static core, dynamic discovery added something; if it equals the
+  // core exactly we couldn't add anything (could be empty table OR DB error
+  // — both are functionally "static-fallback" from a consumer perspective).
+  const source: "dynamic" | "static-fallback" =
+    tokens.length > STATIC_TOKEN_IDS.length ? "dynamic" : "static-fallback";
+
+  return NextResponse.json(
+    {
+      tokens,
+      count: tokens.length,
+      source,
+      staticCore: STATIC_TOKEN_IDS,
+      maxTracked: MAX_TRACKED_TOKENS,
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=60, s-maxage=60",
+      },
+    }
+  );
+}

--- a/lib/external/tenero/__tests__/tokens.test.ts
+++ b/lib/external/tenero/__tests__/tokens.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import {
+  STATIC_TOKEN_IDS,
+  MAX_TRACKED_TOKENS,
+  getActiveTokenIds,
+  isValidTokenId,
+} from "../tokens";
+
+/**
+ * Minimal D1Database double. The function under test only calls
+ * `prepare(sql).bind(...).all<T>()`, so we mock that chain and assert on
+ * the rows the test scenario returns.
+ */
+function createFakeDb(opts: {
+  rows?: Array<{ id: string; cnt: number | string }>;
+  throws?: boolean;
+}): D1Database {
+  return {
+    prepare: vi.fn().mockReturnValue({
+      bind: vi.fn().mockReturnValue({
+        all: vi.fn(async () => {
+          if (opts.throws) throw new Error("D1 unavailable");
+          return { results: opts.rows ?? [], success: true, meta: {} };
+        }),
+      }),
+    }),
+  } as unknown as D1Database;
+}
+
+describe("isValidTokenId", () => {
+  it("accepts the literal 'stx'", () => {
+    expect(isValidTokenId("stx")).toBe(true);
+  });
+
+  it("accepts SP-prefixed contract ids with the ::asset suffix", () => {
+    expect(
+      isValidTokenId(
+        "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts SM-prefixed contract ids", () => {
+    expect(
+      isValidTokenId(
+        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc"
+      )
+    ).toBe(true);
+  });
+
+  it("accepts contract ids without the ::asset suffix", () => {
+    expect(
+      isValidTokenId("SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token")
+    ).toBe(true);
+  });
+
+  it("rejects the 'unknown' parser sentinel", () => {
+    expect(isValidTokenId("unknown")).toBe(false);
+  });
+
+  it("rejects empty strings and random junk", () => {
+    expect(isValidTokenId("")).toBe(false);
+    expect(isValidTokenId("not a token")).toBe(false);
+    expect(isValidTokenId("STX")).toBe(false); // case matters for the literal
+  });
+
+  it("rejects malformed deployer prefixes", () => {
+    expect(isValidTokenId("XX1234.contract")).toBe(false);
+    expect(isValidTokenId("SP123.contract")).toBe(false); // too-short deployer hash
+  });
+});
+
+describe("getActiveTokenIds", () => {
+  it("falls back to STATIC_TOKEN_IDS when no DB binding is provided", async () => {
+    const result = await getActiveTokenIds(undefined);
+    expect(result).toEqual(STATIC_TOKEN_IDS);
+  });
+
+  it("falls back to STATIC_TOKEN_IDS when the D1 query throws", async () => {
+    const db = createFakeDb({ throws: true });
+    const result = await getActiveTokenIds(db);
+    expect(result).toEqual(STATIC_TOKEN_IDS);
+  });
+
+  it("returns just the static core when the swaps table is empty", async () => {
+    const db = createFakeDb({ rows: [] });
+    const result = await getActiveTokenIds(db);
+    expect(result).toEqual(STATIC_TOKEN_IDS);
+  });
+
+  it("unions dynamic rows with the static core, preserving static-first order", async () => {
+    const db = createFakeDb({
+      rows: [
+        { id: "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.usda-token::usda", cnt: 12 },
+        { id: "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.aeusdc-token::aeusdc", cnt: 8 },
+      ],
+    });
+    const result = await getActiveTokenIds(db);
+    // Static core first, then dynamic entries in the order D1 returned them.
+    expect(result.slice(0, STATIC_TOKEN_IDS.length)).toEqual(STATIC_TOKEN_IDS);
+    expect(result).toContain(
+      "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.usda-token::usda"
+    );
+    expect(result).toContain(
+      "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.aeusdc-token::aeusdc"
+    );
+    expect(result.length).toBe(STATIC_TOKEN_IDS.length + 2);
+  });
+
+  it("deduplicates when a dynamic row repeats a static core entry", async () => {
+    const db = createFakeDb({
+      rows: [
+        { id: "stx", cnt: 100 },
+        { id: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc", cnt: 50 },
+      ],
+    });
+    const result = await getActiveTokenIds(db);
+    // No duplicates — static-core entries are NOT re-added.
+    expect(result.length).toBe(STATIC_TOKEN_IDS.length);
+    expect(result).toEqual(STATIC_TOKEN_IDS);
+  });
+
+  it("filters out malformed token ids from the dynamic set", async () => {
+    const db = createFakeDb({
+      rows: [
+        { id: "unknown", cnt: 99 }, // parser sentinel — must be excluded
+        { id: "", cnt: 5 }, // empty
+        { id: "STX", cnt: 4 }, // wrong case for the literal
+        { id: "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.real-token::real", cnt: 3 },
+      ],
+    });
+    const result = await getActiveTokenIds(db);
+    // Only `SPABCDE…real-token::real` should join the static core.
+    expect(result).toContain(
+      "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.real-token::real"
+    );
+    expect(result).not.toContain("unknown");
+    expect(result).not.toContain("");
+    expect(result).not.toContain("STX");
+    expect(result.length).toBe(STATIC_TOKEN_IDS.length + 1);
+  });
+
+  it("uses the MAX_TRACKED_TOKENS bound when calling prepare().bind()", async () => {
+    const all = vi.fn(async () => ({ results: [], success: true, meta: {} }));
+    const bind = vi.fn().mockReturnValue({ all });
+    const prepare = vi.fn().mockReturnValue({ bind });
+    const db = { prepare } as unknown as D1Database;
+
+    await getActiveTokenIds(db);
+
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(bind).toHaveBeenCalledWith(MAX_TRACKED_TOKENS);
+  });
+});

--- a/lib/external/tenero/index.ts
+++ b/lib/external/tenero/index.ts
@@ -3,7 +3,12 @@ export {
   tokenIdToTeneroAddress,
   type TeneroPriceResult,
 } from "./prices";
-export { STATIC_TOKEN_IDS } from "./tokens";
+export {
+  STATIC_TOKEN_IDS,
+  MAX_TRACKED_TOKENS,
+  getActiveTokenIds,
+  isValidTokenId,
+} from "./tokens";
 export {
   getCachedTokenPrice,
   getCachedTokenPrices,

--- a/lib/external/tenero/tokens.ts
+++ b/lib/external/tenero/tokens.ts
@@ -1,20 +1,119 @@
 /**
- * Active token set for the SchedulerDO's Tenero price-refresh task. The
- * leaderboard no longer reads this cache — it calls Tenero directly from
- * the browser and reads `decimals` straight from the response — so this
- * list is now only consumed by `/api/prices` and any other future server
- * consumer of `tenero:price:*` KV entries.
+ * Token-id source for the SchedulerDO's Tenero price-refresh task.
  *
- * Adding a new priceable token: probe Tenero's
- * `/v1/stacks/tokens/{contract_id}` first to confirm a 200 with a
- * non-null `price_usd`, then add the id here so the scheduler refreshes it.
+ * Two sources, in priority order:
  *
- * Future work (per #768 review): if this grows past ~30 tokens, consider
- * splitting Tenero refresh into per-tick chunks so a slow run can't blow
- * the alarm budget.
+ *   1. STATIC_TOKEN_IDS — a small always-include core set (STX + sBTC + stSTX).
+ *      Acts as a safe fallback when the swaps table is empty (cold start) or
+ *      D1 query fails, so the SchedulerDO can still keep popular tokens warm.
+ *
+ *   2. Distinct token_in / token_out from the `swaps` table, restricted to
+ *      successful agent/cron swaps, junk-filtered (no `"unknown"`, must match
+ *      a Stacks identifier shape), ranked by trade count, and capped at
+ *      MAX_TRACKED_TOKENS.
+ *
+ * The dynamic path replaces an earlier hand-curated list. Rationale: now that
+ * the `swaps` table is the source of truth for what agents actually trade,
+ * the refresh schedule should follow that data instead of a list someone has
+ * to remember to update. Junk filter + bounded LIMIT keep the quota footprint
+ * predictable even if a malformed token id ever leaks into a swap row.
+ *
+ * /api/prices still uses STATIC_TOKEN_IDS directly as its supported-token
+ * surface — that endpoint's contract is "the 3 baseline tokens", not "every
+ * token we know about", and its aggressive Cache-Control would make a
+ * dynamic list confusing. Keep them decoupled.
  */
+
 export const STATIC_TOKEN_IDS: readonly string[] = [
   "stx",
   "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc",
   "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx",
 ];
+
+/**
+ * Maximum number of distinct tokens to refresh per SchedulerDO tick. Bounds
+ * the Tenero quota cost so a memecoin-trading spree can't blow the monthly
+ * budget. At 50 tokens × 12 ticks/hr × 24 × 30 ≈ 432k requests/month — fine
+ * once authenticated; the unauthenticated tier (50k/month) would burst the
+ * ceiling, but during free-tier operation the swaps table won't realistically
+ * surface 50 distinct ids per tick so this is a safety net, not a typical cap.
+ */
+export const MAX_TRACKED_TOKENS = 50;
+
+/**
+ * Accepts the literal `stx` OR a `SP|SM|ST{38-40-hex}.contract-name(::asset)?`
+ * shape. Filters out the `"unknown"` sentinel and anything else the parser
+ * might emit that isn't a legitimate Stacks identifier.
+ *
+ * The character classes follow the Stacks crockford-base32 alphabet (no I/L/O/U)
+ * and the standard SIP-010 contract-name + asset-name rules (alphanumeric +
+ * `-`/`_`, the SIP-010 `::asset` suffix optional on the trait reference).
+ */
+const TOKEN_ID_RE =
+  /^(?:stx|S[PMTN][0-9A-HJKMNP-TV-Z]{38,40}\.[A-Za-z][A-Za-z0-9_-]*(?:::[A-Za-z][A-Za-z0-9_-]*)?)$/;
+
+export function isValidTokenId(id: string): boolean {
+  return TOKEN_ID_RE.test(id);
+}
+
+interface TrackedTokenRow {
+  id: string;
+  cnt: number | string;
+}
+
+/**
+ * Derive the active token-refresh set from the swaps table. Returns the union
+ * of STATIC_TOKEN_IDS (always-include core) and the top-{MAX_TRACKED_TOKENS}
+ * tokens by trade count from successful agent/cron swaps, deduplicated.
+ *
+ * Falls back to STATIC_TOKEN_IDS on:
+ *   - missing D1 binding (local dev, preview without DB)
+ *   - D1 query failure (transient DB issue shouldn't blow the refresh)
+ *
+ * Pure async function — no logging, no side effects. Caller wires logging.
+ */
+export async function getActiveTokenIds(
+  db: D1Database | undefined
+): Promise<readonly string[]> {
+  if (!db) return STATIC_TOKEN_IDS;
+
+  let dynamic: string[] = [];
+  try {
+    const result = await db
+      .prepare(
+        `
+        SELECT id, SUM(cnt) AS cnt FROM (
+          SELECT token_in AS id, COUNT(*) AS cnt FROM swaps
+          WHERE source IN ('agent','cron')
+            AND tx_status = 'success'
+            AND token_in IS NOT NULL
+            AND token_in != 'unknown'
+          GROUP BY token_in
+          UNION ALL
+          SELECT token_out AS id, COUNT(*) AS cnt FROM swaps
+          WHERE source IN ('agent','cron')
+            AND tx_status = 'success'
+            AND token_out IS NOT NULL
+            AND token_out != 'unknown'
+          GROUP BY token_out
+        )
+        GROUP BY id
+        ORDER BY SUM(cnt) DESC
+        LIMIT ?1
+        `
+      )
+      .bind(MAX_TRACKED_TOKENS)
+      .all<TrackedTokenRow>();
+    dynamic = (result.results ?? [])
+      .map((r) => r.id)
+      .filter((id): id is string => typeof id === "string" && isValidTokenId(id));
+  } catch {
+    return STATIC_TOKEN_IDS;
+  }
+
+  // Union with the static core. Set semantics; preserve insertion order
+  // (static first, then dynamic) so the static tokens lead the refresh loop
+  // and stay warm even if the loop is cut short by rate-limiting mid-run.
+  const merged = new Set<string>([...STATIC_TOKEN_IDS, ...dynamic]);
+  return Array.from(merged);
+}

--- a/worker.ts
+++ b/worker.ts
@@ -12,7 +12,7 @@ import {
 } from "./lib/logging";
 import { getPaymentRepoVersion } from "./lib/inbox/payment-logging";
 import { processInboxReconciliationQueue } from "./lib/inbox/reconciliation-queue";
-import { STATIC_TOKEN_IDS } from "./lib/external/tenero";
+import { getActiveTokenIds } from "./lib/external/tenero";
 import {
   runTeneroTask,
   type TeneroRunResult,
@@ -210,10 +210,16 @@ export class SchedulerDO extends DurableObject<CloudflareEnv> {
       ? parentLogger.child({ task: "tenero" })
       : parentLogger;
 
+    // Pull the active token set from the swaps table (union'd with the
+    // static core; falls back to static-only on missing binding or query
+    // failure). See `getActiveTokenIds` doc for the SQL + filter.
+    const tokenIds = await getActiveTokenIds(this.env.DB);
+    logger.info("tenero.token_set_resolved", { count: tokenIds.length });
+
     const { result, rateLimited, rateLimitBackoffMs } = await runTeneroTask({
       logger,
       kv: this.env.VERIFIED_AGENTS,
-      tokenIds: STATIC_TOKEN_IDS,
+      tokenIds,
       apiKey: this.lookupTeneroApiKey(),
     });
 


### PR DESCRIPTION
## Summary

The SchedulerDO has been refreshing prices for a hand-curated 3-token list (`STATIC_TOKEN_IDS`). Now that the `swaps` table is the source of truth for what agents actually trade, the refresh schedule should follow the data instead of a hardcoded list someone has to remember to update.

## What changed

| File | Change |
|---|---|
| `lib/external/tenero/tokens.ts` | New `getActiveTokenIds(db)` + `MAX_TRACKED_TOKENS=50` + `isValidTokenId(id)` regex filter. Unions the static core with D1-discovered tokens, ranked by trade count, junk-filtered. |
| `lib/external/tenero/index.ts` | Barrel re-exports for the new symbols. |
| `worker.ts` (`SchedulerDO.runTenero`) | Calls `getActiveTokenIds(this.env.DB)` instead of importing `STATIC_TOKEN_IDS` directly. Logs the resolved count. |
| `app/api/competition/tracked-tokens/route.ts` | New public read endpoint exposing the active set for debug visibility. 1-min cache. |
| `lib/external/tenero/__tests__/tokens.test.ts` | 14 unit tests: regex shape filter, union semantics, bounds, fallback paths. |

## Behavior

- **Happy path**: D1 query returns distinct (token_in ∪ token_out) from successful agent/cron swaps, ranked by trade count, capped at `MAX_TRACKED_TOKENS`, filtered by `isValidTokenId` (matches `stx` literal OR `S[PMTN]…contract::asset` shape — drops the `\"unknown\"` parser sentinel and any other malformed ids). Result is `[...STATIC_TOKEN_IDS, ...dynamic]` deduplicated.
- **Empty swaps table**: returns `STATIC_TOKEN_IDS` only (cold-start safe — never an empty refresh set).
- **Missing D1 binding** (local dev, preview without DB): returns `STATIC_TOKEN_IDS` only.
- **D1 query throws**: caught, returns `STATIC_TOKEN_IDS` only — a transient DB blip doesn't drop all price refreshes.

## Quota note

`STATIC_TOKEN_IDS` × 5min refresh = 3 × 8,640 ticks/month ≈ 26k Tenero calls/month — well under the 50k free-tier ceiling.

If dynamic discovery actually saturated to `MAX_TRACKED_TOKENS=50`, the math is 50 × 8,640 ≈ 432k/month — would burst free-tier and trigger the existing `TENERO_MONTH_QUOTA_BACKOFF_MS = 24h` adaptive backoff in `runTeneroTask`. The scheduler won't get banned (it backs off cleanly) but prices would go stale for the remainder of the month.

In practice today the swaps table has 1 row, so dynamic discovery adds 0-1 tokens. Once `env.TENERO_API_KEY` is set (already plumbed end-to-end via `SchedulerDO.lookupTeneroApiKey` → `runTeneroTask` → `teneroFetch`), the authenticated tier removes the cap concern.

## What doesn't change

- `STATIC_TOKEN_IDS` is still exported and is the always-include core. Dynamic discovery layers on top.
- `/api/prices` still uses `STATIC_TOKEN_IDS` directly. That endpoint's contract is \"the 3 baseline tokens\" and its aggressive Cache-Control (`s-maxage=86400`) would make a dynamic list confusing. Decoupled by design.
- `runTeneroTask`'s signature is unchanged (still takes `tokenIds: readonly string[]`). Only the caller's source changes.
- No DB migration, no DO storage shape change.

## Why SchedulerDO, not a Worker cron trigger

(Came up in design conversation.) The DO + alarms pattern was chosen because Tenero rate-limit semantics need state across runs — when a tick hits `x-ratelimit-month-remaining: 0`, the scheduler writes `nextRunAfter.tenero = now + 24h` to DO storage and the next alarm checks that. With a cron-only setup, that state would have to live in KV with manual coordination. Same pattern as `x402-sponsor-relay`. Switching to dynamic token discovery doesn't change the DO choice — just the input list.

## Test plan

- [x] `npm test -- --run lib/external/tenero lib/scheduler app/api/admin/scheduler` — 26+ tests pass.
- [x] `npm run build` — clean.
- [ ] After deploy: `curl https://aibtc.com/api/competition/tracked-tokens` should return the static core (3 tokens) since the swaps table has only the one `\"unknown\"`-tagged trade today (which gets filtered out by `isValidTokenId`).
- [ ] After more trades land: the same endpoint should reflect new tokens. The next SchedulerDO tick after a new token first appears will start refreshing its price into KV.

## Related

- The `\"unknown\"` filter is what made me confident dropping the junk-safety reason for keeping the list static. The parser bug that produced `\"unknown\"` was fixed in commit `21f16f4`, but the filter belt-and-suspenders is cheap.
- This is foundational for the (forthcoming) `GET /api/competition/pnl?address=` endpoint — server-side P&L will read swaps from D1, get distinct tokens, and lean on KV prices populated by this exact refresh path.