### PR TITLE
fix(leaderboard): count scheduler-ingested competition trades

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -106,7 +106,9 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   //
   // `tx_status = 'success'` filter: only successful swaps move tokens.
   // Failed / aborted txs are recorded in the table for audit but shouldn't
-  // count toward volume or P&L.
+  // count toward volume or P&L. Keep the explicit source allowlist aligned
+  // with migrations/005_swaps.sql so future ingestion sources opt in here
+  // deliberately.
   let rows: LeaderboardJoinedRow[] = [];
   try {
     const sql = `

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -118,7 +118,8 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
              a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
       FROM swaps s
       LEFT JOIN agents a ON a.stx_address = s.sender
-      WHERE s.source = 'agent' AND s.tx_status = 'success'
+      WHERE s.tx_status = 'success'
+        AND s.source IN ('agent', 'cron', 'chainhook')
       GROUP BY s.sender, s.token_in, s.token_out
     `;
     const result = await db.prepare(sql).all<LeaderboardJoinedRow>();


### PR DESCRIPTION
## Summary

- updates the trading leaderboard aggregate query to include all valid ingestion sources: `agent`, `cron`, and future `chainhook`
- keeps the existing `tx_status = 'success'` filter so failed/aborted rows remain excluded from volume/P&L stats
- documents that the explicit source allowlist must stay aligned with `migrations/005_swaps.sql`

This aligns `/leaderboard` with the canonical rules in #815: agents can compete by submitting txids directly or by letting the SchedulerDO catch-up ingest their valid swaps.

## Test plan

- `npm test -- lib/competition/__tests__/scheduler.test.ts`
- PR preview deployed successfully via Cloudflare Workers

Note: the focused test exercises scheduler ingestion, not the leaderboard SQL directly. The query change is a surgical read-path fix; a dedicated aggregate regression test should be added when leaderboard aggregation is extracted into a shared/testable helper.