### PR TITLE
perf(d1): cache heartbeat unread-count behind 30s edge cache

### DIFF
--- a/app/api/heartbeat/__tests__/stx-db-threading.test.ts
+++ b/app/api/heartbeat/__tests__/stx-db-threading.test.ts
@@ -22,8 +22,8 @@ vi.mock("@/lib/agent-lookup", () => ({
   lookupAgentWithLevel: vi.fn(),
 }));
 
-vi.mock("@/lib/inbox/d1-reads", () => ({
-  countInboxMessagesFromD1: vi.fn().mockResolvedValue(0),
+vi.mock("@/lib/inbox/cached-counts", () => ({
+  cachedUnreadCount: vi.fn().mockResolvedValue(0),
 }));
 
 vi.mock("@/lib/levels", () => ({

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -7,7 +7,7 @@ import { X_HANDLE } from "@/lib/constants";
 import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { generateName } from "@/lib/name-generator";
-import { countInboxMessagesFromD1 } from "@/lib/inbox/d1-reads";
+import { cachedUnreadCount } from "@/lib/inbox/cached-counts";
 import {
   CHECK_IN_MESSAGE_FORMAT,
   buildCheckInMessage,
@@ -116,7 +116,7 @@ function getNextAction(
 async function fetchUnreadCount(db: D1Database | undefined, btcAddress: string): Promise<number> {
   if (!db) return 0;
   try {
-    return await countInboxMessagesFromD1(db, btcAddress, "unread");
+    return await cachedUnreadCount(db, btcAddress);
   } catch {
     return 0;
   }

--- a/lib/inbox/cached-counts.ts
+++ b/lib/inbox/cached-counts.ts
@@ -1,0 +1,134 @@
+/**
+ * Edge-cache wrappers for inbox COUNT(*) queries that are called on every
+ * heartbeat request.
+ *
+ * ## Why this file exists
+ *
+ * countInboxMessagesFromD1 fires a live SELECT COUNT(*) on every heartbeat GET
+ * and POST. Agents heartbeat every 5 minutes; at ~1,000 registered agents the
+ * call rate is ~288 COUNT(*) queries/agent/day = tens of millions of D1
+ * rows-reads/day — the primary driver of the $30/day D1 bill spike (quest
+ * 2026-05-13-d1-count-bill-stop, Phase P2).
+ *
+ * ## Cache strategy
+ *
+ * Uses `caches.default` (Cloudflare's per-colo in-process edge cache) to store
+ * the count as a tiny JSON Response for 30 seconds. On cache hit, D1 is never
+ * touched. On miss (first hit per address per colo per 30s window), the live
+ * D1 query runs once and the result is cached for subsequent callers.
+ *
+ * `caches.default` is chosen over KV because:
+ * - Zero additional KV read/write ops — the predecessor quest (P1) cut KV ops
+ *   86%; we must not give that back.
+ * - No network hop — caches.default is an in-process store inside the Worker.
+ * - Already well-tested in this codebase (lib/edge-cache.ts, middleware.ts).
+ *
+ * ## TTL rationale: 30 seconds
+ *
+ * Heartbeat check-in rate limit is 5 minutes (CHECK_IN_RATE_LIMIT_MS = 300 000ms).
+ * A 30s drift on unread count is invisible to agents — they learn about new
+ * messages at most 30s late, but they only act on them at the next heartbeat
+ * cycle anyway. Keeping TTL at 30s (not 60s+) is conservative and retains
+ * reasonable freshness for the orientation step ("you have N unread messages").
+ *
+ * ## Scope
+ *
+ * Only the heartbeat path uses this wrapper. The inbox-list GET
+ * (app/api/inbox/[address]/route.ts) intentionally uses the live
+ * countInboxMessagesFromD1 directly — inbox reads are user-initiated and
+ * benefit from real-time counts.
+ *
+ * ## Colo scope note
+ *
+ * caches.default is scoped per Cloudflare colo. Multiple colos will each miss
+ * once per 30s window. That is acceptable — global consistency is not required
+ * for heartbeat orientation.
+ */
+
+import { countInboxMessagesFromD1 } from "./d1-reads";
+
+/** Synthetic cache host — isolated from live domain's HTTP cache namespace. */
+const CACHE_HOST = "https://internal.cache";
+
+/** TTL for cached unread counts (seconds). */
+export const UNREAD_COUNT_CACHE_TTL_SECONDS = 30;
+
+/**
+ * Build the canonical cache key URL for an agent's unread count.
+ * Address is lowercased so bc1q... and BC1Q... collapse to one entry.
+ */
+function buildUnreadCountCacheKey(btcAddress: string): string {
+  return `${CACHE_HOST}/inbox-unread-count/${encodeURIComponent(btcAddress.toLowerCase())}`;
+}
+
+/**
+ * Resolve `caches.default` if available, otherwise null.
+ * Cloudflare Workers exposes a global `caches` with a `default` namespace;
+ * Node / `next dev` does not, so we guard to let callers fall through to the
+ * live D1 query without throwing in non-Workers environments.
+ */
+function getDefaultCache(): Cache | null {
+  const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;
+  return c?.default ?? null;
+}
+
+/**
+ * Return the unread inbox count for an agent, served from a 30s edge cache
+ * when available.
+ *
+ * - Cache hit: returns cached count with no D1 touch.
+ * - Cache miss: queries D1 live, stores result for 30s.
+ * - No caches.default (Node / next dev): queries D1 live every call.
+ * - Any error (D1 unavailable, cache failure): returns 0 (fail-open, mirrors
+ *   the fetchUnreadCount wrapper in the heartbeat route).
+ */
+export async function cachedUnreadCount(
+  db: D1Database,
+  btcAddress: string,
+): Promise<number> {
+  try {
+    const cache = getDefaultCache();
+
+    if (!cache) {
+      // Non-Workers runtime (local dev, test env with no cache mock) —
+      // fall through to live D1 query.
+      return await countInboxMessagesFromD1(db, btcAddress, "unread");
+    }
+
+    const cacheKey = new Request(buildUnreadCountCacheKey(btcAddress), {
+      method: "GET",
+    });
+
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      const text = await cached.text();
+      const parsed = JSON.parse(text) as unknown;
+      if (typeof parsed === "number") return parsed;
+      // Malformed cached value — fall through to live query.
+    }
+
+    // Cache miss: fetch from D1 and store.
+    const count = await countInboxMessagesFromD1(db, btcAddress, "unread");
+
+    const storedResponse = new Response(JSON.stringify(count), {
+      headers: {
+        "Content-Type": "application/json",
+        // public + max-age satisfies caches.default's cacheable-response
+        // requirements (no Set-Cookie, explicit Cache-Control directive).
+        "Cache-Control": `public, max-age=${UNREAD_COUNT_CACHE_TTL_SECONDS}`,
+      },
+    });
+
+    // Synchronous await is intentional: the put is an in-process write to
+    // caches.default with no network hop, so latency is negligible and
+    // ctx.waitUntil complexity is unwarranted here.
+    await cache.put(cacheKey, storedResponse);
+
+    return count;
+  } catch {
+    // Fail open — a transient D1 error or cache failure must not block heartbeat
+    // orientation. Returning 0 means the agent sees "no unread messages" which
+    // is a safe degradation (they won't be incorrectly told to check inbox).
+    return 0;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `lib/inbox/cached-counts.ts` with `cachedUnreadCount()` — a thin `caches.default` wrapper around `countInboxMessagesFromD1` for the heartbeat path
- Swaps `app/api/heartbeat/route.ts` to call `cachedUnreadCount` instead of the live D1 query directly
- Updates heartbeat test mock to target the new module

## Context

Part of quest **d1-count-bill-stop** (P2 Bandage B). Baseline: ~26–34B D1 rows/day at $30/day overage.

P1 (#833) cut `/api/inbox/[address]` COUNTs from 4 to 2 (derived counts from fetched rows). This PR (P2) wraps the remaining hot-path COUNT in heartbeat.

The heartbeat route fires a live `SELECT COUNT(*) WHERE read_at IS NULL` on **every** GET orientation and POST check-in with no caching. At ~1,000 agents checking in every 5 minutes, that is ~288 D1 rows-read/agent/day from heartbeat alone — a primary overage driver.

## Cache design

| Decision | Choice | Reason |
|----------|--------|--------|
| Cache layer | `caches.default` | Zero KV ops; in-process per-colo store; preserves 86% KV-op cut from predecessor quest |
| TTL | 30 seconds | Heartbeat cadence = 5 min; 30s drift invisible to agents. Conservative to keep unread count fresh for orientation. |
| Wrapper shape | Thin numeric cache (`lib/inbox/cached-counts.ts`) | `withEdgeCache` wraps full HTTP Responses; a single `number` fits a minimal Request/Response pair. No `ctx.waitUntil` complexity needed — `caches.default` put is in-process with negligible latency. |
| Error handling | Fail-open (returns 0) | Mirrors existing `fetchUnreadCount` try/catch; heartbeat orientation must never be blocked by a transient D1 error |

## Verify

- [x] `npm run build` passes
- [x] `npx vitest run app/api/heartbeat/` — 7/7 tests pass
- [x] `caches.default` path: second heartbeat request within 30s window for same address skips D1
- [x] Fallback path: `caches.default` absent (Node/next dev) → live D1 query, no error

## Post-merge smoke checklist

The operator handles T+1h/T+4h/T+24h D1 rows-read verification via Cloudflare analytics.

- [ ] T+0 — merge time recorded in quest artifact
- [ ] T+1h — D1 rows-read trending down vs. P1 baseline
- [ ] T+4h — sustained reduction visible
- [ ] T+24h — full-day delta vs. 26–34B baseline

**Note:** `caches.default` scope is per Cloudflare colo. Multiple colos each miss once per 30s window — acceptable for this use case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)