### PR TITLE
feat(d1): composite indexes on swaps for dynamic-token-discovery query

### DIFF
--- a/migrations/010_swaps_token_indexes.sql
+++ b/migrations/010_swaps_token_indexes.sql
@@ -1,0 +1,35 @@
+-- Migration 010: composite indexes on swaps for dynamic-token-discovery queries.
+--
+-- Backs the `getActiveTokenIds(db)` SQL in `lib/external/tenero/tokens.ts`
+-- (shipped in PR #800), which runs every 5 min on the SchedulerDO tick:
+--
+--   SELECT id, SUM(cnt) AS cnt FROM (
+--     SELECT token_in AS id, COUNT(*) AS cnt FROM swaps
+--     WHERE source IN ('agent','cron') AND tx_status = 'success'
+--       AND token_in IS NOT NULL AND token_in != 'unknown'
+--     GROUP BY token_in
+--     UNION ALL
+--     SELECT token_out AS id, COUNT(*) AS cnt FROM swaps
+--     WHERE source IN ('agent','cron') AND tx_status = 'success'
+--       AND token_out IS NOT NULL AND token_out != 'unknown'
+--     GROUP BY token_out
+--   )
+--   GROUP BY id ORDER BY SUM(cnt) DESC LIMIT 50;
+--
+-- Today the swaps table has ~1 row so the full-table scan is invisible. arc
+-- flagged in PR #800 review that once `swaps` reaches ~10k rows this fires
+-- on every tick and a composite (source, tx_status, token_in/_out) index will
+-- let SQLite range-scan the right slice and group it without touching rows
+-- outside the active scope.
+--
+-- Both columns are indexed because the UNION ALL hits one then the other;
+-- a single-column index on either alone wouldn't cover both legs.
+--
+-- The pre-existing indexes from migration 005 (sender_burn_time, scored_at,
+-- contract_burn_time) cover the other read paths and are untouched.
+
+CREATE INDEX IF NOT EXISTS idx_swaps_token_in_active
+  ON swaps (source, tx_status, token_in);
+
+CREATE INDEX IF NOT EXISTS idx_swaps_token_out_active
+  ON swaps (source, tx_status, token_out);


### PR DESCRIPTION
## Summary

Follow-up to PR #800 per arc's review. Adds two composite indexes to the `swaps` table covering the dynamic-token-discovery query that runs every 5 min on the SchedulerDO tick.

Today the swaps table has ~1 row so the unindexed scan is invisible. arc flagged that once volume reaches ~10k rows, the query will start showing in `tenero.refresh_*` durations and burn the worker's D1 row-read budget. Cheap to land now, before that threshold.

## The query being indexed

From `lib/external/tenero/tokens.ts:getActiveTokenIds` (shipped in PR #800):

```sql
SELECT id, SUM(cnt) AS cnt FROM (
  SELECT token_in  AS id, COUNT(*) AS cnt FROM swaps
  WHERE source IN ('agent','cron') AND tx_status = 'success'
    AND token_in IS NOT NULL AND token_in != 'unknown'
  GROUP BY token_in
  UNION ALL
  SELECT token_out AS id, COUNT(*) AS cnt FROM swaps
  WHERE source IN ('agent','cron') AND tx_status = 'success'
    AND token_out IS NOT NULL AND token_out != 'unknown'
  GROUP BY token_out
)
GROUP BY id ORDER BY SUM(cnt) DESC LIMIT 50;
```

## What changed

`migrations/010_swaps_token_indexes.sql`:

```sql
CREATE INDEX IF NOT EXISTS idx_swaps_token_in_active
  ON swaps (source, tx_status, token_in);

CREATE INDEX IF NOT EXISTS idx_swaps_token_out_active
  ON swaps (source, tx_status, token_out);
```

Both columns are indexed because the UNION ALL hits one leg then the other; a single-column index on either alone wouldn't cover both legs.

`IF NOT EXISTS` so the migration is idempotent — safe to re-run if the apply ever needs to be retried.

## What doesn't change

Pre-existing indexes from migration 005 — `idx_swaps_sender_burn_time`, `idx_swaps_scored_at`, `idx_swaps_contract_burn_time` — cover the other read paths and stay as-is. No schema column change, no data migration.

## Test plan

- [x] SQL parses cleanly against an in-memory SQLite with migration 005 + 010 stacked. Indexes appear in `sqlite_master` with correct definitions.
- [ ] On deploy: `wrangler d1 migrations apply landing-page --remote --env production` should report migration 010 applied.
- [ ] Post-deploy verify: `wrangler d1 execute landing-page --remote --command "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name='swaps' ORDER BY name"` should list both `idx_swaps_token_in_active` and `idx_swaps_token_out_active`.
- [ ] Sanity-check with `EXPLAIN QUERY PLAN` once the indexes are live — should use the new indexes for the dynamic-discovery SQL (look for `SEARCH swaps USING INDEX idx_swaps_token_in_active` / `_out_active` instead of `SCAN swaps`).

## Related

- PR #800: `feat(tenero): derive scheduler refresh set from D1 swaps table` — the consumer of these indexes.
- arc's [suggestion](https://github.com/aibtcdev/landing-page/pull/800#pullrequestreview): "Consider a follow-up migration that adds composite indexes before the swaps volume makes it observable."