### PR TITLE
feat(leaderboard): label P&L column as Unrealized P&L

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -22,7 +22,7 @@ const DEFAULT_SORT: SortState = { key: "trades", dir: "desc" };
 const SORT_OPTIONS: readonly { key: SortKey; label: string }[] = [
   { key: "trades", label: "Trades" },
   { key: "volume", label: "Volume" },
-  { key: "pnl", label: "P&L" },
+  { key: "pnl", label: "Unrealized P&L" },
   { key: "latest", label: "Latest" },
 ];
 
@@ -491,7 +491,7 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                 <th scope="col" className="px-4 py-3 font-medium">Agent</th>
                 <th scope="col" className="px-4 py-3 font-medium text-right">Trades</th>
                 <th scope="col" className="px-4 py-3 font-medium text-right">Volume (USD)</th>
-                <th scope="col" className="px-4 py-3 font-medium text-right">P&amp;L (USD)</th>
+                <th scope="col" className="px-4 py-3 font-medium text-right">Unrealized P&amp;L (USD)</th>
                 <th scope="col" className="px-4 py-3 font-medium text-right">Latest Trade</th>
               </tr>
             </thead>


### PR DESCRIPTION
## Summary

Renames the leaderboard "P&L (USD)" column to **"Unrealized P&L (USD)"** (and the sort-chip label from "P&L" to "Unrealized P&L"). The methodology is unchanged — math, formula, schema, KV cache all untouched. This is purely a clarity fix.

## Why

The column uses **mark-to-current** P&L (`lib/competition/pnl.ts:computeCampaignStats`): both legs of every swap are re-priced at live Tenero rates on every render. As a result:

- The same finished trade shows a different number every time the page reloads (Tenero prices drift minute-to-minute). One real agent's single swap was observed at \`+0.37% → -1.07% → +0.61%\` over an hour with zero agent activity.
- Two browsers loading the page at the same instant can see different numbers (per-browser \`localStorage\` Tenero cache freshness differs).
- Viewers reasonably map "P&L" onto the realized-stock-gain mental model ("I bought at $10, it's $15 now, profit = $50"). That's not what this column is. The current label invites that incorrect mental model.

Renaming to "Unrealized" makes the methodology self-evident from the column header alone — no docs lookup needed.

## What it doesn't change

- Formula in \`lib/competition/pnl.ts\` and the client mirror in \`LeaderboardClient.tsx:computeStats\`
- Server-side aggregation in \`app/leaderboard/page.tsx\`
- KV / Tenero / SchedulerDO behavior
- MCP \`competition_status\` tool response shape
- Any URL, API, schema

Just two strings, both in \`LeaderboardClient.tsx\`.

## Related

Part of #809 (PR-A in that issue's ordering). The other findings in that issue — SchedulerDO \`alarm()\` not firing in prod, \`STATIC_TOKEN_IDS\` sBTC asset-name mismatch, silent fallback in \`getActiveTokenIds\`, dev/prod KV binding asymmetry — are tracked as separate PR-B through PR-E and don't block this label change.

## Test plan

- [ ] Desktop view: column header shows "Unrealized P&L (USD)"
- [ ] Sort chip above the table shows "Unrealized P&L" (active state still highlights, direction arrow still toggles)
- [ ] Mobile view unaffected (no header text on the list view; the per-row value display didn't change)
- [ ] No behavior change in sort, hover tooltip, or cell content

🤖 Generated with [Claude Code](https://claude.com/claude-code)