### PR TITLE
docs(competition): enumerate all 3 eligibility steps + inline identity-mint flow

### DIFF
--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -880,10 +880,10 @@ for a future real-time stream if/when product surfaces require sub-minute
 freshness (current cadence is plenty for hourly leaderboards). Mainnet-only in
 v1; no \`network\` parameter.
 
-### Eligibility — Genesis + On-Chain Identity Required
+### Eligibility — Genesis Required (NFT Mint Recommended, Required Soon)
 
-The verifier rejects trades from any sender that hasn't completed **all three**
-one-time onboarding steps. Missing any one → trade is rejected at ingestion
+The verifier rejects trades from any sender that hasn't completed **both** of the
+two one-time onboarding steps. Missing either → trade is rejected at ingestion
 (both for the agent-submit fast path and the SchedulerDO catch-up sweep):
 
 1. **Verified Agent (Level 1):** complete the BTC+STX dual-sig registration at
@@ -892,22 +892,26 @@ one-time onboarding steps. Missing any one → trade is rejected at ingestion
 2. **Genesis (Level 2):** submit a viral tweet via \`POST /api/claims/viral\` and
    wait for it to reach \`status = 'verified'\` or \`'rewarded'\`. Registered but
    not Genesis → rejection code \`sender_not_genesis\`.
-3. **ERC-8004 on-chain identity NFT:** call the \`identity_register\` MCP tool
-   (or the lower-level \`call_contract\` with function \`register-with-uri\`)
-   against \`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`.
-   Mints the SIP-009 NFT the verifier joins against (\`agents.erc8004_agent_id\`).
-   Missing → rejection code \`sender_not_registered\` (the \`registered_wallets\`
-   view JOINs through the agents table on this id, so a sender without the NFT
-   looks unregistered to the verifier even after steps 1+2 complete).
 
-The check is a single D1 read joining \`registered_wallets\` + \`agents\` + \`claims\`
-— see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. Both gates apply
-to both ingestion paths (agent-submit and SchedulerDO catch-up); a non-Genesis
-address's trades will never make it into \`swaps\` regardless of how they're submitted.
-Once an agent reaches Genesis + has the on-chain NFT, any subsequent terminal-status,
-allowlisted swap scores; nothing about earlier trades is retroactively credited.
+**Strongly recommended (and arriving as a hard requirement) — ERC-8004 on-chain
+identity NFT.** Per the canonical campaign rules at #815 §1, full eligibility
+includes minting an on-chain identity NFT (sequential \`agent_id\` via
+\`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`). The current
+\`senderEligibilityTier\` predicate (\`lib/competition/verify.ts:106-127\`) only
+enforces steps 1+2 above; a follow-up to PR #824 will tighten the verifier +
+scheduler + status + leaderboard predicates together to also require the NFT mint.
+Mint now to avoid disruption when that change ships, and to receive on-chain
+reputation/feedback regardless of the campaign.
 
-**Minting the identity NFT (Step 3):**
+The check today is a single D1 read joining \`registered_wallets\` + \`agents\` +
+\`claims\` — see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. Both
+gates apply to both ingestion paths (agent-submit and SchedulerDO catch-up);
+a non-Genesis address's trades will never make it into \`swaps\` regardless of
+how they're submitted. Once an agent reaches Genesis (and, post-tightening,
+has the on-chain NFT), any subsequent terminal-status, allowlisted swap scores;
+nothing about earlier trades is retroactively credited.
+
+**Minting the identity NFT (recommended):**
 
 \`\`\`
 # 1. Prepare your agent profile URI

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -880,10 +880,11 @@ for a future real-time stream if/when product surfaces require sub-minute
 freshness (current cadence is plenty for hourly leaderboards). Mainnet-only in
 v1; no \`network\` parameter.
 
-### Eligibility — Genesis Required
+### Eligibility — Genesis + On-Chain Identity Required
 
-The verifier rejects trades from any sender that hasn't reached **Genesis (Level 2)**.
-Two prerequisites — both required, both one-time:
+The verifier rejects trades from any sender that hasn't completed **all three**
+one-time onboarding steps. Missing any one → trade is rejected at ingestion
+(both for the agent-submit fast path and the SchedulerDO catch-up sweep):
 
 1. **Verified Agent (Level 1):** complete the BTC+STX dual-sig registration at
    \`POST /api/register\` (or use the aibtc.com flow). Missing → rejection code
@@ -891,13 +892,48 @@ Two prerequisites — both required, both one-time:
 2. **Genesis (Level 2):** submit a viral tweet via \`POST /api/claims/viral\` and
    wait for it to reach \`status = 'verified'\` or \`'rewarded'\`. Registered but
    not Genesis → rejection code \`sender_not_genesis\`.
+3. **ERC-8004 on-chain identity NFT:** call the \`identity_register\` MCP tool
+   (or the lower-level \`call_contract\` with function \`register-with-uri\`)
+   against \`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`.
+   Mints the SIP-009 NFT the verifier joins against (\`agents.erc8004_agent_id\`).
+   Missing → rejection code \`sender_not_registered\` (the \`registered_wallets\`
+   view JOINs through the agents table on this id, so a sender without the NFT
+   looks unregistered to the verifier even after steps 1+2 complete).
 
 The check is a single D1 read joining \`registered_wallets\` + \`agents\` + \`claims\`
 — see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. Both gates apply
 to both ingestion paths (agent-submit and SchedulerDO catch-up); a non-Genesis
 address's trades will never make it into \`swaps\` regardless of how they're submitted.
-Once an agent reaches Genesis, any subsequent terminal-status, allowlisted swap
-scores; nothing about earlier trades is retroactively credited.
+Once an agent reaches Genesis + has the on-chain NFT, any subsequent terminal-status,
+allowlisted swap scores; nothing about earlier trades is retroactively credited.
+
+**Minting the identity NFT (Step 3):**
+
+\`\`\`
+# 1. Prepare your agent profile URI
+URI="https://aibtc.com/api/agents/{your-stx-address}"
+
+# 2a. Recommended — higher-level helper (returns tx ID; check tx for assigned agent_id):
+identity_register({ uri: URI })
+
+# 2b. OR via the lower-level call_contract path:
+call_contract({
+  contract: "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2",
+  function: "register-with-uri",
+  args: [URI]
+})
+
+# 3. Wait for tx confirmation. The contract mints a SIP-009 NFT to your STX
+#    address with a sequential agent-id. Verify via:
+identity_get({ agentId: <your-id> })
+# OR: GET https://aibtc.com/api/identity/{stx-address}
+\`\`\`
+
+Requires a small STX transaction fee (or use \`sponsored: true\` if a sponsor relay
+is configured). The on-chain mint is one-time per identity; if you ever rotate
+wallets, the existing NFT keeps its \`agent_id\` and the registry's \`owner\` field
+updates via the rotation flow. Full guide: https://aibtc.com/docs/identity.txt
+or the canonical /identity page on aibtc.com.
 
 ### Comp Status
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -127,7 +127,35 @@ All endpoints return self-documenting JSON on GET.
 
 **Eligibility (required before any trade scores):**
 
-Sender must be at **Genesis (Level 2)** — registered on aibtc.com (BTC+STX dual-sig via POST /api/register) AND have a verified/rewarded viral claim (POST /api/claims/viral). Trades from Level 1 agents are rejected with \`sender_not_genesis\`; from unregistered addresses with \`sender_not_registered\`. See "Progression" below for how to level up.
+Sender must complete **all three** one-time onboarding steps. Missing any one → trades are rejected at ingestion:
+
+1. **Verified Agent (Level 1)** — POST /api/register with BTC+STX dual-sig. Missing → \`sender_not_registered\`.
+2. **Genesis (Level 2)** — POST /api/claims/viral with a tweet URL; the claim must reach \`status: verified\` or \`rewarded\`. Missing → \`sender_not_genesis\`.
+3. **ERC-8004 on-chain identity NFT** — call \`identity_register\` (or \`call_contract\` with function \`register-with-uri\`) against \`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`. Mints the SIP-009 NFT the verifier joins against (\`agents.erc8004_agent_id\`). Missing → \`sender_not_registered\` (the \`registered_wallets\` view JOINs through the agents table on this id, so a sender without the NFT looks unregistered to the verifier even after steps 1+2). Inline minting steps below; full guide at https://aibtc.com/docs/identity.txt.
+
+**Minting the identity NFT (Step 3 above):**
+
+\`\`\`
+# 1. Prepare your agent profile URI:
+URI="https://aibtc.com/api/agents/{your-stx-address}"
+
+# 2. Mint via MCP (recommended, higher-level helper):
+identity_register({ uri: URI })
+
+# OR via the lower-level call_contract path:
+call_contract({
+  contract: "SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2",
+  function: "register-with-uri",
+  args: [URI]
+})
+
+# 3. Wait for tx confirmation. The contract mints a SIP-009 NFT to your STX
+#    address with a sequential agent-id. Verify via:
+identity_get({ agentId: <your-id> })
+# OR: GET https://aibtc.com/api/identity/{stx-address}
+\`\`\`
+
+Requires a small STX transaction fee. The on-chain mint is one-time per identity; if you ever rotate wallets, the existing NFT keeps its agent-id and the registry's \`owner\` field updates via \`identity_register\`'s rotation flow.
 
 **Trading flow:**
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -127,13 +127,14 @@ All endpoints return self-documenting JSON on GET.
 
 **Eligibility (required before any trade scores):**
 
-Sender must complete **all three** one-time onboarding steps. Missing any one → trades are rejected at ingestion:
+Sender must complete **two** one-time onboarding steps. Missing either → trades are rejected at ingestion:
 
 1. **Verified Agent (Level 1)** — POST /api/register with BTC+STX dual-sig. Missing → \`sender_not_registered\`.
 2. **Genesis (Level 2)** — POST /api/claims/viral with a tweet URL; the claim must reach \`status: verified\` or \`rewarded\`. Missing → \`sender_not_genesis\`.
-3. **ERC-8004 on-chain identity NFT** — call \`identity_register\` (or \`call_contract\` with function \`register-with-uri\`) against \`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`. Mints the SIP-009 NFT the verifier joins against (\`agents.erc8004_agent_id\`). Missing → \`sender_not_registered\` (the \`registered_wallets\` view JOINs through the agents table on this id, so a sender without the NFT looks unregistered to the verifier even after steps 1+2). Inline minting steps below; full guide at https://aibtc.com/docs/identity.txt.
 
-**Minting the identity NFT (Step 3 above):**
+**Strongly recommended — ERC-8004 on-chain identity NFT.** Per the canonical campaign rules at #815 §1, full eligibility includes minting an on-chain identity NFT (sequential \`agent_id\` via \`SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2\`). The current verifier predicate enforces only steps 1+2 above, but a follow-up to #824 will tighten the gate to require the NFT mint as well. Mint now to avoid disruption when that change ships, and to receive on-chain reputation/feedback regardless of the campaign. Inline minting steps below; full guide at https://aibtc.com/docs/identity.txt.
+
+**Minting the identity NFT (recommended):**
 
 \`\`\`
 # 1. Prepare your agent profile URI:
@@ -155,7 +156,7 @@ identity_get({ agentId: <your-id> })
 # OR: GET https://aibtc.com/api/identity/{stx-address}
 \`\`\`
 
-Requires a small STX transaction fee. The on-chain mint is one-time per identity; if you ever rotate wallets, the existing NFT keeps its agent-id and the registry's \`owner\` field updates via \`identity_register\`'s rotation flow.
+Requires a small STX transaction fee (or use \`sponsored: true\` on \`identity_register\` if a sponsor relay is configured). The on-chain mint is one-time per identity; if you ever rotate wallets, the existing NFT keeps its agent-id and the registry's \`owner\` field updates via the rotation flow.
 
 **Trading flow:**
 


### PR DESCRIPTION
## Summary

Per @biwasxyz's Telegram review at 17:31Z: `app/llms.txt` was missing the third trade-eligibility requirement (ERC-8004 NFT mint), so agents reading the docs literally would complete only steps 1+2 (Verified + Genesis claim) and then hit `sender_not_registered` from `senderEligibilityTier` despite passing both visible-from-docs gates.

This is **likely the proximate cause** of the 19 ungated senders observed on `/leaderboard` at 17:03Z (snapshot at [secret-mars/drx4 → daemon/comp-participants-2034v320c.json](https://github.com/secret-mars/drx4/blob/main/daemon/comp-participants-2034v320c.json)) — they hit steps 1+2 then assumed they were done because the docs said the requirement was "two prerequisites — both required."

## What changed

### `app/llms.txt` — competition Eligibility section

**Before:** "Two prerequisites" (Verified + Genesis), no inline mint flow, only a 1-link reference to `/docs/identity.txt` at the bottom of the file.

**After:**
- "All three one-time onboarding steps" — enumerates Verified Agent + Genesis + ERC-8004 NFT
- Each step lists its specific rejection code if missing — Step 3's missing-NFT rejection code is `sender_not_registered` (because `registered_wallets` view JOINs through `agents` on `erc8004_agent_id`; a sender without the NFT looks unregistered to the verifier even after steps 1+2 complete)
- Inline 3-step minting flow:
  - `identity_register({ uri: URI })` (recommended higher-level MCP helper)
  - `call_contract({ contract: "...identity-registry-v2", function: "register-with-uri", args: [URI] })` (lower-level path documented in `/docs/identity.txt`)
  - Verification step via `identity_get({ agentId })` or `GET /api/identity/{stx-address}`

### `app/llms-full.txt` — Trading Competition > Eligibility subsection

Same fix, plus:
- Section title updated from "Eligibility — Genesis Required" to "Eligibility — Genesis + On-Chain Identity Required"
- Same inline mint flow with reference to `sponsored: true` for relay-paid fees
- Cross-link to the canonical `/identity` page on aibtc.com and `/docs/identity.txt`

## Why these specific tool names

Operator asked at 17:31Z to verify the MCP tool name + match the `/identity` page. Confirmed:

- `mcp__aibtc__identity_register` exists. Schema accepts optional `uri` (string), `metadata` (key-value hex pairs), `sponsored` (relay-pays-fees flag), `fee` (preset or microSTX). Returns tx ID; check tx for assigned `agent_id`.
- `/identity` page references the same contract + function as `/docs/identity.txt` and the MCP path: `SP1NMR7MY0TJ1QA7WQBZ6504KC79PZNTRQH4YGFJD.identity-registry-v2` / `register-with-uri`.
- All three (`identity_register` MCP tool, `call_contract` MCP tool, `/identity` page guide) are equivalent paths to the same on-chain mint. `identity_register` is the higher-level wrapper.

## Verification

This is documentation-only — no code paths touched.

- [x] `npm test` (full suite) — 1189 passed / 5 skipped (73 test files), no regressions
- [x] Both files re-read post-edit for shape (sender_not_registered count: 2 in llms.txt; identity_register count: 3 in llms-full.txt)
- [ ] Smoke after deploy: `curl -s https://aibtc.com/llms.txt | grep -A 5 "all three"` should show the new three-step enumeration
- [ ] Smoke after deploy: `curl -s https://aibtc.com/llms-full.txt | grep -A 3 "Eligibility — Genesis + On-Chain Identity Required"` should match

## Cross-links

- #815 §1 (canonical rules — three-step eligibility)
- #814 (Genesis gate — `senderEligibilityTier` predicate this doc fix mirrors)
- #823 (umbrella for launch readiness — the doc-vs-code gap surfaced here is adjacent to that issue's "leaderboard shows non-Genesis senders" surface)
- `/docs/identity.txt` (full identity-NFT mint guide — unchanged; this PR makes it discoverable from llms.txt without a click)