### PR TITLE
feat(762c): live agents D1 mirror; wire into register (P3-0a)

### DIFF
--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -1,4 +1,4 @@
-import { NextRequest, NextResponse } from "next/server";
+import { NextRequest, NextResponse, after } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { invalidateAgentListCache } from "@/lib/cache";
 import { invalidateAgentsIndex } from "@/lib/agents-index";
@@ -896,12 +896,17 @@ export async function POST(request: NextRequest) {
     // co-equal store that subsequent P3a–e read flips can rely on.
     // Skip if referralCode generation failed (column is NOT NULL UNIQUE);
     // the admin backfill job will hydrate the row on its next run.
+    // Runs via `after()` so it does not add latency to the registration
+    // response — the write is non-authoritative and errors are swallowed.
     if (referralCode) {
-      try {
-        await insertAgentToD1(db, record, referralCode);
-      } catch (err) {
-        console.error("Failed to mirror agent to D1:", err);
-      }
+      const referralCodeForMirror = referralCode;
+      after(async () => {
+        try {
+          await insertAgentToD1(db, record, referralCodeForMirror);
+        } catch (err) {
+          console.error("Failed to mirror agent to D1:", err);
+        }
+      });
     }
 
     // Build response with conditional sponsorApiKey field

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -24,6 +24,7 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { provisionSponsorKey, DEFAULT_RELAY_URL } from "@/lib/sponsor";
 import { validateTaprootAddress } from "@/lib/challenge";
 import { validateNostrPubkey } from "@/lib/nostr";
+import { insertAgentToD1 } from "@/lib/d1/agents-mirror";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import {
   MIN_REFERRER_LEVEL,
@@ -888,6 +889,19 @@ export async function POST(request: NextRequest) {
       referralCode = await generateAndStoreReferralCode(kv, btcResult.address);
     } catch (err) {
       console.error("Failed to generate referral code:", err);
+    }
+
+    // Mirror the new agent into D1 alongside the KV writes above.
+    // P3-0a: additive only — KV remains source-of-truth; D1 becomes the
+    // co-equal store that subsequent P3a–e read flips can rely on.
+    // Skip if referralCode generation failed (column is NOT NULL UNIQUE);
+    // the admin backfill job will hydrate the row on its next run.
+    if (referralCode) {
+      try {
+        await insertAgentToD1(db, record, referralCode);
+      } catch (err) {
+        console.error("Failed to mirror agent to D1:", err);
+      }
     }
 
     // Build response with conditional sponsorApiKey field

--- a/lib/d1/__tests__/agents-mirror.test.ts
+++ b/lib/d1/__tests__/agents-mirror.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Unit tests for `lib/d1/agents-mirror.ts`.
+ *
+ * Asserts SQL shape + bind values for `insertAgentToD1` and `updateAgentInD1`
+ * so subsequent schema/column changes can't silently drift between the
+ * mirror and the admin backfill (`app/api/admin/backfill/route.ts:260`).
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { insertAgentToD1, updateAgentInD1 } from "../agents-mirror";
+import type { AgentRecord } from "@/lib/types";
+
+const TEST_BTC = "bc1qtest1address1mock1";
+const TEST_STX = "SP1TESTADDRESS1234";
+const TEST_REFERRER_BTC = "bc1qreferrertestaddr";
+const TEST_REFERRAL_CODE = "ABCDEF";
+
+function makeAgent(overrides: Partial<AgentRecord> = {}): AgentRecord {
+  return {
+    btcAddress: TEST_BTC,
+    stxAddress: TEST_STX,
+    stxPublicKey: "02mock_stx_pubkey",
+    btcPublicKey: "03mock_btc_pubkey",
+    verifiedAt: "2026-01-01T00:00:00.000Z",
+    ...overrides,
+  };
+}
+
+/** D1 mock that captures prepare/bind/run calls. */
+function makeMockDb() {
+  const runs: Array<{ sql: string; binds: unknown[] }> = [];
+  let nextThrowOnRun: Error | null = null;
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      bind: vi.fn((...binds: unknown[]) => ({
+        run: vi.fn(async () => {
+          const captured = { sql, binds };
+          runs.push(captured);
+          if (nextThrowOnRun) {
+            const err = nextThrowOnRun;
+            nextThrowOnRun = null;
+            throw err;
+          }
+          return { meta: { changes: 1 } };
+        }),
+      })),
+    })),
+  } as unknown as D1Database;
+  return {
+    db,
+    runs,
+    throwOnNextRun(err: Error) {
+      nextThrowOnRun = err;
+    },
+  };
+}
+
+describe("insertAgentToD1", () => {
+  it("no-ops when db is undefined", async () => {
+    await expect(
+      insertAgentToD1(undefined, makeAgent(), TEST_REFERRAL_CODE)
+    ).resolves.toBeUndefined();
+  });
+
+  it("issues an INSERT with 17 bind values (referred_by_btc hardcoded NULL)", async () => {
+    const { db, runs } = makeMockDb();
+
+    await insertAgentToD1(db, makeAgent(), TEST_REFERRAL_CODE);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].sql).toContain("INSERT INTO agents");
+    expect(runs[0].sql).toContain("ON CONFLICT(btc_address) DO NOTHING");
+    // 17 placeholders + 1 hardcoded NULL = 18 columns; bind() receives 17 values.
+    expect(runs[0].binds).toHaveLength(17);
+    expect(runs[0].binds[0]).toBe(TEST_BTC);
+    expect(runs[0].binds[1]).toBe(TEST_STX);
+    // referral_code is the last bind value.
+    expect(runs[0].binds[16]).toBe(TEST_REFERRAL_CODE);
+  });
+
+  it("coerces empty btcPublicKey to null (BIP-322 case)", async () => {
+    const { db, runs } = makeMockDb();
+
+    await insertAgentToD1(db, makeAgent({ btcPublicKey: "" }), TEST_REFERRAL_CODE);
+
+    // btc_public_key is the 4th bind value.
+    expect(runs[0].binds[3]).toBeNull();
+  });
+
+  it("fires a second-pass UPDATE for referred_by_btc when agent.referredBy is set", async () => {
+    const { db, runs } = makeMockDb();
+
+    await insertAgentToD1(
+      db,
+      makeAgent({ referredBy: TEST_REFERRER_BTC }),
+      TEST_REFERRAL_CODE
+    );
+
+    expect(runs).toHaveLength(2);
+    expect(runs[0].sql).toContain("INSERT INTO agents");
+    expect(runs[1].sql).toContain("UPDATE agents SET referred_by_btc");
+    expect(runs[1].sql).toContain("referred_by_btc IS NULL");
+    expect(runs[1].binds).toEqual([TEST_REFERRER_BTC, TEST_BTC]);
+  });
+
+  it("does NOT fire the second-pass UPDATE when agent.referredBy is absent", async () => {
+    const { db, runs } = makeMockDb();
+
+    await insertAgentToD1(db, makeAgent(), TEST_REFERRAL_CODE);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].sql).toContain("INSERT INTO agents");
+  });
+
+  it("swallows FK errors from the second-pass referred_by_btc UPDATE", async () => {
+    const mock = makeMockDb();
+
+    // Allow the INSERT, then throw on the next run (the UPDATE).
+    const { db, runs } = mock;
+    let runCount = 0;
+    (db.prepare as ReturnType<typeof vi.fn>).mockImplementation((sql: string) => ({
+      bind: vi.fn((...binds: unknown[]) => ({
+        run: vi.fn(async () => {
+          runCount++;
+          runs.push({ sql, binds });
+          if (runCount === 2) {
+            throw new Error(
+              "FOREIGN KEY constraint failed: agents.referred_by_btc -> agents.btc_address"
+            );
+          }
+          return { meta: { changes: 1 } };
+        }),
+      })),
+    }));
+
+    // Should NOT throw — the FK error from the 2nd-pass UPDATE is swallowed.
+    await expect(
+      insertAgentToD1(
+        db,
+        makeAgent({ referredBy: TEST_REFERRER_BTC }),
+        TEST_REFERRAL_CODE
+      )
+    ).resolves.toBeUndefined();
+
+    expect(runs).toHaveLength(2);
+  });
+});
+
+describe("updateAgentInD1", () => {
+  it("no-ops when db is undefined", async () => {
+    await expect(updateAgentInD1(undefined, makeAgent())).resolves.toBeUndefined();
+  });
+
+  it("issues an UPDATE that preserves immutable referred_by_btc via COALESCE", async () => {
+    const { db, runs } = makeMockDb();
+
+    await updateAgentInD1(db, makeAgent());
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].sql).toContain("UPDATE agents SET");
+    expect(runs[0].sql).toContain("referred_by_btc = COALESCE(?, referred_by_btc)");
+    expect(runs[0].sql).toContain("btc_public_key = COALESCE(?, btc_public_key)");
+    // Last bind value is the WHERE clause's btc_address.
+    expect(runs[0].binds[runs[0].binds.length - 1]).toBe(TEST_BTC);
+  });
+
+  it("binds agent.referredBy when present so an incoming non-null value wins", async () => {
+    const { db, runs } = makeMockDb();
+
+    await updateAgentInD1(db, makeAgent({ referredBy: TEST_REFERRER_BTC }));
+
+    // referred_by_btc bind is the 12th in the UPDATE (matches column order).
+    expect(runs[0].binds[11]).toBe(TEST_REFERRER_BTC);
+  });
+
+  it("binds null for referred_by_btc when absent so COALESCE preserves existing", async () => {
+    const { db, runs } = makeMockDb();
+
+    await updateAgentInD1(db, makeAgent());
+
+    expect(runs[0].binds[11]).toBeNull();
+  });
+});

--- a/lib/d1/agents-mirror.ts
+++ b/lib/d1/agents-mirror.ts
@@ -19,14 +19,16 @@ import type { AgentRecord } from "@/lib/types";
 /**
  * Mirror a newly-registered agent into D1. Called from the registration
  * flow once both the KV writes and the referral-code generation have
- * succeeded. Uses `INSERT OR IGNORE` so a re-fired registration (idempotent
- * retry from the client) does not corrupt an existing row.
+ * succeeded. Uses `ON CONFLICT(btc_address) DO NOTHING` so a re-fired
+ * registration (idempotent retry from the client) does not corrupt an
+ * existing row.
  *
- * The agent's `referredBy` is set in a separate path (vouch flow); this
- * function intentionally inserts `referred_by_btc = NULL` so the foreign-key
- * constraint to `agents(btc_address)` is not tripped during the insert
- * window between the new agent and its referrer (if referred_by_btc were
- * set inline and the referrer wasn't yet in D1, the FK would reject).
+ * Inserts with `referred_by_btc = NULL` first to avoid the FK constraint
+ * to `agents(btc_address)` rejecting the row when the referrer hasn't
+ * yet been mirrored. After the insert, if the agent has a `referredBy`,
+ * a best-effort UPDATE attempts to set it; FK violations are swallowed
+ * because the referrer may not be in D1 yet — the admin backfill job
+ * will hydrate the relationship on its next run.
  */
 export async function insertAgentToD1(
   db: D1Database | undefined,
@@ -67,6 +69,22 @@ export async function insertAgentToD1(
       referralCode
     )
     .run();
+
+  // Best-effort second pass: set `referred_by_btc` if the agent has one.
+  // FK to `agents(btc_address)` may reject if the referrer isn't yet in D1
+  // — that's fine; the admin backfill will close the gap on its next run.
+  if (agent.referredBy) {
+    try {
+      await db
+        .prepare(
+          "UPDATE agents SET referred_by_btc = ? WHERE btc_address = ? AND referred_by_btc IS NULL"
+        )
+        .bind(agent.referredBy, agent.btcAddress)
+        .run();
+    } catch {
+      // Referrer not yet in D1; backfill will fill this in. Swallowed.
+    }
+  }
 }
 
 /**
@@ -107,7 +125,7 @@ export async function updateAgentInD1(
          capabilities_json = ?,
          last_identity_check = ?,
          github_username = ?,
-         referred_by_btc = ?,
+         referred_by_btc = COALESCE(?, referred_by_btc),
          btc_public_key = COALESCE(?, btc_public_key)
        WHERE btc_address = ?`
     )
@@ -123,6 +141,9 @@ export async function updateAgentInD1(
       agent.capabilities ? JSON.stringify(agent.capabilities) : null,
       agent.lastIdentityCheck ?? null,
       agent.githubUsername ?? null,
+      // referredBy is immutable once set; COALESCE preserves the existing
+      // value when the incoming AgentRecord omits referredBy (most mutators
+      // don't touch this field). A non-null incoming value still wins.
       agent.referredBy ?? null,
       // btcPublicKey is opportunistic — COALESCE preserves a previously
       // captured value if the current write has none (update-pubkey is

--- a/lib/d1/agents-mirror.ts
+++ b/lib/d1/agents-mirror.ts
@@ -1,0 +1,134 @@
+/**
+ * Live D1 mirror for the `agents` table.
+ *
+ * Before this module, D1 `agents` was populated only by the admin backfill
+ * job (`app/api/admin/backfill/route.ts:260`), making it a hours-to-days-old
+ * snapshot of the canonical KV `stx:`/`btc:` records. That meant any read
+ * flipped from KV to D1 would miss newly-registered agents.
+ *
+ * This mirror is **purely additive** — it writes to D1 alongside the
+ * existing KV writes, preserving KV as the current source-of-truth while
+ * making D1 a co-equal store that subsequent P3a–e read flips can rely on.
+ *
+ * Same shape as `lib/claims/d1-mirror.ts`. Failures are logged but never
+ * thrown; the KV write is the authoritative path for now.
+ */
+
+import type { AgentRecord } from "@/lib/types";
+
+/**
+ * Mirror a newly-registered agent into D1. Called from the registration
+ * flow once both the KV writes and the referral-code generation have
+ * succeeded. Uses `INSERT OR IGNORE` so a re-fired registration (idempotent
+ * retry from the client) does not corrupt an existing row.
+ *
+ * The agent's `referredBy` is set in a separate path (vouch flow); this
+ * function intentionally inserts `referred_by_btc = NULL` so the foreign-key
+ * constraint to `agents(btc_address)` is not tripped during the insert
+ * window between the new agent and its referrer (if referred_by_btc were
+ * set inline and the referrer wasn't yet in D1, the FK would reject).
+ */
+export async function insertAgentToD1(
+  db: D1Database | undefined,
+  agent: AgentRecord,
+  referralCode: string
+): Promise<void> {
+  if (!db) return;
+
+  await db
+    .prepare(
+      `INSERT INTO agents (
+         btc_address, stx_address, stx_public_key, btc_public_key,
+         taproot_address, display_name, description, bns_name,
+         owner, verified_at, last_active_at, erc8004_agent_id,
+         nostr_public_key, capabilities_json, last_identity_check,
+         github_username, referred_by_btc, referral_code
+       ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, ?)
+       ON CONFLICT(btc_address) DO NOTHING`
+    )
+    .bind(
+      agent.btcAddress,
+      agent.stxAddress,
+      agent.stxPublicKey,
+      // btc_public_key is NULLable (migration 008): null when absent/empty.
+      agent.btcPublicKey || null,
+      agent.taprootAddress ?? null,
+      agent.displayName ?? null,
+      agent.description ?? null,
+      agent.bnsName ?? null,
+      agent.owner ?? null,
+      agent.verifiedAt,
+      agent.lastActiveAt ?? null,
+      agent.erc8004AgentId ?? null,
+      agent.nostrPublicKey ?? null,
+      agent.capabilities ? JSON.stringify(agent.capabilities) : null,
+      agent.lastIdentityCheck ?? null,
+      agent.githubUsername ?? null,
+      referralCode
+    )
+    .run();
+}
+
+/**
+ * Mirror a mutated agent into D1. Called from every site that updates a
+ * KV `stx:`/`btc:` AgentRecord (heartbeat, challenge, verify, identity, etc.).
+ *
+ * Wiring scheduled for P3-0b — this helper is defined now so the contract
+ * is reviewable alongside `insertAgentToD1`, and so individual mutator
+ * call sites can be wired in small follow-up PRs without re-introducing
+ * the helper.
+ *
+ * Updates only fields that can change post-registration. Immutable fields
+ * (btc_address, stx_address, public keys, verified_at, referral_code) are
+ * never touched here — they are set by `insertAgentToD1` at registration.
+ *
+ * If no row exists for the agent (i.e. registered before this mirror was
+ * deployed and not yet backfilled), the UPDATE silently no-ops. That is
+ * acceptable because the admin backfill job will hydrate the row on its
+ * next run, picking up the latest KV state.
+ */
+export async function updateAgentInD1(
+  db: D1Database | undefined,
+  agent: AgentRecord
+): Promise<void> {
+  if (!db) return;
+
+  await db
+    .prepare(
+      `UPDATE agents SET
+         taproot_address = ?,
+         display_name = ?,
+         description = ?,
+         bns_name = ?,
+         owner = ?,
+         last_active_at = ?,
+         erc8004_agent_id = ?,
+         nostr_public_key = ?,
+         capabilities_json = ?,
+         last_identity_check = ?,
+         github_username = ?,
+         referred_by_btc = ?,
+         btc_public_key = COALESCE(?, btc_public_key)
+       WHERE btc_address = ?`
+    )
+    .bind(
+      agent.taprootAddress ?? null,
+      agent.displayName ?? null,
+      agent.description ?? null,
+      agent.bnsName ?? null,
+      agent.owner ?? null,
+      agent.lastActiveAt ?? null,
+      agent.erc8004AgentId ?? null,
+      agent.nostrPublicKey ?? null,
+      agent.capabilities ? JSON.stringify(agent.capabilities) : null,
+      agent.lastIdentityCheck ?? null,
+      agent.githubUsername ?? null,
+      agent.referredBy ?? null,
+      // btcPublicKey is opportunistic — COALESCE preserves a previously
+      // captured value if the current write has none (update-pubkey is
+      // a one-time challenge action).
+      agent.btcPublicKey || null,
+      agent.btcAddress
+    )
+    .run();
+}

--- a/lib/d1/agents-mirror.ts
+++ b/lib/d1/agents-mirror.ts
@@ -10,8 +10,13 @@
  * existing KV writes, preserving KV as the current source-of-truth while
  * making D1 a co-equal store that subsequent P3a–e read flips can rely on.
  *
- * Same shape as `lib/claims/d1-mirror.ts`. Failures are logged but never
- * thrown; the KV write is the authoritative path for now.
+ * Same shape as `lib/claims/d1-mirror.ts`. **D1 errors propagate to the
+ * caller** — every wiring site is responsible for try/catch + logging.
+ * This is intentional: the mirror should not be silently swallowed in a
+ * helper that's reused across many call paths with different log contexts.
+ * The one exception is the second-pass `referred_by_btc` UPDATE inside
+ * `insertAgentToD1`, which intentionally swallows FK violations (see
+ * function-level doc below).
  */
 
 import type { AgentRecord } from "@/lib/types";


### PR DESCRIPTION
## Summary

- Adds `lib/d1/agents-mirror.ts` (`insertAgentToD1` + `updateAgentInD1`) matching the shape of `lib/claims/d1-mirror.ts`.
- Wires `insertAgentToD1` into the registration flow so new agents land in D1 immediately alongside the existing KV writes.
- Purely additive: no KV writes removed, no read paths changed. Mirror call is try/catch wrapped — a D1 failure does not break registration.

## Background

Before this PR, D1 `agents` was populated **only** by the admin backfill job (`app/api/admin/backfill/route.ts:260`), making it a hours-to-days-old snapshot of the canonical KV `stx:`/`btc:` records. Any subsequent P3 read-flip from KV to D1 would have missed newly-registered agents until the next backfill — a correctness regression.

This mirror makes D1 a co-equal store. `claims` already had this pattern (`lib/claims/d1-mirror.ts` wired into viral-claim + genesis-payout + backfill); this PR brings `agents` into parity.

`updateAgentInD1` is defined here for review alongside `insertAgentToD1`, but is **not yet wired** into mutator call sites — that's the follow-up P3-0b PR (11 sites: vouch, heartbeat, challenge, verify, identity, identity-refresh, agents-page, bitcoin-verify, admin/backfill-identity, agents/[address]).

## Quest context

- Quest: `2026-05-14-kv-write-bill-stop` (P3-0a sub-phase)
- Umbrella: #762
- Blocks: P3a–e (all read-flip + write-stop sub-phases need the live mirror first)

## Test plan

- [x] `npm run lint` clean
- [x] `npm run build` clean
- [x] `npx vitest run app/api/register` — 8/8 pass (the existing register tests use `db: undefined` mocks; the mirror gracefully no-ops on undefined db)
- [ ] Post-merge T+1h soak: confirm new registrations appear in D1 immediately via `SELECT COUNT(*) FROM agents` before/after a test registration
- [ ] Post-merge T+1h soak: spot-check `wrangler kv key list --prefix=btc: | wc -l` vs. `SELECT COUNT(*) FROM agents` deltas track 1:1

🤖 Generated with [Claude Code](https://claude.com/claude-code)