### PR TITLE
fix(test): update #733 dedup tests to use P3 stats mocks

### DIFF
--- a/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
@@ -426,9 +426,11 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
     });
 
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([receivedMsgFromDualPartner]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
+    // P3: received/unread counts come from getAgentInboxStats, not countInboxMessagesFromD1.
+    // Default mock at module level (receivedCount:1, unreadCount:1) is sufficient here.
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([sentReplyToDualPartner]);
-    (countOutboxRepliesFromD1 as Mock).mockResolvedValue(1);
+    // P3: sentCount is derived from listOutboxRepliesFromD1 length; countOutboxRepliesFromD1
+    // is no longer called by the route.
 
     const res = await GET(
       buildGetRequest(AGENT_ADDR, "?include=partners"),
@@ -471,9 +473,11 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
     });
 
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([receivedMsgFromDualPartner]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
+    // P3: received/unread counts come from getAgentInboxStats, not countInboxMessagesFromD1.
+    // Default mock at module level (receivedCount:1, unreadCount:1) is sufficient here.
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([sentReplyToDualPartner]);
-    (countOutboxRepliesFromD1 as Mock).mockResolvedValue(1);
+    // P3: sentCount is derived from listOutboxRepliesFromD1 length; countOutboxRepliesFromD1
+    // is no longer called by the route.
 
     const res = await GET(
       buildGetRequest(AGENT_ADDR, "?include=partners"),


### PR DESCRIPTION
## Summary

Follow-up to PR #735 (merged): the two new partner-dedup regression tests referenced `countOutboxRepliesFromD1` which was removed by P3 (#845) in favour of `getAgentInboxStats` + `listOutboxRepliesFromD1.length`.

- Replace stale `countOutboxRepliesFromD1` mock calls in the transient-recovery and persistent-failure tests with comments explaining the P3 stats model
- The module-level `getAgentInboxStats` default mock already covers received/unread counts
- `sentCount` now comes from `listOutboxRepliesFromD1` length (no separate count call needed)

This is a test-only fix — no route code changes.

## Test plan

- [x] Both #733 partner-dedup regression tests pass: `partner dedup: transient lookup failure → direction='both'` and `partner dedup: persistent lookup failure preserves received partner`
- [x] All 26 tests in `d1-sentcount-partners.test.ts` pass
- [x] No existing tests broken

Part of quest `d1-count-bill-stop` P4 transition fallout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)