### PR TITLE
fix(competition): add USDA + sUSDT to stablecoin price fallback map

### DIFF
--- a/lib/external/tenero/stablecoin-fallbacks.ts
+++ b/lib/external/tenero/stablecoin-fallbacks.ts
@@ -27,6 +27,18 @@ const USD_PEGGED_TOKEN_FALLBACKS: Readonly<Record<string, StablecoinUsdFallback>
     priceUsd: 1,
     decimals: 6,
   },
+  // Arkadiko USDA — Tenero returns price_usd: 0 despite active Bitflow stableswap pools
+  "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token": {
+    symbol: "USDA",
+    priceUsd: 1,
+    decimals: 6,
+  },
+  // Bitflow-deployed bridged USDT — same deployer as token-aeusdc; Tenero returns price_usd: 0
+  "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt": {
+    symbol: "sUSDT",
+    priceUsd: 1,
+    decimals: 8,
+  },
 };
 
 export function getStablecoinUsdFallback(


### PR DESCRIPTION
## Summary

- Adds `SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token` (USDA, 6 decimals) to `USD_PEGGED_TOKEN_FALLBACKS`
- Adds `SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt` (sUSDT, 8 decimals) to `USD_PEGGED_TOKEN_FALLBACKS`

Tenero returns `price_usd: 0` for both tokens despite 4 active Bitflow stableswap pools that use them (`stableswap-usda-susdt-v-1-2`, `stableswap-aeusdc-susdt-v-1-2`, `stableswap-usda-aeusdc-v-1-2`, `stableswap-usda-aeusdc-v-1-4`). Without fallback entries, any agent holding USDA or sUSDT output legs lands on `allPriced: false` and gets a `*`-marked P&L — understating performance for agents who hedged into these stablecoins during the competition.

## Why this is the complete fix

`getStablecoinUsdFallback` is already wired in two places (both landing in #866):
- `LeaderboardClient.tsx::fetchTokenPrice` — client-side P&L compute
- `/api/prices?token=X` single-token path — server-side read surface

No routing changes needed — just adding to the fallback map.

## Verification

Both contracts verified against Tenero:
- `price_usd: 0` (confirmed Tenero data bug, not delisting — both tokens have active pools)
- `decimals: 6` (USDA) and `decimals: 8` (sUSDT) from Hiro metadata + Tenero `/v1/stacks/tokens/` endpoint

Closes the remaining gap flagged in [#815 (T+4 status comment)](https://github.com/aibtcdev/landing-page/issues/815) after #866 covered aeUSDC. Follows the same pattern @whoabuddy established in #849.

## Test plan

- [ ] `GET /api/prices?token=SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.usda-token` → `{ priceUsd: 1 }`
- [ ] `GET /api/prices?token=SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-susdt` → `{ priceUsd: 1 }`
- [ ] Leaderboard rows for agents with USDA or sUSDT output legs no longer show `*` P&L markers
- [ ] `allPriced: false` clears for any row where the only unpriced token was USDA or sUSDT

🤖 Generated with [Claude Code](https://claude.com/claude-code)