### PR TITLE
fix(competition): map Genesis rejection response

### DIFF
--- a/app/api/competition/trades/route.ts
+++ b/app/api/competition/trades/route.ts
@@ -331,6 +331,7 @@ export async function POST(request: NextRequest) {
   // result.status === "rejected"
   switch (result.code) {
     case "sender_not_registered":
+    case "sender_not_genesis":
     case "contract_not_allowlisted":
     case "tx_failed":
     case "before_comp_start":


### PR DESCRIPTION
## Summary

Follow-up to #814. The verifier added `sender_not_genesis`, but `POST /api/competition/trades` still had an exhaustive rejection-code switch that did not map the new code to an HTTP response.

This maps `sender_not_genesis` to the existing 422 non-retryable client rejection class, same as `sender_not_registered`.

## Verification

```bash
npm run test -- lib/competition/__tests__/verify.test.ts app/api/competition/trades/__tests__/route.test.ts
# 1 file passed, 28 tests passed
```

Note: `app/api/competition/trades/__tests__/route.test.ts` does not exist on this branch, so Vitest ran the verifier suite only. The production OpenNext build failed before this fix on the route exhaustiveness check; this one-line mapping is the missing case.