### PR TITLE
fix(leaderboard): route price reads through /api/prices to pick up #849 stablecoin fallback

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -152,31 +152,40 @@ async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
 
   const addr = tokenIdToTeneroAddress(tokenId);
   try {
-    const res = await fetch(
-      `${TENERO_API_BASE}/tokens/${encodeURIComponent(addr)}`,
-      { headers: { Accept: "application/json" } }
-    );
-    if (!res.ok) {
+    // Per the /api/prices route docstring: "The leaderboard reads decimals
+    // directly from Tenero on the client". We split the two reads so the
+    // price hop picks up the server-side stablecoin fallback (#849) — which
+    // is the only way aeUSDC and USDCx hydrate at $1 when Tenero responds
+    // with price_usd: 0 — while decimals continue to come from Tenero, which
+    // is the long-standing source of truth for that field.
+    const [priceRes, decimalsRes] = await Promise.all([
+      fetch(`/api/prices?token=${encodeURIComponent(tokenId)}`, {
+        headers: { Accept: "application/json" },
+      }),
+      fetch(`${TENERO_API_BASE}/tokens/${encodeURIComponent(addr)}`, {
+        headers: { Accept: "application/json" },
+      }),
+    ]);
+
+    if (!priceRes.ok || !decimalsRes.ok) {
       writeCachedPrice(tokenId, null, null);
       return null;
     }
-    const body = (await res.json()) as {
-      data?: {
-        price_usd?: number | string | null;
-        decimals?: number | string | null;
-      };
+
+    const priceBody = (await priceRes.json()) as {
+      priceUsd?: number | null;
     };
-    const rawPrice = body.data?.price_usd;
-    const parsedPrice =
-      typeof rawPrice === "string" ? parseFloat(rawPrice) : rawPrice;
     const priceUsd =
-      typeof parsedPrice === "number" &&
-      Number.isFinite(parsedPrice) &&
-      parsedPrice > 0
-        ? parsedPrice
+      typeof priceBody.priceUsd === "number" &&
+      Number.isFinite(priceBody.priceUsd) &&
+      priceBody.priceUsd > 0
+        ? priceBody.priceUsd
         : null;
 
-    const rawDecimals = body.data?.decimals;
+    const decimalsBody = (await decimalsRes.json()) as {
+      data?: { decimals?: number | string | null };
+    };
+    const rawDecimals = decimalsBody.data?.decimals;
     const parsedDecimals =
       typeof rawDecimals === "string" ? parseInt(rawDecimals, 10) : rawDecimals;
     const decimals =

--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -152,12 +152,8 @@ async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
 
   const addr = tokenIdToTeneroAddress(tokenId);
   try {
-    // Per the /api/prices route docstring: "The leaderboard reads decimals
-    // directly from Tenero on the client". We split the two reads so the
-    // price hop picks up the server-side stablecoin fallback (#849) — which
-    // is the only way aeUSDC and USDCx hydrate at $1 when Tenero responds
-    // with price_usd: 0 — while decimals continue to come from Tenero, which
-    // is the long-standing source of truth for that field.
+    // Split fetch: price via /api/prices (picks up server-side stablecoin fallback from #849),
+    // decimals via Tenero directly (intentionally not mirrored server-side).
     const [priceRes, decimalsRes] = await Promise.all([
       fetch(`/api/prices?token=${encodeURIComponent(tokenId)}`, {
         headers: { Accept: "application/json" },
@@ -168,6 +164,20 @@ async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
     ]);
 
     if (!priceRes.ok || !decimalsRes.ok) {
+      if (!priceRes.ok) {
+        console.warn(
+          "[leaderboard] /api/prices fetch failed for",
+          tokenId,
+          priceRes.status
+        );
+      }
+      if (!decimalsRes.ok) {
+        console.warn(
+          "[leaderboard] Tenero decimals fetch failed for",
+          addr,
+          decimalsRes.status
+        );
+      }
       writeCachedPrice(tokenId, null, null);
       return null;
     }


### PR DESCRIPTION
## Summary

- Route `app/leaderboard/LeaderboardClient.tsx::fetchTokenPrice` price reads through `/api/prices` so the leaderboard picks up PR #849's USD-stablecoin fallback. Decimals continue to come from Tenero, per the `/api/prices` route docstring.
- Closes the visible-leaderboard half of #815's aeUSDC mismark — `/api/prices` is correct, but row #5 on the live leaderboard still shows `$22.19* / -25.41%*` with `allPriced=false` because the client path never went through the server.

## Repro (pre-fix)

```
$ curl -s -H 'Accept: application/json' \
    'https://aibtc.com/api/prices?token=SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc'
{"tokenId":"SP3Y2ZSH…token-aeusdc","priceUsd":1,"fetchedAt":null}   ✅ #849 working

# But https://aibtc.com/leaderboard row #5 still shows pre-#849 numbers with `*` flag.
```

@ThankNIXlater's diagnosis on #815 (issuecomment-4454792186) was the load-bearing observation — that the leaderboard renders client-side via `fetchTokenPrice()` which calls Tenero directly via `${TENERO_API_BASE}/tokens/…`, not `/api/prices`. So PR #849's server-side `getStablecoinUsdFallback` never runs on the visible code path.

## Shape of the fix

Two-fetch via `Promise.all`:

```ts
const [priceRes, decimalsRes] = await Promise.all([
  fetch(`/api/prices?token=${encodeURIComponent(tokenId)}`, {...}),         // #849 stablecoin fallback applies here
  fetch(`${TENERO_API_BASE}/tokens/${encodeURIComponent(addr)}`, {...}),    // decimals (per /api/prices route docstring)
]);
```

I went with split-fetch rather than inlining `getStablecoinUsdFallback` on the client because the route docstring (`/api/prices`) explicitly carves out the architecture: prices are server-mirrored, decimals are intentionally not — "the leaderboard reads decimals directly from Tenero on the client, so no second list is required there." Adding a parallel `/api/prices` hop preserves that boundary and keeps the stablecoin-fallback list in one place (server-side).

If you'd prefer the alternative shape — add `decimals` to the cached `tenero:price:{tokenId}` KV record so `/api/prices` becomes the single source of truth and we drop the Tenero call entirely from the client — happy to revise. That's a bigger change (touches `lib/external/tenero/kv-cache.ts` and `SchedulerDO`) but architecturally cleaner long-term.

## Verification

- `git diff --check` clean
- Static read of the change — no new imports needed; existing `TENERO_API_BASE` constant retained for the decimals fetch
- Local test rig: I did not run the dev server (no Cloudflare-Wrangler local sBTC setup in this checkout); recommend a `vercel preview` / wrangler-preview spot-check post-merge against a row that has aeUSDC in either leg

## Notes

- One test case worth adding eventually: a `LeaderboardClient` integration that mocks `fetch` and asserts the price hop hits `/api/prices?token=...` rather than `TENERO_API_BASE`. Did not add in this PR to keep scope to the bug fix; happy to add as a follow-up if useful.
- The cached-price localStorage record format is unchanged, so the 5-min client cache continues to work and a stale wrong-priced entry will roll over within that TTL after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
