### PR TITLE
fix(competition): allowlist current Bitflow gen + restore stablecoin P&L

### DIFF
--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { generateName } from "@/lib/name-generator";
 import { truncateAddress, formatRelativeTime } from "@/lib/utils";
+import { getStablecoinUsdFallback } from "@/lib/external/tenero/stablecoin-fallbacks";
 import Tooltip from "../components/Tooltip";
 
 /**
@@ -142,6 +143,19 @@ function writeCachedPrice(
 }
 
 async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
+  // USD-pegged tokens: Tenero 404s on these (verified for aeUSDC / USDCx),
+  // so short-circuit to the shared $1 fallback before the HTTP call.
+  // Mirrors the server-side fast path in `lib/external/tenero/prices.ts` so
+  // server and client agree on what a stablecoin is worth, and the
+  // leaderboard's P&L stops silently dropping any trade leg in this set.
+  const stablecoinFallback = getStablecoinUsdFallback(tokenId);
+  if (stablecoinFallback) {
+    return {
+      priceUsd: stablecoinFallback.priceUsd,
+      decimals: stablecoinFallback.decimals,
+    };
+  }
+
   const cached = readCachedPrice(tokenId);
   if (cached) {
     if (cached.priceUsd != null && cached.decimals != null) {

--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -143,11 +143,7 @@ function writeCachedPrice(
 }
 
 async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
-  // USD-pegged tokens: Tenero 404s on these (verified for aeUSDC / USDCx),
-  // so short-circuit to the shared $1 fallback before the HTTP call.
-  // Mirrors the server-side fast path in `lib/external/tenero/prices.ts` so
-  // server and client agree on what a stablecoin is worth, and the
-  // leaderboard's P&L stops silently dropping any trade leg in this set.
+  // Tenero 404s on USD-pegged tokens; use the shared fallback instead.
   const stablecoinFallback = getStablecoinUsdFallback(tokenId);
   if (stablecoinFallback) {
     return {

--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -143,7 +143,8 @@ function writeCachedPrice(
 }
 
 async function fetchTokenPrice(tokenId: string): Promise<TokenPrice | null> {
-  // Tenero 404s on USD-pegged tokens; use the shared fallback instead.
+  // Tenero 404s on USD-pegged tokens — both price and decimals come from
+  // the shared fallback table instead.
   const stablecoinFallback = getStablecoinUsdFallback(tokenId);
   if (stablecoinFallback) {
     return {

--- a/lib/competition/allowlist.ts
+++ b/lib/competition/allowlist.ts
@@ -299,8 +299,32 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
     contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-multihop-v-1-1`,
     functions: ["swap-3", "swap-4", "swap-5"],
   },
+  // wrapper-alex-v-1-1 (older sibling of v-2-1 below). Public ABI exposes
+  // `swap-helper-a` / `swap-helper-b` (the v-2-1 family is wider — 4 helpers
+  // including the unsuffixed `swap-helper`). Lives on the same deployer as
+  // v-2-1; both can be picked by the Bitflow SDK depending on the route.
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-alex-v-1-1`,
+    functions: ["swap-helper-a", "swap-helper-b"],
+  },
   {
     contract_id: `${BITFLOW_DEPLOYER}.wrapper-alex-v-2-1`,
+    functions: [
+      "swap-helper",
+      "swap-helper-a",
+      "swap-helper-b",
+      "swap-helper-c",
+    ],
+  },
+  // wrapper-alex-v-2-2 (XYK deployer, not BITFLOW_DEPLOYER like v-2-1).
+  // Same 4-helper shape as v-2-1 (`swap-helper` + `swap-helper-a/b/c`);
+  // signatures gain the optional `provider` arg for Bitflow attribution.
+  // On-chain source header reads `;; wrapper-alex-v-2-2` and the body
+  // calls SP102V8P0F7JX67ARQ77WEA3D3CFB5XW39REDT0AM.amm-pool-v2-01 (ALEX's
+  // canonical AMM), confirming it's an ALEX wrapper despite sharing the
+  // XYK deployer principal with the velar / arkadiko / xyk wrappers.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.wrapper-alex-v-2-2`,
     functions: [
       "swap-helper",
       "swap-helper-a",
@@ -320,17 +344,29 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
     functions: ["swap-x-for-y", "swap-y-for-x"],
   },
 
-  // -- wrapper-velar-path (new path-based wrapper family) --
+  // -- wrapper-velar-path (path-based wrapper family) --
   // Distinct from `wrapper-velar` and `wrapper-velar-multihop` — this is
   // a separate generalized "path" wrapper that composes Velar univ2v2
   // pools, Bitflow curves, stSTX, and USDH along an arbitrary route.
   // Surfaced when an agent's sBTC→STX trade was rejected as
   // `contract_not_allowlisted` even though the sBTC transfer succeeded
-  // on-chain. Reproducer tx (rejected, `swap-univ2v2`, sBTC→wSTX via
-  // Velar pool 0070):
+  // on-chain. Reproducer tx for v-1-2 (rejected, `swap-univ2v2`, sBTC→wSTX
+  // via Velar pool 0070):
   // 0xd714b35559cf76ab22f339dbe9d6648e4ce2afed42e16eebd07c274e33b1663b
-  // Sibling `wrapper-{alex,arkadiko,xyk}-path-v-1-2` do NOT exist on-chain
-  // (Hiro 404 as of 2026-05-16) — only the velar variant is deployed.
+  //
+  // v-1-1 lives on BITFLOW_DEPLOYER, v-1-2 on BITFLOW_XYK_DEPLOYER — same
+  // cross-deployer split pattern as the other wrapper families
+  // (`wrapper-velar` v-1-1/v-1-2, `wrapper-arkadiko` v-1-1/v-1-2). Both
+  // versions expose `swap-{curve,ststx,univ2v2,usdh}`; v-1-2 adds an
+  // optional `provider` arg for attribution.
+  //
+  // Sibling `wrapper-{alex,arkadiko,xyk}-path-*` do NOT exist on either
+  // deployer (Hiro 404 across the board as of 2026-05-16) — only the
+  // velar variant of the path family is deployed.
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.wrapper-velar-path-v-1-1`,
+    functions: ["swap-curve", "swap-ststx", "swap-univ2v2", "swap-usdh"],
+  },
   {
     contract_id: `${BITFLOW_XYK_DEPLOYER}.wrapper-velar-path-v-1-2`,
     functions: ["swap-curve", "swap-ststx", "swap-univ2v2", "swap-usdh"],

--- a/lib/competition/allowlist.ts
+++ b/lib/competition/allowlist.ts
@@ -78,9 +78,35 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
     functions: STABLESWAP_FUNCTIONS,
   },
 
+  // -- New-deployer stableswap cores (pool + core split architecture) --
+  // Newer Bitflow stableswap pools (deployed under BITFLOW_XYK_DEPLOYER)
+  // split into pool (state) + core (logic): the pool contract is passed as
+  // a trait arg, and `swap-x-for-y` / `swap-y-for-x` are invoked on the
+  // *core*. The pool contracts themselves have no public `swap-*` fns and
+  // are never the top-level contract_call target, so only the cores need
+  // allowlisting. Verified against on-chain ABI for v-1-2, v-1-3, v-1-4.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.stableswap-core-v-1-2`,
+    functions: STABLESWAP_FUNCTIONS,
+  },
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.stableswap-core-v-1-3`,
+    functions: STABLESWAP_FUNCTIONS,
+  },
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.stableswap-core-v-1-4`,
+    functions: STABLESWAP_FUNCTIONS,
+  },
+
   // -- XYK --
   {
     contract_id: `${BITFLOW_XYK_DEPLOYER}.xyk-core-v-1-1`,
+    functions: ["swap-x-for-y", "swap-y-for-x"],
+  },
+  // Successor to xyk-core-v-1-1. Identical swap ABI; both versions are
+  // live on-chain and the Bitflow SDK may pick either depending on routing.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.xyk-core-v-1-2`,
     functions: ["swap-x-for-y", "swap-y-for-x"],
   },
   // XYK swap helper — where the optional `provider` clarity arg lives
@@ -136,12 +162,33 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
       "swap-y-for-x-simple-range-multi",
     ],
   },
+  // Successor to dlmm-swap-router-v-1-1. Identical 8-variant swap ABI;
+  // both versions are live and the SDK may pick either.
+  {
+    contract_id: `${BITFLOW_DLMM_DEPLOYER}.dlmm-swap-router-v-1-2`,
+    functions: [
+      "swap-multi",
+      "swap-simple-multi",
+      "swap-x-for-y-same-multi",
+      "swap-x-for-y-simple-multi",
+      "swap-x-for-y-simple-range-multi",
+      "swap-y-for-x-same-multi",
+      "swap-y-for-x-simple-multi",
+      "swap-y-for-x-simple-range-multi",
+    ],
+  },
 
   // -- Cross-DEX routers (13 contracts) --
   // Most expose only `swap-helper-a` and `swap-helper-b`. Two velar-alex
   // versions expose `swap-helper-a..p` (16 helpers each).
   {
     contract_id: `${BITFLOW_DEPLOYER}.router-stx-ststx-bitflow-arkadiko-v-1-1`,
+    functions: ROUTER_HELPER_AB,
+  },
+  // Both v-1-1 and v-1-2 of the velar router are live on-chain; v-1-2 was
+  // already allowlisted, v-1-1 was missing.
+  {
+    contract_id: `${BITFLOW_DEPLOYER}.router-stx-ststx-bitflow-velar-v-1-1`,
     functions: ROUTER_HELPER_AB,
   },
   {
@@ -264,6 +311,29 @@ export const BITFLOW_ALLOWLIST: readonly AllowlistEntry[] = [
   {
     contract_id: `${BITFLOW_DEPLOYER}.wrapper-arkadiko-v-1-1`,
     functions: ["swap-x-for-y", "swap-y-for-x"],
+  },
+  // wrapper-arkadiko-v-1-2 lives under the XYK deployer (not BITFLOW_DEPLOYER
+  // like v-1-1). Same `swap-x-for-y` / `swap-y-for-x` names; signature adds
+  // the optional `provider` arg used for Bitflow attribution.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.wrapper-arkadiko-v-1-2`,
+    functions: ["swap-x-for-y", "swap-y-for-x"],
+  },
+
+  // -- wrapper-velar-path (new path-based wrapper family) --
+  // Distinct from `wrapper-velar` and `wrapper-velar-multihop` — this is
+  // a separate generalized "path" wrapper that composes Velar univ2v2
+  // pools, Bitflow curves, stSTX, and USDH along an arbitrary route.
+  // Surfaced when an agent's sBTC→STX trade was rejected as
+  // `contract_not_allowlisted` even though the sBTC transfer succeeded
+  // on-chain. Reproducer tx (rejected, `swap-univ2v2`, sBTC→wSTX via
+  // Velar pool 0070):
+  // 0xd714b35559cf76ab22f339dbe9d6648e4ce2afed42e16eebd07c274e33b1663b
+  // Sibling `wrapper-{alex,arkadiko,xyk}-path-v-1-2` do NOT exist on-chain
+  // (Hiro 404 as of 2026-05-16) — only the velar variant is deployed.
+  {
+    contract_id: `${BITFLOW_XYK_DEPLOYER}.wrapper-velar-path-v-1-2`,
+    functions: ["swap-curve", "swap-ststx", "swap-univ2v2", "swap-usdh"],
   },
 ] as const;
 

--- a/lib/external/tenero/stablecoin-fallbacks.ts
+++ b/lib/external/tenero/stablecoin-fallbacks.ts
@@ -7,20 +7,31 @@
 export interface StablecoinUsdFallback {
   symbol: string;
   priceUsd: number;
+  /**
+   * On-chain decimals. Server-side callers (the scheduler / `/api/prices`)
+   * read only `priceUsd`; the leaderboard client also needs decimals to
+   * convert raw amounts to USD, and Tenero 404s on these contracts so it
+   * can't get the value there. Verified via SIP-010 `get-decimals` on
+   * 2026-05-16.
+   */
+  decimals: number;
 }
 
 const USD_PEGGED_TOKEN_FALLBACKS: Readonly<Record<string, StablecoinUsdFallback>> = {
   "SP120SBRBQJ00MCWS7TM5R8WJNTTKD5K0HFRC2CNE.usdcx": {
     symbol: "USDCx",
     priceUsd: 1,
+    decimals: 6,
   },
   "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-aeusdc": {
     symbol: "aeUSDC",
     priceUsd: 1,
+    decimals: 6,
   },
   "SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc": {
     symbol: "aeUSDC",
     priceUsd: 1,
+    decimals: 6,
   },
 };
 

--- a/lib/external/tenero/stablecoin-fallbacks.ts
+++ b/lib/external/tenero/stablecoin-fallbacks.ts
@@ -7,13 +7,7 @@
 export interface StablecoinUsdFallback {
   symbol: string;
   priceUsd: number;
-  /**
-   * On-chain decimals. Server-side callers (the scheduler / `/api/prices`)
-   * read only `priceUsd`; the leaderboard client also needs decimals to
-   * convert raw amounts to USD, and Tenero 404s on these contracts so it
-   * can't get the value there. Verified via SIP-010 `get-decimals` on
-   * 2026-05-16.
-   */
+  /** On-chain SIP-010 decimals. */
   decimals: number;
 }
 


### PR DESCRIPTION
## Summary

Three competition-correctness fixes that surfaced from the same rejected sBTC→STX trade reproducer (`0xd714b3…`) — and from review pushback on which contracts I'd actually verified.

### 1. Allowlist current Bitflow generation (+11 entries, 28 → 39)

The verifier was rejecting legitimate Bitflow-mediated trades as `contract_not_allowlisted` because several live Bitflow contracts were missing. Each new entry's function names verified against the on-chain ABI via Hiro.

**New-deployer stableswap cores** — `v-1-2`, `v-1-3`, `v-1-4`. The new pool/core architecture splits state (pools) from logic (cores); pools are passed as trait args, cores are the top-level swap entry points.

**Next-version successors** — `xyk-core-v-1-2`, `dlmm-swap-router-v-1-2`, `wrapper-arkadiko-v-1-2`.

**Cross-deployer siblings I missed in the first pass** — Bitflow's wrappers split across two principals (`SPQC38…` and `SM1793…`); v-1-1 of a wrapper may live on one and v-1-2 on the other. My initial sweep only probed one principal per name, so I missed:
- `SPQC38…wrapper-alex-v-1-1` — sibling of the already-allowlisted `wrapper-alex-v-2-1`
- `SM1793…wrapper-alex-v-2-2` — XYK-deployer variant of `v-2-1`; on-chain source header reads `;; wrapper-alex-v-2-2` and calls ALEX's `amm-pool-v2-01`
- `SPQC38…wrapper-velar-path-v-1-1` — older sibling of the velar-path wrapper
- `router-stx-ststx-bitflow-velar-v-1-1` — we already had v-1-2

**New "path" wrapper family** — `wrapper-velar-path-v-1-1` and `wrapper-velar-path-v-1-2` (`swap-curve`, `swap-ststx`, `swap-univ2v2`, `swap-usdh`). Surfaced by reproducer tx `0xd714b35559cf76ab22f339dbe9d6648e4ce2afed42e16eebd07c274e33b1663b` (sBTC→wSTX via Velar pool 0070, rejected despite settling on-chain).

**Deliberately *not* added (re-verified across both deployers):**
- Individual `stableswap-pool-*` contracts — they're delegate targets, never the top-level `contract_call`; verifier matches top-level only
- `wrapper-{alex,arkadiko,xyk}-path-*` siblings — Hiro 404 on both `SPQC38…` and `SM1793…`; only the velar variant of the path family exists
- `aggregator-core-v-1-1` — public ABI is admin / `set-*` / fee transfer; no `swap-*` functions, never a top-level entry point

### 2. Apply stablecoin fallback in the leaderboard client

`LeaderboardClient.fetchTokenPrice` calls Tenero directly from the browser. Tenero 404s on `aeUSDC` / `USDCx`, so those legs were being marked unpriced and silently dropped from both Volume and P&L — an agent stableswapping aeUSDC↔USDH would render with near-zero volume and a misleading partial P&L.

Server-side `fetchTokenPriceUsd` already short-circuits to a $1 fallback for these contracts via `getStablecoinUsdFallback`. This PR lifts the same fast path into the client fetcher so server and client agree on the price. `StablecoinUsdFallback` gains a `decimals` field (6 for all three current entries; server consumers ignore it).

## Test plan

- [x] All 9 related vitest suites pass (104/104): `lib/external`, `lib/competition`, `lib/scheduler`
- [ ] Visit `/leaderboard` in preview — agents with aeUSDC/USDCx trade legs now show non-zero volume + a P&L number (no leading `*` partial-flag for stablecoin-only trades)
- [ ] Submit a Velar-path tx through `/api/competition/trades` and confirm it's accepted (not `contract_not_allowlisted`)
