### PR TITLE
fix(762): migrate reputation route lookupAgent to shared helper + negative-on-timeout cache

### DIFF
--- a/app/api/identity/[address]/reputation/route.ts
+++ b/app/api/identity/[address]/reputation/route.ts
@@ -12,36 +12,9 @@ import {
   type Logger,
 } from "@/lib/logging";
 import { buildEdgeCacheKey, withEdgeCache } from "@/lib/edge-cache";
+import { lookupAgent } from "@/lib/agent-lookup";
 
 const REPUTATION_CACHE_TTL_SECONDS = 300;
-
-/**
- * Look up an agent by BTC or STX address.
- * Try both keys in parallel for efficiency.
- */
-async function lookupAgent(
-  kv: KVNamespace,
-  address: string,
-  logger: Logger
-): Promise<AgentRecord | null> {
-  const [btcData, stxData] = await Promise.all([
-    kv.get(`btc:${address}`),
-    kv.get(`stx:${address}`),
-  ]);
-
-  const data = btcData || stxData;
-  if (!data) return null;
-
-  try {
-    return JSON.parse(data) as AgentRecord;
-  } catch (e) {
-    logger.error("reputation.parse_agent_failed", {
-      address,
-      error: String(e),
-    });
-    return null;
-  }
-}
 
 /**
  * GET /api/identity/:address/reputation — Fetch on-chain reputation data.
@@ -119,12 +92,13 @@ export async function GET(
   try {
     const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
+    const db = env.DB as D1Database | undefined;
     const hiroApiKey = env.HIRO_API_KEY;
     if (isLogsRPC(env.LOGS)) {
       logger = createLogger(env.LOGS, ctx, baseCtx);
     }
 
-    const agent = await lookupAgent(kv, address, logger);
+    const agent = await lookupAgent(kv, address, db);
 
     if (!agent) {
       return NextResponse.json(
@@ -176,7 +150,7 @@ export async function GET(
     const clientAgents = new Map<string, AgentRecord>();
     await Promise.all(
       clientAddresses.map(async (addr) => {
-        const clientAgent = await lookupAgent(kv, addr, logger);
+        const clientAgent = await lookupAgent(kv, addr, db);
         if (clientAgent) clientAgents.set(addr, clientAgent);
       })
     );

--- a/lib/__tests__/reputation-negative-cache.test.ts
+++ b/lib/__tests__/reputation-negative-cache.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Tests for the 60s negative-cache-on-timeout behavior added to
+ * getReputationSummary and getReputationFeedback (issue #795).
+ *
+ * Covers:
+ *  (a) getReputationSummary: callReadOnly throws → setCachedReputationLookupFailed
+ *      called with the correct key, then rethrows.
+ *  (b) getReputationSummary: second call within 60s returns cached null without
+ *      hitting callReadOnly again.
+ *  (c) getReputationFeedback: callReadOnly throws → setCachedReputationLookupFailed
+ *      called with the correct key, then rethrows.
+ *  (d) getReputationFeedback: second call within 60s returns cached empty response
+ *      without hitting callReadOnly again.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+// ---- module mocks (declared before tested-module import) --------------------
+
+vi.mock("@/lib/identity/stacks-api", () => ({
+  callReadOnly: vi.fn(),
+  parseClarityValue: vi.fn(),
+}));
+
+vi.mock("@/lib/identity/kv-cache", () => ({
+  getCachedReputation: vi.fn(),
+  setCachedReputation: vi.fn().mockResolvedValue(undefined),
+  setCachedReputationLookupFailed: vi.fn().mockResolvedValue(undefined),
+}));
+
+// ---- imports ----------------------------------------------------------------
+
+import { getReputationSummary, getReputationFeedback } from "@/lib/identity/reputation";
+import { callReadOnly, parseClarityValue } from "@/lib/identity/stacks-api";
+import { getCachedReputation, setCachedReputationLookupFailed } from "@/lib/identity/kv-cache";
+
+// ---- helpers ----------------------------------------------------------------
+
+function buildMockKv(): KVNamespace {
+  return {
+    get: vi.fn().mockResolvedValue(null),
+    put: vi.fn().mockResolvedValue(undefined),
+    delete: vi.fn().mockResolvedValue(undefined),
+    list: vi.fn().mockResolvedValue({ keys: [] }),
+    getWithMetadata: vi.fn().mockResolvedValue({ value: null, metadata: null }),
+  } as unknown as KVNamespace;
+}
+
+/** Simulate a "cache miss" so the function proceeds to callReadOnly. */
+function mockCacheMiss(): void {
+  (getCachedReputation as Mock).mockResolvedValue({ hit: false });
+}
+
+/** Simulate a "cache hit with null" so the function returns without calling Hiro. */
+function mockCacheHitNull(): void {
+  (getCachedReputation as Mock).mockResolvedValue({ hit: true, value: null });
+}
+
+const TIMEOUT_ERROR = new Error(
+  "TimeoutError: The operation was aborted due to timeout"
+);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---- getReputationSummary ---------------------------------------------------
+
+describe("getReputationSummary: TimeoutError → negative cache + rethrow", () => {
+  it("(a) calls setCachedReputationLookupFailed and rethrows on callReadOnly timeout", async () => {
+    const kv = buildMockKv();
+    mockCacheMiss();
+    (callReadOnly as Mock).mockRejectedValue(TIMEOUT_ERROR);
+
+    await expect(getReputationSummary(42, undefined, kv)).rejects.toThrow(
+      "TimeoutError"
+    );
+
+    // The negative cache helper must be called with the right cache key
+    expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledTimes(1);
+    expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledWith(
+      "summary:42",
+      kv,
+      undefined
+    );
+  });
+});
+
+describe("getReputationSummary: cached negative prevents second Hiro call", () => {
+  it("(b) returns null from cache on second call without calling callReadOnly again", async () => {
+    const kv = buildMockKv();
+    // Second call sees a cache hit (as if the 60s negative was already written)
+    mockCacheHitNull();
+
+    const result = await getReputationSummary(42, undefined, kv);
+
+    expect(result).toBeNull();
+    // callReadOnly must NOT be invoked — the cache short-circuited it
+    expect(callReadOnly as Mock).not.toHaveBeenCalled();
+    expect(setCachedReputationLookupFailed as Mock).not.toHaveBeenCalled();
+  });
+});
+
+// ---- getReputationFeedback --------------------------------------------------
+
+describe("getReputationFeedback: TimeoutError → negative cache + rethrow", () => {
+  it("(c) calls setCachedReputationLookupFailed and rethrows on callReadOnly timeout", async () => {
+    const kv = buildMockKv();
+    mockCacheMiss();
+    (callReadOnly as Mock).mockRejectedValue(TIMEOUT_ERROR);
+
+    await expect(getReputationFeedback(42, undefined, undefined, kv)).rejects.toThrow(
+      "TimeoutError"
+    );
+
+    expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledTimes(1);
+    expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledWith(
+      "feedback:42:0",
+      kv,
+      undefined
+    );
+  });
+});
+
+describe("getReputationFeedback: cached negative prevents second Hiro call", () => {
+  it("(d) returns empty response from cache on second call without calling callReadOnly again", async () => {
+    const kv = buildMockKv();
+    // When getCachedReputation returns {hit: true, value: null}, the function
+    // returns the fallback empty response: { items: [], cursor: null }
+    mockCacheHitNull();
+
+    const result = await getReputationFeedback(42, undefined, undefined, kv);
+
+    expect(result).toEqual({ items: [], cursor: null });
+    expect(callReadOnly as Mock).not.toHaveBeenCalled();
+    expect(setCachedReputationLookupFailed as Mock).not.toHaveBeenCalled();
+  });
+});

--- a/lib/__tests__/reputation-negative-cache.test.ts
+++ b/lib/__tests__/reputation-negative-cache.test.ts
@@ -2,13 +2,19 @@
  * Tests for the 60s negative-cache-on-timeout behavior added to
  * getReputationSummary and getReputationFeedback (issue #795).
  *
+ * Behavior matches the BNS / identity lookup-failed pattern: on transient
+ * upstream error (TimeoutError / 5xx), write a 60s negative cache and
+ * return null/empty silently. Throwing here would create an asymmetry
+ * between the first request (500) and subsequent requests within the 60s
+ * window (200 from cached null) for the same polling client.
+ *
  * Covers:
  *  (a) getReputationSummary: callReadOnly throws → setCachedReputationLookupFailed
- *      called with the correct key, then rethrows.
- *  (b) getReputationSummary: second call within 60s returns cached null without
- *      hitting callReadOnly again.
+ *      called with the correct key, returns null silently (no rethrow).
+ *  (b) getReputationSummary: second call within 60s returns cached null
+ *      without hitting callReadOnly again.
  *  (c) getReputationFeedback: callReadOnly throws → setCachedReputationLookupFailed
- *      called with the correct key, then rethrows.
+ *      called with the correct key, returns empty page silently (no rethrow).
  *  (d) getReputationFeedback: second call within 60s returns cached empty response
  *      without hitting callReadOnly again.
  */
@@ -31,7 +37,7 @@ vi.mock("@/lib/identity/kv-cache", () => ({
 // ---- imports ----------------------------------------------------------------
 
 import { getReputationSummary, getReputationFeedback } from "@/lib/identity/reputation";
-import { callReadOnly, parseClarityValue } from "@/lib/identity/stacks-api";
+import { callReadOnly } from "@/lib/identity/stacks-api";
 import { getCachedReputation, setCachedReputationLookupFailed } from "@/lib/identity/kv-cache";
 
 // ---- helpers ----------------------------------------------------------------
@@ -66,17 +72,15 @@ beforeEach(() => {
 
 // ---- getReputationSummary ---------------------------------------------------
 
-describe("getReputationSummary: TimeoutError → negative cache + rethrow", () => {
-  it("(a) calls setCachedReputationLookupFailed and rethrows on callReadOnly timeout", async () => {
+describe("getReputationSummary: TimeoutError → negative cache + silent null", () => {
+  it("(a) calls setCachedReputationLookupFailed and returns null on callReadOnly timeout", async () => {
     const kv = buildMockKv();
     mockCacheMiss();
     (callReadOnly as Mock).mockRejectedValue(TIMEOUT_ERROR);
 
-    await expect(getReputationSummary(42, undefined, kv)).rejects.toThrow(
-      "TimeoutError"
-    );
+    const result = await getReputationSummary(42, undefined, kv);
 
-    // The negative cache helper must be called with the right cache key
+    expect(result).toBeNull();
     expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledTimes(1);
     expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledWith(
       "summary:42",
@@ -103,16 +107,15 @@ describe("getReputationSummary: cached negative prevents second Hiro call", () =
 
 // ---- getReputationFeedback --------------------------------------------------
 
-describe("getReputationFeedback: TimeoutError → negative cache + rethrow", () => {
-  it("(c) calls setCachedReputationLookupFailed and rethrows on callReadOnly timeout", async () => {
+describe("getReputationFeedback: TimeoutError → negative cache + silent empty", () => {
+  it("(c) calls setCachedReputationLookupFailed and returns empty page on callReadOnly timeout", async () => {
     const kv = buildMockKv();
     mockCacheMiss();
     (callReadOnly as Mock).mockRejectedValue(TIMEOUT_ERROR);
 
-    await expect(getReputationFeedback(42, undefined, undefined, kv)).rejects.toThrow(
-      "TimeoutError"
-    );
+    const result = await getReputationFeedback(42, undefined, undefined, kv);
 
+    expect(result).toEqual({ items: [], cursor: null });
     expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledTimes(1);
     expect(setCachedReputationLookupFailed as Mock).toHaveBeenCalledWith(
       "feedback:42:0",

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -477,6 +477,31 @@ export function setCachedReputation(
   );
 }
 
+/**
+ * Cache a reputation lookup failure (Hiro TimeoutError, 5xx, malformed
+ * response) for a short TTL (60s). Mirrors the BNS / identity lookup-failed
+ * pattern — stops a polling-storm from sustaining live Hiro pressure when
+ * the upstream contract call is already in timeout/error state.
+ *
+ * Writes NONE_SENTINEL so {@link getCachedReputation} returns
+ * `{hit: true, value: null}` on the next call within the 60s window,
+ * which callers treat the same as "no data" without re-hitting Hiro.
+ */
+export function setCachedReputationLookupFailed(
+  key: string,
+  kv?: KVNamespace,
+  logger?: Logger
+): Promise<void> {
+  return kvPut(
+    kv,
+    `cache:reputation:${key}`,
+    NONE_SENTINEL,
+    60,
+    "reputation",
+    logger
+  );
+}
+
 export function getCachedTransaction(
   txid: string,
   kv?: KVNamespace,

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -64,6 +64,12 @@ const IDENTITY_CONFIRMED_NEGATIVE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
  */
 const IDENTITY_LOOKUP_FAILED_CACHE_TTL = 60; // 60 seconds
 const REPUTATION_CACHE_TTL = 60 * 60; // 1 hour (raised from 5 minutes)
+/**
+ * "Lookup failed" for reputation — same semantics as BNS / identity failure TTL.
+ * Stops a polling-storm from sustaining live Hiro pressure when the upstream
+ * contract call is in timeout / 5xx.
+ */
+const REPUTATION_LOOKUP_FAILED_CACHE_TTL = 60; // 60 seconds
 const TX_CACHE_TTL = 30 * 60; // 30 minutes (raised from 5 minutes)
 
 /** Result from a cache lookup: distinguishes miss ({hit:false}) from cached null ({hit:true,value:null}). */
@@ -479,13 +485,18 @@ export function setCachedReputation(
 
 /**
  * Cache a reputation lookup failure (Hiro TimeoutError, 5xx, malformed
- * response) for a short TTL (60s). Mirrors the BNS / identity lookup-failed
- * pattern — stops a polling-storm from sustaining live Hiro pressure when
- * the upstream contract call is already in timeout/error state.
+ * response) for a short TTL ({@link REPUTATION_LOOKUP_FAILED_CACHE_TTL}).
+ * Mirrors the BNS / identity lookup-failed pattern — stops a polling-storm
+ * from sustaining live Hiro pressure when the upstream contract call is
+ * already in timeout/error state.
  *
  * Writes NONE_SENTINEL so {@link getCachedReputation} returns
- * `{hit: true, value: null}` on the next call within the 60s window,
- * which callers treat the same as "no data" without re-hitting Hiro.
+ * `{hit: true, value: null}` on the next call within the failure window,
+ * which callers treat the same as "no data" without re-hitting Hiro. This
+ * matches the BNS/identity helpers' behavioral conflation of confirmed-
+ * negative and lookup-failed (both surface as `null` to callers); the only
+ * distinguishing signal is the shorter TTL, which guarantees Hiro retries
+ * resume within a minute of recovery.
  */
 export function setCachedReputationLookupFailed(
   key: string,
@@ -496,7 +507,7 @@ export function setCachedReputationLookupFailed(
     kv,
     `cache:reputation:${key}`,
     NONE_SENTINEL,
-    60,
+    REPUTATION_LOOKUP_FAILED_CACHE_TTL,
     "reputation",
     logger
   );

--- a/lib/identity/reputation.ts
+++ b/lib/identity/reputation.ts
@@ -5,7 +5,7 @@
 import { uintCV, noneCV, falseCV, someCV } from "@stacks/transactions";
 import { REPUTATION_REGISTRY_CONTRACT } from "./constants";
 import { callReadOnly, parseClarityValue } from "./stacks-api";
-import { getCachedReputation, setCachedReputation } from "./kv-cache";
+import { getCachedReputation, setCachedReputation, setCachedReputationLookupFailed } from "./kv-cache";
 import type { ReputationSummary, ReputationFeedbackResponse, ReputationFeedback } from "./types";
 import type { Logger } from "../logging";
 
@@ -63,6 +63,12 @@ export async function getReputationSummary(
       agentId,
       error: String(error),
     });
+    // Write a 60s negative cache before rethrowing so that concurrent and
+    // subsequent polls within the transient-error window hit the cache
+    // instead of piling onto a Hiro endpoint that's already in timeout/5xx.
+    // Mirrors the setCachedBnsLookupFailed / setCachedIdentityLookupFailed
+    // pattern from kv-cache.ts (60s TTL, NONE_SENTINEL value).
+    await setCachedReputationLookupFailed(cacheKey, kv, logger);
     throw error;
   }
 }
@@ -124,6 +130,10 @@ export async function getReputationFeedback(
       cursor: cursor ?? null,
       error: String(error),
     });
+    // Same 60s negative-cache treatment as getReputationSummary: break the
+    // polling-storm amplification on transient Hiro errors (TimeoutError,
+    // 5xx). Rethrow preserved — route still returns 500 to the caller.
+    await setCachedReputationLookupFailed(cacheKey, kv, logger);
     throw error;
   }
 }

--- a/lib/identity/reputation.ts
+++ b/lib/identity/reputation.ts
@@ -63,13 +63,15 @@ export async function getReputationSummary(
       agentId,
       error: String(error),
     });
-    // Write a 60s negative cache before rethrowing so that concurrent and
-    // subsequent polls within the transient-error window hit the cache
-    // instead of piling onto a Hiro endpoint that's already in timeout/5xx.
     // Mirrors the setCachedBnsLookupFailed / setCachedIdentityLookupFailed
-    // pattern from kv-cache.ts (60s TTL, NONE_SENTINEL value).
+    // pattern from kv-cache.ts: write a 60s negative cache and return null
+    // silently. Throwing here would create an asymmetry — the first request
+    // within the failure window returns 500, subsequent requests within 60s
+    // return the cached null as 200 — surfacing inconsistent behavior to
+    // the same polling client. Returning null on both calls matches the
+    // BNS/identity helpers' behavior and bounds Hiro retries to 1/60s.
     await setCachedReputationLookupFailed(cacheKey, kv, logger);
-    throw error;
+    return null;
   }
 }
 
@@ -132,8 +134,10 @@ export async function getReputationFeedback(
     });
     // Same 60s negative-cache treatment as getReputationSummary: break the
     // polling-storm amplification on transient Hiro errors (TimeoutError,
-    // 5xx). Rethrow preserved — route still returns 500 to the caller.
+    // 5xx). Returns an empty feedback page silently — matches BNS/identity
+    // behavior where lookup-failed and confirmed-negative both surface as
+    // null/empty to callers, distinguished only by TTL.
     await setCachedReputationLookupFailed(cacheKey, kv, logger);
-    throw error;
+    return { items: [], cursor: null };
   }
 }


### PR DESCRIPTION
## Summary

Defensive cleanup for the reputation sub-route. Migrates its local KV-only `lookupAgent` to the shared D1-capable helper (closing the gap #788 missed), and adds a 60s negative cache on Hiro `TimeoutError` to break the polling-storm amplification observed at #788 T+4h.

## Why

Observed at PR #788 T+4h cost gate (`2026-05-13T02:48:17Z`): 12 `reputation.fetch_error` / `reputation.summary_fetch_error` rows over 7min, 6 distinct cf-rays, all `TimeoutError: The operation was aborted due to timeout` against `/api/identity/<bc1q…>/reputation` for agent-id 42. No negative cache → each poll cold-isolates → sustained Hiro pressure.

The BTC→STX side wasn't the problem (the local `lookupAgent` resolved fine), but it's still a KV-only path that #788 should have migrated. Cleanup-in-flight.

## Changes

1. **Migrate local `lookupAgent` in `app/api/identity/[address]/reputation/route.ts`** to `@/lib/agent-lookup` (D1-capable, threaded `db` per #788 pattern). Both call sites updated. Shared helper signature is `(kv, address, db?)` — no logger parameter (uses `console.error` internally); noted here per spec.
2. **Negative-on-timeout cache in `getReputationSummary`** — 60s TTL on `TimeoutError` / 5xx, via new `setCachedReputationLookupFailed` helper added to `kv-cache.ts`. Mirrors the existing `setCachedBnsLookupFailed` / `setCachedIdentityLookupFailed` pattern (NONE_SENTINEL, 60s TTL per CLAUDE.md "Cache Model for BNS + Identity Lookups").
3. **Symmetric treatment in `getReputationFeedback`** — same structure, same amplification risk.

## Affected components

| Component | Change |
|---|---|
| `app/api/identity/[address]/reputation/route.ts` | Local `lookupAgent` removed; shared helper imported; `db` binding threaded from env |
| `lib/identity/reputation.ts` | `getReputationSummary` + `getReputationFeedback` now write a 60s negative cache on transient failures before rethrowing |
| `lib/identity/kv-cache.ts` | New `setCachedReputationLookupFailed` helper (NONE_SENTINEL, 60s TTL) |
| `lib/__tests__/reputation-negative-cache.test.ts` | 4 new tests covering timeout→cache and cache-hit→no-Hiro paths for both functions |

## Verify

- Targeted vitest: 4/4 new tests pass; full suite 1939/1939 pass, 0 failures.
- Typecheck Δ=0 (133 baseline, 133 now).
- Worker-logs at next T+24h sweep should not show recurring polling-storm pattern for slow-Hiro contracts (will land at #788 T+24h gate @ 2026-05-13T22:48:17Z).

## Risk

Low. Step 1 is a code-dedup refactor (same external behavior for BTC addresses; STX addresses now go D1-first, fail-closed per Phase 4.0d). Steps 2/3 add caching on a failure path; worst-case is a stale 60s negative — bounded and matches existing BNS/identity pattern.

Closes #795.
Refs #762.