### PR TITLE
fix(competition): allowlist router-stableswap-xyk-multihop-v-1-2 (#830)

### DIFF
--- a/lib/competition/allowlist.ts
+++ b/lib/competition/allowlist.ts
@@ -96,6 +96,29 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
       "swap-helper-e",
     ],
   },
+  // Router stableswap-xyk multihop — Bitflow SDK auto-routes here for
+  // multi-hop swaps that compose a stableswap pool with an XYK pool
+  // (e.g. sBTC -> STX -> stSTX). Same XYK deployer family as
+  // `xyk-core-v-1-1` and `xyk-swap-helper-v-1-3` above; functionally the
+  // multihop variant of the helper. Per-Hiro on-chain ABI exposes 9
+  // swap-helper-* variants (a..i). Surfaced as a launch-window blocker
+  // on issue #830 with a reproducer txid:
+  // 0xd298a52d1197a36778c64b4cb1c83aebba12f3969d4a7a9a5f9add07252b2bc9
+  // (Prime Spoke / agent_id 67, T+2.5min after launch, sBTC->stSTX).
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.router-stableswap-xyk-multihop-v-1-2`,
+    functions: [
+      "swap-helper-a",
+      "swap-helper-b",
+      "swap-helper-c",
+      "swap-helper-d",
+      "swap-helper-e",
+      "swap-helper-f",
+      "swap-helper-g",
+      "swap-helper-h",
+      "swap-helper-i",
+    ],
+  },
 
   // -- DLMM router (8 swap variants per on-chain ABI) --
   // Previous seed only included `swap-simple-multi`, causing the other 7


### PR DESCRIPTION
## Summary

Adds `SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.router-stableswap-xyk-multihop-v-1-2` (functions `swap-helper-a..i`) to the trading-competition allowlist, closing #830.

The Bitflow SDK's `bitflow_swap` MCP tool auto-routes through this contract for multi-hop swaps composing a stableswap pool with an XYK pool (e.g. sBTC → STX → stSTX). The route is more capital-efficient than forcing the already-allowlisted `xyk-swap-helper-v-1-3` for some pool combinations, so the SDK selects it without operator input.

This was the **first launch-window blocker observed**: legitimately-eligible agents using the canonical Bitflow SDK have been hitting `contract_not_allowlisted` on otherwise-correct trades since 19:30:00Z launch.

## Empirical reproducer (#830)

Tx `0xd298a52d1197a36778c64b4cb1c83aebba12f3969d4a7a9a5f9add07252b2bc9` (Prime Spoke, agent_id 67) at burn_block_time `1778700754` (= 2026-05-13T19:32:34Z, T+2.5m post-launch):

- `tx_status: success` (Hiro)
- `contract: SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR.router-stableswap-xyk-multihop-v-1-2`
- `function: swap-helper-a`
- Swap: 0.01290156 sBTC → 3,159.72 stSTX via sBTC → STX → stSTX multi-hop

Sender eligibility (post-#827):
- `/api/verify/SP3TH5S631RYN7Z485TY0KPFVX24R7RW7P25HVZ73` returns `level: 2` (Genesis), `erc8004AgentId: 67` — fully eligible per #815 §1 + the new `senderEligibilityTier`.
- `/api/competition/status?address=SP3TH5S…` returns `trade_count: 0` — the verifier accepted the sender + Genesis + identity gates and was rejecting at the allowlist check.

So this is squarely an allowlist-coverage gap, not an eligibility issue.

## Why it's safe to add

- **Same deployer family**: `SM1793C4R5PZ4NS4VQ4WMP7SKKYVH8JZEWSZ9HCCR` already has `xyk-core-v-1-1`, `xyk-swap-helper-v-1-3`, and `wrapper-velar-v-1-2` allowlisted. Functionally the multihop variant of the helper that's already trusted.
- **All swap-helper-* functions enumerated from on-chain ABI** via Hiro `/v2/contracts/interface/.../router-stableswap-xyk-multihop-v-1-2` — 9 variants (a..i). All `public` swap-* functions are added per the existing allowlist convention; admin/quote functions stay excluded.
- **No protocol surface change** — the allowlist is read-only from the competition's perspective. Adding an entry only allows more swaps to score; it doesn't change what already scores or what the verifier does for ineligible senders.

## What this does NOT cover

- Other potentially-relevant contracts in the SM1793 deployer family beyond the one #830 reproduces against. If the SDK auto-routes through additional router contracts that aren't allowlisted yet, those will surface as `contract_not_allowlisted` rejections too — handle as separate follow-ups when reproducers land.
- `lib/competition/allowlist.ts` is the source of truth read by `/api/competition/allowlist`. After this PR merges + deploys, that endpoint will return 28 entries (was 27).

## Test plan

- [x] `npm test -- lib/competition/__tests__` — 77 passed / 5 test files passed (no new tests; the existing predicate fixtures cover the contract+function gate path generically)
- [ ] After preview deploy: `curl https://aibtc.com/api/competition/allowlist` returns 28 entries including the new contract with all 9 functions
- [ ] After production deploy: re-submit `0xd298a52d1197a36778c64b4cb1c83aebba12f3969d4a7a9a5f9add07252b2bc9` via `POST /api/competition/trades` — expect `200 { accepted: true, verified: true }` (was 422 `contract_not_allowlisted`)
- [ ] After production deploy: `/api/competition/status?address=SP3TH5S631RYN7Z485TY0KPFVX24R7RW7P25HVZ73` returns `trade_count: 1, verified_trade_count: 1` once the catch-up cron picks it up (~15min) or the agent re-submits via `competition_submit_trade`

## Why no test for the new entry specifically

The existing `lib/competition/__tests__/parse.test.ts` exercises the allowlist-gate predicate generically (any allowlisted contract+function should pass; any non-allowlisted should fail with `contract_not_allowlisted`). Adding a per-contract assertion would tightly couple the test to the data + invite drift on every allowlist append. Per #815 §4 the allowlist evolves on a per-PR basis as the Bitflow team ships new contracts; a snapshot test against the entries array would create churn on every legitimate addition.

If a stronger guard is wanted, an alternative is a "no contract removed" snapshot test (asserts that current allowlist is a strict superset of a prior reference). Out of scope for this fix; happy to file as a follow-up.

## Cross-links

- #830 (this fix's reproducer)
- #815 §4 (allowlist convention + the four required-pieces format @JoeVezzani filed against)
- #827 (predicate tightening — confirms Prime Spoke passes the eligibility gate; failure is allowlist-only)
- #812 (prior allowlist-add for `wrapper-velar-v-1-2`)