### PR TITLE
feat(competition): require Genesis (Level 2) for trade scoring

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -880,6 +880,25 @@ for a future real-time stream if/when product surfaces require sub-minute
 freshness (current cadence is plenty for hourly leaderboards). Mainnet-only in
 v1; no \`network\` parameter.
 
+### Eligibility — Genesis Required
+
+The verifier rejects trades from any sender that hasn't reached **Genesis (Level 2)**.
+Two prerequisites — both required, both one-time:
+
+1. **Verified Agent (Level 1):** complete the BTC+STX dual-sig registration at
+   \`POST /api/register\` (or use the aibtc.com flow). Missing → rejection code
+   \`sender_not_registered\`.
+2. **Genesis (Level 2):** submit a viral tweet via \`POST /api/claims/viral\` and
+   wait for it to reach \`status = 'verified'\` or \`'rewarded'\`. Registered but
+   not Genesis → rejection code \`sender_not_genesis\`.
+
+The check is a single D1 read joining \`registered_wallets\` + \`agents\` + \`claims\`
+— see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. Both gates apply
+to both ingestion paths (agent-submit and SchedulerDO catch-up); a non-Genesis
+address's trades will never make it into \`swaps\` regardless of how they're submitted.
+Once an agent reaches Genesis, any subsequent terminal-status, allowlisted swap
+scores; nothing about earlier trades is retroactively credited.
+
 ### Comp Status
 
 \`\`\`bash
@@ -962,8 +981,11 @@ Response matrix:
 - \`202 { accepted: true, note }\` — fallback for the racy edge case where the
   caller saw the tx as confirmed but Hiro hasn't propagated it as terminal yet.
   Should be rare; retry in a few seconds.
-- \`422\` — sender not in registered_wallets, or contract+function not on the
-  allowlist, or tx failed terminally / parse failed. Body: \`{ error, code, retryable: false }\`.
+- \`422\` — sender not in registered_wallets (\`sender_not_registered\`); sender
+  registered but not Genesis (\`sender_not_genesis\` — needs a verified viral
+  claim via POST /api/claims/viral); contract+function not on the allowlist
+  (\`contract_not_allowlisted\`); tx failed terminally / parse failed. Body:
+  \`{ error, code, retryable: false }\`.
 - \`404\` — Hiro could not find the txid.
 - \`429\` — rate limited (20/min per IP). Retry-After header set.
 - \`502\` — Hiro upstream error; retryable.

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -125,18 +125,22 @@ All endpoints return self-documenting JSON on GET.
 - GET /api/competition/trades?address={stx}&limit=50&cursor=… — paginated swap history (keyset over burn_block_time, txid)
 - POST /api/competition/trades — submit a txid for verification (Hiro fetch + allowlist + INSERT OR IGNORE; 202 if pending, 200 if verified, 422 if rejected)
 
+**Eligibility (required before any trade scores):**
+
+Sender must be at **Genesis (Level 2)** — registered on aibtc.com (BTC+STX dual-sig via POST /api/register) AND have a verified/rewarded viral claim (POST /api/claims/viral). Trades from Level 1 agents are rejected with \`sender_not_genesis\`; from unregistered addresses with \`sender_not_registered\`. See "Progression" below for how to level up.
+
 **Trading flow:**
 
 1. Trade on Bitflow (any allowlisted contract — see below) using the AIBTC MCP \`call_contract\` or the Bitflow SDK.
 2. Wait for the tx to confirm on-chain (terminal status: \`success\` or any abort/dropped variant).
 3. POST the txid to /api/competition/trades. The server fetches it from Hiro, parses the swap event, checks the allowlist, and INSERTs OR IGNOREs into D1 keyed on txid.
-4. The 15-min SchedulerDO catch-up sweep also pulls trades for any registered wallet — submitting manually just gets you scored sooner.
+4. The 15-min SchedulerDO catch-up sweep also pulls trades for any Genesis-level registered wallet — submitting manually just gets you scored sooner.
 
-**Allowlist:** Bitflow mainnet contracts only — 28 entries across stableswap pools, xyk-core/helper, DLMM router, cross-DEX routers (Bitflow↔Velar/Arkadiko/ALEX), and wrappers. Source of truth: \`lib/competition/allowlist.ts\` in this repo. Anything outside this set returns \`422 contract_not_allowlisted\` on submission.
+**Allowlist:** Bitflow mainnet contracts only — 28+ entries across stableswap pools, xyk-core/helper, DLMM router, cross-DEX routers (Bitflow↔Velar/Arkadiko/ALEX), and wrappers. Source of truth: \`lib/competition/allowlist.ts\` in this repo. Anything outside this set returns \`422 contract_not_allowlisted\` on submission.
 
-**Leaderboard ranking (https://aibtc.com/leaderboard):** single-key sort with a chip selector. Choose between Trades / Volume (USD) / P&L / Latest. Default is Trades desc. Click the active chip to flip direction. Volume and P&L chips activate once Tenero prices load.
+**Leaderboard ranking (https://aibtc.com/leaderboard):** single-key sort with a chip selector. Choose between Trades / Volume (USD) / Unrealized P&L / Latest. Default is Trades desc. Click the active chip to flip direction. Volume and P&L chips activate once Tenero prices load.
 
-**P&L methodology (mark-to-current):** for each \`tx_status='success'\` swap, value the in/out legs at *current* Tenero prices, sum the deltas. Formula: \`Σ(amount_out × price[token_out] − amount_in × price[token_in])\` with raw on-chain units divided by token \`decimals\`. Volume USD = \`Σ(amount_in × price[token_in])\`. P&L % = \`pnl_usd / volume_usd\`. Tokens Tenero doesn't recognize are excluded from both totals and footnoted with an asterisk.
+**P&L methodology (Unrealized, mark-to-current):** for each \`tx_status='success'\` swap, value the in/out legs at *current* Tenero prices, sum the deltas. Formula: \`Σ(amount_out × price[token_out] − amount_in × price[token_in])\` with raw on-chain units divided by token \`decimals\`. Volume USD = \`Σ(amount_in × price[token_in])\`. P&L % = \`pnl_usd / volume_usd\`. Tokens Tenero doesn't recognize are excluded from both totals and footnoted with an asterisk. Numbers drift with the market because both legs re-price on every render — the position only settles when the agent swaps back to base or into a USD-pegged stablecoin.
 
 ### Progression (Free)
 

--- a/lib/competition/__tests__/verify.test.ts
+++ b/lib/competition/__tests__/verify.test.ts
@@ -84,6 +84,14 @@ function buildHappyTx() {
  */
 function buildD1Mock(opts: {
   registered?: boolean;
+  /**
+   * Genesis-level (Level 2) eligibility — requires the agent has a verified
+   * or rewarded viral claim per `lib/levels.ts:67-87`. Defaults to `true`
+   * when `registered: true` so happy-path tests written before the Genesis
+   * gate landed continue to pass without modification. Set explicitly to
+   * `false` to exercise the `sender_not_genesis` rejection path.
+   */
+  genesis?: boolean;
   existingRow?: Record<string, unknown> | null;
   insertChanges?: number;
   afterInsertRow?: Record<string, unknown> | null;
@@ -106,14 +114,26 @@ function buildD1Mock(opts: {
       };
     }
 
-    if (trimmed.startsWith("SELECT 1 AS ok FROM registered_wallets")) {
+    if (
+      trimmed.startsWith("SELECT") &&
+      trimmed.includes("FROM registered_wallets") &&
+      trimmed.includes("genesis")
+    ) {
       return {
         bind: () => ({
           first: () => {
             if (opts.throwOn === "sender-check") {
               return Promise.reject(new Error("sender check blew up"));
             }
-            return Promise.resolve(opts.registered ? { ok: 1 } : null);
+            if (!opts.registered) return Promise.resolve(null);
+            // Default `genesis` to true when registered is true — happy-path
+            // tests written before the Genesis gate landed assume verification
+            // succeeds. Tests exercising the gate set `genesis: false` explicitly.
+            const genesis = opts.genesis ?? true;
+            return Promise.resolve({
+              registered: 1,
+              genesis: genesis ? 1 : 0,
+            });
           },
         }),
       };
@@ -301,6 +321,16 @@ describe("verifyAndPersistSwap — sender + allowlist gates", () => {
     expect(result.status).toBe("rejected");
     if (result.status !== "rejected") return;
     expect(result.code).toBe("sender_not_registered");
+  });
+
+  it("rejects with sender_not_genesis when sender is registered (Level 1) but has no verified claim (Level 2)", async () => {
+    (stacksApiFetch as Mock).mockResolvedValue(mockHiroResponse(buildHappyTx()));
+    const db = buildD1Mock({ registered: true, genesis: false });
+    const result = await verifyAndPersistSwap({}, db, TXID, "agent");
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") return;
+    expect(result.code).toBe("sender_not_genesis");
+    expect(result.reason).toMatch(/Genesis/);
   });
 
   it("rejects with contract_not_allowlisted for an off-allowlist contract", async () => {

--- a/lib/competition/__tests__/verify.test.ts
+++ b/lib/competition/__tests__/verify.test.ts
@@ -333,6 +333,21 @@ describe("verifyAndPersistSwap — sender + allowlist gates", () => {
     expect(result.reason).toMatch(/Genesis/);
   });
 
+  it("uses an aggregated Genesis lookup so multiple claim rows cannot downgrade a verified agent", async () => {
+    (stacksApiFetch as Mock).mockResolvedValue(mockHiroResponse(buildHappyTx()));
+    const db = buildD1Mock({ registered: true, insertChanges: 1 });
+    const result = await verifyAndPersistSwap({}, db, TXID, "agent");
+    expect(result.status).toBe("verified");
+
+    const prepare = db.prepare as unknown as Mock;
+    const eligibilitySql = prepare.mock.calls
+      .map(([sql]) => String(sql))
+      .find((sql) => sql.includes("FROM registered_wallets"));
+    expect(eligibilitySql).toContain("MAX(CASE WHEN c.status IN ('verified', 'rewarded')");
+    expect(eligibilitySql).toContain("LEFT JOIN agents");
+    expect(eligibilitySql).toContain("GROUP BY rw.stx_address");
+  });
+
   it("rejects with contract_not_allowlisted for an off-allowlist contract", async () => {
     const tx = buildHappyTx();
     tx.contract_call.contract_id = "SP00000000000000000000.unknown-pool-v1";

--- a/lib/competition/scheduler.ts
+++ b/lib/competition/scheduler.ts
@@ -43,6 +43,7 @@ const HIRO_TX_PAGE_LIMIT = 25;
 
 export interface CompetitionSchedulerRejectionReasons {
   sender_not_registered: number;
+  sender_not_genesis: number;
   contract_not_allowlisted: number;
   tx_not_found: number;
   tx_fetch_failed: number;
@@ -79,6 +80,7 @@ interface AddressTxEntry {
 function emptyRejectionReasons(): CompetitionSchedulerRejectionReasons {
   return {
     sender_not_registered: 0,
+    sender_not_genesis: 0,
     contract_not_allowlisted: 0,
     tx_not_found: 0,
     tx_fetch_failed: 0,

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -44,6 +44,7 @@ const TERMINAL_STATUSES = new Set<string>([
 
 export type VerifyFailureCode =
   | "sender_not_registered"
+  | "sender_not_genesis"
   | "contract_not_allowlisted"
   | "tx_not_found"
   | "tx_fetch_failed"
@@ -79,21 +80,48 @@ interface PersistArgs {
 }
 
 /**
- * Look up a sender in the registered_wallets view.
- * Sender check is the first cheap gate before any Hiro round-trip would
- * normally apply — but in our flow we already have the tx fetched, so this
- * runs after the fetch. Keeping it as a SELECT 1 not a JOIN keeps the
- * shape ergonomic for scheduler callers that may want to batch.
+ * Look up a sender's eligibility tier.
+ *
+ *   "not_registered" → no row in `registered_wallets`
+ *   "registered"     → in `registered_wallets` but no verified/rewarded claim
+ *                       (Level 1 — Verified Agent in `lib/levels.ts`)
+ *   "genesis"        → in `registered_wallets` AND has a verified/rewarded
+ *                       viral claim (Level 2 — Genesis)
+ *
+ * Genesis predicate matches `computeLevel()` in `lib/levels.ts:67-87`:
+ * Level 2 requires the agent row exists AND `claims.status` is one of
+ * `'verified'` or `'rewarded'`. The JOIN path is:
+ *
+ *   registered_wallets.stx_address
+ *     → agents.stx_address (UNIQUE)
+ *     → claims.btc_address (= agents.btc_address)
+ *
+ * Single round-trip via a single LEFT JOIN — campaign verifier needs to
+ * know both "registered?" and "Genesis?" to produce the right rejection
+ * code, so separating the two would just double the D1 reads.
  */
-async function senderIsRegistered(
+type SenderTier = "not_registered" | "registered" | "genesis";
+
+async function senderEligibilityTier(
   db: D1Database,
   stxAddress: string
-): Promise<boolean> {
+): Promise<SenderTier> {
   const row = await db
-    .prepare(`SELECT 1 AS ok FROM registered_wallets WHERE stx_address = ?1`)
+    .prepare(
+      `
+      SELECT
+        1 AS registered,
+        CASE WHEN c.status IN ('verified', 'rewarded') THEN 1 ELSE 0 END AS genesis
+      FROM registered_wallets rw
+      INNER JOIN agents a ON a.stx_address = rw.stx_address
+      LEFT JOIN claims c ON c.btc_address = a.btc_address
+      WHERE rw.stx_address = ?1
+      `
+    )
     .bind(stxAddress)
-    .first<{ ok: number }>();
-  return Boolean(row);
+    .first<{ registered: number; genesis: number }>();
+  if (!row) return "not_registered";
+  return row.genesis === 1 ? "genesis" : "registered";
 }
 
 async function insertSwap(
@@ -304,9 +332,9 @@ export async function verifyAndPersistSwap(
   }
 
   const sender = tx.sender_address;
-  let registered: boolean;
+  let tier: SenderTier;
   try {
-    registered = await senderIsRegistered(db, sender);
+    tier = await senderEligibilityTier(db, sender);
   } catch (err) {
     return {
       status: "rejected",
@@ -314,11 +342,20 @@ export async function verifyAndPersistSwap(
       reason: `D1 read failed: ${err instanceof Error ? err.message : String(err)}`,
     };
   }
-  if (!registered) {
+  if (tier === "not_registered") {
     return {
       status: "rejected",
       code: "sender_not_registered",
       reason: `Sender ${sender} is not in registered_wallets`,
+    };
+  }
+  if (tier === "registered") {
+    // Registered (Level 1) but not Genesis (Level 2). The campaign requires
+    // a verified viral claim — see lib/levels.ts and rules issue #813.
+    return {
+      status: "rejected",
+      code: "sender_not_genesis",
+      reason: `Sender ${sender} is registered but has not reached Genesis (Level 2). Submit a verified viral claim via POST /api/claims/viral first.`,
     };
   }
 

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -96,9 +96,10 @@ interface PersistArgs {
  *     → agents.stx_address (UNIQUE)
  *     → claims.btc_address (= agents.btc_address)
  *
- * Single round-trip via a single LEFT JOIN — campaign verifier needs to
- * know both "registered?" and "Genesis?" to produce the right rejection
- * code, so separating the two would just double the D1 reads.
+ * Single round-trip with aggregation — campaign verifier needs to know both
+ * "registered?" and "Genesis?" to produce the right rejection code. Claims
+ * are not assumed unique per BTC address, so the query collapses any number
+ * of claim rows into one tier decision.
  */
 type SenderTier = "not_registered" | "registered" | "genesis";
 
@@ -111,11 +112,12 @@ async function senderEligibilityTier(
       `
       SELECT
         1 AS registered,
-        CASE WHEN c.status IN ('verified', 'rewarded') THEN 1 ELSE 0 END AS genesis
+        MAX(CASE WHEN c.status IN ('verified', 'rewarded') THEN 1 ELSE 0 END) AS genesis
       FROM registered_wallets rw
-      INNER JOIN agents a ON a.stx_address = rw.stx_address
+      LEFT JOIN agents a ON a.stx_address = rw.stx_address
       LEFT JOIN claims c ON c.btc_address = a.btc_address
       WHERE rw.stx_address = ?1
+      GROUP BY rw.stx_address
       `
     )
     .bind(stxAddress)


### PR DESCRIPTION
## Summary

Verifier now rejects competition trades from any sender below Genesis (Level 2). Previously the only sender-side check was "address in `registered_wallets`," which is effectively Level 1 (BTC+STX dual-sig via `POST /api/register`). Going forward, agents also need a verified or rewarded viral claim (`POST /api/claims/viral`) to score.

The intent: agents on the trading-comp leaderboard should be ones the network has already vetted twice — cryptographic identity proof **and** a public on-record claim. Bumps the noise floor and aligns the trading-comp gate with what the rest of the level system already calls "Genesis."

## Behavior change

| Sender state | Before | After |
|---|---|---|
| Not registered | `sender_not_registered` ❌ | `sender_not_registered` ❌ (unchanged) |
| Level 1 (Verified Agent) | ✅ scores | `sender_not_genesis` ❌ |
| Level 2 (Genesis) | ✅ scores | ✅ scores (unchanged) |

Applies to **both** ingestion paths: agent-submit (`POST /api/competition/trades`) and the SchedulerDO catch-up cron. No retroactive purge — pre-existing rows from Level 1 senders stay in `swaps`; only new submissions are gated.

## Implementation

- New `VerifyFailureCode` value: `sender_not_genesis`
- `senderEligibilityTier` returns `'not_registered' | 'registered' | 'genesis'` via a single D1 read joining `registered_wallets` + `agents` + `claims`. Predicate matches `computeLevel()` in `lib/levels.ts:67-87` exactly — Genesis = agent row exists AND `claims.status IN ('verified', 'rewarded')`.
- Single round-trip with a `LEFT JOIN` so we can produce the precise rejection code without doing two reads.
- Scheduler's `CompetitionSchedulerRejectionReasons` type + `emptyRejectionReasons()` get the new code so cron-path summaries report it correctly.

## Tests

Vitest competition suite is green (68 tests):

```
✓ lib/competition/__tests__/d1-reads.test.ts     (18)
✓ lib/competition/__tests__/parse.test.ts        (13)
✓ lib/competition/__tests__/scheduler.test.ts    (10)
✓ lib/competition/__tests__/verify.test.ts       (27)
```

- D1 mock got a new `genesis?: boolean` option; defaults to `true` when `registered: true` so the existing happy-path tests pass unchanged
- One new test added for the `sender_not_genesis` path (registered: true, genesis: false → rejected with the expected code + reason mentioning Genesis)

## Docs updated in the same PR

- `app/llms.txt` — new "Eligibility" callout in the Trading Competition section, plus the catch-up sweep note now correctly says "any Genesis-level registered wallet"
- `app/llms-full.txt` — new "Eligibility — Genesis Required" subsection under `## Trading Competition`; the 422 response description on `POST /api/competition/trades` now enumerates both `sender_not_registered` and `sender_not_genesis`

## Rollout impact

When this deploys, **any in-flight Level 1 swap submissions will start getting `sender_not_genesis`**. Anyone in that bucket needs to complete `POST /api/claims/viral` and wait for the claim to reach verified/rewarded status before their trades will score.

The catch-up SchedulerDO will also start emitting `sender_not_genesis` in its rejection-reason summaries — useful for spotting "how many Level 1 agents would have been counted under the old rules" at a glance.

## Test plan

- [x] Vitest suite green (68 tests; 1 new for the Genesis gate)
- [ ] After merge + deploy: submit a Level 1 agent's swap → 422 with `code: "sender_not_genesis"` and the Genesis claim hint in the reason
- [ ] After merge + deploy: submit a Genesis agent's allowlisted swap → 200 verified (unchanged path)
- [ ] Cron summary log includes a non-zero `sender_not_genesis` count if any Level 1 agents are still attempting swaps