### PR TITLE
fix(competition): sync Genesis claims into D1

### DIFF
--- a/app/api/admin/backfill/__tests__/route.test.ts
+++ b/app/api/admin/backfill/__tests__/route.test.ts
@@ -552,7 +552,7 @@ describe("referral code generation", () => {
 
     // KV put should have been called for both referral-code: and referral-lookup: keys
     const kvPutMock = kv.put as Mock;
-    const putCalls = kvPutMock.mock.calls.map(([key]: [string]) => key);
+    const putCalls = kvPutMock.mock.calls.map((call) => call[0] as string);
 
     const hasReferralCodeKey = putCalls.some((k: string) =>
       k.startsWith("referral-code:bc1qagent1")
@@ -760,6 +760,46 @@ describe("GET self-documentation", () => {
 // ── claims backfill tests ────────────────────────────────────────────────
 
 describe("claims backfill", () => {
+  it("upserts existing claims when force=resync is set", async () => {
+    const kv = buildKvMock({ "claim:bc1qagent1": CLAIM_1 });
+    const { db, prepareMock, bindMock } = buildD1Mock({ changesSequence: [1] });
+
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        ARC_ADMIN_API_KEY: "test-admin-key",
+        VERIFIED_AGENTS: kv,
+        DB: db,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+
+    const req = buildPostRequest({ table: "claims", force: "resync" });
+    const resp = await POST(req);
+    const body = await resp.json() as {
+      inserted: number;
+      skipped_idempotent: number;
+      forceResync: boolean;
+      failed: { key: string; reason: string }[];
+    };
+
+    expect(resp.status).toBe(200);
+    expect(body.forceResync).toBe(true);
+    expect(body.inserted).toBe(1);
+    expect(body.skipped_idempotent).toBe(0);
+    expect(body.failed).toHaveLength(0);
+    expect(String(prepareMock.mock.calls[0][0])).toContain("DO UPDATE SET");
+    expect(bindMock).toHaveBeenCalledWith(
+      "bc1qagent1",
+      "Agent One",
+      "https://x.com/agent1/status/123",
+      "agent1",
+      "2026-01-01T01:00:00Z",
+      50000,
+      null,
+      "verified"
+    );
+  });
+
   it("skips rows with invalid status values and records them in failed[]", async () => {
     const badClaim = JSON.stringify({
       btcAddress: "bc1qbad",

--- a/app/api/admin/backfill/route.ts
+++ b/app/api/admin/backfill/route.ts
@@ -9,6 +9,7 @@ import { deriveReplyD1Id } from "@/lib/inbox/d1-pk";
 import { generateClaimCode } from "@/lib/claim-code";
 import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { isStxAddress } from "@/lib/validation/address";
+import { mirrorClaimToD1 } from "@/lib/claims/d1-mirror";
 
 // ── Types ──────────────────────────────────────────────────────────────────
 
@@ -17,6 +18,7 @@ type TableTarget = "agents" | "claims" | "inbox_messages" | "vouches" | "all";
 interface BackfillResult {
   table: TableTarget;
   dryRun: boolean;
+  forceResync: boolean;
   batchSize: number;
   inserted: number;
   inserted_null_btcpubkey: number;
@@ -343,7 +345,8 @@ async function backfillClaims(
   db: D1Database,
   batchSize: number,
   cursor: string | null,
-  dryRun: boolean
+  dryRun: boolean,
+  forceResync: boolean
 ): Promise<AccumulatedCounts & { nextCursor: string | null }> {
   const counts: AccumulatedCounts = {
     inserted: 0,
@@ -391,25 +394,27 @@ async function backfillClaims(
     }
 
     try {
-        const result = await db
-          .prepare(
-            `INSERT INTO claims (
-            btc_address, display_name, tweet_url, tweet_author,
-            claimed_at, reward_satoshis, reward_txid, status
-          ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-           ON CONFLICT(btc_address) DO NOTHING`
-          )
-        .bind(
-          claim.btcAddress,
-          claim.displayName,
-          claim.tweetUrl,
-          claim.tweetAuthor ?? null,
-          claim.claimedAt,
-          claim.rewardSatoshis,
-          claim.rewardTxid ?? null,
-          claim.status
-        )
-        .run();
+      const result = forceResync
+        ? await mirrorClaimToD1(db, claim).then(() => ({ meta: { changes: 1 } }))
+        : await db
+            .prepare(
+              `INSERT INTO claims (
+              btc_address, display_name, tweet_url, tweet_author,
+              claimed_at, reward_satoshis, reward_txid, status
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+             ON CONFLICT(btc_address) DO NOTHING`
+            )
+            .bind(
+              claim.btcAddress,
+              claim.displayName,
+              claim.tweetUrl,
+              claim.tweetAuthor ?? null,
+              claim.claimedAt,
+              claim.rewardSatoshis,
+              claim.rewardTxid ?? null,
+              claim.status
+            )
+            .run();
 
       if (result.meta.changes === 1) {
         counts.inserted++;
@@ -782,12 +787,14 @@ export async function GET(request: NextRequest) {
       batchSize: "KV scan page size: 10–500 (default: 100)",
       cursor: "Resume cursor from previous response. For inbox_messages: encoded as 'inbound:<kv-cursor>' or 'reply:<kv-cursor>'.",
       dryRun: "If 'true', counts rows without writing to D1 or KV. Default: false.",
+      forceResync: "If 'true' with table=claims, upserts claim rows so D1 status/reward fields match KV. Default: false.",
     },
     warning:
       "table=all is one-shot with no cursor; use per-table + cursor loop for large datasets to avoid request timeout.",
     response: {
       table: "Table targeted",
       dryRun: "Whether this was a dry run",
+      forceResync: "Whether claims used upsert/resync mode",
       batchSize: "Effective batch size used",
       inserted: "Rows newly inserted",
       inserted_null_btcpubkey: "Subset of inserted with btc_public_key = NULL (BIP-322 bc1q agents; expected ~708 on first full backfill)",
@@ -841,6 +848,7 @@ export async function POST(request: NextRequest) {
   const batchSize = parseBatchSize(searchParams.get("batchSize"));
   const cursor = searchParams.get("cursor") ?? null;
   const dryRun = searchParams.get("dryRun") === "true";
+  const forceResync = searchParams.get("forceResync") === "true" || searchParams.get("force") === "resync";
 
   const validTables: TableTarget[] = ["agents", "claims", "inbox_messages", "vouches", "all"];
   if (!validTables.includes(rawTable as TableTarget)) {
@@ -851,7 +859,7 @@ export async function POST(request: NextRequest) {
   }
   const table = rawTable as TableTarget;
 
-  logger.info("backfill.start", { table, batchSize, dryRun });
+  logger.info("backfill.start", { table, batchSize, dryRun, forceResync });
 
   try {
     // ── table=all: one-shot, no cursor support ──────────────────────────────
@@ -886,7 +894,7 @@ export async function POST(request: NextRequest) {
       // Claims
       let claimCursor: string | null = null;
       do {
-        const res = await backfillClaims(kv, db, batchSize, claimCursor, dryRun);
+        const res = await backfillClaims(kv, db, batchSize, claimCursor, dryRun, forceResync);
         totals.inserted += res.inserted;
         totals.skipped_idempotent += res.skipped_idempotent;
         totals.failed.push(...res.failed);
@@ -945,6 +953,7 @@ export async function POST(request: NextRequest) {
       const result: BackfillResult = {
         table: "all",
         dryRun,
+        forceResync,
         batchSize,
         inserted: totals.inserted,
         inserted_null_btcpubkey: totals.inserted_null_btcpubkey,
@@ -965,7 +974,7 @@ export async function POST(request: NextRequest) {
         res = await backfillAgents(kv, db, batchSize, cursor, dryRun);
         break;
       case "claims":
-        res = await backfillClaims(kv, db, batchSize, cursor, dryRun);
+        res = await backfillClaims(kv, db, batchSize, cursor, dryRun, forceResync);
         break;
       case "inbox_messages":
         res = await backfillInboxMessages(kv, db, batchSize, cursor, dryRun);
@@ -1011,6 +1020,7 @@ export async function POST(request: NextRequest) {
     const result: BackfillResult = {
       table,
       dryRun,
+      forceResync,
       batchSize,
       inserted: res.inserted,
       inserted_null_btcpubkey: res.inserted_null_btcpubkey,

--- a/app/api/admin/genesis-payout/route.ts
+++ b/app/api/admin/genesis-payout/route.ts
@@ -3,6 +3,8 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
 import { validateGenesisPayoutBody } from "@/lib/admin/validation";
 import { GenesisPayoutRecord } from "@/lib/admin/types";
+import type { ClaimRecord } from "@/lib/types";
+import { mirrorClaimToD1 } from "@/lib/claims/d1-mirror";
 
 /**
  * GET /api/admin/genesis-payout
@@ -198,11 +200,19 @@ export async function POST(request: NextRequest) {
     let claimRecordUpdated = false;
     if (existingClaimData) {
       try {
-        const claimRecord = JSON.parse(existingClaimData);
+        const claimRecord = JSON.parse(existingClaimData) as ClaimRecord;
         claimRecord.status = "rewarded";
         claimRecord.rewardTxid = rewardTxid;
         claimRecord.rewardSatoshis = rewardSatoshis;
         await kv.put(`claim:${btcAddress}`, JSON.stringify(claimRecord));
+        try {
+          await mirrorClaimToD1(env.DB as D1Database | undefined, claimRecord);
+        } catch (e) {
+          console.warn("genesis-payout D1 mirror write failed", {
+            btcAddress,
+            error: e instanceof Error ? e.message : String(e),
+          });
+        }
         claimRecordUpdated = true;
       } catch (e) {
         console.error("Failed to update claim record:", e);

--- a/app/api/claims/viral/route.ts
+++ b/app/api/claims/viral/route.ts
@@ -5,6 +5,7 @@ import { generateName } from "@/lib/name-generator";
 import { getNextLevel } from "@/lib/levels";
 import { X_HANDLE } from "@/lib/constants";
 import type { ClaimRecord } from "@/lib/types";
+import { mirrorClaimToD1 } from "@/lib/claims/d1-mirror";
 
 const MIN_REWARD_SATS = 5000;
 const MAX_REWARD_SATS = 10000;
@@ -234,6 +235,14 @@ export async function POST(request: NextRequest) {
     };
 
     await agentsKv.put(`claim:${btcAddress}`, JSON.stringify(claimRecord));
+    try {
+      await mirrorClaimToD1(env.DB as D1Database | undefined, claimRecord);
+    } catch (e) {
+      console.warn("claims/viral D1 mirror write failed", {
+        btcAddress,
+        error: e instanceof Error ? e.message : String(e),
+      });
+    }
 
     // Update agent record with owner (X handle) and create reverse index
     const updatedAgent = { ...agent, owner: ownerHandle };

--- a/lib/claims/d1-mirror.ts
+++ b/lib/claims/d1-mirror.ts
@@ -1,0 +1,35 @@
+import type { ClaimRecord } from "@/lib/types";
+
+export async function mirrorClaimToD1(
+  db: D1Database | undefined,
+  claim: ClaimRecord
+): Promise<void> {
+  if (!db) return;
+
+  await db
+    .prepare(
+      `INSERT INTO claims (
+         btc_address, display_name, tweet_url, tweet_author,
+         claimed_at, reward_satoshis, reward_txid, status
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(btc_address) DO UPDATE SET
+         display_name = excluded.display_name,
+         tweet_url = excluded.tweet_url,
+         tweet_author = excluded.tweet_author,
+         claimed_at = excluded.claimed_at,
+         reward_satoshis = excluded.reward_satoshis,
+         reward_txid = excluded.reward_txid,
+         status = excluded.status`
+    )
+    .bind(
+      claim.btcAddress,
+      claim.displayName,
+      claim.tweetUrl,
+      claim.tweetAuthor ?? null,
+      claim.claimedAt,
+      claim.rewardSatoshis,
+      claim.rewardTxid ?? null,
+      claim.status
+    )
+    .run();
+}


### PR DESCRIPTION
## Summary
- mirror verified viral claim writes from KV into D1 `claims`
- mirror rewarded Genesis payout status flips from KV into D1 `claims`
- add claims backfill resync mode via `force=resync` / `forceResync=true` so stale D1 claim rows are updated instead of skipped

## Production follow-up after deploy
Run the claims resync until `cursor` is `null`:

```bash
curl -X POST "https://aibtc.com/api/admin/backfill?table=claims&force=resync" \
  -H "X-Admin-Key: $ARC_ADMIN_API_KEY"
```

Then verify:
- `/api/admin/reconcile?table=claims` shows no unexplained claims drift
- txids from #835 and #836 verify instead of returning `sender_not_genesis`
- affected agents show non-zero competition trade counts after resubmission/scheduler catch-up

Fixes #836
Refs #835, #815, #830, #831

## Tests
- `npm test -- app/api/admin/backfill/__tests__/route.test.ts`
- `git diff --check`

Note: repo-wide `npm run typecheck -- --pretty false` still fails on pre-existing test typing issues in reconcile/inbox/outbox/reconciliation-queue suites, unrelated to this patch.