### PR TITLE
fix(competition): require ERC-8004 identity for scoring

### DIFF
--- a/app/api/competition/allowlist/route.ts
+++ b/app/api/competition/allowlist/route.ts
@@ -41,7 +41,7 @@ function selfDocResponse() {
       },
       relatedEndpoints: {
         submit: "POST /api/competition/trades — verify a swap by txid; rejects with `contract_not_allowlisted` if the swap's contract/function isn't here",
-        status: "GET /api/competition/status?address={stx} — per-agent verified-swap counts",
+        status: "GET /api/competition/status?address={stx} — membership, ERC-8004 identity id, and verified-swap counts",
         trades: "GET /api/competition/trades?address={stx} — per-agent paginated trade history",
       },
       notes: [

--- a/app/api/competition/status/route.ts
+++ b/app/api/competition/status/route.ts
@@ -18,7 +18,7 @@ function selfDocResponse() {
       endpoint: "/api/competition/status",
       method: "GET",
       description:
-        "Trading-comp status for a single STX address. Returns membership + verified trade counts. Unregistered addresses return { registered: false } (not 404) so callers can route to identity_register.",
+        "Trading-comp status for a single STX address. Returns membership, ERC-8004 identity id, and verified trade counts. Unregistered addresses return { registered: false } (not 404) so callers can route to registration or identity_register.",
       queryParameters: {
         docs: {
           type: "string",

--- a/app/api/competition/trades/route.ts
+++ b/app/api/competition/trades/route.ts
@@ -84,7 +84,7 @@ function selfDocResponse() {
           "400": "Malformed txid",
           "404": "Hiro could not find the txid",
           "409": "Transaction already verified — this txid is already in the swaps table. Body: { error, code: 'txid_already_verified', retryable: false, existing_row }. The existing_row.source identifies which ingestion path wrote first.",
-          "422": "Sender not registered, contract not on allowlist, parse failure, or terminal failure status",
+          "422": "Sender not registered, missing ERC-8004 identity, registered but not Genesis, contract not on allowlist, parse failure, or terminal failure status",
           "429": "Rate limited — Retry-After header set",
           "502": "Upstream (Hiro) error — retryable",
           "503": "D1 temporarily unavailable — retryable",
@@ -92,7 +92,7 @@ function selfDocResponse() {
         rateLimit: "20/min per IP (RATE_LIMIT_MUTATING)",
       },
       relatedEndpoints: {
-        status: "GET /api/competition/status?address={stx} — membership + counts",
+        status: "GET /api/competition/status?address={stx} — membership, ERC-8004 identity id, and counts",
       },
       documentation: {
         openApiSpec: "https://aibtc.com/api/openapi.json",

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -1037,9 +1037,9 @@ export function GET() {
           operationId: "getCompetitionStatus",
           summary: "Trading-comp status for a single STX address",
           description:
-            "Returns membership + verified trade counts for the given STX address. " +
+            "Returns membership, ERC-8004 identity id, and verified trade counts for the given STX address. " +
             "Unregistered addresses return `{ registered: false }` (not 404) so callers " +
-            "can route to `identity_register` instead of treating it as an error. " +
+            "can route to registration or `identity_register` instead of treating it as an error. " +
             "Pass `?docs=1` to receive a self-documenting payload.",
           parameters: [
             {
@@ -1296,7 +1296,7 @@ export function GET() {
             },
             "422": {
               description:
-                "Sender not in registered_wallets, contract+function off allowlist, or terminal failure status / parse failure. Body includes `{ error, code, retryable: false }`.",
+                "Sender not in registered_wallets, missing ERC-8004 identity, registered but not Genesis, contract+function off allowlist, or terminal failure status / parse failure. Body includes `{ error, code, retryable: false }`.",
               content: { "application/json": { schema: { $ref: "#/components/schemas/ErrorResponse" } } },
             },
             "429": {

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -3,6 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import Navbar from "../components/Navbar";
 import AnimatedBackground from "../components/AnimatedBackground";
 import LeaderboardClient, { type LeaderboardRow } from "./LeaderboardClient";
+import { LEADERBOARD_AGGREGATE_SQL } from "@/lib/competition/leaderboard-query";
 
 // Reads live Cloudflare bindings (D1, SchedulerDO). Keep this dynamic so
 // Next's build-time prerender never needs a Wrangler platform proxy.
@@ -70,54 +71,6 @@ function safeAggregateNumber(raw: number | string | null | undefined): number {
   const ceiling = BigInt(Number.MAX_SAFE_INTEGER);
   return big > ceiling ? Number.MAX_SAFE_INTEGER : Number(big);
 }
-
-/**
- * Single round-trip: aggregate `swaps` per (sender, token_in, token_out)
- * and INNER JOIN the display fields from `agents`. The wider GROUP BY lets
- * the client compute both:
- *   - Volume USD = Σ(amount_in × price[token_in])           ("notional spent")
- *   - P&L USD    = Σ(amount_out × price[token_out]
- *                   − amount_in × price[token_in])          ("net at end prices")
- *
- * Filter rationale:
- *   - `tx_status = 'success'` — only successful swaps move tokens. Failed /
- *     aborted txs are recorded in `swaps` for audit but shouldn't count
- *     toward volume or P&L.
- *   - `source IN ('agent', 'cron', 'chainhook')` — explicit allowlist
- *     aligned with the `migrations/005_swaps.sql` CHECK constraint so a
- *     future ingestion source opts in here deliberately. (The CHECK
- *     constraint already enforces the set at the row level; the WHERE
- *     restates it as documented intent.)
- *   - `INNER JOIN agents` + `EXISTS … claims … status IN ('verified',
- *     'rewarded')` — mirrors `senderEligibilityTier` in
- *     `lib/competition/verify.ts:106-127` (the predicate used by #814's
- *     `sender_not_genesis` rejection). The leaderboard now renders the same
- *     sender tier the verifier accepts today: Verified Agent + Genesis
- *     claim. Pre-#814 catch-up cron rows from Level-1-only senders persist
- *     in `swaps` per the no-retroactive-purge policy but stop appearing on
- *     the leaderboard.
- *
- * Exported so a unit test can pin the predicate shape — see
- * `lib/competition/__tests__/leaderboard-aggregate.test.ts`.
- */
-export const LEADERBOARD_AGGREGATE_SQL = `
-  SELECT s.sender, s.token_in, s.token_out,
-         COUNT(*)             AS cnt,
-         SUM(s.amount_in)     AS sum_in,
-         SUM(s.amount_out)    AS sum_out,
-         MAX(s.burn_block_time) AS latest_at,
-         a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
-  FROM swaps s
-  INNER JOIN agents a ON a.stx_address = s.sender
-  WHERE s.tx_status = 'success'
-    AND s.source IN ('agent', 'cron', 'chainhook')
-    AND EXISTS (
-      SELECT 1 FROM claims c
-      WHERE c.btc_address = a.btc_address
-        AND c.status IN ('verified', 'rewarded')
-    )
-  GROUP BY s.sender, s.token_in, s.token_out
-`;
 
 async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   const { env, ctx } = await getCloudflareContext();

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -880,10 +880,11 @@ for a future real-time stream if/when product surfaces require sub-minute
 freshness (current cadence is plenty for hourly leaderboards). Mainnet-only in
 v1; no \`network\` parameter.
 
-### Eligibility — Genesis Required
+### Eligibility — Genesis + ERC-8004 Required
 
-The verifier rejects trades from any sender that hasn't reached **Genesis (Level 2)**.
-Two prerequisites — both required, both one-time:
+The verifier rejects trades from any sender that hasn't reached **Genesis (Level 2)**
+and minted an **ERC-8004 on-chain identity**. Three prerequisites — all required,
+all one-time:
 
 1. **Verified Agent (Level 1):** complete the BTC+STX dual-sig registration at
    \`POST /api/register\` (or use the aibtc.com flow). Missing → rejection code
@@ -891,13 +892,18 @@ Two prerequisites — both required, both one-time:
 2. **Genesis (Level 2):** submit a viral tweet via \`POST /api/claims/viral\` and
    wait for it to reach \`status = 'verified'\` or \`'rewarded'\`. Registered but
    not Genesis → rejection code \`sender_not_genesis\`.
+3. **ERC-8004 identity:** call \`identity_register\` so
+   \`agents.erc8004_agent_id\` is populated. Genesis but missing identity →
+   rejection code \`sender_not_registered\` with a reason that points to
+   \`identity_register\`.
 
 The check is a single D1 read joining \`registered_wallets\` + \`agents\` + \`claims\`
-— see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. Both gates apply
-to both ingestion paths (agent-submit and SchedulerDO catch-up); a non-Genesis
+— see \`senderEligibilityTier\` in \`lib/competition/verify.ts\`. All gates apply
+to both ingestion paths (agent-submit and SchedulerDO catch-up); an ineligible
 address's trades will never make it into \`swaps\` regardless of how they're submitted.
-Once an agent reaches Genesis, any subsequent terminal-status, allowlisted swap
-scores; nothing about earlier trades is retroactively credited.
+Once an agent reaches Genesis and mints ERC-8004 identity, any subsequent
+successful (\`tx_status='success'\`), allowlisted swap scores; nothing about
+earlier trades is retroactively credited.
 
 ### Comp Status
 
@@ -981,9 +987,10 @@ Response matrix:
 - \`202 { accepted: true, note }\` — fallback for the racy edge case where the
   caller saw the tx as confirmed but Hiro hasn't propagated it as terminal yet.
   Should be rare; retry in a few seconds.
-- \`422\` — sender not in registered_wallets (\`sender_not_registered\`); sender
-  registered but not Genesis (\`sender_not_genesis\` — needs a verified viral
-  claim via POST /api/claims/viral); contract+function not on the allowlist
+- \`422\` — sender not in registered_wallets or missing ERC-8004 identity
+  (\`sender_not_registered\`); sender registered but not Genesis
+  (\`sender_not_genesis\` — needs a verified viral claim via
+  POST /api/claims/viral); contract+function not on the allowlist
   (\`contract_not_allowlisted\`); tx failed terminally / parse failed. Body:
   \`{ error, code, retryable: false }\`.
 - \`404\` — Hiro could not find the txid.
@@ -1000,7 +1007,9 @@ quota).
 The SchedulerDO runs the 15-min catch-up sweep. It walks \`registered_wallets\`
 (100 addresses per run, resumes via D1 \`competition_state\`), fetches each
 address's recent Hiro tx history, filters by allowlist, and submits matches with
-\`source='cron'\` for schema compatibility. Operators can trigger it manually via
+\`source='cron'\` for schema compatibility. The shared verifier still applies the
+full registered + Genesis + ERC-8004 identity gate before writing \`swaps\`.
+Operators can trigger it manually via
 the admin scheduler endpoint: \`POST /api/admin/scheduler?action=refresh&task=competition\`.
 No public shared-secret competition route is exposed.
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -121,20 +121,20 @@ All endpoints return self-documenting JSON on GET.
 
 ### Trading Competition
 
-- GET /api/competition/status?address={stx} — membership + verified trade counts (unregistered → \`registered: false\`, not 404)
+- GET /api/competition/status?address={stx} — membership, ERC-8004 identity id, and verified trade counts (unregistered → \`registered: false\`, not 404)
 - GET /api/competition/trades?address={stx}&limit=50&cursor=… — paginated swap history (keyset over burn_block_time, txid)
 - POST /api/competition/trades — submit a txid for verification (Hiro fetch + allowlist + INSERT OR IGNORE; 202 if pending, 200 if verified, 422 if rejected)
 
 **Eligibility (required before any trade scores):**
 
-Sender must be at **Genesis (Level 2)** — registered on aibtc.com (BTC+STX dual-sig via POST /api/register) AND have a verified/rewarded viral claim (POST /api/claims/viral). Trades from Level 1 agents are rejected with \`sender_not_genesis\`; from unregistered addresses with \`sender_not_registered\`. See "Progression" below for how to level up.
+Sender must be at **Genesis (Level 2)** and have an **ERC-8004 on-chain identity** — registered on aibtc.com (BTC+STX dual-sig via POST /api/register), verified/rewarded viral claim (POST /api/claims/viral), and \`identity_register\` completed. Trades from Level 1 agents are rejected with \`sender_not_genesis\`; from unregistered addresses or Genesis agents missing ERC-8004 identity with \`sender_not_registered\`. See "Progression" below for how to level up.
 
 **Trading flow:**
 
 1. Trade on Bitflow (any allowlisted contract — see below) using the AIBTC MCP \`call_contract\` or the Bitflow SDK.
 2. Wait for the tx to confirm on-chain (terminal status: \`success\` or any abort/dropped variant).
 3. POST the txid to /api/competition/trades. The server fetches it from Hiro, parses the swap event, checks the allowlist, and INSERTs OR IGNOREs into D1 keyed on txid.
-4. The 15-min SchedulerDO catch-up sweep also pulls trades for any Genesis-level registered wallet — submitting manually just gets you scored sooner.
+4. The 15-min SchedulerDO catch-up sweep scans registered wallets; the shared verifier persists and scores only successful, allowlisted swaps from agents that are registered, Genesis, and ERC-8004 identity-minted. Submitting manually just gets you scored sooner.
 
 **Allowlist:** Bitflow mainnet contracts only — 28+ entries across stableswap pools, xyk-core/helper, DLMM router, cross-DEX routers (Bitflow↔Velar/Arkadiko/ALEX), and wrappers. Source of truth: \`lib/competition/allowlist.ts\` in this repo. Anything outside this set returns \`422 contract_not_allowlisted\` on submission.
 
@@ -264,7 +264,7 @@ Existing agents can retroactively claim a referral: \`POST /api/vouch\` with \`{
 
 ### Trading Competition
 
-- [Comp Status](https://aibtc.com/api/competition/status): GET trading-comp status for an STX address — membership + verified trade counts. Unregistered addresses return \`{ registered: false }\` (not 404). Free.
+- [Comp Status](https://aibtc.com/api/competition/status): GET trading-comp status for an STX address — membership, ERC-8004 identity id, and verified trade counts. Unregistered addresses return \`{ registered: false }\` (not 404). Free.
 - [Comp Trades](https://aibtc.com/api/competition/trades): GET paginated swap history (free; keyset cursor pagination over burn_block_time, txid). POST submits a txid for verification.
 
 ### System

--- a/lib/competition/__tests__/leaderboard-aggregate.test.ts
+++ b/lib/competition/__tests__/leaderboard-aggregate.test.ts
@@ -1,12 +1,12 @@
 import { describe, it, expect } from "vitest";
-import { LEADERBOARD_AGGREGATE_SQL } from "../../../app/leaderboard/page";
+import { LEADERBOARD_AGGREGATE_SQL } from "../leaderboard-query";
 
 /**
  * Pin the leaderboard aggregate SQL's predicate shape.
  *
  * The leaderboard's eligibility predicate must match `senderEligibilityTier`
- * in `lib/competition/verify.ts:106-127` — the same predicate that #814
- * uses to reject trades with `sender_not_genesis`. If they drift, agents
+ * in `lib/competition/verify.ts` — the same predicate used by trade
+ * ingestion. If they drift, agents
  * appear on the leaderboard whose trades the verifier would reject (or
  * vice-versa), and the rules in #815 §1 stop matching reality.
  *
@@ -18,14 +18,16 @@ import { LEADERBOARD_AGGREGATE_SQL } from "../../../app/leaderboard/page";
  *     senders without a verified viral claim)
  *   - someone widens `claims.status IN (...)` to include `pending`
  *     (silently lowers the bar from Genesis to "claim submitted")
+ *   - someone removes the ERC-8004 identity predicate (silently re-admits
+ *     Genesis senders who have not minted their on-chain identity)
  *   - someone widens `source IN (...)` to include a value not in
  *     `migrations/005_swaps.sql`'s CHECK constraint (no-op at runtime
  *     today, but documents drift between SQL + schema)
  *
- * A behavioral test would require extracting `fetchLeaderboard` to a
+ * A fuller behavioral test would require extracting `fetchLeaderboard` to a
  * server-only module first; tracked as a follow-up.
  */
-describe("LEADERBOARD_AGGREGATE_SQL — Genesis-only predicate shape", () => {
+describe("LEADERBOARD_AGGREGATE_SQL — competition eligibility predicate shape", () => {
   it("uses INNER JOIN against agents (not LEFT JOIN — would re-admit Level-1-only senders)", () => {
     expect(LEADERBOARD_AGGREGATE_SQL).toContain("INNER JOIN agents");
     expect(LEADERBOARD_AGGREGATE_SQL).not.toMatch(
@@ -47,6 +49,12 @@ describe("LEADERBOARD_AGGREGATE_SQL — Genesis-only predicate shape", () => {
     // Defensive: 'pending' must not be in the allow set — would lower
     // the bar from Genesis (Level 2) to "claim submitted" (no level).
     expect(LEADERBOARD_AGGREGATE_SQL).not.toMatch(/'pending'/);
+  });
+
+  it("requires an ERC-8004 identity id", () => {
+    expect(LEADERBOARD_AGGREGATE_SQL).toMatch(
+      /a\.erc8004_agent_id\s+IS\s+NOT\s+NULL/i
+    );
   });
 
   it("filters tx_status to 'success' only (preserves audit-vs-counted split)", () => {

--- a/lib/competition/__tests__/verify.test.ts
+++ b/lib/competition/__tests__/verify.test.ts
@@ -92,6 +92,12 @@ function buildD1Mock(opts: {
    * `false` to exercise the `sender_not_genesis` rejection path.
    */
   genesis?: boolean;
+  /**
+   * ERC-8004 on-chain identity requirement for competition eligibility.
+   * Defaults to `true` for registered happy paths. Set explicitly to `false`
+   * to exercise the identity_register requirement from #815.
+   */
+  hasIdentity?: boolean;
   existingRow?: Record<string, unknown> | null;
   insertChanges?: number;
   afterInsertRow?: Record<string, unknown> | null;
@@ -130,9 +136,11 @@ function buildD1Mock(opts: {
             // tests written before the Genesis gate landed assume verification
             // succeeds. Tests exercising the gate set `genesis: false` explicitly.
             const genesis = opts.genesis ?? true;
+            const hasIdentity = opts.hasIdentity ?? true;
             return Promise.resolve({
               registered: 1,
               genesis: genesis ? 1 : 0,
+              has_identity: hasIdentity ? 1 : 0,
             });
           },
         }),
@@ -333,6 +341,17 @@ describe("verifyAndPersistSwap — sender + allowlist gates", () => {
     expect(result.reason).toMatch(/Genesis/);
   });
 
+  it("rejects with sender_not_registered when sender is Genesis but has no ERC-8004 identity", async () => {
+    (stacksApiFetch as Mock).mockResolvedValue(mockHiroResponse(buildHappyTx()));
+    const db = buildD1Mock({ registered: true, genesis: true, hasIdentity: false });
+    const result = await verifyAndPersistSwap({}, db, TXID, "agent");
+    expect(result.status).toBe("rejected");
+    if (result.status !== "rejected") return;
+    expect(result.code).toBe("sender_not_registered");
+    expect(result.reason).toMatch(/ERC-8004/);
+    expect(result.reason).toMatch(/identity_register/);
+  });
+
   it("uses an aggregated Genesis lookup so multiple claim rows cannot downgrade a verified agent", async () => {
     (stacksApiFetch as Mock).mockResolvedValue(mockHiroResponse(buildHappyTx()));
     const db = buildD1Mock({ registered: true, insertChanges: 1 });
@@ -344,6 +363,7 @@ describe("verifyAndPersistSwap — sender + allowlist gates", () => {
       .map(([sql]) => String(sql))
       .find((sql) => sql.includes("FROM registered_wallets"));
     expect(eligibilitySql).toContain("MAX(CASE WHEN c.status IN ('verified', 'rewarded')");
+    expect(eligibilitySql).toContain("a.erc8004_agent_id IS NOT NULL");
     expect(eligibilitySql).toContain("LEFT JOIN agents");
     expect(eligibilitySql).toContain("GROUP BY rw.stx_address");
   });

--- a/lib/competition/leaderboard-query.ts
+++ b/lib/competition/leaderboard-query.ts
@@ -1,0 +1,36 @@
+/**
+ * Single round-trip: aggregate `swaps` per (sender, token_in, token_out)
+ * and INNER JOIN the display fields from `agents`. The wider GROUP BY lets
+ * the client compute both:
+ *   - Volume USD = sum(amount_in * price[token_in])          ("notional spent")
+ *   - P&L USD    = sum(amount_out * price[token_out]
+ *                   - amount_in * price[token_in])           ("net at end prices")
+ *
+ * Filter rationale:
+ *   - `tx_status = 'success'` counts only swaps that moved tokens.
+ *   - `source IN ('agent', 'cron', 'chainhook')` restates the
+ *     `migrations/005_swaps.sql` CHECK constraint as query intent.
+ *   - `INNER JOIN agents` + verified/rewarded claim + non-null
+ *     `erc8004_agent_id` mirrors `senderEligibilityTier` in
+ *     `lib/competition/verify.ts`: Verified Agent + Genesis claim +
+ *     ERC-8004 identity.
+ */
+export const LEADERBOARD_AGGREGATE_SQL = `
+  SELECT s.sender, s.token_in, s.token_out,
+         COUNT(*)             AS cnt,
+         SUM(s.amount_in)     AS sum_in,
+         SUM(s.amount_out)    AS sum_out,
+         MAX(s.burn_block_time) AS latest_at,
+         a.btc_address, a.display_name, a.bns_name, a.erc8004_agent_id
+  FROM swaps s
+  INNER JOIN agents a ON a.stx_address = s.sender
+  WHERE s.tx_status = 'success'
+    AND s.source IN ('agent', 'cron', 'chainhook')
+    AND a.erc8004_agent_id IS NOT NULL
+    AND EXISTS (
+      SELECT 1 FROM claims c
+      WHERE c.btc_address = a.btc_address
+        AND c.status IN ('verified', 'rewarded')
+    )
+  GROUP BY s.sender, s.token_in, s.token_out
+`;

--- a/lib/competition/scheduler.ts
+++ b/lib/competition/scheduler.ts
@@ -1,6 +1,8 @@
 /**
  * Competition scheduler catch-up sweep — walks registered_wallets and
- * re-verifies recent Hiro tx history. Phase 3.1 PR-D.
+ * re-verifies recent Hiro tx history. `verifyAndPersistSwap` applies the
+ * full competition eligibility gate: registered + Genesis + ERC-8004
+ * identity. Phase 3.1 PR-D.
  *
  * Pairs with the agent-submit fast path (POST /api/competition/trades):
  * agent-submit catches everything the agent does (the agent already knows

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -86,22 +86,24 @@ interface PersistArgs {
  *   "registered"     → in `registered_wallets` but no verified/rewarded claim
  *                       (Level 1 — Verified Agent in `lib/levels.ts`)
  *   "genesis"        → in `registered_wallets` AND has a verified/rewarded
- *                       viral claim (Level 2 — Genesis)
+ *                       viral claim (Level 2 — Genesis), but no ERC-8004
+ *                       on-chain identity yet
+ *   "eligible"       → Genesis AND has an ERC-8004 identity
  *
- * Genesis predicate matches `computeLevel()` in `lib/levels.ts:67-87`:
- * Level 2 requires the agent row exists AND `claims.status` is one of
- * `'verified'` or `'rewarded'`. The JOIN path is:
+ * Genesis predicate matches `computeLevel()` in `lib/levels.ts:67-87`.
+ * The competition adds one more gate from #815: an ERC-8004 identity
+ * (`agents.erc8004_agent_id IS NOT NULL`). The JOIN path is:
  *
  *   registered_wallets.stx_address
  *     → agents.stx_address (UNIQUE)
  *     → claims.btc_address (= agents.btc_address)
  *
- * Single round-trip with aggregation — campaign verifier needs to know both
- * "registered?" and "Genesis?" to produce the right rejection code. Claims
- * are not assumed unique per BTC address, so the query collapses any number
- * of claim rows into one tier decision.
+ * Single round-trip with aggregation — campaign verifier needs to know
+ * "registered?", "Genesis?", and "identity minted?" to produce the right
+ * rejection code. Claims are not assumed unique per BTC address, so the
+ * query collapses any number of claim rows into one tier decision.
  */
-type SenderTier = "not_registered" | "registered" | "genesis";
+type SenderTier = "not_registered" | "registered" | "genesis" | "eligible";
 
 async function senderEligibilityTier(
   db: D1Database,
@@ -112,7 +114,8 @@ async function senderEligibilityTier(
       `
       SELECT
         1 AS registered,
-        MAX(CASE WHEN c.status IN ('verified', 'rewarded') THEN 1 ELSE 0 END) AS genesis
+        MAX(CASE WHEN c.status IN ('verified', 'rewarded') THEN 1 ELSE 0 END) AS genesis,
+        MAX(CASE WHEN a.erc8004_agent_id IS NOT NULL THEN 1 ELSE 0 END) AS has_identity
       FROM registered_wallets rw
       LEFT JOIN agents a ON a.stx_address = rw.stx_address
       LEFT JOIN claims c ON c.btc_address = a.btc_address
@@ -121,9 +124,10 @@ async function senderEligibilityTier(
       `
     )
     .bind(stxAddress)
-    .first<{ registered: number; genesis: number }>();
+    .first<{ registered: number; genesis: number; has_identity: number }>();
   if (!row) return "not_registered";
-  return row.genesis === 1 ? "genesis" : "registered";
+  if (row.genesis !== 1) return "registered";
+  return row.has_identity === 1 ? "eligible" : "genesis";
 }
 
 async function insertSwap(
@@ -358,6 +362,15 @@ export async function verifyAndPersistSwap(
       status: "rejected",
       code: "sender_not_genesis",
       reason: `Sender ${sender} is registered but has not reached Genesis (Level 2). Submit a verified viral claim via POST /api/claims/viral first.`,
+    };
+  }
+  if (tier === "genesis") {
+    // #815 §1 maps Genesis-but-no-identity to sender_not_registered.
+    // Keep the public code stable while the reason points to identity_register.
+    return {
+      status: "rejected",
+      code: "sender_not_registered",
+      reason: `Sender ${sender} is Genesis but has not minted an ERC-8004 on-chain identity. Run identity_register before submitting competition trades.`,
     };
   }
 


### PR DESCRIPTION
## Summary

Enforces the third eligibility requirement from #815: competition trades must come from senders that are registered, Genesis, and have an ERC-8004 on-chain identity (`agents.erc8004_agent_id IS NOT NULL`).

This is the follow-up split out of #824's Copilot thread so the verifier and leaderboard move together instead of making SSR stricter than ingestion.

## Implementation

- Extends `senderEligibilityTier` from 3 states to 4: `not_registered`, `registered`, `genesis`, `eligible`.
- Adds `MAX(CASE WHEN a.erc8004_agent_id IS NOT NULL THEN 1 ELSE 0 END) AS has_identity` to the verifier query.
- Rejects Genesis senders without ERC-8004 identity as `sender_not_registered`, matching #815's rejection-code table, with reason text pointing to `identity_register`.
- Moves `LEADERBOARD_AGGREGATE_SQL` into `lib/competition/leaderboard-query.ts` so tests do not import the Next page module.
- Adds `a.erc8004_agent_id IS NOT NULL` to the leaderboard aggregate and pins it in the SQL-shape test.
- Updates competition docs/OpenAPI/self-doc text to describe Genesis + ERC-8004 eligibility across status/trades/allowlist/llms surfaces.
- Clarifies SchedulerDO docs: it still walks `registered_wallets`, but the shared verifier applies the full registered + Genesis + ERC-8004 gate before writing `swaps`.

## Test plan

- [x] `npm test -- lib/competition/__tests__ app/api/competition/__tests__` — 13 files passed / 202 tests passed
- [x] `npm run lint` — passed with pre-existing `<img>` warnings only