### PR TITLE
docs(kv): mark rate-limit migration complete (#762-A audit)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -350,6 +350,20 @@ Genesis-level agents (Level 2+) can vouch for new agents using private referral 
 - `app/api/referral-code/route.ts` — Retrieve/regenerate private referral code
 - `app/api/register/route.ts` — Integration point (ref query parameter)
 
+## Rate Limiting
+
+Rate limiting is handled by the Cloudflare first-party **`ratelimits` binding** (NOT KV writes).
+Four bindings are declared in `wrangler.jsonc` (top-level + `env.production` + `env.preview`):
+
+| Binding | Limit | Period | Used By |
+|---|---:|---:|---|
+| `RATE_LIMIT_READ` | 300 req | 60s | Competition trades GET, competition status, prices |
+| `RATE_LIMIT_MUTATING` | 20 req | 60s | Inbox sender, outbox, mark-read, txid recovery, competition submit |
+| `RATE_LIMIT_AUTHENTICATED` | 200 req | 60s | Outbox authenticated replies |
+| `RATE_LIMIT_STRICT` | 1 req | 60s | /api/challenge POST (per IP) |
+
+Prior KV-RMW rate-limit pattern was migrated to `RATE_LIMIT_STRICT` by PR #769 (`feat(rate-limit): migrate challenge from KV-RMW to RATE_LIMIT_STRICT`). The `lib/rate-limit.ts` module no longer exists. The only remaining `ratelimit:` prefixed KV key is the misnamed `ratelimit:payment-failure:` negative-result cache in `lib/inbox/payment-cache.ts` — this is a typed cache entry, not a rate-limit counter (see KV Storage Patterns table below).
+
 ## KV Storage Patterns
 
 All data stored in Cloudflare KV namespace `VERIFIED_AGENTS`:

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2103,7 +2103,7 @@ export function GET() {
                             type: "array",
                             items: { type: "string" },
                             description:
-                              "Challenge and rate limit records (challenge:..., checkin:..., ratelimit:...)",
+                              "Challenge and check-in records (challenge:..., checkin:...)",
                           },
                           inbox: {
                             type: "array",


### PR DESCRIPTION
## Summary

P1 audit (kv-write-bill-stop quest, phase P1) confirmed the rate-limit KV → Cloudflare `ratelimits` binding migration is complete. This PR closes the doc gap:

- **Add `## Rate Limiting` section to CLAUDE.md** documenting all four `ratelimits` bindings (`RATE_LIMIT_READ`, `RATE_LIMIT_MUTATING`, `RATE_LIMIT_AUTHENTICATED`, `RATE_LIMIT_STRICT`), their limits, periods, and current callers. Makes explicit that rate-limiting does NOT use KV writes. References PR #769 that completed the migration.
- **Remove stale `ratelimit:...` from openapi.json** admin/delete-agent challenges group description. The delete-agent route only handles `challenge:` and `checkin:` keys in that group — the `ratelimit:` family no longer exists in production code (except the intentional `ratelimit:payment-failure:` negative-result cache, which belongs in the `inbox:` category and is already documented in the KV Storage Patterns table).

## Audit findings (P1)

- `lib/rate-limit.ts`: does not exist (migration complete)
- `ratelimit:*` KV writes in non-test, non-payment-failure code: **zero**
- `ratelimits` bindings in `wrangler.jsonc`: 4 bindings × 3 envs (top-level, production, preview) — all present and correct
- Full inventory: `~/.planning/active/2026-05-14-kv-write-bill-stop/phases/P1-rate-limits/2026-05-14T2200Z-binding-inventory.md`

## Linked issues

Closes #762-A (rate-limit primitive audit). Part of kv-write-bill-stop quest.

## Test plan

- [ ] `grep "ratelimits" CLAUDE.md` returns the new section
- [ ] `grep "RATE_LIMIT_STRICT" CLAUDE.md` finds the challenge rate-limit reference
- [ ] `grep "ratelimit\.\.\." app/api/openapi.json/route.ts` returns no results (stale text removed)
- [ ] No production behavior change (doc-only PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)