### PR TITLE
fix(bounty): show all bounties regardless of status, inline chip filters

### DIFF
--- a/app/bounty/BountyDirectory.tsx
+++ b/app/bounty/BountyDirectory.tsx
@@ -96,7 +96,7 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
 }
 
 const STATUS_OPTIONS: { value: BountyStatus | "all"; label: string }[] = [
-  { value: "all", label: "All active" },
+  { value: "all", label: "All" },
   { value: "open", label: "Open" },
   { value: "judging", label: "Judging" },
   { value: "winner-announced", label: "Winner" },
@@ -167,21 +167,46 @@ export default function BountyDirectory({
         </Link>
       </div>
 
-      <div className="flex flex-wrap items-center gap-3">
-        <label htmlFor="bounty-status-filter" className="sr-only">Filter by status</label>
-        <select
-          id="bounty-status-filter"
-          value={statusFilter}
-          onChange={(e) => setStatusFilter(e.target.value as BountyStatus | "all")}
-          className={FILTER_CONTROL_CLASS}
-        >
-          {STATUS_OPTIONS.map((opt) => (
-            <option key={opt.value} value={opt.value} className="bg-[#1a1a1a]">
+      <div
+        className="flex flex-wrap items-center gap-2 -mx-1 px-1 max-md:overflow-x-auto max-md:flex-nowrap"
+        role="tablist"
+        aria-label="Filter bounties by status"
+      >
+        {STATUS_OPTIONS.map((opt) => {
+          const active = statusFilter === opt.value;
+          const count =
+            opt.value === "all"
+              ? (initialBounties?.length ?? 0)
+              : (initialBounties?.filter((b) => b.status === opt.value).length ?? 0);
+          return (
+            <button
+              key={opt.value}
+              type="button"
+              role="tab"
+              aria-selected={active}
+              onClick={() => setStatusFilter(opt.value)}
+              className={`inline-flex items-center gap-1.5 whitespace-nowrap rounded-full border px-3 py-1.5 text-sm transition-colors ${
+                active
+                  ? "border-[#F7931A]/40 bg-[#F7931A]/[0.10] text-[#F7931A]"
+                  : "border-white/[0.08] bg-white/[0.02] text-white/60 hover:border-white/[0.16] hover:text-white/80"
+              }`}
+            >
               {opt.label}
-            </option>
-          ))}
-        </select>
+              {count > 0 && (
+                <span
+                  className={`rounded-full px-1.5 py-0.5 text-[10px] font-medium leading-none ${
+                    active ? "bg-[#F7931A]/[0.20] text-[#F7931A]" : "bg-white/[0.06] text-white/40"
+                  }`}
+                >
+                  {count}
+                </span>
+              )}
+            </button>
+          );
+        })}
+      </div>
 
+      <div className="flex flex-wrap items-center gap-3">
         <label htmlFor="bounty-search" className="sr-only">Search by title, tag, or description</label>
         <input
           id="bounty-search"

--- a/app/bounty/page.tsx
+++ b/app/bounty/page.tsx
@@ -42,7 +42,11 @@ async function fetchBounties(): Promise<{ bounties: BountyWithStatus[]; total: n
     const kv = env.VERIFIED_AGENTS as KVNamespace | undefined;
     if (!db) return null;
     const now = new Date();
-    const { bounties, total } = await listBounties(db, { status: "active", limit: 100, now });
+    // Fetch every bounty regardless of status — the client filter chips
+    // (All / Open / Judging / Winner / Paid / Abandoned / Cancelled) need
+    // the full set to filter against. Paid + abandoned bounties stay
+    // visible forever for transparency.
+    const { bounties, total } = await listBounties(db, { limit: 100, now });
 
     // Enrich each bounty with the poster's display name so cards can show
     // identity instead of a raw BTC address. Dedupe by poster so the same


### PR DESCRIPTION
## Summary

Reported issue: paid bounties disappear from `/bounty` after the status flips, and the status filter can't bring them back.

Two related issues, both fixed here:

### 1. Server was filtering out paid + cancelled bounties

`app/bounty/page.tsx` called `listBounties(db, { status: "active" })`. In `lib/bounty/d1-helpers.ts:151`, \`"active"\` translates to:

```sql
cancelled_at IS NULL AND paid_at IS NULL
```

So **paid and cancelled bounties were dropped before the client ever saw them**. The client-side status filter chips for "Paid" / "Cancelled" / "Abandoned" had nothing to filter against.

**Fix:** drop the server-side status filter. Fetch all bounties (`limit: 100`). Client chips drive the view. Paid + abandoned + cancelled bounties stay visible forever (transparency — see the history of completed work).

### 2. Status filter was a dropdown

Replace the `<select>` with inline pill-style chips that wrap on desktop and scroll horizontally on mobile. Each chip carries a count badge so the user can see at a glance how many bounties fall into each state.

\`\`\`
[All 1]  [Open 0]  [Judging 0]  [Winner 0]  [Paid 1]  [Abandoned 0]  [Cancelled 0]
\`\`\`

Active chip is highlighted in `#F7931A` (Bitcoin orange) to match the rest of the bounty UI.

Bonus: the "All" chip label was previously "All active" — which made sense when the server filter was excluding paid/cancelled, but is now misleading. Renamed to just "All."

## Files

| File | Change |
|---|---|
| `app/bounty/page.tsx` | Drop `status: "active"` from `listBounties()` call. |
| `app/bounty/BountyDirectory.tsx` | Replace `<select>` with chip buttons + count badges. Rename "All active" → "All". |

## Verification

- `npx tsc --noEmit` clean
- `npm run lint` clean
- Existing smoke-test bounty `mp8c7kmu189ae01f53dd` (status `paid`) should now appear on `/bounty` under the **Paid** chip and under **All**.

## Test plan

- [ ] CI green
- [ ] `/bounty` shows the smoke-test bounty (currently `paid`)
- [ ] Clicking the **Paid** chip filters to just paid bounties
- [ ] Clicking **All** shows everything
- [ ] On a narrow viewport, chips scroll horizontally instead of wrapping awkwardly