### PR TITLE
feat(leaderboard): add P&L (USD) column with mark-to-current pricing

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -7,7 +7,8 @@ import { truncateAddress, formatRelativeTime } from "@/lib/utils";
 
 export interface LeaderboardTokenAggregate {
   tokenId: string;
-  sumAmountIn: number;
+  /** Raw on-chain units. Direction is implied by which array this lives in. */
+  sumAmount: number;
 }
 
 export interface LeaderboardRow {
@@ -19,16 +20,22 @@ export interface LeaderboardRow {
   tradeCount: number;
   latestTradeAt: number;
   /**
-   * Per-token aggregates from D1. USD volume is computed client-side
-   * by calling Tenero directly (`api.tenero.io/v1/stacks/tokens/{id}`),
-   * which returns `decimals` alongside `price_usd` — no hardcoded
-   * decimals map and no dependency on the KV price cache.
+   * Tokens the agent gave up across their swaps (aggregated `amount_in`
+   * grouped by `token_in`). Used to compute volume USD (= notional spent).
    */
-  tokens: LeaderboardTokenAggregate[];
+  tokensSpent: LeaderboardTokenAggregate[];
+  /**
+   * Tokens the agent received across their swaps (aggregated `amount_out`
+   * grouped by `token_out`). Combined with `tokensSpent` to derive P&L —
+   * mark-to-current on net token deltas at end prices.
+   */
+  tokensReceived: LeaderboardTokenAggregate[];
 }
 
-interface RowVolume {
+interface RowStats {
   volumeUsd: number;
+  pnlUsd: number;
+  pnlPercent: number | null;
   allPriced: boolean;
 }
 
@@ -181,18 +188,18 @@ function rowDisplayName(row: LeaderboardRow): string {
 
 function renderVolumeCell(
   row: LeaderboardRow,
-  volume: RowVolume | undefined
+  stats: RowStats | undefined
 ): React.ReactNode {
-  if (!volume) {
+  if (!stats) {
     return (
       <span className="text-white/30" aria-label="Loading USD volume">
         …
       </span>
     );
   }
-  if (volume.volumeUsd > 0) {
-    const label = formatUsd(volume.volumeUsd);
-    return volume.allPriced ? (
+  if (stats.volumeUsd > 0) {
+    const label = formatUsd(stats.volumeUsd);
+    return stats.allPriced ? (
       <span className="font-medium text-white/80">{label}</span>
     ) : (
       <span
@@ -206,40 +213,114 @@ function renderVolumeCell(
   return <span className="text-white/20">—</span>;
 }
 
-function computeVolumes(
+function renderPnlCell(
+  row: LeaderboardRow,
+  stats: RowStats | undefined
+): React.ReactNode {
+  if (!stats) {
+    return (
+      <span className="text-white/30" aria-label="Loading P&L">
+        …
+      </span>
+    );
+  }
+  if (stats.volumeUsd <= 0) return <span className="text-white/20">—</span>;
+
+  const positive = stats.pnlUsd >= 0;
+  const color = positive ? "text-[#4dcd5e]" : "text-[#f06464]";
+  const usdLabel = formatUsd(stats.pnlUsd);
+  const pctLabel =
+    stats.pnlPercent != null
+      ? `${positive ? "+" : ""}${stats.pnlPercent.toFixed(2)}%`
+      : null;
+  const title = stats.allPriced
+    ? undefined
+    : "Partial — some tokens couldn't be priced and were excluded from this total";
+
+  return (
+    <span className={`font-medium ${color}`} title={title}>
+      {positive ? "+" : ""}
+      {usdLabel}
+      {pctLabel && (
+        <span className="ml-1 text-[11px] text-white/40 font-normal">
+          ({pctLabel})
+        </span>
+      )}
+      {!stats.allPriced && "*"}
+    </span>
+  );
+}
+
+/**
+ * Compute per-row volume + P&L from per-sender token aggregates and the
+ * Tenero price map. Volume USD = Σ(amount_in × price[token_in]), the
+ * notional value of what was put at risk. P&L USD = mark-to-end on net
+ * token deltas — equivalently Σ(amount_out × price[token_out] -
+ * amount_in × price[token_in]).
+ *
+ * Tokens with no price entry (Tenero doesn't know, fetch failed, or the
+ * literal `"unknown"` parser sentinel) are excluded from both totals and
+ * flip `allPriced` to false so the UI can footnote the row instead of
+ * silently under-reporting.
+ */
+function computeStats(
   rows: LeaderboardRow[],
   prices: Record<string, TokenPrice | null>
-): Map<string, RowVolume> {
-  const out = new Map<string, RowVolume>();
+): Map<string, RowStats> {
+  const out = new Map<string, RowStats>();
   for (const row of rows) {
     let volumeUsd = 0;
+    let receivedUsd = 0;
     let allPriced = true;
-    for (const t of row.tokens) {
+
+    for (const t of row.tokensSpent) {
       const entry = prices[t.tokenId];
       if (!entry) {
         allPriced = false;
         continue;
       }
-      volumeUsd += (t.sumAmountIn / 10 ** entry.decimals) * entry.priceUsd;
+      volumeUsd += (t.sumAmount / 10 ** entry.decimals) * entry.priceUsd;
     }
-    out.set(row.stxAddress, { volumeUsd, allPriced });
+
+    for (const t of row.tokensReceived) {
+      const entry = prices[t.tokenId];
+      if (!entry) {
+        allPriced = false;
+        continue;
+      }
+      receivedUsd += (t.sumAmount / 10 ** entry.decimals) * entry.priceUsd;
+    }
+
+    const pnlUsd = receivedUsd - volumeUsd;
+    const pnlPercent = volumeUsd > 0 ? (pnlUsd / volumeUsd) * 100 : null;
+
+    out.set(row.stxAddress, { volumeUsd, pnlUsd, pnlPercent, allPriced });
   }
   return out;
 }
 
 export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) {
-  const [volumes, setVolumes] = useState<Map<string, RowVolume> | null>(null);
+  const [stats, setStats] = useState<Map<string, RowStats> | null>(null);
 
   useEffect(() => {
     if (rows.length === 0) {
-      setVolumes(new Map());
+      setStats(new Map());
       return;
     }
     let cancelled = false;
     (async () => {
+      // Distinct token ids across both legs (spent + received). The
+      // literal `"unknown"` parser sentinel is filtered out — no point
+      // burning a Tenero call on a string we know isn't a real token.
       const distinctTokenIds = Array.from(
-        new Set(rows.flatMap((r) => r.tokens.map((t) => t.tokenId)))
-      );
+        new Set(
+          rows.flatMap((r) => [
+            ...r.tokensSpent.map((t) => t.tokenId),
+            ...r.tokensReceived.map((t) => t.tokenId),
+          ])
+        )
+      ).filter((id) => id !== "unknown");
+
       const priced = await Promise.all(
         distinctTokenIds.map(
           async (id) => [id, await fetchTokenPrice(id)] as const
@@ -247,7 +328,7 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
       );
       const priceLookup: Record<string, TokenPrice | null> = {};
       for (const [id, entry] of priced) priceLookup[id] = entry;
-      if (!cancelled) setVolumes(computeVolumes(rows, priceLookup));
+      if (!cancelled) setStats(computeStats(rows, priceLookup));
     })();
     return () => {
       cancelled = true;
@@ -277,6 +358,7 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
               <th scope="col" className="px-4 py-3 font-medium">Agent</th>
               <th scope="col" className="px-4 py-3 font-medium text-right">Trades</th>
               <th scope="col" className="px-4 py-3 font-medium text-right">Volume (USD)</th>
+              <th scope="col" className="px-4 py-3 font-medium text-right">P&amp;L (USD)</th>
               <th scope="col" className="px-4 py-3 font-medium text-right">Latest Trade</th>
             </tr>
           </thead>
@@ -333,7 +415,10 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                   {row.tradeCount}
                 </td>
                 <td className="px-4 py-3 text-right">
-                  {renderVolumeCell(row, volumes?.get(row.stxAddress))}
+                  {renderVolumeCell(row, stats?.get(row.stxAddress))}
+                </td>
+                <td className="px-4 py-3 text-right">
+                  {renderPnlCell(row, stats?.get(row.stxAddress))}
                 </td>
                 <td className="px-4 py-3 text-right text-white/50">
                   {row.latestTradeAt > 0
@@ -349,12 +434,24 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
       {/* Mobile list */}
       <ul className="md:hidden divide-y divide-white/[0.04]">
         {rows.map((row, idx) => {
-          const volume = volumes?.get(row.stxAddress);
-          const volumeLabel = !volume
+          const rowStats = stats?.get(row.stxAddress);
+          const volumeLabel = !rowStats
             ? "…"
-            : volume.volumeUsd > 0
-              ? `${formatUsd(volume.volumeUsd)}${volume.allPriced ? "" : "*"}`
+            : rowStats.volumeUsd > 0
+              ? `${formatUsd(rowStats.volumeUsd)}${rowStats.allPriced ? "" : "*"}`
               : "—";
+          const pnlPositive = rowStats ? rowStats.pnlUsd >= 0 : false;
+          const pnlLabel = !rowStats
+            ? "…"
+            : rowStats.volumeUsd <= 0
+              ? "—"
+              : `${pnlPositive ? "+" : ""}${formatUsd(rowStats.pnlUsd)}${rowStats.pnlPercent != null ? ` (${pnlPositive ? "+" : ""}${rowStats.pnlPercent.toFixed(2)}%)` : ""}${rowStats.allPriced ? "" : "*"}`;
+          const pnlColor =
+            !rowStats || rowStats.volumeUsd <= 0
+              ? "text-white/40"
+              : pnlPositive
+                ? "text-[#4dcd5e]"
+                : "text-[#f06464]";
           const inner = (
             <div className="flex items-start gap-3 px-4 py-3">
               <div className="relative shrink-0">
@@ -381,10 +478,12 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                 <div className="text-[11px] font-mono text-white/40 truncate">
                   {truncateAddress(row.stxAddress)}
                 </div>
-                <div className="mt-1 flex items-center gap-3 text-[11px] text-white/50">
+                <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-white/50">
                   <span className="text-[#F7931A]">{row.tradeCount} trades</span>
                   <span>·</span>
                   <span>{volumeLabel}</span>
+                  <span>·</span>
+                  <span className={pnlColor}>{pnlLabel}</span>
                   <span>·</span>
                   <span>
                     {row.latestTradeAt > 0

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -29,11 +29,13 @@ export const metadata: Metadata = {
 interface LeaderboardJoinedRow {
   sender: string;
   token_in: string;
+  token_out: string;
   cnt: number;
   // D1 returns SUM of an INTEGER column as a JS number, but the runtime
   // boundary isn't tightly typed — Cloudflare's docs leave room for
   // string returns on very large aggregates. Type defensively here.
   sum_in: number | string | null;
+  sum_out: number | string | null;
   latest_at: number;
   btc_address: string | null;
   display_name: string | null;
@@ -95,22 +97,29 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
 
   if (!db) return [];
 
-  // Single round-trip: aggregate `swaps` per (sender, token_in) and
-  // LEFT JOIN the four display fields from `agents`. The agent columns
-  // are functionally dependent on `sender` (in the GROUP BY) so SQLite
-  // returns them consistently across the per-token rows for one sender.
+  // Single round-trip: aggregate `swaps` per (sender, token_in, token_out)
+  // and LEFT JOIN the four display fields from `agents`. The wider GROUP BY
+  // lets the client compute both:
+  //   - Volume USD = Σ(amount_in × price[token_in])           ("notional spent")
+  //   - P&L USD    = Σ(amount_out × price[token_out]
+  //                   − amount_in × price[token_in])          ("net at end prices")
+  //
+  // `tx_status = 'success'` filter: only successful swaps move tokens.
+  // Failed / aborted txs are recorded in the table for audit but shouldn't
+  // count toward volume or P&L.
   let rows: LeaderboardJoinedRow[] = [];
   try {
     const sql = `
-      SELECT s.sender, s.token_in,
+      SELECT s.sender, s.token_in, s.token_out,
              COUNT(*)             AS cnt,
              SUM(s.amount_in)     AS sum_in,
+             SUM(s.amount_out)    AS sum_out,
              MAX(s.burn_block_time) AS latest_at,
              a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
       FROM swaps s
       LEFT JOIN agents a ON a.stx_address = s.sender
-      WHERE s.source = 'agent'
-      GROUP BY s.sender, s.token_in
+      WHERE s.source = 'agent' AND s.tx_status = 'success'
+      GROUP BY s.sender, s.token_in, s.token_out
     `;
     const result = await db.prepare(sql).all<LeaderboardJoinedRow>();
     rows = result.results ?? [];
@@ -120,16 +129,21 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
 
   if (rows.length === 0) return [];
 
-  // Aggregate per sender — sum count, keep max(latest_at), preserve
-  // per-token breakdown for the client-side volume calculation, and
-  // capture display fields once (they're identical across per-token
-  // rows of the same sender).
+  // Roll up per (sender, pair) rows into per-sender state. For each pair we
+  // bump:
+  //   - count (one row per pair contributes COUNT(*))
+  //   - tokensSpent[token_in]    += sum_in
+  //   - tokensReceived[token_out] += sum_out
+  // Display fields are functionally dependent on `sender` (LEFT JOIN against
+  // a row keyed by stx_address) so they're identical across all pair-rows
+  // for one sender — capture once on first sight.
   const bySender = new Map<
     string,
     {
       count: number;
       latestAt: number;
-      tokens: Array<{ tokenId: string; sumAmountIn: number }>;
+      spent: Map<string, number>;
+      received: Map<string, number>;
       display: {
         btcAddress: string | null;
         displayName: string | null;
@@ -142,7 +156,8 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
     const existing = bySender.get(r.sender) ?? {
       count: 0,
       latestAt: 0,
-      tokens: [] as Array<{ tokenId: string; sumAmountIn: number }>,
+      spent: new Map<string, number>(),
+      received: new Map<string, number>(),
       display: {
         btcAddress: r.btc_address,
         displayName: r.display_name,
@@ -152,16 +167,22 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
     };
     existing.count += r.cnt;
     if (r.latest_at > existing.latestAt) existing.latestAt = r.latest_at;
-    existing.tokens.push({
-      tokenId: r.token_in,
-      sumAmountIn: safeAggregateNumber(r.sum_in),
-    });
+    const sumIn = safeAggregateNumber(r.sum_in);
+    const sumOut = safeAggregateNumber(r.sum_out);
+    existing.spent.set(
+      r.token_in,
+      (existing.spent.get(r.token_in) ?? 0) + sumIn
+    );
+    existing.received.set(
+      r.token_out,
+      (existing.received.get(r.token_out) ?? 0) + sumOut
+    );
     bySender.set(r.sender, existing);
   }
 
   // Per-token breakdowns ride along to the client, which calls Tenero
   // directly per distinct token id and reads both `price_usd` and
-  // `decimals` from the response — no hardcoded decimals table, no KV
+  // `decimals` from the response. No hardcoded decimals table, no KV
   // price-cache dependency on this path.
   const ranked: LeaderboardRow[] = Array.from(bySender.entries())
     .map(([sender, agg]) => ({
@@ -172,7 +193,13 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
       erc8004AgentId: agg.display.erc8004AgentId,
       tradeCount: agg.count,
       latestTradeAt: agg.latestAt,
-      tokens: agg.tokens,
+      tokensSpent: Array.from(agg.spent.entries()).map(([tokenId, sumAmount]) => ({
+        tokenId,
+        sumAmount,
+      })),
+      tokensReceived: Array.from(agg.received.entries()).map(
+        ([tokenId, sumAmount]) => ({ tokenId, sumAmount })
+      ),
     }))
     .sort((a, b) => {
       // Primary: count desc. Tiebreak: latest trade desc.


### PR DESCRIPTION
## Summary

Adds a "P&L (USD)" column to the leaderboard table next to the existing "Volume (USD)" column. Mark-to-current pricing on net token deltas — same Tenero direct-fetch path the volume column already uses, sharing the same `aibtc:tenero-price:*` 5-min `localStorage` cache. No new server endpoints, no new infrastructure.

## How P&L is computed

```
pnl_usd = Σ(amount_out × end_price[token_out])
        − Σ(amount_in  × end_price[token_in])
```

Equivalently, the net token positions an agent built through swaps, marked to current prices.

| Scenario | Formula returns |
|---|---|
| Bought STX cheap, sold expensive | Positive |
| Bought STX, held to a higher price | Positive (unrealized gain counted — they still hold the appreciated token) |
| Round-tripped USDC→STX→USDC at same price | $0 |
| Bought high and held while price dropped | Negative |
| Token transfers into the agent's wallet | Zero P&L impact (deposits don't create swap rows) |

## What changed

| File | Change |
|---|---|
| `app/leaderboard/page.tsx` | SQL widens to `GROUP BY (sender, token_in, token_out)` and adds `SUM(amount_out)` so the client has both legs. Adds `WHERE tx_status = 'success'` filter — failed/aborted swaps no longer count toward Volume or P&L (or the trade count). Wire shape: `tokens` becomes two arrays `tokensSpent` + `tokensReceived` for clarity. |
| `app/leaderboard/LeaderboardClient.tsx` | New `renderPnlCell` + `computeStats` (replaces `computeVolumes`). Same Tenero fetch + localStorage cache. New P&L column desktop, P&L badge in mobile meta row. Green/red color coding by sign. `*` footnote when any token couldn't be priced. |

## "unknown" token handling

The literal string `"unknown"` (parser sentinel for the pre-`21f16f4` STX-event bug) is filtered out of the Tenero-fetch list — no wasted requests on a non-existent token. Rows that contain `"unknown"` in any leg get flagged with `*` (partial total). No backfill of legacy `"unknown"` rows.

## Behavioral notes / call-outs

- **`tx_status = 'success'` filter added.** Failed/aborted txs are recorded in D1 for audit (migration 005 reserves 7 terminal-failure codes) but don't count toward Volume / P&L / Trades on the leaderboard. Most submitted txids are successful so the diff in counts should be near zero in practice.
- **Unrealized gains count.** An agent who bought low and is still holding shows positive P&L. Standard portfolio-view semantics. If a future requirement says "only count closed positions," that's a different methodology (FIFO/LIFO accounting on the swap stream).
- **Percent base is notional spent** (volume USD). So `pnl_pct = pnl_usd / volume_usd × 100`. Matches the brokerage convention of "trading return on capital deployed."

## Test plan

- [x] `npm run build` — clean.
- [x] `npx next lint --file app/leaderboard` — clean.
- [ ] Visit `/leaderboard` — Volume + P&L cells show `…`, resolve once Tenero prices land. Secret Mars's one trade should show a small loss (~-0.5% per the manual calc we ran earlier in design discussion).
- [ ] Mobile breakpoint: P&L appears inline in the meta row next to volume; color coding works; line wraps if cramped (flex-wrap).
- [ ] Block `api.tenero.io` in devtools — table still renders with all USD cells as `—`.
- [ ] Inspect a row whose mix includes `token_in = "unknown"` — P&L still computes from the other legs, shows `*`.

## What is NOT in this PR

- No backfill of pre-fix `"unknown"` token rows. They render partial. Backfill is a separate admin migration.
- No server-side P&L endpoint (`/api/competition/pnl?address=`). When the Tenero API key lands, that's a small follow-up that reads swaps from D1 + prices from KV (already warmed by the SchedulerDO refresh after PR #800) — the math function in `computeStats` can be hoisted into `lib/competition/pnl.ts` as a pure function and reused server-side. For now everything stays client-side.
- No per-agent profile P&L card. The leaderboard column is the single surface.
- No P&L sorting on the column (still ranked by trade count). Could add `?sort=pnl` query param if/when there's demand.