### PR TITLE
feat(competition): clean pre-launch swaps so 19:30Z renders empty (#823 Part 2)

### DIFF
--- a/migrations/011_competition_clean_pre_launch.sql
+++ b/migrations/011_competition_clean_pre_launch.sql
@@ -1,0 +1,44 @@
+-- Migration 011: Clean pre-launch swaps so 19:30Z renders empty.
+--
+-- The trading competition campaign starts at COMP_START_TIMESTAMP = 1778700600
+-- (2026-05-13T19:30:00Z), defined in `lib/competition/constants.ts:16`.
+--
+-- Going forward the verifier rejects any swap with `burn_block_time <
+-- COMP_START_TIMESTAMP` as `before_comp_start` (`lib/competition/verify.ts:
+-- 318-323`). However, `swaps` already contains pre-launch rows ingested by
+-- the catch-up cron during the development window, including:
+--
+--   - rows from Level-1-only senders that pre-date #814's Genesis gate
+--     (deployed 2026-05-13T14:25Z) and were preserved by the
+--     no-retroactive-purge policy
+--   - rows from Genesis-tier senders' development-period trades that the
+--     campaign should not retroactively count
+--
+-- Per #823 Part 2: clean these so the leaderboard renders empty at
+-- COMP_START_TIMESTAMP and accumulates only fresh post-launch trades.
+--
+-- The DELETE preserves rows whose `burn_block_time >= COMP_START_TIMESTAMP`
+-- as a safety boundary against accidentally cleaning a row that landed
+-- exactly at start (matches the `>=` boundary in `verify.ts:318` and the
+-- vitest "boundary accepted" assertion at `verify.test.ts:268-275`).
+--
+-- This migration is **forward-only**. There is no rollback for deleted
+-- audit rows. Any pre-launch swap data that downstream consumers want to
+-- retain (e.g. per-agent trade-history endpoints, debugging) must be
+-- exported BEFORE this migration runs. Same trade-off as #818's "no
+-- retroactive purge" choice, inverted — here we explicitly purge so the
+-- competition window is the canonical scoring window from launch.
+--
+-- Idempotent: re-running on an already-clean table is a no-op DELETE.
+--
+-- References:
+--   - #823 Part 2 (this migration)
+--   - #815 §6 (frozen-snapshot scoring at campaign close)
+--   - #819 (set COMP_START_TIMESTAMP = 19:30Z, merged 2026-05-13T16:33Z)
+--   - #814 (Genesis gate, merged 2026-05-13T14:25Z)
+--   - #821 (source filter widening, merged 2026-05-13T16:54Z — surfaced
+--     the pre-launch rows on the leaderboard)
+--   - secret-mars/drx4 → daemon/comp-participants-2034v320c.json (snapshot
+--     showing 22 distinct senders with pre-launch trades, 17:03Z)
+
+DELETE FROM swaps WHERE burn_block_time < 1778700600;


### PR DESCRIPTION
## Summary

D1 migration that DELETEs all `swaps` rows with `burn_block_time < COMP_START_TIMESTAMP` (1778700600 = 2026-05-13T19:30:00Z, set by #819). Pairs with #824 (SSR Genesis filter) for full launch readiness — together they ensure the leaderboard renders empty at deploy through 19:30Z and accumulates only fresh post-launch trades from Genesis-tier senders.

## Why a DELETE migration (vs a WHERE filter)

Originally proposed Option Y (filter at SSR) on the parent issue, but @biwasxyz clarified on Telegram that the intent is to remove the data entirely so it disappears from `/api/competition/trades?address=…` per-agent history as well as from the leaderboard. This is the cleaner end-to-end option for "fresh launch":

| Approach | Leaderboard empty? | Per-agent history empty? | Reversible? |
|---|---|---|---|
| Option Y — SSR/client WHERE filter | ✅ | ❌ (rows still in `swaps`) | ✅ (just remove the WHERE) |
| **Option X — DELETE migration (this PR)** | **✅** | **✅** | **❌** |

Trade-off: forward-only. Any pre-launch data that downstream consumers want to retain must be exported BEFORE this migration runs. Same shape as #818's "no retroactive purge" choice, inverted.

## What gets deleted

Per snapshot at 17:03Z (post-#821 merge), `swaps` contains pre-launch rows from ~22 distinct senders, including:
- 19 Level-1-only senders that pre-date #814's Genesis gate (deployed 14:25Z) and were preserved by the no-retroactive-purge policy
- 3 Genesis-tier senders (agent_id=5/me + 349 + 355) with development-period trades the campaign shouldn't retroactively count

All have `burn_block_time` strictly less than 1778700600. Snapshot persisted at [secret-mars/drx4 → daemon/comp-participants-2034v320c.json](https://github.com/secret-mars/drx4/blob/main/daemon/comp-participants-2034v320c.json).

## Boundary semantics

Rows where `burn_block_time = 1778700600` exactly are **preserved** (the migration uses `<`, not `<=`). This matches:
- `lib/competition/verify.ts:318` (`if (txBurnTime < COMP_START_TIMESTAMP)` — rejection on `<`, acceptance on `>=`)
- Vitest assertion `verify.test.ts:268-275` ("accepts a tx whose burn_block_time equals COMP_START_TIMESTAMP exactly (boundary)")

## Idempotency

Re-running this migration on an already-clean table is a no-op DELETE — important because Wrangler's migration apply is at-least-once on retry.

Sanity-tested in sqlite locally:
```
before: [('a', 1778600000), ('b', 1778700600), ('c', 1778800000)]
after:  [('b', 1778700600), ('c', 1778800000)]
after re-run: same  # idempotent
```

## What this does NOT do

- Does not change the ingestion path. The verifier still rejects new pre-launch txids as `before_comp_start`. The catch-up cron still walks `registered_wallets` every ~15 min — but pre-19:30Z swaps it might find get rejected at insert time per existing logic.
- Does not affect agents/claims/inbox/vouches/balances tables. Competition-relevant only.
- Does not retroactively purge swaps that confirm AFTER `COMP_START_TIMESTAMP` (those are valid campaign trades).

## Test plan

- [x] Sanity sqlite test (above): pre-launch rows deleted, boundary row preserved, idempotent on re-run
- [x] Full vitest suite green: 1189 passed / 5 skipped (73 test files), no regressions (no .ts touched, only the migration file)
- [ ] After preview deploy: `wrangler d1 migrations apply landing-page --remote --env preview` succeeds; `wrangler d1 execute landing-page --remote --env preview --command "SELECT COUNT(*) FROM swaps WHERE burn_block_time < 1778700600"` returns 0
- [ ] After preview deploy: leaderboard SSR returns 0 rows (combined with #824)
- [ ] After production deploy at/before 19:30Z: same checks against `--env production`

## Cross-links

- #815 (canonical rules — §6 frozen-snapshot scoring at campaign close)
- #819 (set `COMP_START_TIMESTAMP` = 19:30Z, merged 16:33Z)
- #814 (Genesis gate, merged 14:25Z)
- #821 (source filter widening, merged 16:54Z — surfaced the pre-launch rows on the leaderboard)
- #823 (umbrella issue this addresses Part 2 of)
- #824 (Part 1 SSR Genesis filter — pair this PR with that one for full launch readiness)