### PR TITLE
fix(bounty): show poster identity on card, remove top stats block

### DIFF
--- a/app/bounty/AgentBadge.tsx
+++ b/app/bounty/AgentBadge.tsx
@@ -1,0 +1,39 @@
+import { truncAddr } from "./utils";
+
+/**
+ * Avatar + display name pill for a BTC address.
+ *
+ * Used on bounty cards, the bounty detail page (poster + winner + each
+ * submission row), and anywhere we need to surface an agent's identity from
+ * just a raw address. Falls back to a truncated address when no display name
+ * is known (e.g. the address belongs to someone who hasn't registered).
+ *
+ * Avatar source follows the codebase convention (Leaderboard, AgentStrip,
+ * ActivityFeedHero, InteractionGraph): bitcoinfaces.xyz.
+ */
+export default function AgentBadge({
+  address,
+  name,
+  size = "sm",
+  textClass = "text-white/60",
+}: {
+  address: string;
+  name?: string;
+  size?: "xs" | "sm" | "md";
+  textClass?: string;
+}) {
+  const imgSizeClass = size === "xs" ? "size-4" : size === "md" ? "size-6" : "size-5";
+  const gapClass = size === "xs" ? "gap-1" : "gap-1.5";
+  return (
+    <span className={`inline-flex items-center min-w-0 ${gapClass}`}>
+      <img
+        src={`https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(address)}`}
+        alt=""
+        role="presentation"
+        className={`${imgSizeClass} shrink-0 rounded-full bg-white/[0.04] object-cover`}
+        loading="lazy"
+      />
+      <span className={`truncate ${textClass}`}>{name ?? truncAddr(address)}</span>
+    </span>
+  );
+}

--- a/app/bounty/BountyDirectory.tsx
+++ b/app/bounty/BountyDirectory.tsx
@@ -13,17 +13,6 @@ import {
   submissionWindowLabel,
 } from "./utils";
 
-function StatCard({ label, value }: { label: string; value: string | number }) {
-  return (
-    <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-5 py-4 text-center max-md:px-3 max-md:py-3">
-      <div className="text-2xl font-semibold tracking-tight text-white max-md:text-xl">
-        {typeof value === "number" ? formatSats(value) : value}
-      </div>
-      <div className="mt-1 text-xs text-white/40">{label}</div>
-    </div>
-  );
-}
-
 function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
   const tags = bounty.tags ?? [];
   const windowLabel = submissionWindowLabel(bounty.expiresAt, bounty.status);
@@ -69,8 +58,19 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
         </div>
       )}
 
-      <div className="mt-auto flex items-center justify-between pt-1 text-[11px] text-white/30">
-        <span>{truncAddr(bounty.posterBtcAddress)}</span>
+      <div className="mt-auto flex items-center justify-between gap-2 pt-1 text-[11px] text-white/30">
+        <span className="flex items-center gap-1.5 min-w-0">
+          <img
+            src={`https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(bounty.posterBtcAddress)}`}
+            alt=""
+            role="presentation"
+            className="size-5 shrink-0 rounded-full bg-white/[0.04] object-cover"
+            loading="lazy"
+          />
+          <span className="truncate text-white/50">
+            {bounty.posterDisplayName ?? truncAddr(bounty.posterBtcAddress)}
+          </span>
+        </span>
         <div className="flex items-center gap-3">
           {windowLabel && (
             <span className={windowLabel === "Submissions closed" ? "text-red-400/60" : "text-white/40"}>
@@ -144,23 +144,6 @@ export default function BountyDirectory({
     });
   }, [initialBounties, statusFilter, searchFilter, sort]);
 
-  const stats = useMemo(() => {
-    if (!initialBounties) return null;
-    const byStatus = initialBounties.reduce<Record<string, number>>((acc, b) => {
-      acc[b.status] = (acc[b.status] ?? 0) + 1;
-      return acc;
-    }, {});
-    const totalPaid = initialBounties
-      .filter((b) => b.status === "paid")
-      .reduce((sum, b) => sum + b.rewardSats, 0);
-    return {
-      open: byStatus.open ?? 0,
-      paid: byStatus.paid ?? 0,
-      totalPaidSats: totalPaid,
-      total: initialTotal,
-    };
-  }, [initialBounties, initialTotal]);
-
   return (
     <section className="space-y-8">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -177,15 +160,6 @@ export default function BountyDirectory({
           Post a bounty
         </Link>
       </div>
-
-      {stats && (
-        <div className="grid grid-cols-2 gap-3 sm:grid-cols-4">
-          <StatCard label="Open" value={stats.open} />
-          <StatCard label="Paid" value={stats.paid} />
-          <StatCard label="Total Paid" value={`${formatSats(stats.totalPaidSats)} sats`} />
-          <StatCard label="All Bounties" value={stats.total} />
-        </div>
-      )}
 
       <div className="flex flex-wrap items-center gap-3">
         <label htmlFor="bounty-status-filter" className="sr-only">Filter by status</label>

--- a/app/bounty/BountyDirectory.tsx
+++ b/app/bounty/BountyDirectory.tsx
@@ -8,10 +8,10 @@ import {
   statusStyle,
   statusLabel,
   formatSats,
-  truncAddr,
   relativeTime,
   submissionWindowLabel,
 } from "./utils";
+import AgentBadge from "./AgentBadge";
 
 function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
   const tags = bounty.tags ?? [];
@@ -58,31 +58,37 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
         </div>
       )}
 
-      <div className="mt-auto flex items-center justify-between gap-2 pt-1 text-[11px] text-white/30">
-        <span className="flex items-center gap-1.5 min-w-0">
-          <img
-            src={`https://bitcoinfaces.xyz/api/get-image?name=${encodeURIComponent(bounty.posterBtcAddress)}`}
-            alt=""
-            role="presentation"
-            className="size-5 shrink-0 rounded-full bg-white/[0.04] object-cover"
-            loading="lazy"
-          />
-          <span className="truncate text-white/50">
-            {bounty.posterDisplayName ?? truncAddr(bounty.posterBtcAddress)}
-          </span>
-        </span>
-        <div className="flex items-center gap-3">
-          {windowLabel && (
-            <span className={windowLabel === "Submissions closed" ? "text-red-400/60" : "text-white/40"}>
-              {windowLabel}
-            </span>
-          )}
-          {bounty.submissionCount > 0 && (
-            <span>
-              {bounty.submissionCount} submission{bounty.submissionCount !== 1 ? "s" : ""}
-            </span>
-          )}
-          <span>{relativeTime(bounty.createdAt)}</span>
+      <div className="mt-auto flex flex-col gap-2 border-t border-white/[0.04] pt-3 text-[11px]">
+        <AgentBadge
+          address={bounty.posterBtcAddress}
+          name={bounty.posterDisplayName}
+          textClass="text-white/60"
+        />
+        <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-white/30">
+          {[
+            windowLabel && (
+              <span
+                key="window"
+                className={`whitespace-nowrap ${
+                  windowLabel === "Submissions closed" ? "text-red-400/60" : "text-white/40"
+                }`}
+              >
+                {windowLabel}
+              </span>
+            ),
+            bounty.submissionCount > 0 && (
+              <span key="subs" className="whitespace-nowrap">
+                {bounty.submissionCount} submission{bounty.submissionCount !== 1 ? "s" : ""}
+              </span>
+            ),
+            <span key="time" className="whitespace-nowrap">{relativeTime(bounty.createdAt)}</span>,
+          ]
+            .filter(Boolean)
+            .flatMap((node, i, arr) =>
+              i < arr.length - 1
+                ? [node, <span key={`sep-${i}`} className="text-white/15" aria-hidden="true">·</span>]
+                : [node]
+            )}
         </div>
       </div>
     </Link>

--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -11,6 +11,7 @@ import {
   formatDate,
   submissionWindowLabel,
 } from "../utils";
+import AgentBadge from "../AgentBadge";
 
 function linkify(text: string) {
   const urlRegex = /(https?:\/\/[^\s]+)/g;
@@ -119,7 +120,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
     );
   }
 
-  const { bounty, submissions, submissionCount, winner, payment } = data;
+  const { bounty, submissions, submissionCount, winner, payment, agentNames } = data;
   const tags = bounty.tags ?? [];
   const windowLabel = submissionWindowLabel(bounty.expiresAt, bounty.status);
   const explorerUrl = bounty.paidTxid
@@ -147,9 +148,15 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
 
         <Timeline status={bounty.status} />
 
-        <div className="flex flex-wrap items-center gap-4 text-xs text-white/40">
-          <span>
-            Poster: <span className="text-white/60">{truncAddr(bounty.posterBtcAddress)}</span>
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-white/40">
+          <span className="flex items-center gap-1.5">
+            <span>Poster:</span>
+            <AgentBadge
+              address={bounty.posterBtcAddress}
+              name={agentNames?.[bounty.posterBtcAddress]}
+              size="xs"
+              textClass="text-white/70"
+            />
           </span>
           <span>
             Posted: <span className="text-white/60">{formatDate(bounty.createdAt)}</span>
@@ -189,10 +196,12 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
         <Section title="Winner">
           <div className="rounded-lg border border-[#7DA2FF]/20 bg-[#7DA2FF]/[0.04] p-4 space-y-2">
             <div className="flex items-center justify-between gap-2">
-              <span className="text-sm font-medium text-white/80">
-                {truncAddr(winner.submitterBtcAddress)}
-              </span>
-              <span className="text-[11px] text-white/40">
+              <AgentBadge
+                address={winner.submitterBtcAddress}
+                name={agentNames?.[winner.submitterBtcAddress]}
+                textClass="text-white/80 text-sm font-medium"
+              />
+              <span className="text-[11px] text-white/40 whitespace-nowrap">
                 Accepted {formatDate(winner.acceptedAt)}
               </span>
             </div>
@@ -266,11 +275,13 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
                   }`}
                 >
                   <div className="flex items-center justify-between gap-2">
-                    <span className="text-sm font-medium text-white/70">
-                      {truncAddr(sub.submitterBtcAddress)}
-                    </span>
+                    <AgentBadge
+                      address={sub.submitterBtcAddress}
+                      name={agentNames?.[sub.submitterBtcAddress]}
+                      textClass="text-white/70 text-sm font-medium"
+                    />
                     {isWinner && (
-                      <span className="inline-flex rounded-md border border-[#7DA2FF]/30 bg-[#7DA2FF]/[0.10] px-2 py-0.5 text-[10px] font-medium uppercase text-[#7DA2FF]">
+                      <span className="inline-flex rounded-md border border-[#7DA2FF]/30 bg-[#7DA2FF]/[0.10] px-2 py-0.5 text-[10px] font-medium uppercase text-[#7DA2FF] whitespace-nowrap">
                         Winner
                       </span>
                     )}

--- a/app/bounty/[id]/page.tsx
+++ b/app/bounty/[id]/page.tsx
@@ -15,6 +15,7 @@ import {
   type BountyPaymentHint,
   type BountyWinner,
 } from "@/lib/bounty";
+import { lookupAgent } from "@/lib/agent-lookup";
 
 interface PageProps {
   params: Promise<{ id: string }>;
@@ -24,6 +25,7 @@ async function fetchBountyDetail(id: string): Promise<BountyDetailData | null> {
   try {
     const { env } = await getCloudflareContext();
     const db = env.DB as D1Database | undefined;
+    const kv = env.VERIFIED_AGENTS as KVNamespace | undefined;
     if (!db) return null;
 
     const bounty = await getBounty(db, id);
@@ -62,13 +64,35 @@ async function fetchBountyDetail(id: string): Promise<BountyDetailData | null> {
       };
     }
 
-    const decorated: BountyWithStatus = { ...bounty, status };
+    // Enrich with display names for every actor on the page (poster + all
+    // submitters). Dedupe so we don't look up the same address twice.
+    const addressesToLookup = Array.from(
+      new Set([bounty.posterBtcAddress, ...submissions.map((s) => s.submitterBtcAddress)])
+    );
+    const agentNames: Record<string, string> = {};
+    if (kv) {
+      const lookups = await Promise.all(
+        addressesToLookup.map(async (addr) => [addr, await lookupAgent(kv, addr, db)] as const)
+      );
+      for (const [addr, agent] of lookups) {
+        if (agent?.displayName) agentNames[addr] = agent.displayName;
+      }
+    }
+
+    const decorated: BountyWithStatus = {
+      ...bounty,
+      status,
+      ...(agentNames[bounty.posterBtcAddress] && {
+        posterDisplayName: agentNames[bounty.posterBtcAddress],
+      }),
+    };
     return {
       bounty: decorated,
       submissions,
       submissionCount: total,
       ...(winner && { winner }),
       ...(payment && { payment }),
+      agentNames,
     };
   } catch {
     return null;

--- a/app/bounty/page.tsx
+++ b/app/bounty/page.tsx
@@ -7,6 +7,7 @@ import Footer from "../components/Footer";
 import BountyDirectory from "./BountyDirectory";
 import type { BountyWithStatus } from "./types";
 import { bountyStatus, listBounties } from "@/lib/bounty";
+import { lookupAgent } from "@/lib/agent-lookup";
 
 export const metadata: Metadata = {
   title: "Bounties",
@@ -38,10 +39,32 @@ async function fetchBounties(): Promise<{ bounties: BountyWithStatus[]; total: n
   try {
     const { env } = await getCloudflareContext();
     const db = env.DB as D1Database | undefined;
+    const kv = env.VERIFIED_AGENTS as KVNamespace | undefined;
     if (!db) return null;
     const now = new Date();
     const { bounties, total } = await listBounties(db, { status: "active", limit: 100, now });
-    const withStatus = bounties.map((b) => ({ ...b, status: bountyStatus(b, now) }));
+
+    // Enrich each bounty with the poster's display name so cards can show
+    // identity instead of a raw BTC address. Dedupe by poster so the same
+    // agent isn't looked up twice in a single render.
+    const posters = Array.from(new Set(bounties.map((b) => b.posterBtcAddress)));
+    const nameByPoster = new Map<string, string>();
+    if (kv) {
+      const lookups = await Promise.all(
+        posters.map(async (addr) => [addr, await lookupAgent(kv, addr, db)] as const)
+      );
+      for (const [addr, agent] of lookups) {
+        if (agent?.displayName) nameByPoster.set(addr, agent.displayName);
+      }
+    }
+
+    const withStatus: BountyWithStatus[] = bounties.map((b) => ({
+      ...b,
+      status: bountyStatus(b, now),
+      ...(nameByPoster.has(b.posterBtcAddress) && {
+        posterDisplayName: nameByPoster.get(b.posterBtcAddress),
+      }),
+    }));
     return { bounties: withStatus, total };
   } catch {
     return null;

--- a/app/bounty/types.ts
+++ b/app/bounty/types.ts
@@ -28,4 +28,10 @@ export interface BountyDetailData {
   submissionCount: number;
   winner?: import("@/lib/bounty").BountyWinner;
   payment?: import("@/lib/bounty").BountyPaymentHint;
+  /**
+   * Map of BTC address → registered display name for every actor on the
+   * page (poster, winner, every submitter). Addresses without a known
+   * display name are absent from the map — render with truncAddr fallback.
+   */
+  agentNames?: Record<string, string>;
 }

--- a/app/bounty/types.ts
+++ b/app/bounty/types.ts
@@ -17,6 +17,8 @@ export type {
 /** Bounty record decorated with the derived status (the shape responses return). */
 export type BountyWithStatus = import("@/lib/bounty").BountyRecord & {
   status: import("@/lib/bounty").BountyStatus;
+  /** Poster's agent display name, when looked up by the server. */
+  posterDisplayName?: string;
 };
 
 /** Detail response — what GET /api/bounties/[id] returns. */

--- a/lib/bounty/validation.ts
+++ b/lib/bounty/validation.ts
@@ -357,7 +357,9 @@ export function validateSubmit(body: unknown):
     });
   }
 
-  if (b.contentUrl !== undefined) {
+  // Treat an empty string as "not provided" — the field is optional and
+  // clients (MCP tools, curl users) commonly send "" when they have no URL.
+  if (b.contentUrl !== undefined && b.contentUrl !== "") {
     if (typeof b.contentUrl !== "string") {
       errors.push({
         message: "contentUrl must be a string",
@@ -402,7 +404,7 @@ export function validateSubmit(body: unknown):
     data: {
       submitterBtcAddress: b.submitterBtcAddress as string,
       message: (b.message as string).trim(),
-      ...(typeof b.contentUrl === "string" && { contentUrl: b.contentUrl }),
+      ...(typeof b.contentUrl === "string" && b.contentUrl.length > 0 && { contentUrl: b.contentUrl }),
       signedAt: b.signedAt as string,
       signature: b.signature as string,
     },


### PR DESCRIPTION
## Summary

Two small UI cleanups on `/bounty`:

1. **BountyCard now shows agent identity.** Each card's footer used to render `truncAddr(posterBtcAddress)` — a meaningless 8-char prefix. Now it renders the poster's display name + bitcoinfaces avatar, falling back to the truncated address only when the poster isn't a registered agent.
2. **Removed the 4-card stats block** at the top of the directory (Open / Paid / Total Paid / All Bounties). It was eating roughly a third of the viewport before any actual bounty was visible. Counters per status are already discoverable via the status filter; the totals weren't paying for the space.

## How identity is resolved

`app/bounty/page.tsx` (server component) now batches `lookupAgent()` for the unique poster addresses returned by `listBounties()` and attaches `posterDisplayName` to each `BountyWithStatus` before it ships to the client. Dedupe by poster, so the same agent isn't looked up twice in a single render. Avatar URL convention (`bitcoinfaces.xyz/api/get-image?name={btc}`) matches existing components: `Leaderboard.tsx`, `AgentStrip.tsx`, `ActivityFeedHero.tsx`, `InteractionGraph.tsx`.

## Before / after (footer of one card)

```
before:  bc1qqax…3vxpp                           [stats] [time]
after:   [avatar] Secret Mars                    [stats] [time]
```

## Files

| File | Change |
|---|---|
| `app/bounty/types.ts` | Add optional `posterDisplayName` to `BountyWithStatus`. |
| `app/bounty/page.tsx` | Batched poster lookups (`Promise.all`), dedupe by address, attach `posterDisplayName`. |
| `app/bounty/BountyDirectory.tsx` | Delete `StatCard` component, `stats` useMemo, and the stats render block. Update `BountyCard` footer with avatar + display name. |

## Verification

```
$ npx tsc --noEmit
clean for bounty files

$ npm run lint
only pre-existing <img> warning that the rest of the codebase already has
for bitcoinfaces avatars (intentional — bitcoinfaces is external and
not configured for next/image)
```

## Test plan

- [ ] CI green
- [ ] `/bounty` no longer renders the 4 stat cards at the top
- [ ] The existing smoke-test bounty (id `mp8c7kmu189ae01f53dd`) renders its card with "Secret Mars" + avatar instead of `bc1qqax…3vxpp`
- [ ] Bounties posted by an unregistered/unknown address still render correctly with the address fallback