### PR TITLE
fix(inbox): clamp reconciliation queue to nonceExpiresAt (#375)

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -19,8 +19,9 @@ import {
   buildSenderAuthMessage,
   DEFAULT_RELAY_URL,
   enqueueInboxReconciliation,
-  SPONSOR_NONCE_TTL_MS,
 } from "@/lib/inbox";
+// Import directly from constants to avoid test-mock interference on the barrel.
+import { SPONSOR_NONCE_TTL_MS } from "@/lib/inbox/constants";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { networkToCAIP2, X402_HEADERS } from "x402-stacks";
 import type { PaymentPayloadV2 } from "x402-stacks";

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -19,6 +19,7 @@ import {
   buildSenderAuthMessage,
   DEFAULT_RELAY_URL,
   enqueueInboxReconciliation,
+  SPONSOR_NONCE_TTL_MS,
 } from "@/lib/inbox";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { networkToCAIP2, X402_HEADERS } from "x402-stacks";
@@ -1535,11 +1536,28 @@ export async function POST(
       const checkStatusUrl =
         paymentResult.checkStatusUrl ?? `/api/payment-status/${paymentResult.paymentId}`;
 
+      // Capture the original sponsored tx hex and settle options so the
+      // reconciliation queue can re-submit after the relay's sponsor nonce
+      // expires (Phase 5 of quest nonce-conflict-attribution, issue #375).
+      const stagedTxHex = paymentPayload?.payload?.transaction ?? undefined;
+      const stagedNonceExpiresAt = new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
+      const stagedSettleOptions =
+        agent.stxAddress && paymentRequirements.amount
+          ? {
+              expectedRecipient: agent.stxAddress,
+              minAmount: String(paymentRequirements.amount),
+              tokenType: "sBTC" as const,
+            }
+          : undefined;
+
       await storeStagedInboxPayment(kv, {
         paymentId: paymentResult.paymentId,
         createdAt: now,
         ...(senderAgent?.btcAddress && { senderSentIndexBtcAddress: senderAgent.btcAddress }),
         message,
+        ...(stagedTxHex && { txHex: stagedTxHex }),
+        nonceExpiresAt: stagedNonceExpiresAt,
+        ...(stagedSettleOptions && { settleOptions: stagedSettleOptions }),
       });
 
       await enqueueInboxReconciliation(

--- a/lib/inbox/__tests__/reconciliation-queue.test.ts
+++ b/lib/inbox/__tests__/reconciliation-queue.test.ts
@@ -389,4 +389,340 @@ describe("inbox reconciliation queue", () => {
       })
     );
   });
+
+  // ---- Sponsor-nonce TTL tests (#375 Phase 5) ----
+
+  it("acks when nonce is expired and staged record has no txHex (pre-Phase-5 record)", async () => {
+    const kv = createMockKV();
+    const { db } = createMockD1();
+    // Store a staged record WITHOUT txHex (old-format record)
+    const stagedAt = new Date(Date.now() - 15 * 60 * 1000).toISOString(); // 15 min ago
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_ttl_no_txhex",
+      createdAt: stagedAt,
+      // no txHex, nonceExpiresAt is implicitly expired (15 min ago)
+      message: {
+        messageId: "msg_ttl_no_txhex",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt: stagedAt,
+        paymentStatus: "pending",
+        paymentId: "pay_ttl_no_txhex",
+      },
+    });
+
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const submitPayment = vi.fn();
+
+    await processInboxReconciliationQueue(
+      {
+        queue: "landing-page-inbox-reconciliation",
+        messages: [
+          {
+            id: "queue-msg-ttl-1",
+            timestamp: new Date(),
+            attempts: 1,
+            body: {
+              paymentId: "pay_ttl_no_txhex",
+              stagedAt, // 15 min ago — nonce expired
+              attempt: 0,
+              source: "queue_retry" as const,
+            },
+            ack,
+            retry,
+          },
+        ],
+        ackAll: vi.fn(),
+        retryAll: vi.fn(),
+      },
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        X402_RELAY: {
+          submitPayment,
+          checkPayment: vi.fn(), // should NOT be called
+        },
+        INBOX_RECONCILIATION_QUEUE: { send: vi.fn(), sendBatch: vi.fn() },
+      },
+      mocks.logger,
+      "test-version"
+    );
+
+    // Should ack (discard) without calling checkPayment or submitPayment
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    expect(submitPayment).not.toHaveBeenCalled();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "payment.retry_decision",
+      expect.objectContaining({
+        paymentId: "pay_ttl_no_txhex",
+        action: "ack_nonce_expired_no_tx_hex",
+      })
+    );
+  });
+
+  it("re-submits txHex via submitPayment when nonce is expired and txHex is stored", async () => {
+    const kv = createMockKV();
+    const { db } = createMockD1();
+    const stagedAt = new Date(Date.now() - 15 * 60 * 1000).toISOString(); // 15 min ago
+    const expiredNonceExpiresAt = new Date(Date.now() - 5 * 60 * 1000).toISOString(); // 5 min ago
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_ttl_resubmit",
+      createdAt: stagedAt,
+      nonceExpiresAt: expiredNonceExpiresAt,
+      txHex: "0xdeadbeef01",
+      settleOptions: {
+        expectedRecipient: "SP456",
+        minAmount: "100",
+        tokenType: "sBTC",
+      },
+      message: {
+        messageId: "msg_ttl_resubmit",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt: stagedAt,
+        paymentStatus: "pending",
+        paymentId: "pay_ttl_resubmit",
+      },
+    });
+
+    const ack = vi.fn();
+    const retry = vi.fn();
+    const queueSend = vi.fn().mockResolvedValue(undefined);
+    const submitPayment = vi.fn().mockResolvedValue({
+      accepted: true,
+      paymentId: "pay_ttl_resubmit_fresh",
+      status: "queued",
+    });
+
+    await processInboxReconciliationQueue(
+      {
+        queue: "landing-page-inbox-reconciliation",
+        messages: [
+          {
+            id: "queue-msg-ttl-2",
+            timestamp: new Date(),
+            attempts: 1,
+            body: {
+              paymentId: "pay_ttl_resubmit",
+              stagedAt,
+              attempt: 1,
+              source: "queue_retry" as const,
+            },
+            ack,
+            retry,
+          },
+        ],
+        ackAll: vi.fn(),
+        retryAll: vi.fn(),
+      },
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        X402_RELAY: {
+          submitPayment,
+          checkPayment: vi.fn(), // should NOT be called (TTL already expired)
+        },
+        INBOX_RECONCILIATION_QUEUE: { send: queueSend, sendBatch: vi.fn() },
+      },
+      mocks.logger,
+      "test-version"
+    );
+
+    // submitPayment called with stored txHex and settleOptions
+    expect(submitPayment).toHaveBeenCalledWith(
+      "0xdeadbeef01",
+      expect.objectContaining({
+        expectedRecipient: "SP456",
+        minAmount: "100",
+        tokenType: "sBTC",
+      }),
+      undefined // no paymentIdentifier
+    );
+
+    // staged record updated with new paymentId
+    const updatedStaged = await getStagedInboxPayment(kv, "pay_ttl_resubmit_fresh");
+    expect(updatedStaged).not.toBeNull();
+    expect(updatedStaged?.paymentId).toBe("pay_ttl_resubmit_fresh");
+    expect(updatedStaged?.txHex).toBe("0xdeadbeef01");
+
+    // old paymentId should still exist (storeStagedInboxPayment creates a new key)
+    // queue re-enqueued with new paymentId
+    expect(queueSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        paymentId: "pay_ttl_resubmit_fresh",
+        attempt: 2,
+        source: "queue_retry",
+      }),
+      expect.objectContaining({ delaySeconds: expect.any(Number) })
+    );
+
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  it("acks without retrying when submitPayment rejects after nonce expiry", async () => {
+    const kv = createMockKV();
+    const { db } = createMockD1();
+    const stagedAt = new Date(Date.now() - 15 * 60 * 1000).toISOString();
+    const expiredNonceExpiresAt = new Date(Date.now() - 5 * 60 * 1000).toISOString();
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_ttl_resubmit_rejected",
+      createdAt: stagedAt,
+      nonceExpiresAt: expiredNonceExpiresAt,
+      txHex: "0xdeadbeef02",
+      settleOptions: {
+        expectedRecipient: "SP456",
+        minAmount: "100",
+      },
+      message: {
+        messageId: "msg_ttl_resubmit_rejected",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt: stagedAt,
+        paymentStatus: "pending",
+        paymentId: "pay_ttl_resubmit_rejected",
+      },
+    });
+
+    const ack = vi.fn();
+    const retry = vi.fn();
+
+    await processInboxReconciliationQueue(
+      {
+        queue: "landing-page-inbox-reconciliation",
+        messages: [
+          {
+            id: "queue-msg-ttl-3",
+            timestamp: new Date(),
+            attempts: 1,
+            body: {
+              paymentId: "pay_ttl_resubmit_rejected",
+              stagedAt,
+              attempt: 0,
+              source: "queue_retry" as const,
+            },
+            ack,
+            retry,
+          },
+        ],
+        ackAll: vi.fn(),
+        retryAll: vi.fn(),
+      },
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        X402_RELAY: {
+          submitPayment: vi.fn().mockResolvedValue({
+            accepted: false,
+            error: "Relay rejected",
+            code: "INTERNAL_ERROR",
+          }),
+          checkPayment: vi.fn(),
+        },
+        INBOX_RECONCILIATION_QUEUE: { send: vi.fn(), sendBatch: vi.fn() },
+      },
+      mocks.logger,
+      "test-version"
+    );
+
+    // Must ack without retrying — do NOT fall back to stale hex
+    expect(ack).toHaveBeenCalledTimes(1);
+    expect(retry).not.toHaveBeenCalled();
+    expect(mocks.logger.warn).toHaveBeenCalledWith(
+      "payment.retry_decision",
+      expect.objectContaining({
+        paymentId: "pay_ttl_resubmit_rejected",
+        action: "ack_resubmit_rejected",
+      })
+    );
+  });
+
+  it("does not trigger TTL path when nonce has not yet expired", async () => {
+    const kv = createMockKV();
+    const { db } = createMockD1();
+    const sentAt = new Date().toISOString(); // just now — within TTL
+
+    await storeStagedInboxPayment(kv, {
+      paymentId: "pay_ttl_not_expired",
+      createdAt: sentAt,
+      nonceExpiresAt: new Date(Date.now() + 8 * 60 * 1000).toISOString(), // 8 min from now
+      txHex: "0xdeadbeef03",
+      settleOptions: { expectedRecipient: "SP456", minAmount: "100" },
+      message: {
+        messageId: "msg_ttl_not_expired",
+        fromAddress: "SP123",
+        toBtcAddress: "bc1recipient",
+        toStxAddress: "SP456",
+        content: "hello",
+        paymentSatoshis: 100,
+        sentAt,
+        paymentStatus: "pending",
+        paymentId: "pay_ttl_not_expired",
+      },
+    });
+
+    const ack = vi.fn();
+    const submitPayment = vi.fn();
+    const checkPayment = vi.fn().mockResolvedValue({
+      paymentId: "pay_ttl_not_expired",
+      status: "queued",
+      checkStatusUrl: "https://relay.example/check/pay_ttl_not_expired",
+    });
+    const queueSend = vi.fn().mockResolvedValue(undefined);
+
+    await processInboxReconciliationQueue(
+      {
+        queue: "landing-page-inbox-reconciliation",
+        messages: [
+          {
+            id: "queue-msg-ttl-4",
+            timestamp: new Date(),
+            attempts: 1,
+            body: {
+              paymentId: "pay_ttl_not_expired",
+              stagedAt: sentAt,
+              attempt: 0,
+              source: "inbox_post" as const,
+            },
+            ack,
+            retry: vi.fn(),
+          },
+        ],
+        ackAll: vi.fn(),
+        retryAll: vi.fn(),
+      },
+      {
+        VERIFIED_AGENTS: kv,
+        DB: db,
+        X402_RELAY: { submitPayment, checkPayment },
+        INBOX_RECONCILIATION_QUEUE: { send: queueSend, sendBatch: vi.fn() },
+      },
+      mocks.logger,
+      "test-version"
+    );
+
+    // TTL not expired: should go through normal reconcile path (checkPayment called)
+    expect(submitPayment).not.toHaveBeenCalled();
+    expect(checkPayment).toHaveBeenCalledTimes(1);
+    // Payment is still queued → re-enqueued
+    expect(queueSend).toHaveBeenCalledWith(
+      expect.objectContaining({ paymentId: "pay_ttl_not_expired", attempt: 1 }),
+      expect.objectContaining({ delaySeconds: 30 })
+    );
+    expect(ack).toHaveBeenCalledTimes(1);
+  });
 });

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -113,6 +113,25 @@ export const PAYMENT_FAILURE_CACHE_TTL_SECONDS = 300;
  */
 export const CACHEABLE_PAYMENT_FAILURE_CODES = new Set(["INSUFFICIENT_FUNDS"]);
 
+// --- Sponsor nonce TTL constants ---
+
+/**
+ * Mirror of STALE_THRESHOLD_MS in the relay's NonceDO (currently 10 minutes).
+ *
+ * After this duration the relay may reclaim the sponsor nonce assigned to a
+ * submitted payment, making the original sponsored hex invalid for rebroadcast.
+ *
+ * Used to populate `nonceExpiresAt` in StagedInboxMessage at submission time
+ * and to detect expiry in the reconciliation queue.
+ *
+ * MUST stay in sync with the relay's `STALE_THRESHOLD_MS` constant in
+ * `src/durable-objects/nonce-do.ts`.  The relay also publishes this value as
+ * `sponsorNonceValidForMs` in its `/sponsor` and `/relay` responses (Phase 3,
+ * issue #374).  When the relay response includes that field, prefer it over
+ * this constant for forward-compatibility.
+ */
+export const SPONSOR_NONCE_TTL_MS = 10 * 60 * 1000; // 600 000 ms
+
 // --- RPC service binding polling constants ---
 
 /** Interval between checkPayment() polls (ms). */

--- a/lib/inbox/index.ts
+++ b/lib/inbox/index.ts
@@ -13,6 +13,7 @@ export type {
   SentMessageIndex,
   RelayPaymentStatus,
   StagedInboxMessage,
+  StagedSettleOptions,
   PaymentFailureCache,
 } from "./types";
 
@@ -37,6 +38,7 @@ export {
   PAYMENT_FAILURE_CACHE_PREFIX,
   PAYMENT_FAILURE_CACHE_TTL_SECONDS,
   STAGED_PAYMENT_TTL_SECONDS,
+  SPONSOR_NONCE_TTL_MS,
   CACHEABLE_PAYMENT_FAILURE_CODES,
   buildMarkReadMessage,
   buildReplyMessage,

--- a/lib/inbox/reconciliation-queue.ts
+++ b/lib/inbox/reconciliation-queue.ts
@@ -1,11 +1,15 @@
-import { STAGED_PAYMENT_TTL_SECONDS } from "@/lib/inbox/constants";
-import type { RelayRPC } from "@/lib/inbox/relay-rpc";
+import { STAGED_PAYMENT_TTL_SECONDS, SPONSOR_NONCE_TTL_MS } from "@/lib/inbox/constants";
+import type { RelayRPC, RelaySettleOptions } from "@/lib/inbox/relay-rpc";
 import type { Logger } from "@/lib/logging";
 import { logPaymentEvent } from "@/lib/inbox/payment-logging";
 import {
   reconcileStagedInboxPayment,
   type ReconciliationTrigger,
 } from "@/lib/inbox/reconcile-staged-payment";
+import {
+  getStagedInboxPayment,
+  storeStagedInboxPayment,
+} from "@/lib/inbox/kv-helpers";
 
 export interface InboxReconciliationQueueMessage {
   paymentId: string;
@@ -17,6 +21,9 @@ export interface InboxReconciliationQueueMessage {
 const MAX_RECONCILIATION_ATTEMPTS = 10;
 const RECONCILIATION_DELAYS_SECONDS = [30, 60, 120, 300, 600];
 export const INBOX_RECONCILIATION_QUEUE_ROUTE = "/__queue/inbox-reconciliation";
+
+/** Small clock-skew buffer subtracted from nonceExpiresAt before comparing (ms). */
+const NONCE_EXPIRY_BUFFER_MS = 5_000;
 
 function isInboxReconciliationQueueMessage(
   value: unknown
@@ -45,6 +52,33 @@ function getStagedAgeSeconds(stagedAt: string): number {
   // Treat unparseable dates as expired to prevent infinite retries
   if (!Number.isFinite(time)) return STAGED_PAYMENT_TTL_SECONDS;
   return Math.max(0, Math.floor((Date.now() - time) / 1000));
+}
+
+/**
+ * Determine whether the relay's sponsor nonce for this payment has expired.
+ *
+ * Uses `nonceExpiresAt` from the staged record when available (preferred —
+ * relay clock is authoritative).  Falls back to `stagedAt + SPONSOR_NONCE_TTL_MS`
+ * for records created before Phase 5 that lack the explicit field.
+ *
+ * A small clock-skew buffer (NONCE_EXPIRY_BUFFER_MS) is subtracted so the
+ * queue never races the relay's NonceDO reclaim alarm.
+ */
+function isSponsorNonceExpired(stagedAt: string, nonceExpiresAt?: string): boolean {
+  const now = Date.now();
+  if (nonceExpiresAt) {
+    const expiryMs = new Date(nonceExpiresAt).getTime();
+    if (!Number.isFinite(expiryMs)) {
+      // Unparseable timestamp — fall back to derived TTL
+      const derivedExpiry = new Date(stagedAt).getTime() + SPONSOR_NONCE_TTL_MS;
+      return now >= derivedExpiry - NONCE_EXPIRY_BUFFER_MS;
+    }
+    return now >= expiryMs - NONCE_EXPIRY_BUFFER_MS;
+  }
+  // No stored timestamp — derive from stagedAt
+  const stagedMs = new Date(stagedAt).getTime();
+  if (!Number.isFinite(stagedMs)) return true; // unparseable → treat as expired
+  return now >= stagedMs + SPONSOR_NONCE_TTL_MS - NONCE_EXPIRY_BUFFER_MS;
 }
 
 export async function enqueueInboxReconciliation(
@@ -177,6 +211,195 @@ export async function processInboxReconciliationQueue(
         trigger,
       },
     });
+
+    // --- Sponsor-nonce TTL check (#375 Option C) ---
+    // Read the staged record to check whether the relay's sponsor nonce has
+    // expired.  If it has, rebroadcasting the same sponsored hex would produce
+    // a ConflictingNonceInMempool error because the relay already reclaimed
+    // that nonce slot.  Instead, re-call submitPayment(txHex) to obtain a
+    // fresh sponsor assignment before continuing the poll cycle.
+    const stagedRecord = await getStagedInboxPayment(env.VERIFIED_AGENTS, body.paymentId);
+
+    if (stagedRecord && isSponsorNonceExpired(body.stagedAt, stagedRecord.nonceExpiresAt)) {
+      if (!stagedRecord.txHex) {
+        // Pre-Phase-5 record: no txHex stored — cannot re-sponsor.
+        // Log a warning and ack so the payment is discarded gracefully.
+        logPaymentEvent(logger, "warn", "payment.retry_decision", repoVersion, {
+          route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+          paymentId: body.paymentId,
+          status: "pending",
+          action: "ack_nonce_expired_no_tx_hex",
+          additionalContext: {
+            attempt: body.attempt,
+            stagedAgeSeconds,
+            nonceExpiresAt: stagedRecord.nonceExpiresAt ?? null,
+            worker_stage: "queue_consumer",
+            trigger,
+          },
+        });
+        message.ack();
+        continue;
+      }
+
+      // Re-submit the original tx hex to obtain a fresh sponsor nonce.
+      // Do NOT fall back to the stale hex on failure — treat submit failure
+      // as a terminal condition and ack so the message is not retried.
+      logPaymentEvent(logger, "info", "payment.retry_decision", repoVersion, {
+        route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+        paymentId: body.paymentId,
+        status: "pending",
+        action: "resubmit_after_nonce_expiry",
+        additionalContext: {
+          attempt: body.attempt,
+          stagedAgeSeconds,
+          nonceExpiresAt: stagedRecord.nonceExpiresAt ?? null,
+          worker_stage: "queue_consumer",
+          trigger,
+        },
+      });
+
+      let resubmitResult: Awaited<ReturnType<RelayRPC["submitPayment"]>>;
+      try {
+        const settle: RelaySettleOptions | undefined = stagedRecord.settleOptions
+          ? {
+              expectedRecipient: stagedRecord.settleOptions.expectedRecipient,
+              minAmount: stagedRecord.settleOptions.minAmount,
+              ...(stagedRecord.settleOptions.tokenType && {
+                tokenType: stagedRecord.settleOptions.tokenType,
+              }),
+            }
+          : undefined;
+        resubmitResult = await rpc.submitPayment(
+          stagedRecord.txHex,
+          settle,
+          stagedRecord.paymentIdentifier
+        );
+      } catch (err) {
+        // Network or binding error — log and ack (do NOT rebroadcast stale hex).
+        logPaymentEvent(logger, "warn", "payment.retry_decision", repoVersion, {
+          route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+          paymentId: body.paymentId,
+          status: "pending",
+          action: "ack_resubmit_exception",
+          additionalContext: {
+            attempt: body.attempt,
+            stagedAgeSeconds,
+            worker_stage: "queue_consumer",
+            trigger,
+            error: String(err),
+          },
+        });
+        message.ack();
+        continue;
+      }
+
+      if (!resubmitResult.accepted) {
+        // Relay rejected the re-submission — ack and discard.
+        logPaymentEvent(logger, "warn", "payment.retry_decision", repoVersion, {
+          route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+          paymentId: body.paymentId,
+          status: "pending",
+          action: "ack_resubmit_rejected",
+          additionalContext: {
+            attempt: body.attempt,
+            stagedAgeSeconds,
+            worker_stage: "queue_consumer",
+            trigger,
+            code: resubmitResult.code ?? null,
+            error: resubmitResult.error,
+          },
+        });
+        message.ack();
+        continue;
+      }
+
+      // Re-submission succeeded: update staged record with the new paymentId
+      // and a fresh nonceExpiresAt, then re-enqueue for the next poll cycle.
+      const newPaymentId = resubmitResult.paymentId;
+      const newNonceExpiresAt = new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
+
+      try {
+        await storeStagedInboxPayment(env.VERIFIED_AGENTS, {
+          ...stagedRecord,
+          paymentId: newPaymentId,
+          nonceExpiresAt: newNonceExpiresAt,
+        });
+      } catch (err) {
+        // KV write failed — cannot safely continue (old paymentId is stale,
+        // new paymentId is not persisted).  Log and ack to avoid orphaned state.
+        logPaymentEvent(logger, "warn", "payment.retry_decision", repoVersion, {
+          route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+          paymentId: body.paymentId,
+          status: "pending",
+          action: "ack_resubmit_kv_write_failed",
+          additionalContext: {
+            attempt: body.attempt,
+            newPaymentId,
+            worker_stage: "queue_consumer",
+            trigger,
+            error: String(err),
+          },
+        });
+        message.ack();
+        continue;
+      }
+
+      logPaymentEvent(logger, "info", "payment.retry_decision", repoVersion, {
+        route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+        paymentId: body.paymentId,
+        status: "pending",
+        action: "resubmit_succeeded",
+        additionalContext: {
+          oldPaymentId: body.paymentId,
+          newPaymentId,
+          newNonceExpiresAt,
+          attempt: body.attempt,
+          nextAttempt: body.attempt + 1,
+          queueDelaySeconds: getRetryDelaySeconds(body.attempt),
+          stagedAgeSeconds,
+          worker_stage: "queue_consumer",
+          trigger,
+        },
+      });
+
+      const nextAttempt = body.attempt + 1;
+      const queueDelaySeconds = getRetryDelaySeconds(body.attempt);
+
+      if (queue) {
+        try {
+          await queue.send(
+            {
+              paymentId: newPaymentId,
+              stagedAt: body.stagedAt,
+              attempt: nextAttempt,
+              source: "queue_retry",
+            },
+            { delaySeconds: queueDelaySeconds }
+          );
+          message.ack();
+        } catch (err) {
+          logPaymentEvent(logger, "warn", "payment.queue", repoVersion, {
+            route: INBOX_RECONCILIATION_QUEUE_ROUTE,
+            paymentId: newPaymentId,
+            status: "pending",
+            action: "enqueue_failed",
+            additionalContext: {
+              attempt: body.attempt,
+              nextAttempt,
+              queueDelaySeconds,
+              worker_stage: "queue_consumer",
+              trigger: "queue_retry",
+              error: String(err),
+            },
+          });
+          message.retry({ delaySeconds: queueDelaySeconds });
+        }
+      } else {
+        message.retry({ delaySeconds: queueDelaySeconds });
+      }
+      continue;
+    }
+    // --- End sponsor-nonce TTL check ---
 
     const reconciliation = await reconcileStagedInboxPayment({
       kv: env.VERIFIED_AGENTS,

--- a/lib/inbox/types.ts
+++ b/lib/inbox/types.ts
@@ -74,6 +74,16 @@ export interface InboxMessage {
 export type RelayPaymentStatus = "confirmed" | "pending";
 
 /**
+ * Settle options used when submitting a sponsored transaction via RPC.
+ * Stored alongside staged payments so the queue can re-submit after TTL expiry.
+ */
+export interface StagedSettleOptions {
+  expectedRecipient: string;
+  minAmount: string;
+  tokenType?: string;
+}
+
+/**
  * Provisional inbox record staged locally until the relay reaches `confirmed`.
  */
 export interface StagedInboxMessage {
@@ -81,6 +91,33 @@ export interface StagedInboxMessage {
   message: InboxMessage;
   senderSentIndexBtcAddress?: string;
   createdAt: string;
+  /**
+   * Original sponsored tx hex (client-signed, pre-sponsored by the relay).
+   * Stored so the reconciliation queue can re-submit after the relay's sponsor
+   * nonce expires (see `nonceExpiresAt`).  Absent for records staged before
+   * Phase 5 (#375); the queue falls back to discard in that case.
+   */
+  txHex?: string;
+  /**
+   * ISO 8601 UTC timestamp after which the relay's sponsor nonce for this
+   * payment is considered stale and may be reclaimed.  Derived from the relay's
+   * `sponsorNonceValidForMs` constant (10 minutes) at submission time.
+   *
+   * The reconciliation queue must not poll `checkPayment` past this timestamp
+   * using the same `paymentId`.  Instead it re-calls `submitPayment(txHex)`
+   * to obtain a fresh sponsor assignment.
+   */
+  nonceExpiresAt?: string;
+  /**
+   * Settle options forwarded to the relay on re-submission after TTL expiry.
+   * Required when `txHex` is present.
+   */
+  settleOptions?: StagedSettleOptions;
+  /**
+   * Idempotency key forwarded to the relay on re-submission.
+   * If absent, no idempotency key is sent (relay assigns a fresh paymentId).
+   */
+  paymentIdentifier?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Stops the inbox reconciliation queue from polling a stale `paymentId` past the relay's 10-minute sponsor-nonce TTL, and replaces the stale entry with a fresh sponsor assignment via `submitPayment`.

- **Root cause (issue #375 in aibtcdev/x402-sponsor-relay):** The relay reclaims sponsor nonces after `STALE_THRESHOLD_MS = 10 min`, but the reconciliation queue was polling for up to ~70 min (`RECONCILIATION_DELAYS_SECONDS` × `MAX_RECONCILIATION_ATTEMPTS`). Past the relay's TTL, polling the old `paymentId` is wasteful and later retries using the same sponsored hex produce `ConflictingNonceInMempool` errors.
- **Fix (Option C from the issue):** At staging time, record `nonceExpiresAt = now + 10 min` alongside the original `txHex` and `settleOptions`. In the queue, check `isSponsorNonceExpired()` before each reconcile cycle. Past TTL: call `rpc.submitPayment(txHex, settle)` to obtain a fresh sponsor assignment, update the staged record, and re-enqueue with the new `paymentId`.

## Changes

| File | Change |
|------|--------|
| `lib/inbox/constants.ts` | Add `SPONSOR_NONCE_TTL_MS = 600 000 ms` (mirrors relay `STALE_THRESHOLD_MS`) |
| `lib/inbox/types.ts` | Extend `StagedInboxMessage` with `txHex?`, `nonceExpiresAt?`, `settleOptions?`, `paymentIdentifier?` |
| `lib/inbox/index.ts` | Export new type `StagedSettleOptions` and constant `SPONSOR_NONCE_TTL_MS` |
| `app/api/inbox/[address]/route.ts` | Populate new fields at staging time |
| `lib/inbox/reconciliation-queue.ts` | Add TTL clamp + re-submit path (import helpers; add `isSponsorNonceExpired`; splice TTL check before reconcile) |
| `lib/inbox/__tests__/reconciliation-queue.test.ts` | 4 new integration tests covering all TTL paths |

## Behavior guarantees

- **Pre-TTL:** Normal `checkPayment` poll path unchanged.
- **Post-TTL + txHex stored:** Call `submitPayment(txHex, settle)` → update staged record → re-enqueue with new `paymentId`.
- **Post-TTL + no txHex (pre-Phase-5 records):** Log warn, ack/discard gracefully.
- **`submitPayment` failure post-TTL:** Ack without retrying. Do NOT fall back to stale hex.
- **Backward compatible:** Old staged records without `nonceExpiresAt` fall back to `stagedAt + SPONSOR_NONCE_TTL_MS` for the expiry check.

## Test plan

- [ ] `npm run typecheck` passes (no new errors beyond pre-existing worktree issues)
- [ ] `npm test -- reconciliation-queue` — 8 tests pass in main file (4 existing + 4 new TTL tests)
- [ ] Verify TTL test: expired + txHex → submitPayment called, staged record updated, re-enqueued with new paymentId
- [ ] Verify TTL test: expired + no txHex → ack without submitPayment
- [ ] Verify TTL test: submitPayment rejection → ack without retry
- [ ] Verify TTL test: non-expired → normal checkPayment path (submitPayment not called)

## Cross-links

- Relay wire contract (Phase 3): aibtcdev/x402-sponsor-relay#383 (`nonceExpiresAt` + `sponsorNonceValidForMs` on `/sponsor` responses)
- Relay contract test (Phase 4): aibtcdev/x402-sponsor-relay#384
- Issue: aibtcdev/x402-sponsor-relay#375 (consumer half, Option C)

🤖 Generated with [Claude Code](https://claude.com/claude-code)