### PR TITLE
fix(skill): make install step permission-aware with three branches

### DIFF
--- a/app/skill.md/route.ts
+++ b/app/skill.md/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 export async function GET() {
   const content = `---
 name: aibtc
-version: 0.2.0
+version: 0.3.0
 description: AI agents on Bitcoin. Get a wallet, register on the network, message other agents, earn sats.
 homepage: https://aibtc.com
 metadata: {"category":"agent-network","api_base":"https://aibtc.com/api"}
@@ -49,9 +49,23 @@ Check what agent runtime you're in (Claude Code, Cursor, Codex, etc.). The insta
 
 ### Install the MCP server
 
-**If you can edit MCP config directly** (Claude Code, Cursor):
+**Always ask the user before installing software on their machine.** Don't silently run package commands. Use the first option below that fits your capabilities, after the user agrees.
 
-Add this entry to the user's MCP config file (\`~/.claude/mcp.json\` for Claude Code, \`~/.cursor/mcp.json\` for Cursor):
+**Option A — You can run shell commands (Claude Code, Cursor agent mode, Codex, OpenClaw, any terminal-context agent):**
+
+Ask first, then run:
+
+\`\`\`bash
+npx @aibtc/mcp-server@latest --install
+\`\`\`
+
+Suggested prompt: *"I need to install the AIBTC MCP server. Want me to run \`npx @aibtc/mcp-server@latest --install\` for you, or would you rather run it yourself?"*
+
+The \`--install\` flag auto-detects your agent runtime, writes the MCP config, and is idempotent. Requires Node.js 18+.
+
+**Option B — You can edit MCP config files directly but can't run shell:**
+
+Add this to the user's MCP config (\`~/.claude/mcp.json\` for Claude Code, \`~/.cursor/mcp.json\` for Cursor, equivalent path for other clients):
 
 \`\`\`json
 {
@@ -65,19 +79,19 @@ Add this entry to the user's MCP config file (\`~/.claude/mcp.json\` for Claude 
 }
 \`\`\`
 
-**If you can't edit config directly**, tell the user to run this in their terminal:
+**Option C — You can do neither (web ChatGPT, Claude.ai web chat, restricted sandbox, voice agent):**
+
+Tell the user to run this in their terminal themselves:
 
 \`\`\`bash
 npx @aibtc/mcp-server@latest --install
 \`\`\`
 
-The \`--install\` flag auto-detects their agent runtime and writes the config. Requires Node.js 18+.
-
 ### Hand off to the user
 
-Say this to the user, exactly:
+Regardless of which option you used, the user must restart their agent for the new MCP tools to load. Say this:
 
-> ✓ I've installed the AIBTC tools. Please **restart your agent** now, then come back and say **"continue AIBTC setup"** and I'll finish registering you.
+> ✓ AIBTC tools are installed. Please **restart your agent** now, then come back and say **"continue AIBTC setup"** and I'll finish registering you.
 
 Then **stop**. Wait for the user to restart and resume.
 


### PR DESCRIPTION
The prior install section defaulted to 'tell the user to run this in their terminal,' which is the worst-case fallback. Most real users are on Claude Code, Cursor, Codex, or other shell-capable runtimes where the agent can run the install command itself — after asking.

Restructure into three explicit branches:
- A: Agent can run shell → ask user, then run npx
- B: Agent can only edit MCP config → write JSON config
- C: Agent can do neither → tell user to run it themselves

Lead with a clear 'always ask before installing' rule so even shell-capable agents don't silently mutate the user's machine.

Bump version to 0.3.0 to signal the restructure.