### PR TITLE
ui(bounty): compact detail page with inline timeline

### DIFF
--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import type { BountyDetailData } from "../types";
 import type { BountyStatus } from "@/lib/bounty";
+import type { BountySubmission } from "@/lib/bounty";
 import {
   statusStyle,
   statusLabel,
@@ -71,25 +72,25 @@ function Timeline({ status }: { status: BountyStatus }) {
         const isUpcoming = i > activeIndex || isTerminalFail;
 
         return (
-          <div key={step} className="flex flex-1 items-start gap-0 min-w-[80px]">
-            <div className="flex flex-col items-center gap-1.5 flex-1">
+          <div key={step} className="flex flex-1 items-start gap-0 min-w-[70px]">
+            <div className="flex flex-col items-center gap-1 flex-1">
               <div className="relative flex items-center w-full">
                 {i > 0 && (
                   <div
-                    className={`absolute right-1/2 mr-[14px] h-px w-[calc(50%-14px)] ${
+                    className={`absolute right-1/2 mr-[12px] h-px w-[calc(50%-12px)] ${
                       isCompleted || isCurrent ? "bg-emerald-400/30" : "bg-white/[0.06]"
                     }`}
                   />
                 )}
                 {i < TIMELINE_STEPS.length - 1 && (
                   <div
-                    className={`absolute left-1/2 ml-[14px] h-px w-[calc(50%-14px)] ${
+                    className={`absolute left-1/2 ml-[12px] h-px w-[calc(50%-12px)] ${
                       isCompleted ? "bg-emerald-400/30" : "bg-white/[0.06]"
                     }`}
                   />
                 )}
                 <div
-                  className={`relative mx-auto flex size-7 items-center justify-center rounded-full border text-[10px] font-semibold ${
+                  className={`relative mx-auto flex size-6 items-center justify-center rounded-full border text-[10px] font-semibold ${
                     isCompleted
                       ? "border-emerald-400/40 bg-emerald-400/[0.12] text-emerald-400"
                       : isCurrent
@@ -97,11 +98,11 @@ function Timeline({ status }: { status: BountyStatus }) {
                       : "border-white/[0.08] bg-white/[0.02] text-white/30"
                   }`}
                 >
-                  {isCompleted ? <CheckIcon className="size-3.5" /> : i + 1}
+                  {isCompleted ? <CheckIcon className="size-3" /> : i + 1}
                 </div>
               </div>
               <span
-                className={`text-[10px] font-medium uppercase tracking-wider ${
+                className={`text-[9px] font-medium uppercase tracking-wider ${
                   isCurrent ? "text-[#F7931A]" : isCompleted ? "text-white/60" : isUpcoming ? "text-white/25" : "text-white/40"
                 }`}
               >
@@ -112,11 +113,11 @@ function Timeline({ status }: { status: BountyStatus }) {
         );
       })}
       {isTerminalFail && (
-        <div className="ml-2 flex flex-col items-center gap-1.5 min-w-[80px]">
-          <div className="flex size-7 items-center justify-center rounded-full border border-red-400/30 bg-red-400/[0.10] text-[11px] font-semibold text-red-400">
+        <div className="ml-2 flex flex-col items-center gap-1 min-w-[70px]">
+          <div className="flex size-6 items-center justify-center rounded-full border border-red-400/30 bg-red-400/[0.10] text-[10px] font-semibold text-red-400">
             !
           </div>
-          <span className="text-[10px] font-medium uppercase tracking-wider text-red-400/70">
+          <span className="text-[9px] font-medium uppercase tracking-wider text-red-400/70">
             {statusLabel(status)}
           </span>
         </div>
@@ -125,30 +126,13 @@ function Timeline({ status }: { status: BountyStatus }) {
   );
 }
 
-function timelineMessage(status: BountyStatus): { tone: "ok" | "warn" | "bad"; text: string } {
-  switch (status) {
-    case "open":
-      return { tone: "ok", text: "Accepting submissions." };
-    case "judging":
-      return { tone: "warn", text: "Submission window closed. Poster reviewing entries." };
-    case "winner-announced":
-      return { tone: "warn", text: "Winner accepted. Awaiting on-chain payment." };
-    case "paid":
-      return { tone: "ok", text: "Bounty paid out and verified on Stacks." };
-    case "abandoned":
-      return { tone: "bad", text: "Poster did not follow through within the grace window." };
-    case "cancelled":
-      return { tone: "bad", text: "Bounty cancelled by poster before acceptance." };
-  }
-}
-
 function MetaItem({ label, icon, children }: { label: string; icon?: React.ReactNode; children: React.ReactNode }) {
   return (
-    <div className="flex items-start gap-2.5 min-w-0">
+    <div className="flex items-start gap-2 min-w-0">
       {icon && <div className="mt-0.5 text-white/40 shrink-0">{icon}</div>}
       <div className="min-w-0">
-        <div className="text-[10px] font-medium uppercase tracking-wider text-white/40">{label}</div>
-        <div className="mt-0.5 text-[13px] text-white/80 truncate">{children}</div>
+        <div className="text-[9px] font-medium uppercase tracking-wider text-white/40">{label}</div>
+        <div className="mt-0.5 text-[12px] text-white/80 truncate">{children}</div>
       </div>
     </div>
   );
@@ -156,7 +140,7 @@ function MetaItem({ label, icon, children }: { label: string; icon?: React.React
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="space-y-2.5">
+    <div className="space-y-2">
       <h2 className="text-[10px] font-semibold uppercase tracking-wider text-white/40">{title}</h2>
       {children}
     </div>
@@ -174,6 +158,105 @@ function BackLink() {
       </svg>
       Back to Bounties
     </Link>
+  );
+}
+
+function SubmissionCard({
+  sub,
+  isWinner,
+  acceptedAt,
+  agentNames,
+  paidTxid,
+  paidAt,
+  explorerUrl,
+  rewardSats,
+}: {
+  sub: BountySubmission;
+  isWinner: boolean;
+  acceptedAt?: string;
+  agentNames?: Record<string, string>;
+  paidTxid?: string;
+  paidAt?: string;
+  explorerUrl?: string | null;
+  rewardSats?: number;
+}) {
+  return (
+    <div
+      id={`submission-${sub.id}`}
+      className={`rounded-xl border p-4 space-y-3 ${
+        isWinner
+          ? "border-[#7DA2FF]/20 bg-[#7DA2FF]/[0.04]"
+          : "border-white/[0.06] bg-white/[0.02]"
+      }`}
+    >
+      <div className="flex flex-wrap items-start justify-between gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <AgentBadge
+            address={sub.submitterBtcAddress}
+            name={agentNames?.[sub.submitterBtcAddress]}
+            size={isWinner ? "sm" : "sm"}
+            textClass={isWinner ? "text-white/90 text-sm font-medium" : "text-white/75 text-sm font-medium"}
+          />
+          {isWinner && (
+            <span className="inline-flex items-center gap-1 rounded-md border border-[#7DA2FF]/30 bg-[#7DA2FF]/[0.10] px-1.5 py-0.5 text-[10px] font-medium uppercase tracking-wider text-[#7DA2FF]">
+              <TrophyIcon className="size-3 text-[#F7931A]" />
+              Winner
+            </span>
+          )}
+        </div>
+        <div className="text-right shrink-0">
+          {isWinner && acceptedAt ? (
+            <>
+              <div className="text-[9px] font-medium uppercase tracking-wider text-white/40">Accepted</div>
+              <div className="mt-0.5 text-[11px] text-white/60">{formatDate(acceptedAt)}</div>
+            </>
+          ) : (
+            <span className="text-[11px] text-white/30">{formatDate(sub.createdAt)}</span>
+          )}
+        </div>
+      </div>
+
+      <p className="text-[13px] leading-relaxed text-white/65 whitespace-pre-wrap">
+        {linkify(sub.message)}
+      </p>
+
+      {sub.contentUrl && (
+        <a
+          href={sub.contentUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="inline-flex items-center gap-1 text-[12px] text-[#7DA2FF] hover:text-[#9db8ff] transition-colors"
+        >
+          View submission
+          <ExternalLinkIcon className="size-3" />
+        </a>
+      )}
+
+      {isWinner && paidTxid && explorerUrl && rewardSats != null && (
+        <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[#7DA2FF]/10 pt-2.5 text-[12px]">
+          <div className="flex items-center gap-2 min-w-0">
+            <CheckIcon className="size-3.5 text-emerald-400 shrink-0" />
+            <div className="min-w-0">
+              <span className="text-emerald-400/90 font-medium">
+                Paid {formatSats(rewardSats)} sats
+              </span>
+              {paidAt && (
+                <span className="text-white/40"> on {formatDate(paidAt)}</span>
+              )}
+            </div>
+          </div>
+          <a
+            href={explorerUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 font-mono text-[11px] text-white/70 hover:border-white/15 hover:text-white transition-colors"
+          >
+            {truncAddr(paidTxid)}
+            <ExternalLinkIcon className="size-3" />
+          </a>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -195,39 +278,42 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
   const explorerUrl = bounty.paidTxid
     ? `https://explorer.hiro.so/txid/${bounty.paidTxid}?chain=mainnet`
     : null;
-  const msg = timelineMessage(bounty.status);
-  const msgToneClass =
-    msg.tone === "ok" ? "text-emerald-400/80" : msg.tone === "warn" ? "text-amber-400/80" : "text-red-400/80";
 
-  const otherSubmissions = winner ? submissions.filter((s) => s.id !== winner.submissionId) : submissions;
+  // Winner pinned to the top of the submissions list, others follow.
+  const orderedSubmissions = winner
+    ? [
+        ...submissions.filter((s) => s.id === winner.submissionId),
+        ...submissions.filter((s) => s.id !== winner.submissionId),
+      ]
+    : submissions;
 
   return (
-    <div className="space-y-6">
+    <div className="space-y-4">
       <BackLink />
 
-      {/* HERO CARD: status, reward, title, meta grid, tags, description */}
-      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 max-md:p-5 space-y-5">
+      {/* HERO CARD: status, reward, title, meta row, timeline, tags, description */}
+      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5 max-md:p-4 space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <span
-            className={`inline-flex items-center gap-1.5 rounded-full border px-3 py-1 text-[11px] font-semibold uppercase tracking-wider ${statusStyle(bounty.status)}`}
+            className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${statusStyle(bounty.status)}`}
           >
             <span className="size-1.5 rounded-full bg-current" />
             {statusLabel(bounty.status)}
           </span>
           <div className="text-right">
-            <div className="flex items-baseline gap-1 text-2xl font-bold text-[#F7931A] max-md:text-xl">
-              <span className="text-[#F7931A]/60 text-[18px]">&#8383;</span>
+            <div className="flex items-baseline gap-1 text-lg font-bold text-[#F7931A]">
+              <span className="text-[#F7931A]/60 text-[14px]">&#8383;</span>
               {formatSats(bounty.rewardSats)}
             </div>
-            <div className="text-[10px] font-medium uppercase tracking-wider text-white/30">
+            <div className="text-[9px] font-medium uppercase tracking-wider text-white/30">
               sats reward
             </div>
           </div>
         </div>
 
-        <h1 className="text-2xl font-bold tracking-tight max-md:text-xl">{bounty.title}</h1>
+        <h1 className="text-xl font-bold tracking-tight max-md:text-lg">{bounty.title}</h1>
 
-        <div className="grid gap-4 sm:grid-cols-3 border-y border-white/[0.06] py-4">
+        <div className="grid gap-3 sm:grid-cols-3 border-y border-white/[0.06] py-3">
           <MetaItem
             label="Posted by"
             icon={
@@ -247,7 +333,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
             </span>
             {windowLabel && (
               <span
-                className={`ml-2 text-[11px] ${
+                className={`ml-1.5 text-[10px] ${
                   windowLabel === "Submissions closed" ? "text-red-400/60" : "text-white/40"
                 }`}
               >
@@ -259,6 +345,8 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
             {submissionCount}
           </MetaItem>
         </div>
+
+        <Timeline status={bounty.status} />
 
         {tags.length > 0 && (
           <div className="flex flex-wrap gap-1.5">
@@ -273,149 +361,37 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
           </div>
         )}
 
-        <div className="text-[14px] leading-relaxed text-white/70 whitespace-pre-wrap">
+        <div className="text-[13px] leading-relaxed text-white/70 whitespace-pre-wrap">
           {linkify(bounty.description)}
         </div>
       </div>
 
-      {/* TIMELINE CARD */}
-      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-6 max-md:p-4 space-y-4">
-        <Timeline status={bounty.status} />
-        <div className="flex items-start gap-2 border-t border-white/[0.06] pt-3.5">
-          {msg.tone === "ok" ? (
-            <CheckIcon className={`size-3.5 mt-0.5 ${msgToneClass}`} />
-          ) : (
-            <span className={`mt-1 size-1.5 rounded-full ${
-              msg.tone === "warn" ? "bg-amber-400/80" : "bg-red-400/80"
-            }`} />
-          )}
-          <p className={`text-[13px] ${msgToneClass}`}>{msg.text}</p>
-        </div>
-      </div>
-
-      {/* WINNER CARD */}
-      {winner && (
-        <Section title="Winner">
-          <div
-            id={`submission-${winner.submissionId}`}
-            className="rounded-2xl border border-[#7DA2FF]/15 bg-[#7DA2FF]/[0.03] p-5 max-md:p-4 space-y-4"
-          >
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div className="flex items-center gap-2 min-w-0">
-                <AgentBadge
-                  address={winner.submitterBtcAddress}
-                  name={agentNames?.[winner.submitterBtcAddress]}
-                  size="md"
-                  textClass="text-white/90 text-sm font-semibold"
-                />
-                <TrophyIcon className="size-3.5 text-[#F7931A] shrink-0" />
-              </div>
-              <div className="text-right shrink-0">
-                <div className="text-[10px] font-medium uppercase tracking-wider text-white/40">
-                  Accepted
-                </div>
-                <div className="mt-0.5 text-[12px] text-white/60">{formatDate(winner.acceptedAt)}</div>
-              </div>
-            </div>
-
-            <div className="relative pl-4">
-              <span className="absolute left-0 top-0 text-2xl leading-none text-white/20" aria-hidden="true">
-                &ldquo;
-              </span>
-              <p className="text-[13px] leading-relaxed text-white/70 whitespace-pre-wrap">
-                {linkify(winner.message)}
-              </p>
-            </div>
-
-            <div className="flex flex-wrap gap-2">
-              {winner.contentUrl && (
-                <a
-                  href={winner.contentUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.10] bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-white/80 transition-colors hover:border-white/20 hover:bg-white/[0.08]"
-                >
-                  <svg className="size-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth="2">
-                    <path strokeLinecap="round" strokeLinejoin="round" d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7-11-7-11-7z" />
-                    <circle cx="12" cy="12" r="3" />
-                  </svg>
-                  View full submission
-                </a>
-              )}
-              <Link
-                href={`/agents/${encodeURIComponent(winner.submitterBtcAddress)}`}
-                className="inline-flex items-center gap-1.5 rounded-lg border border-white/[0.10] bg-white/[0.04] px-3 py-1.5 text-[12px] font-medium text-white/80 transition-colors hover:border-white/20 hover:bg-white/[0.08]"
-              >
-                <ExternalLinkIcon className="size-3" />
-                Author profile
-              </Link>
-            </div>
-
-            {bounty.paidTxid && explorerUrl && (
-              <div className="flex flex-wrap items-center justify-between gap-2 border-t border-[#7DA2FF]/10 pt-3 text-[12px]">
-                <div className="flex items-center gap-2 min-w-0">
-                  <CheckIcon className="size-3.5 text-emerald-400 shrink-0" />
-                  <div className="min-w-0">
-                    <span className="text-emerald-400/90 font-medium">
-                      Paid {formatSats(bounty.rewardSats)} sats
-                    </span>
-                    {bounty.paidAt && (
-                      <span className="text-white/40"> on {formatDate(bounty.paidAt)}</span>
-                    )}
-                  </div>
-                </div>
-                <a
-                  href={explorerUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="inline-flex items-center gap-1.5 rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-1 font-mono text-[11px] text-white/70 hover:border-white/15 hover:text-white transition-colors"
-                >
-                  {truncAddr(bounty.paidTxid)}
-                  <ExternalLinkIcon className="size-3" />
-                </a>
-              </div>
-            )}
-          </div>
-        </Section>
-      )}
-
-      {/* OTHER SUBMISSIONS */}
-      {otherSubmissions.length > 0 && (
-        <Section title={winner ? `Other Submissions (${otherSubmissions.length})` : `Submissions (${submissionCount})`}>
+      {/* SUBMISSIONS (winner pinned at top) */}
+      {orderedSubmissions.length > 0 && (
+        <Section title={`Submissions (${submissionCount})`}>
           <div className="space-y-2">
-            {otherSubmissions.map((sub) => (
-              <div
-                key={sub.id}
-                className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 space-y-2"
-              >
-                <div className="flex items-center justify-between gap-2">
-                  <AgentBadge
-                    address={sub.submitterBtcAddress}
-                    name={agentNames?.[sub.submitterBtcAddress]}
-                    textClass="text-white/75 text-sm font-medium"
-                  />
-                  <span className="text-[11px] text-white/30">{formatDate(sub.createdAt)}</span>
-                </div>
-                <p className="text-[13px] text-white/55 whitespace-pre-wrap">{linkify(sub.message)}</p>
-                {sub.contentUrl && (
-                  <a
-                    href={sub.contentUrl}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="inline-flex items-center gap-1 text-[12px] text-[#7DA2FF] hover:text-[#9db8ff] transition-colors"
-                  >
-                    View submission
-                    <ExternalLinkIcon className="size-3" />
-                  </a>
-                )}
-              </div>
-            ))}
+            {orderedSubmissions.map((sub) => {
+              const isWinner = winner?.submissionId === sub.id;
+              return (
+                <SubmissionCard
+                  key={sub.id}
+                  sub={sub}
+                  isWinner={isWinner}
+                  acceptedAt={isWinner ? winner?.acceptedAt : undefined}
+                  agentNames={agentNames}
+                  paidTxid={isWinner ? bounty.paidTxid : undefined}
+                  paidAt={isWinner ? bounty.paidAt : undefined}
+                  explorerUrl={isWinner ? explorerUrl : null}
+                  rewardSats={isWinner ? bounty.rewardSats : undefined}
+                />
+              );
+            })}
             {submissionCount > submissions.length && (
               <a
                 href={`/api/bounties/${bounty.id}/submissions`}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block text-xs text-[#7DA2FF]/70 hover:text-[#7DA2FF] mt-2"
+                className="block text-xs text-[#7DA2FF]/70 hover:text-[#7DA2FF] mt-1"
               >
                 See all {submissionCount} submissions (API) →
               </a>
@@ -427,7 +403,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
       {/* PAYMENT HINT (for poster) */}
       {payment && (
         <Section title="Payment Hint (for poster)">
-          <div className="rounded-xl border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2 text-sm">
+          <div className="rounded-xl border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2">
             <p className="text-white/70 text-[13px]">
               Send {formatSats(payment.amountSats)} sats sBTC to{" "}
               <span className="text-white/90 font-mono text-[12px]">{truncAddr(payment.recipientStxAddress)}</span> with memo:

--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -183,7 +183,7 @@ function SubmissionCard({
   return (
     <div
       id={`submission-${sub.id}`}
-      className={`rounded-xl border p-4 space-y-3 ${
+      className={`rounded-md border p-4 space-y-3 ${
         isWinner
           ? "border-[#7DA2FF]/20 bg-[#7DA2FF]/[0.04]"
           : "border-white/[0.06] bg-white/[0.02]"
@@ -265,7 +265,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
     return (
       <div className="space-y-4">
         <BackLink />
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] px-8 py-16 text-center">
+        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] px-8 py-16 text-center">
           <p className="text-white/40">Bounty not found.</p>
         </div>
       </div>
@@ -292,7 +292,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
       <BackLink />
 
       {/* HERO CARD: status, reward, title, meta row, timeline, tags, description */}
-      <div className="rounded-2xl border border-white/[0.06] bg-white/[0.02] p-5 max-md:p-4 space-y-4">
+      <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-5 max-md:p-4 space-y-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <span
             className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-[10px] font-semibold uppercase tracking-wider ${statusStyle(bounty.status)}`}
@@ -403,7 +403,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
       {/* PAYMENT HINT (for poster) */}
       {payment && (
         <Section title="Payment Hint (for poster)">
-          <div className="rounded-xl border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2">
+          <div className="rounded-md border border-[#F7931A]/20 bg-[#F7931A]/[0.04] p-4 space-y-2">
             <p className="text-white/70 text-[13px]">
               Send {formatSats(payment.amountSats)} sats sBTC to{" "}
               <span className="text-white/90 font-mono text-[12px]">{truncAddr(payment.recipientStxAddress)}</span> with memo:
@@ -420,7 +420,7 @@ export default function BountyDetail({ data }: { data: BountyDetailData | null }
 
       {/* API */}
       <Section title="API">
-        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] p-4 text-xs text-white/40 space-y-1">
+        <div className="rounded-md border border-white/[0.06] bg-white/[0.02] p-4 text-xs text-white/40 space-y-1">
           <div>
             Detail: <code className="text-white/60">GET /api/bounties/{bounty.id}</code>
           </div>


### PR DESCRIPTION
## Summary
- **Inline timeline**: 4-step flow (Open → Judging → Winner → Paid) lives inside the hero card right below the meta row. The separate timeline card is gone.
- **Tighter spacing**: hero padding `p-5`, section gaps `space-y-4`, title `text-xl`, reward `text-lg`, meta labels `text-[9px]`, meta values `text-[12px]`. Hero no longer takes half the viewport.
- **Unified Submissions section**: winner is pinned at the top of the list with the trophy/Winner pill and (for paid bounties) an inline payment proof row with the explorer link. No separate Winner card.
- **No "verified on Stacks"** wording anywhere on the page.