### PR TITLE
fix(leaderboard): show P&L as percentage primary, USD on hover

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -178,6 +178,24 @@ function formatUsd(value: number | null): string {
   return `${sign}$${formatted}`;
 }
 
+/**
+ * USD formatter that keeps small amounts legible — at a few-cent trade
+ * the standard 2-decimal `formatUsd` truncates "-$0.0013" to "-$0.00",
+ * which is misleading. Used for the P&L hover so the full magnitude is
+ * always visible even when the cell shows just the percentage.
+ */
+function formatUsdPrecise(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  const fractionDigits = abs >= 100 ? 2 : abs >= 1 ? 4 : 6;
+  const formatted = abs.toLocaleString("en-US", {
+    minimumFractionDigits: fractionDigits,
+    maximumFractionDigits: fractionDigits,
+  });
+  const sign = value < 0 ? "-" : "";
+  return `${sign}$${formatted}`;
+}
+
 function rowDisplayName(row: LeaderboardRow): string {
   return (
     row.displayName?.trim() ||
@@ -224,28 +242,27 @@ function renderPnlCell(
       </span>
     );
   }
-  if (stats.volumeUsd <= 0) return <span className="text-white/20">—</span>;
+  if (stats.volumeUsd <= 0 || stats.pnlPercent == null) {
+    return <span className="text-white/20">—</span>;
+  }
 
   const positive = stats.pnlUsd >= 0;
   const color = positive ? "text-[#4dcd5e]" : "text-[#f06464]";
-  const usdLabel = formatUsd(stats.pnlUsd);
-  const pctLabel =
-    stats.pnlPercent != null
-      ? `${positive ? "+" : ""}${stats.pnlPercent.toFixed(2)}%`
-      : null;
+  const pctLabel = `${positive ? "+" : ""}${stats.pnlPercent.toFixed(2)}%`;
+  // Tooltip carries the full-precision USD value so a tiny percentage
+  // like `-0.03%` still has the underlying magnitude (`-$0.001300`)
+  // available on hover. The 2-decimal `formatUsd` truncates anything
+  // smaller than a cent to `$0.00` which makes the cell look broken;
+  // showing only the percentage in the cell plus full $ on hover keeps
+  // both signals legible at any trade size.
+  const usdDetail = `${positive ? "+" : ""}${formatUsdPrecise(stats.pnlUsd)}`;
   const title = stats.allPriced
-    ? undefined
-    : "Partial — some tokens couldn't be priced and were excluded from this total";
+    ? usdDetail
+    : `${usdDetail} (partial — some tokens couldn't be priced and were excluded)`;
 
   return (
     <span className={`font-medium ${color}`} title={title}>
-      {positive ? "+" : ""}
-      {usdLabel}
-      {pctLabel && (
-        <span className="ml-1 text-[11px] text-white/40 font-normal">
-          ({pctLabel})
-        </span>
-      )}
+      {pctLabel}
       {!stats.allPriced && "*"}
     </span>
   );
@@ -441,11 +458,18 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
               ? `${formatUsd(rowStats.volumeUsd)}${rowStats.allPriced ? "" : "*"}`
               : "—";
           const pnlPositive = rowStats ? rowStats.pnlUsd >= 0 : false;
+          // Mobile cell: percentage only (matches desktop posture); the
+          // precise USD goes in the `title` so tap-and-hold or assistive
+          // tooling can surface it.
           const pnlLabel = !rowStats
             ? "…"
-            : rowStats.volumeUsd <= 0
+            : rowStats.volumeUsd <= 0 || rowStats.pnlPercent == null
               ? "—"
-              : `${pnlPositive ? "+" : ""}${formatUsd(rowStats.pnlUsd)}${rowStats.pnlPercent != null ? ` (${pnlPositive ? "+" : ""}${rowStats.pnlPercent.toFixed(2)}%)` : ""}${rowStats.allPriced ? "" : "*"}`;
+              : `${pnlPositive ? "+" : ""}${rowStats.pnlPercent.toFixed(2)}%${rowStats.allPriced ? "" : "*"}`;
+          const pnlTitle =
+            !rowStats || rowStats.volumeUsd <= 0
+              ? undefined
+              : `${pnlPositive ? "+" : ""}${formatUsdPrecise(rowStats.pnlUsd)}${rowStats.allPriced ? "" : " (partial)"}`;
           const pnlColor =
             !rowStats || rowStats.volumeUsd <= 0
               ? "text-white/40"
@@ -483,7 +507,9 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                   <span>·</span>
                   <span>{volumeLabel}</span>
                   <span>·</span>
-                  <span className={pnlColor}>{pnlLabel}</span>
+                  <span className={pnlColor} title={pnlTitle}>
+                    {pnlLabel}
+                  </span>
                   <span>·</span>
                   <span>
                     {row.latestTradeAt > 0


### PR DESCRIPTION
## Summary

Follow-up fix to PR #803. At small trade sizes the P&L cell renders as `-$0.00 (-0.03%)` — the dollar amount is being truncated by `formatUsd`'s 2-decimal rounding (anything below a cent rounds to `$0.00`), making the cell look broken. Only the percentage actually carries signal at sub-cent magnitudes.

**The fix**: cell shows just the percentage; full-precision USD goes in the `title` attribute (hover/tap-and-hold).

## Before / after on Secret Mars's row

```
Before:  −$0.00 (-0.03%)   ← looks broken, $0.00 carries no info
After:   -0.03%             ← clean; hover reveals "-$0.001300"
```

## What changed

- **`renderPnlCell`** (desktop column) — drops the inline USD; cell now reads `-0.03%` (or `+12.45%`, etc.) with the precise USD in `title`. Empty / unpriceable rows still render `—`.
- **Mobile list** — same treatment; `title` carries the precise USD so tap-and-hold and assistive tech still surface it.
- **New `formatUsdPrecise`** helper that scales decimals to magnitude:
  - `abs >= 100` → 2 decimals (e.g. `-$1,234.56`)
  - `abs >= 1`   → 4 decimals (e.g. `-$0.4567`)
  - otherwise    → 6 decimals (e.g. `-$0.001300`)
- The existing `formatUsd` (2-decimal, used for the Volume column) is unchanged. Volume realistically never drops below a cent in production.
- The `*` partial-priced footnote still appears on the percentage when applicable; the title text gets the full explanation.

## What's NOT in this PR

- No change to the underlying P&L math.
- No change to color coding (still green for gains, red for losses).
- No change to the Volume column.

## Test plan

- [x] `npm run build` clean.
- [x] `npx next lint --file app/leaderboard` clean.
- [ ] On `/leaderboard`, Secret Mars's row reads as `-0.03%` (or similar) — no `-$0.00`.
- [ ] Hovering reveals `-$0.001300` (or current actual P&L at the precision the helper chose).
- [ ] For a larger hypothetical P&L (e.g. `+$1,234.56` / `+5.20%`) the cell shows `+5.20%` and hover shows `+$1,234.56`.
- [ ] On mobile, tap-and-hold the P&L pill — title shows up via the platform tooltip (or screen reader announces it).
- [ ] Partial-priced rows still get `*` on the percentage and the title includes the `partial — some tokens couldn't be priced and were excluded` note.