### PR TITLE
fix(bounty): drop hidden default-to-active in listBounties

### DIFF
--- a/lib/bounty/d1-helpers.ts
+++ b/lib/bounty/d1-helpers.ts
@@ -216,7 +216,11 @@ export async function listBounties(
   const offset = Math.max(filters.offset ?? 0, 0);
   const now = filters.now ?? new Date();
 
-  const statusFrag = statusToSql(filters.status ?? "active", now);
+  // No internal default — callers who want active-only must pass it
+  // explicitly. The /bounty UI page wants everything (chip filters drive
+  // the view); the /api/bounties GET handler has its own default-to-active
+  // applied before calling. An undefined here means "no status filter."
+  const statusFrag = statusToSql(filters.status, now);
   const conditions: string[] = [statusFrag.sql];
   const bindings: (string | number)[] = [...statusFrag.bindings];
 


### PR DESCRIPTION
## Summary

Follow-up to #871. The paid smoke-test bounty is still not showing on `/bounty` because the fix didn't go deep enough.

#871 dropped the explicit `status: "active"` filter from the `/bounty` SSR call:

\`\`\`ts
// before
listBounties(db, { status: "active", limit: 100, now });
// after #871
listBounties(db, { limit: 100, now });
\`\`\`

Expected behavior: no status passed → no filter → return all.

Actual behavior: `listBounties` internally had `filters.status ?? "active"`, so it silently re-applied the same filter. The bounty `mp8c7kmu189ae01f53dd` (status `paid`) is still excluded server-side, even after #871.

## Fix

`lib/bounty/d1-helpers.ts:219` — drop the `?? "active"` fallback:

\`\`\`diff
-const statusFrag = statusToSql(filters.status ?? "active", now);
+// No internal default — callers who want active-only pass it explicitly.
+const statusFrag = statusToSql(filters.status, now);
\`\`\`

`statusToSql(undefined)` already returns `{ sql: "1=1", bindings: [] }` (line 153-154), so this is the right shape — undefined → no predicate.

## Impact on the two callers

| Caller | Before | After |
|---|---|---|
| `app/bounty/page.tsx` (UI) | secretly active-filtered | shows all bounties — chip filters drive the visible subset client-side |
| `app/api/bounties/route.ts` (agent API) | active by default (explicit) | active by default (explicit, unchanged — sets status before calling at route.ts:126) |

## Verification

\`\`\`
$ npm run test -- lib/bounty
 lib/bounty/__tests__/signatures.test.ts  (10 tests)
 lib/bounty/__tests__/types.test.ts       (15 tests)
 lib/bounty/__tests__/txid-verify.test.ts (17 tests)
Test Files  3 passed (3)
     Tests  42 passed (42)

$ npx tsc --noEmit
clean
\`\`\`

## Test plan

- [ ] CI green
- [ ] After deploy: `/bounty` shows the smoke-test bounty `mp8c7kmu189ae01f53dd` (currently `paid`)
- [ ] The "Paid" chip shows the bounty; the "Open" chip does not
- [ ] `GET /api/bounties` (no params) still returns active-only — agent behavior unchanged