### PR TITLE
feat(leaderboard): rules link + instant P&L tooltip + set comp start to 19:30Z

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { generateName } from "@/lib/name-generator";
 import { truncateAddress, formatRelativeTime } from "@/lib/utils";
+import Tooltip from "../components/Tooltip";
 
 /**
  * Single-key sort. Clicking the active chip flips direction; clicking a
@@ -215,12 +216,20 @@ function formatUsd(value: number | null): string {
 function formatUsdPrecise(value: number | null): string {
   if (value == null || !Number.isFinite(value)) return "—";
   const abs = Math.abs(value);
-  const fractionDigits = abs >= 100 ? 2 : abs >= 1 ? 4 : 6;
+  const sign = value < 0 ? "-" : "";
+  if (abs === 0) return `${sign}$0.00`;
+  // For ultra-small magnitudes, pick enough digits to show ~3 sig figs so
+  // a value like 1.21e-8 renders "$0.0000000121" instead of being rounded
+  // away. `toLocaleString` caps at 20 fraction digits, so we cap there too.
+  const fractionDigits =
+    abs >= 100 ? 2 :
+    abs >= 1 ? 4 :
+    abs >= 0.0001 ? 6 :
+    Math.min(20, Math.max(6, 2 - Math.floor(Math.log10(abs))));
   const formatted = abs.toLocaleString("en-US", {
     minimumFractionDigits: fractionDigits,
     maximumFractionDigits: fractionDigits,
   });
-  const sign = value < 0 ? "-" : "";
   return `${sign}$${formatted}`;
 }
 
@@ -278,21 +287,21 @@ function renderPnlCell(
   const color = positive ? "text-[#4dcd5e]" : "text-[#f06464]";
   const pctLabel = `${positive ? "+" : ""}${stats.pnlPercent.toFixed(2)}%`;
   // Tooltip carries the full-precision USD value so a tiny percentage
-  // like `-0.03%` still has the underlying magnitude (`-$0.001300`)
-  // available on hover. The 2-decimal `formatUsd` truncates anything
-  // smaller than a cent to `$0.00` which makes the cell look broken;
-  // showing only the percentage in the cell plus full $ on hover keeps
-  // both signals legible at any trade size.
+  // like `-0.03%` still has the underlying magnitude available on hover.
+  // The portal-based Tooltip shows instantly (no native ~1s title-attr
+  // delay) and survives table-cell clipping.
   const usdDetail = `${positive ? "+" : ""}${formatUsdPrecise(stats.pnlUsd)}`;
   const title = stats.allPriced
     ? usdDetail
     : `${usdDetail} (partial — some tokens couldn't be priced and were excluded)`;
 
   return (
-    <span className={`font-medium ${color}`} title={title}>
-      {pctLabel}
-      {!stats.allPriced && "*"}
-    </span>
+    <Tooltip text={title}>
+      <span className={`font-medium cursor-pointer ${color}`}>
+        {pctLabel}
+        {!stats.allPriced && "*"}
+      </span>
+    </Tooltip>
   );
 }
 
@@ -623,9 +632,15 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                   <span>·</span>
                   <span>{volumeLabel}</span>
                   <span>·</span>
-                  <span className={pnlColor} title={pnlTitle}>
-                    {pnlLabel}
-                  </span>
+                  {pnlTitle ? (
+                    <Tooltip text={pnlTitle}>
+                      <span className={`cursor-pointer ${pnlColor}`}>
+                        {pnlLabel}
+                      </span>
+                    </Tooltip>
+                  ) : (
+                    <span className={pnlColor}>{pnlLabel}</span>
+                  )}
                   <span>·</span>
                   <span>
                     {row.latestTradeAt > 0

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -15,10 +15,10 @@ const SCHEDULER_INSTANCE_NAME = "v2";
 export const metadata: Metadata = {
   title: "Trading Leaderboard - AIBTC",
   description:
-    "Agents ranked by the number of swaps they've done via aibtc mcp.",
+    "Trading leaderboard for AIBTC agents — ranked by Unrealized P&L (USD) and Volume across allowlisted Bitflow swaps.",
   openGraph: {
     title: "AIBTC Trading Leaderboard",
-    description: "MCP-submitted swap rankings across the AIBTC agent network.",
+    description: "Ranked by Unrealized P&L and Volume across allowlisted Bitflow swaps.",
   },
   other: {
     "aibtc:page-type": "trading-leaderboard",
@@ -240,7 +240,15 @@ export default async function LeaderboardPage() {
               Leaderboard
             </h1>
             <p className="text-[clamp(14px,1.3vw,16px)] text-white/50">
-              Agents ranked by the number of swaps they&apos;ve done via aibtc mcp.
+              Ranked by Unrealized P&amp;L (USD) and Volume across allowlisted Bitflow swaps — trade better, not more.{" "}
+              <a
+                href="https://github.com/aibtcdev/landing-page/issues/815"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-[#F7931A] underline-offset-2 hover:text-[#FFAA40] hover:underline"
+              >
+                Read the full rules →
+              </a>
             </p>
           </div>
 

--- a/lib/competition/constants.ts
+++ b/lib/competition/constants.ts
@@ -7,10 +7,10 @@
  * neither the agent-submit fast path nor the scheduler catch-up pass can
  * pollute `swaps` with pre-campaign history.
  *
- * 1778630400 = 2026-05-13T00:00:00Z.
+ * 1778700600 = 2026-05-13T19:30:00Z.
  *
  * To shift the start, update this constant and re-deploy. If we ever need
  * separate preview vs prod values, promote to an env-var read from the
  * worker bindings.
  */
-export const COMP_START_TIMESTAMP = 1778630400;
+export const COMP_START_TIMESTAMP = 1778700600;


### PR DESCRIPTION
## Summary

Two related changes bundled together so a single deploy aligns the UI with the campaign launch:

### 1. Leaderboard tagline + rules link (`app/leaderboard/page.tsx`)

The on-page tagline still said *"Agents ranked by the number of swaps they've done via aibtc mcp"*, which contradicts the actual ranking intent (Unrealized P&L USD + Volume, see [#815](https://github.com/aibtcdev/landing-page/issues/815) §5). New copy:

> Ranked by Unrealized P&L (USD) and Volume across allowlisted Bitflow swaps — trade better, not more. **Read the full rules →**

Link target: https://github.com/aibtcdev/landing-page/issues/815 (canonical rules doc).

`metadata.description` + OG description updated to match.

### 2. P&L tooltip: instant hover, cursor affordance, ultra-small values (`app/leaderboard/LeaderboardClient.tsx`)

- Replaced the native `title=` tooltip (which has a ~1s OS-level delay and is invisible on touch) with the existing `Tooltip` component. Portal-rendered, fires on `onMouseEnter` — instant, and survives table-cell clipping.
- Added `cursor-pointer` to the percentage span so the hover affordance is discoverable.
- Extended `formatUsdPrecise` so ultra-small P&L values render with enough decimals to show ~3 sig figs. Previously a value like `1.21e-8` rounded to `$0.000000`; now it renders as `$0.0000000121`.

Applies to both the desktop table cell and the mobile list cell.

### 3. Campaign start gate (`lib/competition/constants.ts`)

`COMP_START_TIMESTAMP` shifted from `2026-05-13T00:00:00Z` (`1778630400`) → `2026-05-13T19:30:00Z` (`1778700600`) to match the announced ~3h-from-now launch. Tests reference the constant symbolically, so no test changes required.

## Test plan

- [ ] Browser: leaderboard tagline renders, the **Read the full rules →** link opens issue #815 in a new tab.
- [ ] Hover the P&L percentage on desktop — tooltip with precise USD appears instantly, no native ~1s delay.
- [ ] Hover affordance: cursor changes to pointer over the percentage cell.
- [ ] Spot-check an agent whose P&L is tiny (e.g. < $0.0001) — tooltip shows the full magnitude rather than a rounded `$0.000000`.
- [ ] Mobile: P&L cell still renders cleanly; tooltip surfaces on tap/focus where supported.
- [ ] After deploy: submit a swap with `burn_block_time < 1778700600` via the catch-up cron and confirm it's rejected as `before_comp_start`; submit one at exactly the timestamp and confirm it's accepted (boundary).