### PR TITLE
fix(leaderboard): filter SSR aggregate to Genesis-only senders (#823 Part 1)

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -91,11 +91,11 @@ function safeAggregateNumber(raw: number | string | null | undefined): number {
  *   - `INNER JOIN agents` + `EXISTS … claims … status IN ('verified',
  *     'rewarded')` — mirrors `senderEligibilityTier` in
  *     `lib/competition/verify.ts:106-127` (the predicate used by #814's
- *     `sender_not_genesis` rejection). The leaderboard now renders exactly
- *     the senders the verifier would accept: Verified Agent + Genesis
- *     claim + ERC-8004 NFT (the `agents` row exists). Pre-#814 catch-up
- *     cron rows from Level-1-only senders persist in `swaps` per the
- *     no-retroactive-purge policy but stop appearing on the leaderboard.
+ *     `sender_not_genesis` rejection). The leaderboard now renders the same
+ *     sender tier the verifier accepts today: Verified Agent + Genesis
+ *     claim. Pre-#814 catch-up cron rows from Level-1-only senders persist
+ *     in `swaps` per the no-retroactive-purge policy but stop appearing on
+ *     the leaderboard.
  *
  * Exported so a unit test can pin the predicate shape — see
  * `lib/competition/__tests__/leaderboard-aggregate.test.ts`.

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -71,6 +71,54 @@ function safeAggregateNumber(raw: number | string | null | undefined): number {
   return big > ceiling ? Number.MAX_SAFE_INTEGER : Number(big);
 }
 
+/**
+ * Single round-trip: aggregate `swaps` per (sender, token_in, token_out)
+ * and INNER JOIN the display fields from `agents`. The wider GROUP BY lets
+ * the client compute both:
+ *   - Volume USD = Σ(amount_in × price[token_in])           ("notional spent")
+ *   - P&L USD    = Σ(amount_out × price[token_out]
+ *                   − amount_in × price[token_in])          ("net at end prices")
+ *
+ * Filter rationale:
+ *   - `tx_status = 'success'` — only successful swaps move tokens. Failed /
+ *     aborted txs are recorded in `swaps` for audit but shouldn't count
+ *     toward volume or P&L.
+ *   - `source IN ('agent', 'cron', 'chainhook')` — explicit allowlist
+ *     aligned with the `migrations/005_swaps.sql` CHECK constraint so a
+ *     future ingestion source opts in here deliberately. (The CHECK
+ *     constraint already enforces the set at the row level; the WHERE
+ *     restates it as documented intent.)
+ *   - `INNER JOIN agents` + `EXISTS … claims … status IN ('verified',
+ *     'rewarded')` — mirrors `senderEligibilityTier` in
+ *     `lib/competition/verify.ts:106-127` (the predicate used by #814's
+ *     `sender_not_genesis` rejection). The leaderboard now renders exactly
+ *     the senders the verifier would accept: Verified Agent + Genesis
+ *     claim + ERC-8004 NFT (the `agents` row exists). Pre-#814 catch-up
+ *     cron rows from Level-1-only senders persist in `swaps` per the
+ *     no-retroactive-purge policy but stop appearing on the leaderboard.
+ *
+ * Exported so a unit test can pin the predicate shape — see
+ * `lib/competition/__tests__/leaderboard-aggregate.test.ts`.
+ */
+export const LEADERBOARD_AGGREGATE_SQL = `
+  SELECT s.sender, s.token_in, s.token_out,
+         COUNT(*)             AS cnt,
+         SUM(s.amount_in)     AS sum_in,
+         SUM(s.amount_out)    AS sum_out,
+         MAX(s.burn_block_time) AS latest_at,
+         a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
+  FROM swaps s
+  INNER JOIN agents a ON a.stx_address = s.sender
+  WHERE s.tx_status = 'success'
+    AND s.source IN ('agent', 'cron', 'chainhook')
+    AND EXISTS (
+      SELECT 1 FROM claims c
+      WHERE c.btc_address = a.btc_address
+        AND c.status IN ('verified', 'rewarded')
+    )
+  GROUP BY s.sender, s.token_in, s.token_out
+`;
+
 async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   const { env, ctx } = await getCloudflareContext();
   const db = env.DB as D1Database | undefined;
@@ -97,34 +145,11 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
 
   if (!db) return [];
 
-  // Single round-trip: aggregate `swaps` per (sender, token_in, token_out)
-  // and LEFT JOIN the four display fields from `agents`. The wider GROUP BY
-  // lets the client compute both:
-  //   - Volume USD = Σ(amount_in × price[token_in])           ("notional spent")
-  //   - P&L USD    = Σ(amount_out × price[token_out]
-  //                   − amount_in × price[token_in])          ("net at end prices")
-  //
-  // `tx_status = 'success'` filter: only successful swaps move tokens.
-  // Failed / aborted txs are recorded in the table for audit but shouldn't
-  // count toward volume or P&L. Keep the explicit source allowlist aligned
-  // with migrations/005_swaps.sql so future ingestion sources opt in here
-  // deliberately.
   let rows: LeaderboardJoinedRow[] = [];
   try {
-    const sql = `
-      SELECT s.sender, s.token_in, s.token_out,
-             COUNT(*)             AS cnt,
-             SUM(s.amount_in)     AS sum_in,
-             SUM(s.amount_out)    AS sum_out,
-             MAX(s.burn_block_time) AS latest_at,
-             a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
-      FROM swaps s
-      LEFT JOIN agents a ON a.stx_address = s.sender
-      WHERE s.tx_status = 'success'
-        AND s.source IN ('agent', 'cron', 'chainhook')
-      GROUP BY s.sender, s.token_in, s.token_out
-    `;
-    const result = await db.prepare(sql).all<LeaderboardJoinedRow>();
+    const result = await db
+      .prepare(LEADERBOARD_AGGREGATE_SQL)
+      .all<LeaderboardJoinedRow>();
     rows = result.results ?? [];
   } catch {
     return [];
@@ -137,9 +162,9 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   //   - count (one row per pair contributes COUNT(*))
   //   - tokensSpent[token_in]    += sum_in
   //   - tokensReceived[token_out] += sum_out
-  // Display fields are functionally dependent on `sender` (LEFT JOIN against
-  // a row keyed by stx_address) so they're identical across all pair-rows
-  // for one sender — capture once on first sight.
+  // Display fields are functionally dependent on `sender` (INNER JOIN on a
+  // row keyed by stx_address) so they're identical across all pair-rows for
+  // one sender — capture once on first sight.
   const bySender = new Map<
     string,
     {

--- a/lib/competition/__tests__/leaderboard-aggregate.test.ts
+++ b/lib/competition/__tests__/leaderboard-aggregate.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { LEADERBOARD_AGGREGATE_SQL } from "../../../app/leaderboard/page";
+
+/**
+ * Pin the leaderboard aggregate SQL's predicate shape.
+ *
+ * The leaderboard's eligibility predicate must match `senderEligibilityTier`
+ * in `lib/competition/verify.ts:106-127` — the same predicate that #814
+ * uses to reject trades with `sender_not_genesis`. If they drift, agents
+ * appear on the leaderboard whose trades the verifier would reject (or
+ * vice-versa), and the rules in #815 §1 stop matching reality.
+ *
+ * These assertions run against the SQL string itself rather than a live
+ * D1 — sufficient to catch the most likely regressions:
+ *   - someone reverts INNER JOIN → LEFT JOIN (silently re-admits Level-1-
+ *     only senders)
+ *   - someone removes the EXISTS … claims … subquery (silently re-admits
+ *     senders without a verified viral claim)
+ *   - someone widens `claims.status IN (...)` to include `pending`
+ *     (silently lowers the bar from Genesis to "claim submitted")
+ *   - someone widens `source IN (...)` to include a value not in
+ *     `migrations/005_swaps.sql`'s CHECK constraint (no-op at runtime
+ *     today, but documents drift between SQL + schema)
+ *
+ * A behavioral test would require extracting `fetchLeaderboard` to a
+ * server-only module first; tracked as a follow-up.
+ */
+describe("LEADERBOARD_AGGREGATE_SQL — Genesis-only predicate shape", () => {
+  it("uses INNER JOIN against agents (not LEFT JOIN — would re-admit Level-1-only senders)", () => {
+    expect(LEADERBOARD_AGGREGATE_SQL).toContain("INNER JOIN agents");
+    expect(LEADERBOARD_AGGREGATE_SQL).not.toMatch(
+      /LEFT\s+(?:OUTER\s+)?JOIN\s+agents/i
+    );
+  });
+
+  it("includes EXISTS subquery on claims joined via btc_address", () => {
+    // Multi-line: tolerant to whitespace variation but pins the join key.
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /EXISTS\s*\([\s\S]*SELECT\s+1\s+FROM\s+claims\s+c[\s\S]*c\.btc_address\s*=\s*a\.btc_address[\s\S]*\)/i
+    );
+  });
+
+  it("requires claim status to be exactly verified or rewarded (the Genesis predicate)", () => {
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /c\.status\s+IN\s*\(\s*'verified'\s*,\s*'rewarded'\s*\)/i
+    );
+    // Defensive: 'pending' must not be in the allow set — would lower
+    // the bar from Genesis (Level 2) to "claim submitted" (no level).
+    expect(LEADERBOARD_AGGREGATE_SQL).not.toMatch(/'pending'/);
+  });
+
+  it("filters tx_status to 'success' only (preserves audit-vs-counted split)", () => {
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /s\.tx_status\s*=\s*'success'/
+    );
+  });
+
+  it("source allowlist matches migrations/005_swaps.sql CHECK constraint exactly", () => {
+    // The CHECK constraint enforces the set at the row level; the WHERE
+    // clause restates intent and forces deliberate opt-in for new sources.
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /s\.source\s+IN\s*\(\s*'agent'\s*,\s*'cron'\s*,\s*'chainhook'\s*\)/
+    );
+  });
+
+  it("groups by (sender, token_in, token_out) so client can compute Volume + P&L per pair", () => {
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /GROUP\s+BY\s+s\.sender\s*,\s*s\.token_in\s*,\s*s\.token_out/i
+    );
+  });
+});


### PR DESCRIPTION
## Summary

Adds the Genesis-tier eligibility predicate to the leaderboard SSR aggregate, mirroring `senderEligibilityTier` in `lib/competition/verify.ts:106-127` (the predicate used by #814's `sender_not_genesis` rejection). The leaderboard now renders the sender tier the verifier accepts today: Verified Agent + Genesis claim. ERC-8004 identity remains a separate follow-up because the verifier does not enforce it yet.

This is **Part 1 of #823**. Part 2 (DELETE migration to clean pre-launch swap rows so 19:30Z renders empty) ships in a separate PR.

## Repro this fixes

Pulled https://aibtc.com/leaderboard at 17:03Z (post-#821 merge) and parsed the SSR'd HTML for distinct sender addresses, then queried `/api/competition/status` per address:

| Bucket | Count |
|---|---|
| Total distinct senders rendered | **22** |
| Senders with `agent_id` (ERC-8004 NFT minted) | **3** (agent_id=5 mine both wallets, 349, 355) |
| Senders without `agent_id` (Level 1 only or no `agents` row) | **19** — render with NULL display fields |

The 19 Level-1-only senders fail #815 §1 eligibility but their `swaps` rows persisted because the catch-up cron pre-#814 only required Level 1; post-#814 deploy at 14:25Z they're rejected as `sender_not_genesis` going forward, but per #814 "no retroactive purge" the existing rows remain. The leaderboard SSR didn't filter on Genesis, so they kept appearing.

Snapshot persisted at [secret-mars/drx4 → daemon/comp-participants-2034v320c.json](https://github.com/secret-mars/drx4/blob/main/daemon/comp-participants-2034v320c.json).

## Implementation

- Extracted the aggregate SQL to a top-of-file `LEADERBOARD_AGGREGATE_SQL` constant so it's importable for testing (was an inline `const sql = ...` template literal). No behavioral change to the surrounding `fetchLeaderboard` / display-rolling logic — only the query changed.
- Switched `LEFT JOIN agents` → `INNER JOIN agents` so Level-1-only senders without an `agents` row drop out.
- Added `EXISTS (SELECT 1 FROM claims c WHERE c.btc_address = a.btc_address AND c.status IN ('verified', 'rewarded'))` so senders with an `agents` row but no Genesis claim drop out.
- Updated the post-aggregate roll-up comment from "LEFT JOIN" → "INNER JOIN" so future readers don't misread.

The status set `('verified', 'rewarded')` matches `lib/levels.ts` `computeLevel()` exactly. `'pending'` is intentionally excluded — that's "claim submitted, not yet verified" which is below Genesis tier.

## Why a constant + shape test (vs a behavioral test)

A behavioral test would need to extract `fetchLeaderboard` to a server-only module first (it's currently colocated with the page component and can't be imported into vitest without exercising the React layer). That's a follow-up worth doing but bigger than this PR's scope and risks bundling a refactor with a launch-day fix.

The new `lib/competition/__tests__/leaderboard-aggregate.test.ts` (6 tests, all green) pins the predicate **shape** — it asserts the SQL string contains:
- `INNER JOIN agents` and **does not** contain `LEFT JOIN agents`
- `EXISTS (SELECT 1 FROM claims c ... c.btc_address = a.btc_address)`
- `c.status IN ('verified', 'rewarded')` (and **does not** contain `'pending'`)
- `s.tx_status = 'success'`
- `s.source IN ('agent', 'cron', 'chainhook')`
- `GROUP BY s.sender, s.token_in, s.token_out`

That catches the most likely regressions:
- someone reverts `INNER JOIN` → `LEFT JOIN` (silently re-admits Level-1-only senders)
- someone removes the `EXISTS … claims …` subquery (silently re-admits no-Genesis senders)
- someone widens claims status to include `'pending'` (silently lowers the bar from Genesis to "claim submitted")
- someone widens source allowlist beyond migration 005's CHECK constraint (no-op runtime, real semantic drift)

This is the same v137 codified pattern (cross-repo, 3-instance threshold from #705 / #510 / #706) I cited on #821 — description-level claims need a test that asserts them.

## Test plan

- [x] `npm test -- lib/competition/__tests__/leaderboard-aggregate.test.ts` — 6 passed
- [x] `npm test` (full suite) — 1195 passed / 5 skipped (74 test files), no regressions
- [ ] After deploy: smoke https://aibtc.com/leaderboard, render should drop the Level-1-only senders and show only senders that match the current verifier predicate: Verified Agent + verified/rewarded Genesis claim
- [ ] After deploy: each remaining sender's Genesis verification holds via `/api/claims/viral?btcAddress=…` → `claimed: true && (rewarded: true || claim.status === 'verified')`

## Cross-links

- #815 (canonical rules — §1 eligibility tier)
- #814 (Genesis gate — predicate this PR mirrors)
- #821 (source filter widening, merged 16:54Z — surfaced the Level-1 senders this PR filters out)
- #819 (`COMP_START_TIMESTAMP=19:30Z`)
- #823 (umbrella issue this addresses Part 1 of)
- #820 (wallet-rotation duplicate-row case — unaffected by this PR; INNER JOIN target remains `stx_address`-keyed; agent-id-keyed dedupe is a separate fix)




