### PR TITLE
feat(762c): drop heartbeat stx: dual-write (P4.2)

### DIFF
--- a/app/api/heartbeat/__tests__/stx-db-threading.test.ts
+++ b/app/api/heartbeat/__tests__/stx-db-threading.test.ts
@@ -52,11 +52,18 @@ vi.mock("@/lib/constants", () => ({
   X_HANDLE: "@aibtcdev",
 }));
 
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+  persistBtcPubkeyIfMissing: vi.fn().mockResolvedValue(undefined),
+}));
+
 // ---- imports after mocks ----------------------------------------------------
 
-import { GET } from "../route";
+import { GET, POST } from "../route";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgentWithLevel } from "@/lib/agent-lookup";
+import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { validateCheckInBody } from "@/lib/heartbeat";
 
 // ---- fixtures ---------------------------------------------------------------
 
@@ -164,5 +171,67 @@ describe("heartbeat GET — STX address db threading (PR #788)", () => {
     expect(body.endpoint).toBe("/api/heartbeat");
     // lookupAgentWithLevel should NOT be called without an address
     expect(lookupAgentWithLevel).not.toHaveBeenCalled();
+  });
+});
+
+// ---- P4.2: heartbeat POST drops stx: dual-write ------------------------------
+
+describe("heartbeat POST — P4.2 stx: write removed", () => {
+  it("writes btc: key but NOT stx: key on successful check-in", async () => {
+    const mockKv = buildMockKv();
+    const mockDb = buildMockDb();
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: mockKv,
+        DB: mockDb,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    // validateCheckInBody needs to return signature + timestamp
+    (validateCheckInBody as Mock).mockReturnValue({
+      success: true,
+      data: {
+        signature: "mock-signature",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      },
+    });
+
+    // verifyBitcoinSignature resolves the BTC address
+    (verifyBitcoinSignature as Mock).mockReturnValue({
+      valid: true,
+      address: TEST_BTC,
+      publicKey: undefined,
+    });
+
+    // lookupAgentWithLevel returns a registered agent (level 1 minimum required for POST)
+    (lookupAgentWithLevel as Mock).mockResolvedValue(makeSuccessResult());
+
+    const request = new NextRequest("http://localhost/api/heartbeat", {
+      method: "POST",
+      body: JSON.stringify({
+        signature: "mock-signature",
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(200);
+
+    // btc: key MUST be written
+    expect(mockKv.put).toHaveBeenCalledWith(
+      `btc:${TEST_BTC}`,
+      expect.any(String)
+    );
+
+    // stx: key MUST NOT be written by heartbeat (P4.2 drop)
+    const putCalls = (mockKv.put as Mock).mock.calls;
+    const stxPutCall = putCalls.find(
+      (call: unknown[]) => typeof call[0] === "string" && call[0].startsWith("stx:")
+    );
+    expect(stxPutCall).toBeUndefined();
   });
 });

--- a/app/api/heartbeat/__tests__/stx-db-threading.test.ts
+++ b/app/api/heartbeat/__tests__/stx-db-threading.test.ts
@@ -41,7 +41,7 @@ vi.mock("@/lib/heartbeat", () => ({
   CHECK_IN_RATE_LIMIT_MS: 3600000,
   getCheckInRecord: vi.fn().mockResolvedValue(null),
   updateCheckInRecord: vi.fn().mockResolvedValue({}),
-  validateCheckInBody: vi.fn().mockReturnValue({ success: true, data: {} }),
+  validateCheckInBody: vi.fn().mockReturnValue({ data: {} }),
 }));
 
 vi.mock("@/lib/news-beats", () => ({
@@ -190,8 +190,8 @@ describe("heartbeat POST — P4.2 stx: write removed", () => {
     });
 
     // validateCheckInBody needs to return signature + timestamp
+    // Real shape: { data } on success or { errors } on failure (no `success` field).
     (validateCheckInBody as Mock).mockReturnValue({
-      success: true,
       data: {
         signature: "mock-signature",
         timestamp: "2026-01-01T00:00:00.000Z",

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -377,15 +377,16 @@ export async function POST(request: NextRequest) {
       lastActiveAt: timestamp,
     };
 
-    // Write updates to both btc: and stx: keys in parallel; fetch D1 unread count.
-    // Pure timestamp updates are tolerated as stale for up to the 2-min cache
-    // TTL — no need to invalidate the cached agent list on every check-in.
-    // Phase 2.5 Step 4 — unreadCount now served from D1 live SELECT COUNT(*);
-    // KV inbox:agent:{btcAddress} read removed.
+    // Write canonical btc: key only; stx: secondary index is no longer
+    // refreshed by heartbeat (P4.2 — drops ~30–40K KV writes/day).
+    // Other writers (vouch / register / identity / challenge / verify) still
+    // refresh stx:, so the secondary index does not stop being updated — just
+    // not on every 5-min check-in. Identical JSON across both sides per
+    // inventory, so this is data-lossless.
+    // Phase 2.5 Step 4 — unreadCount served from D1 live SELECT COUNT(*).
     const db = env.DB as D1Database | undefined;
-    const [, , unreadCount] = await Promise.all([
+    const [, unreadCount] = await Promise.all([
       kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent)),
-      kv.put(`stx:${agent.stxAddress}`, JSON.stringify(updatedAgent)),
       fetchUnreadCount(db, btcAddress),
     ]);
     const orientation = getOrientation(updatedAgent, claim, unreadCount);


### PR DESCRIPTION
## Summary

- Drops the `stx:` write side from `app/api/heartbeat/route.ts`.
- `btc:` stays as the canonical key.
- Other writers (vouch/register/challenge/identity/verify/refresh) keep dual-writing — heartbeat only.

## Why

P4.2 is the campaign primary objective. Heartbeat is the dominant write source on `VERIFIED_AGENTS` (~30–40K writes/day, 60–80% of namespace writes). All P4.0 blockers (#773/#776/#787/#788) migrated dependent readers to D1, so the `stx:` dual-write is no longer in the critical path.

## Data-loss safety

Per `phases/P4-dual-write-cleanup-762c/EXECUTION-inventory.md`: both writes emit identical JSON — dropping `stx:` is data-lossless. `stx:*` records continue to exist (other writers keep them current); they just won't get refreshed on every 5-min heartbeat.

## Affected readers (per inventory)

| Reader | Status |
|---|---|
| `lib/agent-lookup.ts` (`lookupAgent`/`lookupAgentWithLevel`) | D1 via #788 |
| `app/api/agents/[address]/route.ts` | D1-first, KV fallback |
| `app/api/identity/[address]/reputation/route.ts` | Parallel btc:+stx:, btc: wins |
| `app/api/resolve/[identifier]/route.ts` | D1 via #787 |
| `app/api/register/route.ts` | D1 via #776 |
| `lib/agents-index.ts` | D1 via #773 |
| `app/bounty/page.tsx` + `app/bounty/[id]/page.tsx` | KV-only SSR; **graceful fallback** to STX display via try/catch — UX degradation only, no crash |
| `app/api/admin/*` | Admin tools, non-hot-path |

## Smoke

Cost-attribution: T+1h (worker-logs error rate), T+4h (CF GraphQL VERIFIED_AGENTS writes), T+24h (full-day delta).

## Rollback

`git revert` is safe — no schema changes, no data migrations. Reintroducing the `stx:` write just resumes the dual-write.

Closes part of #762.