### PR TITLE
fix(bounty): prefer Stacks block_time_iso over burn_block_time_iso in txid verifier

### DIFF
--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -149,15 +149,12 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
         <Timeline status={bounty.status} />
 
         <div className="flex flex-wrap items-center gap-x-4 gap-y-2 text-xs text-white/40">
-          <span className="flex items-center gap-1.5">
-            <span>Poster:</span>
-            <AgentBadge
-              address={bounty.posterBtcAddress}
-              name={agentNames?.[bounty.posterBtcAddress]}
-              size="xs"
-              textClass="text-white/70"
-            />
-          </span>
+          <AgentBadge
+            address={bounty.posterBtcAddress}
+            name={agentNames?.[bounty.posterBtcAddress]}
+            size="xs"
+            textClass="text-white/70"
+          />
           <span>
             Posted: <span className="text-white/60">{formatDate(bounty.createdAt)}</span>
           </span>
@@ -216,25 +213,6 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
                 View submission
               </a>
             )}
-          </div>
-        </Section>
-      )}
-
-      {payment && (
-        <Section title="Payment Hint (for poster)">
-          <div className="rounded-lg border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2 text-sm">
-            <p className="text-white/70">
-              Send {formatSats(payment.amountSats)} sats sBTC to{" "}
-              <span className="text-white/90">{truncAddr(payment.recipientStxAddress)}</span> with
-              memo:
-            </p>
-            <code className="block break-all rounded-md border border-white/[0.06] bg-black/30 p-2 text-[12px] text-[#F7931A]">
-              {payment.expectedMemo}
-            </code>
-            <p className="text-[11px] text-white/40">
-              Then call <code className="text-white/60">POST /api/bounties/{bounty.id}/paid</code>{" "}
-              with the confirmed txid.
-            </p>
           </div>
         </Section>
       )}
@@ -311,6 +289,25 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
                 See all {submissionCount} submissions (API) →
               </a>
             )}
+          </div>
+        </Section>
+      )}
+
+      {payment && (
+        <Section title="Payment Hint (for poster)">
+          <div className="rounded-lg border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2 text-sm">
+            <p className="text-white/70">
+              Send {formatSats(payment.amountSats)} sats sBTC to{" "}
+              <span className="text-white/90">{truncAddr(payment.recipientStxAddress)}</span> with
+              memo:
+            </p>
+            <code className="block break-all rounded-md border border-white/[0.06] bg-black/30 p-2 text-[12px] text-[#F7931A]">
+              {payment.expectedMemo}
+            </code>
+            <p className="text-[11px] text-white/40">
+              Then call <code className="text-white/60">POST /api/bounties/{bounty.id}/paid</code>{" "}
+              with the confirmed txid.
+            </p>
           </div>
         </Section>
       )}

--- a/lib/bounty/__tests__/txid-verify.test.ts
+++ b/lib/bounty/__tests__/txid-verify.test.ts
@@ -327,6 +327,28 @@ describe("verifyPayoutTxid", () => {
     if (!r.ok) expect(r.code).toBe("TX_TOO_OLD");
   });
 
+  it("prefers Stacks block_time_iso over older burn_block_time_iso", async () => {
+    // Real-world scenario: a Stacks tx broadcast after the bounty was
+    // accepted lands in a Stacks block whose burn anchor (Bitcoin block)
+    // started ~10 min earlier. Using burn_block_time falsely rejects
+    // legitimate payouts. The verifier must prefer block_time_iso (the
+    // Stacks block time — when the tx actually landed).
+    const r = await verifyPayoutTxid({
+      txid: "0xabc",
+      bounty: makeBounty({ acceptedAt: "2026-05-16T13:01:58Z" }),
+      acceptedSubmission: makeSubmission(),
+      fetchFn: mockFetch({
+        json: () =>
+          makeHiroTx({
+            burn_block_time_iso: "2026-05-16T12:56:29Z", // 5 min before accept
+            block_time_iso: "2026-05-16T13:05:16Z", // 3 min after accept
+          }),
+      }),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.blockTimeIso).toBe("2026-05-16T13:05:16Z");
+  });
+
   it("returns HIRO_UNREACHABLE on fetch throw", async () => {
     const r = await verifyPayoutTxid({
       txid: "0xabc",

--- a/lib/bounty/txid-verify.ts
+++ b/lib/bounty/txid-verify.ts
@@ -286,8 +286,12 @@ export async function verifyPayoutTxid(params: {
     };
   }
 
-  // (8) Tx time > acceptedAt - 60s skew.
-  const blockTimeIso = tx.burn_block_time_iso ?? tx.block_time_iso ?? now.toISOString();
+  // (8) Tx time > acceptedAt - 60s skew. Prefer `block_time_iso` (Stacks
+  // block time — when the tx actually landed in a Stacks block) over
+  // `burn_block_time_iso` (Bitcoin anchor block time — can lag by 30+ min).
+  // Using the burn block time falsely rejects payouts whose sBTC transfer
+  // landed after `acceptedAt` but were anchored to an older Bitcoin block.
+  const blockTimeIso = tx.block_time_iso ?? tx.burn_block_time_iso ?? now.toISOString();
   const blockTimeMs = Date.parse(blockTimeIso);
   const acceptedMs = params.bounty.acceptedAt ? Date.parse(params.bounty.acceptedAt) : 0;
   if (!Number.isNaN(blockTimeMs) && blockTimeMs + 60_000 < acceptedMs) {


### PR DESCRIPTION
## Summary

Production fix. Hit a real `TX_TOO_OLD` false-rejection on the first end-to-end smoke-test payout (bounty `mp8c7kmu189ae01f53dd`, tx `0x5d7b3bf31b87c137ae17ca72d4ddd972fb0c6ad7a9e127a4dc4077fedb6be3a3`):

```
acceptedAt:           2026-05-16T13:01:58Z
burn_block_time_iso:  2026-05-16T12:56:29Z   (5 min BEFORE accept)
block_time_iso:       2026-05-16T13:05:16Z   (3 min AFTER accept)
```

The sBTC transfer was broadcast and confirmed **after** the poster accepted, but its Stacks block was anchored to a Bitcoin block that started ~9 min earlier. The verifier was using `burn_block_time_iso` (the **Bitcoin anchor** timestamp) for its "tx must happen after acceptance" check, so it rejected the legitimate payout with `TX_TOO_OLD`.

## Root cause

`burn_block_time_iso` is the timestamp of the Bitcoin block the Stacks block anchors to. It can lag the actual Stacks tx by **30+ minutes** depending on Bitcoin block cadence. The right field for "when did this tx land in a Stacks block" is `block_time_iso` (Stacks block time).

## Fix

`lib/bounty/txid-verify.ts:294` — swap the preference order:

```diff
-const blockTimeIso = tx.burn_block_time_iso ?? tx.block_time_iso ?? now.toISOString();
+const blockTimeIso = tx.block_time_iso ?? tx.burn_block_time_iso ?? now.toISOString();
```

Stacks block time first (real "when did this land"). Fall back to burn block time (the conservative bound), then to `now` if Hiro returned neither.

## Regression test

`lib/bounty/__tests__/txid-verify.test.ts` — new test feeds the exact prod numbers (burn 5 min before accept, block 3 min after accept) and asserts:
- result is `ok: true`
- `blockTimeIso` returned is the Stacks `block_time_iso`, not the burn time

Existing `TX_TOO_OLD` test (burn-only fixture, no `block_time_iso`) still passes via the fallback path.

```
$ npm run test -- lib/bounty
 lib/bounty/__tests__/signatures.test.ts  (10 tests)
 lib/bounty/__tests__/types.test.ts       (15 tests)
 lib/bounty/__tests__/txid-verify.test.ts (17 tests)  ← +1
Test Files  3 passed (3)
     Tests  42 passed (42)
```

## After merge

The blocked payout for bounty `mp8c7kmu189ae01f53dd` will go through cleanly — the on-chain tx is already confirmed, just needs the verifier to accept it. I'll re-POST `/paid` once this deploys.

## Test plan

- [ ] CI green
- [ ] After deploy: re-sign + re-POST `/paid` for the existing tx → status flips `winner-announced` → `paid`
- [ ] Bounty `mp8c7kmu189ae01f53dd` shows status `paid` on the detail page