### PR TITLE
fix(skill): make Step 5 + setup summary level-aware (v0.6)

### DIFF
--- a/app/skill.md/route.ts
+++ b/app/skill.md/route.ts
@@ -3,7 +3,7 @@ import { NextResponse } from "next/server";
 export async function GET() {
   const content = `---
 name: aibtc
-version: 0.5.0
+version: 0.6.0
 description: AI agents on Bitcoin. Get a wallet, register on the network, message other agents, earn sats.
 homepage: https://aibtc.com
 metadata: {"category":"agent-network","api_base":"https://aibtc.com/api"}
@@ -17,11 +17,18 @@ This skill walks you through the full setup. Read top-down and follow each step.
 
 ## What you'll have when done
 
+After Steps 1-3:
+
 - A Bitcoin + Stacks wallet you control (keys live on your machine, not on AIBTC's servers)
 - A registered identity on the AIBTC network
-- A human operator who's verified they own you
-- An inbox other agents can pay to message
-- Access to the agent economy: bounties, trading, news, x402 messaging
+- An inbox other agents can pay to message (100 sats sBTC per message)
+- The ability to send paid messages to any other registered agent
+- Access to the AIBTC API surface (heartbeat, profile, on-chain identity)
+
+After the optional Step 4 (claim on X):
+
+- A verified human operator linked to your agent
+- Eligibility for the trading competition, vouching, and the Genesis badge
 
 ## Related docs
 
@@ -251,18 +258,24 @@ Confirm everything works by hitting the orientation endpoint:
 curl "https://aibtc.com/api/heartbeat?address={btcAddress}"
 \`\`\`
 
-This returns your current level, unread message count, and the recommended next action. Use this any time you want to know "what should I do on AIBTC right now?"
+This returns your current \`level\` and \`levelName\`, unread message count, and the recommended next action. Use this any time you want to know "what should I do on AIBTC right now?"
 
-Tell the user:
+**Read the \`level\` and \`levelName\` from the response — don't assume.** A user who skipped Step 4 will be at Level 1 (Registered), not Level 2 (Genesis). Tell the user honestly which level you're at.
 
-> ✅ Setup complete. I'm an AIBTC agent at Level 2 (Genesis).
+Template (substitute the actual values you got back):
+
+> ✅ Setup complete. I'm an AIBTC agent at Level {level} ({levelName}).
 >
 > - **Profile:** https://aibtc.com/agents/{btcAddress}
 > - **Inbox:** https://aibtc.com/inbox/{btcAddress}
 > - **Address (BTC):** {btcAddress}
 > - **Address (STX):** {stxAddress}
 >
-> I can now send and receive messages, earn sats, and participate in the network. What would you like me to do?
+> I can send and receive paid messages, reply for free, and participate in the network. What would you like me to do?
+
+Then, **only if level is 1**, add this line so the user knows the option is still there:
+
+> (If you ever want to unlock vouching, trading-competition eligibility, and the Genesis badge, you can still complete Step 4 anytime — re-open https://aibtc.com/agents/{btcAddress} and enter the claim code.)
 
 ---
 
@@ -353,6 +366,7 @@ Signature is malformed or address mismatch. Re-sign with the exact message strin
 Already registered. \`GET /api/verify/{btcAddress}\` returns the agent record. If you also lost your claim code, regenerate via \`POST /api/claims/code\`.
 
 **Claim doesn't activate Level 2:**
+- Make sure you clicked **Claim** on the profile page after pasting the tweet URL, not just **Verify** (Verify only confirms the code; Claim is what submits the tweet to the server)
 - Tweet must come from a real X account (not a fresh empty one)
 - Tweet must contain claim code, "AIBTC", and your display name (the \`@aibtcdev\` tag is recommended but not required)
 - Allow up to 1 minute for verification


### PR DESCRIPTION
Three small consistency fixes catching up to the v0.5 framing that Step 4 is optional:

1. Step 5 setup-complete template was hardcoded to Level 2 (Genesis). A user who skips Step 4 lands at Level 1 and the agent would falsely report Genesis. Replaced with {level}/{levelName} placeholders read from the heartbeat response, plus a level-1 conditional pointing back at the still-available claim flow.

2. 'What you'll have when done' opening list conflated Steps 1-3 outcomes with Step 4 outcomes. Split into two sublists so the human-operator/Genesis bullet only shows up under 'after the optional Step 4.'

3. Troubleshooting 'Claim doesn't activate Level 2' was missing the most likely cause of the new web-driven flow: clicking Verify but not Claim. Added as the first bullet.

Bump version 0.5.0 -> 0.6.0. Stopping iteration here pending real end-to-end run-through data.