### PR TITLE
fix(competition): canonical sBTC asset name + allowlist wrapper-velar-v-1-2

### DIFF
--- a/lib/competition/allowlist.ts
+++ b/lib/competition/allowlist.ts
@@ -216,6 +216,15 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
     contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-v-1-1`,
     functions: ["swap-helper-a", "swap-helper-b"],
   },
+  // v-1-2 was deployed under the XYK principal (not the main BITFLOW_DEPLOYER
+  // like v-1-1). Same `swap-helper-a` / `swap-helper-b` ABI. The Bitflow SDK
+  // routes STX↔VELAR through this address; without this entry the verifier
+  // rejects the swap as `contract_not_allowlisted` even though the trade is
+  // a legitimate Bitflow-mediated execution.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.wrapper-velar-v-1-2`,
+    functions: ["swap-helper-a", "swap-helper-b"],
+  },
   {
     contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-multihop-v-1-1`,
     functions: ["swap-3", "swap-4", "swap-5"],

--- a/lib/external/tenero/__tests__/prices.test.ts
+++ b/lib/external/tenero/__tests__/prices.test.ts
@@ -8,7 +8,7 @@ describe("tokenIdToTeneroAddress", () => {
 
   it("strips the ::asset suffix from a fully-qualified asset id", () => {
     const sbtc =
-      "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc";
+      "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token";
     expect(tokenIdToTeneroAddress(sbtc)).toBe(
       "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token"
     );

--- a/lib/external/tenero/__tests__/tokens.test.ts
+++ b/lib/external/tenero/__tests__/tokens.test.ts
@@ -43,7 +43,7 @@ describe("isValidTokenId", () => {
   it("accepts SM-prefixed contract ids", () => {
     expect(
       isValidTokenId(
-        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc"
+        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token"
       )
     ).toBe(true);
   });
@@ -111,7 +111,7 @@ describe("getActiveTokenIds", () => {
     const db = createFakeDb({
       rows: [
         { id: "stx", cnt: 100 },
-        { id: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc", cnt: 50 },
+        { id: "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token", cnt: 50 },
       ],
     });
     const result = await getActiveTokenIds(db);

--- a/lib/external/tenero/tokens.ts
+++ b/lib/external/tenero/tokens.ts
@@ -26,7 +26,7 @@
 
 export const STATIC_TOKEN_IDS: readonly string[] = [
   "stx",
-  "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc",
+  "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token",
   "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx",
 ];
 

--- a/lib/scheduler/__tests__/tenero-task.test.ts
+++ b/lib/scheduler/__tests__/tenero-task.test.ts
@@ -186,7 +186,7 @@ describe("runTeneroTask", () => {
       kv,
       tokenIds: [
         "stx",
-        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc",
+        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token",
         "SP4SZE494VC2YC5JYG7AYFQ44F5Q4PYV7DVMDPBG.ststx-token::ststx",
       ],
     });
@@ -219,7 +219,7 @@ describe("runTeneroTask", () => {
       kv,
       tokenIds: [
         "stx",
-        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc",
+        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token",
       ],
     });
 


### PR DESCRIPTION
## Summary

Two related Bitflow-track fixes bundled on one branch:

1. **`STATIC_TOKEN_IDS` sBTC asset name** — use the canonical `::sbtc-token` form
2. **Allowlist `wrapper-velar-v-1-2`** under the XYK deployer principal

Both unblock real on-chain Bitflow-mediated trades from being rejected or mis-cached by the verifier.

Closes the **PR-B** item from #809 and resolves a freshly-observed `contract_not_allowlisted` rejection for STX→VELAR.

## Fix 1 — sBTC asset name

`STATIC_TOKEN_IDS` had `SM…sbtc-token::sbtc`. The on-chain contract source (Hiro `/v2/contracts/source/.../sbtc-token`) shows:

```clarity
(define-fungible-token sbtc-token)
```

So the canonical SIP-010 asset name is `sbtc-token`, not `sbtc`. The swap parser writes the canonical form to D1 — verified against prod (all 9 sBTC swap rows use `::sbtc-token`). The constant has been wrong since it was introduced; it just happened to be invisible because nothing in production reads the KV cache for the leaderboard / MCP P&L compute (the client paths strip the `::asset` suffix before hitting Tenero, so both forms resolve to the same query at lookup time).

Unblocks server-side leaderboard stats (#811), which reads from KV directly and would otherwise 404 on the canonical key.

## Fix 2 — allowlist `wrapper-velar-v-1-2` (XYK deployer)

Bitflow shipped a `v-1-2` of the wrapper-velar contract, but under the **XYK deployer** (`SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR`) — not the main `BITFLOW_DEPLOYER` (`SPQC…`) like `v-1-1`. The Bitflow SDK now routes STX↔VELAR through this new address.

Verified via Hiro:

```bash
$ curl https://api.hiro.so/v2/contracts/interface/SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR/wrapper-velar-v-1-2
# Public functions:  swap-helper-a, swap-helper-b
```

Same ABI as `v-1-1` — just a different deployer principal. Verifier rejects with `contract_not_allowlisted` until the new tuple is added because `isAllowedSwap(contract_id, function_name)` compares the *full* contract id including the principal. One additional entry covers the new contract.

User-reported symptom this fixes: *"STX → VELAR (2 STX) ❌ executed, but excluded — wrapper-velar-v-1-2 not allowlisted (v-1-1 is, v-1-2 isn't) it was executed using bitflow though"*.

## Tests

Full affected-suite sweep passes:

```
✓ lib/external/tenero/__tests__/kv-cache.test.ts   (4)
✓ lib/external/tenero/__tests__/tokens.test.ts     (14)
✓ lib/external/tenero/__tests__/prices.test.ts     (3)
✓ lib/scheduler/__tests__/tenero-task.test.ts      (5)
✓ lib/competition/__tests__/d1-reads.test.ts       (18)
✓ lib/competition/__tests__/parse.test.ts          (13)
✓ lib/competition/__tests__/scheduler.test.ts      (10)
✓ lib/competition/__tests__/verify.test.ts         (26)

Test Files  8 passed (8)
     Tests  93 passed (93)
```

Test fixtures referencing the old `::sbtc` form (in `tenero-task.test.ts`, `tokens.test.ts`, `prices.test.ts`) updated to the canonical form. None of them were asserting "this is the canonical name" — they were using it as an arbitrary valid-looking token id. The `tokens.test.ts:114` dedup test does depend on the dynamic-row id matching the static-set entry exactly, so updating both keeps that test valid.

## Files

- `lib/external/tenero/tokens.ts` — sBTC asset name in `STATIC_TOKEN_IDS`
- `lib/competition/allowlist.ts` — new `wrapper-velar-v-1-2` entry
- `lib/scheduler/__tests__/tenero-task.test.ts` — fixture update (×2)
- `lib/external/tenero/__tests__/tokens.test.ts` — fixture update (×2)
- `lib/external/tenero/__tests__/prices.test.ts` — fixture update (×1)

## Test plan

- [x] Vitest suite green (8 affected files, 93 tests)
- [ ] After merge + deploy, next SchedulerDO tick writes `tenero:price:SM…sbtc-token::sbtc-token` to KV
- [ ] After merge + deploy, `wrapper-velar-v-1-2` swaps submitted via `competition_submit_trade` are accepted by the verifier
- [ ] Old `tenero:price:SM…sbtc-token::sbtc` KV entry will become stale — natural 24h TTL cleans it up, or `wrangler kv key delete` to free the slot immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)
