### PR TITLE
[codex] Add Codex support to loop installer

### DIFF
--- a/app/install/loop/route.ts
+++ b/app/install/loop/route.ts
@@ -82,7 +82,7 @@ configure_codex_mcp() {
       echo "Warning: could not update Codex global MCP config; writing project config instead."
       write_codex_project_config
     fi
-  elif [ -d "$HOME/.codex" ]; then
+  elif [ -n "${HOME:-}" ] && [ -d "$HOME/.codex" ]; then
     echo "Codex config directory detected; writing project MCP config."
     write_codex_project_config
   else

--- a/app/install/loop/route.ts
+++ b/app/install/loop/route.ts
@@ -5,7 +5,7 @@ const DOCS = "https://github.com/aibtcdev/loop-starter-kit";
 
 const script = `#!/bin/sh
 # AIBTC Loop Starter Kit installer
-# Compatible with Claude Code and OpenClaw
+# Compatible with Claude Code, Codex, and OpenClaw
 set -eu
 
 echo "Installing loop-starter-kit..."
@@ -63,7 +63,7 @@ mkdir -p daemon memory
 [ ! -f memory/journal.md ] && printf '# Journal\\n' > memory/journal.md
 [ ! -f memory/contacts.md ] && printf '# Contacts\\n\\n## Operator\\n- TBD\\n\\n## Agents\\n' > memory/contacts.md
 [ ! -f memory/learnings.md ] && printf '# Learnings\\n\\n## AIBTC Platform\\n- Heartbeat: use curl, NOT execute_x402_endpoint (that auto-pays 100 sats)\\n- Inbox read: use curl (free), NOT execute_x402_endpoint\\n- Reply: use curl with BIP-137 signature (free), max 500 chars\\n- Send: use send_inbox_message MCP tool (100 sats each)\\n- Wallet locks after ~5 min — re-unlock at cycle start if needed\\n- Heartbeat may fail on first attempt — retries automatically each cycle\\n\\n## Cost Guardrails\\n- Maturity levels: bootstrap (cycles 0-10), established (11+), funded (balance > 500 sats)\\n- Bootstrap mode: heartbeat + inbox read + replies only (all free). No outbound sends.\\n- Default daily limit: 200 sats/day\\n\\n## Patterns\\n- MCP tools are deferred — must ToolSearch before first use each session\\n- Within same session, tools stay loaded — skip redundant ToolSearch\\n' > memory/learnings.md
-[ ! -f .gitignore ] && printf '.ssh/\\n*.env\\n.env*\\n.claude/**\\n!.claude/skills/\\n!.claude/skills/**\\n!.claude/agents/\\n!.claude/agents/**\\nnode_modules/\\ndaemon/processed.json\\n*.key\\n*.pem\\n.DS_Store\\n' > .gitignore
+[ ! -f .gitignore ] && printf '.ssh/\\n*.env\\n.env*\\n.claude/**\\n!.claude/skills/\\n!.claude/skills/**\\n!.claude/agents/\\n!.claude/agents/**\\n.codex/**\\n!.codex/config.toml\\nnode_modules/\\ndaemon/processed.json\\n*.key\\n*.pem\\n.DS_Store\\n' > .gitignore
 
 # Pre-configure AIBTC MCP server so it loads on first launch
 if [ ! -f .mcp.json ]; then
@@ -71,6 +71,39 @@ if [ ! -f .mcp.json ]; then
 {"mcpServers":{"aibtc":{"command":"npx","args":["-y","@aibtc/mcp-server@latest"],"env":{"NETWORK":"mainnet"}}}}
 MCPEOF
 fi
+
+configure_codex_mcp() {
+  if command -v codex >/dev/null 2>&1; then
+    if codex mcp get aibtc >/dev/null 2>&1; then
+      echo "Codex MCP server already configured."
+    elif codex mcp add aibtc --env NETWORK=mainnet -- npx -y @aibtc/mcp-server@latest >/dev/null 2>&1; then
+      echo "Configured AIBTC MCP server for Codex."
+    else
+      echo "Warning: could not update Codex global MCP config; writing project config instead."
+      write_codex_project_config
+    fi
+  else
+    write_codex_project_config
+  fi
+}
+
+write_codex_project_config() {
+  mkdir -p .codex
+  if [ ! -f .codex/config.toml ] || ! grep -q '^\\[mcp_servers\\.aibtc\\]' .codex/config.toml; then
+    cat >> .codex/config.toml << 'CODEXEOF'
+
+[mcp_servers.aibtc]
+command = "npx"
+args = ["-y", "@aibtc/mcp-server@latest"]
+
+[mcp_servers.aibtc.env]
+NETWORK = "mainnet"
+CODEXEOF
+    echo "Wrote project Codex MCP config to .codex/config.toml."
+  fi
+}
+
+configure_codex_mcp
 
 # Pre-download MCP server package so it's cached when Claude Code starts
 if command -v npx >/dev/null 2>&1; then
@@ -92,6 +125,7 @@ echo ""
 echo "  For DEDICATED machines (VPS/server):"
 echo ""
 echo "    Claude Code:  claude --dangerously-skip-permissions"
+echo "    Codex:        open this directory in Codex, then check /mcp"
 echo "    OpenClaw:     OPENCLAW_CRON=1 (with cron)"
 echo ""
 echo "  Do NOT auto-approve on your primary machine."

--- a/app/install/loop/route.ts
+++ b/app/install/loop/route.ts
@@ -82,8 +82,12 @@ configure_codex_mcp() {
       echo "Warning: could not update Codex global MCP config; writing project config instead."
       write_codex_project_config
     fi
-  else
+  elif [ -d "$HOME/.codex" ]; then
+    echo "Codex config directory detected; writing project MCP config."
     write_codex_project_config
+  else
+    echo "Codex not detected; skipping Codex MCP config."
+    echo "To enable later: codex mcp add aibtc --env NETWORK=mainnet -- npx -y @aibtc/mcp-server@latest"
   fi
 }
 

--- a/app/install/page.tsx
+++ b/app/install/page.tsx
@@ -8,7 +8,7 @@ const installers = [
     id: "loop",
     title: "Loop Starter Kit",
     subtitle: "Autonomous agent in one command",
-    description: "Turns any AI coding agent into an autonomous AIBTC agent. Wallet, registration, 10-phase self-improving loop, task queue, memory. Works with Claude Code and OpenClaw.",
+    description: "Turns any AI coding agent into an autonomous AIBTC agent. Wallet, registration, 10-phase self-improving loop, task queue, memory. Works with Claude Code, Codex, and OpenClaw.",
     command: "curl -fsSL aibtc.com/install | sh",
     guideLink: "/guide",
     recommended: true,

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -244,7 +244,7 @@ Guide: https://aibtc.com/guide
 
 **Build your own:** Fork the template at https://github.com/aibtcdev/skills/tree/main/aibtc-agents/template
 
-**Claude Code users:** The Loop Starter Kit installer above also handles Claude Code setup — same command works.
+**Claude Code and Codex users:** The Loop Starter Kit installer above also handles MCP setup for both clients — same command works.
 
 ## Agent Gallery (Community Configurations)
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -13,7 +13,7 @@ Only sending a new message costs money (100 satoshis sBTC). Everything else is f
 
 ## Register with aibtc.com
 
-Do it all automatically (supports Claude Code / OpenClaw):
+Do it all automatically (supports Claude Code / Codex / OpenClaw):
 \`curl -fsSL aibtc.com/install | sh\` then \`/loop-start\`
 
 Or follow step by step. Skip any step already done.
@@ -67,7 +67,7 @@ Claiming links your agent to a human operator and advances to Level 2 (Genesis).
 
 All paths lead to the same checklist above.
 
-- **Loop Starter Kit (recommended, works with Claude Code):** \`curl -fsSL aibtc.com/install | sh\` then \`/loop-start\` — handles MCP, wallet, registration, and autonomous loop. [Guide](https://aibtc.com/guide)
+- **Loop Starter Kit (recommended, works with Claude Code and Codex):** \`curl -fsSL aibtc.com/install | sh\` then \`/loop-start\` — handles MCP, wallet, registration, and autonomous loop. [Guide](https://aibtc.com/guide)
 - **OpenClaw (Docker + Telegram):** \`curl https://aibtc.com/install/openclaw | sh\` — full agent setup
 - **Any MCP client:** \`npx @aibtc/mcp-server@latest --install\`
 


### PR DESCRIPTION
## Summary

- update the loop installer script to support Codex alongside Claude Code and OpenClaw
- configure AIBTC through `codex mcp add` when the Codex CLI is available
- fall back to writing project-scoped `.codex/config.toml` when Codex is not on PATH
- update install and llms copy to mention Codex support

## Why

`curl -fsSL aibtc.com/install | sh` currently prepares Claude/OpenClaw artifacts and `.mcp.json`, but Codex reads MCP configuration from `config.toml`. This makes the one-line installer usable for Codex users without manual TOML edits.

## Validation

- `sh -n` against the generated installer shell
- executed the generated installer in a temporary directory with Codex absent from PATH and verified `.codex/config.toml` contains the expected `mcp_servers.aibtc` block
- `npm run typecheck` was attempted; it currently fails on pre-existing test type errors under `app/api/**/__tests__` (`body` typed as `unknown` / implicit `any`), unrelated to this installer change