### PR TITLE
feat(inbox): extend RelayRPC parsers to surface nonceExpiresAt, sponsorNonceValidForMs, responsible, agentErrorCode (Phase 5.1)

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1541,7 +1541,13 @@ export async function POST(
       // reconciliation queue can re-submit after the relay's sponsor nonce
       // expires (Phase 5 of quest nonce-conflict-attribution, issue #375).
       const stagedTxHex = paymentPayload?.payload?.transaction ?? undefined;
-      const stagedNonceExpiresAt = new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
+      // Prefer the relay's authoritative nonceExpiresAt (Phase 5.1: relay
+      // PRs #379/#383 surface this on `/sponsor` + RPC submitPayment
+      // responses).  Falls back to LP local derivation when the relay
+      // version in deploy does not yet emit it.
+      const stagedNonceExpiresAt =
+        paymentResult.nonceExpiresAt ??
+        new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
       const stagedSettleOptions =
         agent.stxAddress && paymentRequirements.amount
           ? {

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1241,9 +1241,14 @@ export async function POST(
 
     const errorCode = paymentResult.errorCode;
     const retryAfterSeconds = paymentResult.retryAfterSeconds ?? 5;
+    // Surface relay broadcast attribution (Phase 5.1: relay PR#381) so
+    // senders can disambiguate sender-fault vs sponsor/network-fault and
+    // choose the correct retry strategy without parsing logs.
     const relayDiag = {
       ...(paymentResult.relayCode && { relayCode: paymentResult.relayCode }),
       ...(paymentResult.relayDetail && { relayDetail: paymentResult.relayDetail }),
+      ...(paymentResult.responsible && { responsible: paymentResult.responsible }),
+      ...(paymentResult.agentErrorCode && { agentErrorCode: paymentResult.agentErrorCode }),
     };
 
     // NONCE_CONFLICT — retryable; same tx hex is idempotent within 5 min.

--- a/lib/inbox/__tests__/relay-rpc-wire-fields.test.ts
+++ b/lib/inbox/__tests__/relay-rpc-wire-fields.test.ts
@@ -1,0 +1,417 @@
+/**
+ * Tests for Phase 5.1 relay RPC wire-field extraction.
+ *
+ * The relay's `/sponsor` + RPC `submitPayment` responses surface four new
+ * fields that the LP parsers must extract and propagate downstream:
+ *   - `nonceExpiresAt`        (relay PR#379, success arm)
+ *   - `sponsorNonceValidForMs` (relay PR#383, success arm)
+ *   - `responsible`           (relay PR#381, error arm)
+ *   - `agentErrorCode`        (relay PR#381, error arm when responsible="sender")
+ *
+ * These are NOT in `@aibtc/tx-schemas`'s `RpcSubmitPaymentResultSchema` yet
+ * (which uses `z.core.$strip`), so the parsers extract them BEFORE the zod
+ * parse and re-attach after.  Backward compat: an older relay version that
+ * omits these fields must continue to parse without error.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { __testUtils, submitViaRPC } from "../relay-rpc";
+import type { RelayRPC, RelaySettleOptions } from "../relay-rpc";
+import type { Logger } from "@/lib/logging";
+
+const mockLogger: Logger = {
+  debug: vi.fn(),
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+};
+
+const baseTxHex = "aabbccdd112233445566778899001122334455667788990011223344556677889900";
+const baseSettle: RelaySettleOptions = {
+  expectedRecipient: "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7",
+  minAmount: "100",
+  tokenType: "sBTC",
+};
+
+const FUTURE_ISO = "2027-01-01T00:00:00.000Z";
+
+describe("extractRelayWireExtras", () => {
+  const { extractRelayWireExtras } = __testUtils;
+
+  it("returns empty object for non-object input", () => {
+    expect(extractRelayWireExtras(null)).toEqual({});
+    expect(extractRelayWireExtras(undefined)).toEqual({});
+    expect(extractRelayWireExtras("string")).toEqual({});
+    expect(extractRelayWireExtras(42)).toEqual({});
+  });
+
+  it("extracts nonceExpiresAt when present and string", () => {
+    expect(extractRelayWireExtras({ nonceExpiresAt: FUTURE_ISO })).toEqual({
+      nonceExpiresAt: FUTURE_ISO,
+    });
+  });
+
+  it("ignores nonceExpiresAt when not a non-empty string", () => {
+    expect(extractRelayWireExtras({ nonceExpiresAt: "" })).toEqual({});
+    expect(extractRelayWireExtras({ nonceExpiresAt: 1234 })).toEqual({});
+    expect(extractRelayWireExtras({ nonceExpiresAt: null })).toEqual({});
+  });
+
+  it("extracts sponsorNonceValidForMs when present and finite number", () => {
+    expect(extractRelayWireExtras({ sponsorNonceValidForMs: 600_000 })).toEqual({
+      sponsorNonceValidForMs: 600_000,
+    });
+  });
+
+  it("ignores sponsorNonceValidForMs when not a finite number", () => {
+    expect(extractRelayWireExtras({ sponsorNonceValidForMs: "600000" })).toEqual({});
+    expect(extractRelayWireExtras({ sponsorNonceValidForMs: NaN })).toEqual({});
+    expect(extractRelayWireExtras({ sponsorNonceValidForMs: Infinity })).toEqual({});
+  });
+
+  it("extracts responsible when one of sender|sponsor|network", () => {
+    expect(extractRelayWireExtras({ responsible: "sender" })).toEqual({ responsible: "sender" });
+    expect(extractRelayWireExtras({ responsible: "sponsor" })).toEqual({ responsible: "sponsor" });
+    expect(extractRelayWireExtras({ responsible: "network" })).toEqual({ responsible: "network" });
+  });
+
+  it("ignores responsible for unrecognized values", () => {
+    expect(extractRelayWireExtras({ responsible: "bogus" })).toEqual({});
+    expect(extractRelayWireExtras({ responsible: 1 })).toEqual({});
+  });
+
+  it("extracts agentErrorCode when non-empty string", () => {
+    expect(extractRelayWireExtras({ agentErrorCode: "sender_nonce_confirmed" })).toEqual({
+      agentErrorCode: "sender_nonce_confirmed",
+    });
+  });
+
+  it("ignores agentErrorCode when empty or non-string", () => {
+    expect(extractRelayWireExtras({ agentErrorCode: "" })).toEqual({});
+    expect(extractRelayWireExtras({ agentErrorCode: null })).toEqual({});
+  });
+
+  it("extracts all four fields from a single object", () => {
+    expect(
+      extractRelayWireExtras({
+        nonceExpiresAt: FUTURE_ISO,
+        sponsorNonceValidForMs: 600_000,
+        responsible: "sender",
+        agentErrorCode: "sender_nonce_confirmed",
+      })
+    ).toEqual({
+      nonceExpiresAt: FUTURE_ISO,
+      sponsorNonceValidForMs: 600_000,
+      responsible: "sender",
+      agentErrorCode: "sender_nonce_confirmed",
+    });
+  });
+});
+
+describe("parseSubmitPaymentResult — success arm", () => {
+  const { parseSubmitPaymentResult } = __testUtils;
+
+  it("extracts nonceExpiresAt + sponsorNonceValidForMs on accepted+all-fields", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: true,
+      paymentId: "pay_001",
+      status: "queued",
+      checkStatusUrl: "https://relay/check/pay_001",
+      nonceExpiresAt: FUTURE_ISO,
+      sponsorNonceValidForMs: 600_000,
+    });
+    expect(result.accepted).toBe(true);
+    if (result.accepted) {
+      expect(result.paymentId).toBe("pay_001");
+      expect(result.nonceExpiresAt).toBe(FUTURE_ISO);
+      expect(result.sponsorNonceValidForMs).toBe(600_000);
+    }
+  });
+
+  it("backward compat: accepted+missing wire fields → fields undefined", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: true,
+      paymentId: "pay_002",
+      status: "queued",
+    });
+    expect(result.accepted).toBe(true);
+    if (result.accepted) {
+      expect(result.paymentId).toBe("pay_002");
+      expect(result.nonceExpiresAt).toBeUndefined();
+      expect(result.sponsorNonceValidForMs).toBeUndefined();
+    }
+  });
+
+  it("preserves wire fields on the pre-paymentId success short-circuit", () => {
+    // This is the legacy shape: accepted=true but paymentId is not a string —
+    // the parser short-circuits with a synthesized 'queued' result.  Wire
+    // fields must still be surfaced for staging code that needs the TTL.
+    const result = parseSubmitPaymentResult({
+      accepted: true,
+      // paymentId omitted (the early-return branch)
+      checkStatusUrl: "https://relay/check/no-id",
+      nonceExpiresAt: FUTURE_ISO,
+      sponsorNonceValidForMs: 600_000,
+    });
+    expect(result.accepted).toBe(true);
+    if (result.accepted) {
+      expect(result.checkStatusUrl).toBe("https://relay/check/no-id");
+      expect(result.nonceExpiresAt).toBe(FUTURE_ISO);
+      expect(result.sponsorNonceValidForMs).toBe(600_000);
+    }
+  });
+});
+
+describe("parseSubmitPaymentResult — error arm", () => {
+  const { parseSubmitPaymentResult } = __testUtils;
+
+  it("extracts responsible + agentErrorCode on rejected+responsible=sender", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: false,
+      error: "Sender nonce already confirmed on chain",
+      code: "SENDER_NONCE_STALE",
+      responsible: "sender",
+      agentErrorCode: "sender_nonce_confirmed",
+    });
+    expect(result.accepted).toBe(false);
+    if (!result.accepted) {
+      expect(result.code).toBe("SENDER_NONCE_STALE");
+      expect(result.responsible).toBe("sender");
+      expect(result.agentErrorCode).toBe("sender_nonce_confirmed");
+    }
+  });
+
+  it("extracts responsible on rejected+responsible=sponsor (no agentErrorCode)", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: false,
+      error: "Sponsor nonce conflict",
+      code: "INTERNAL_ERROR",
+      responsible: "sponsor",
+    });
+    expect(result.accepted).toBe(false);
+    if (!result.accepted) {
+      expect(result.responsible).toBe("sponsor");
+      expect(result.agentErrorCode).toBeUndefined();
+    }
+  });
+
+  it("extracts responsible on rejected+responsible=network", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: false,
+      error: "Mempool rate limited",
+      code: "BROADCAST_RATE_LIMITED",
+      responsible: "network",
+    });
+    expect(result.accepted).toBe(false);
+    if (!result.accepted) {
+      expect(result.responsible).toBe("network");
+      expect(result.agentErrorCode).toBeUndefined();
+    }
+  });
+
+  it("backward compat: rejected without attribution fields parses cleanly", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: false,
+      error: "Some pre-Phase-1 relay rejection",
+      code: "SENDER_NONCE_STALE",
+    });
+    expect(result.accepted).toBe(false);
+    if (!result.accepted) {
+      expect(result.code).toBe("SENDER_NONCE_STALE");
+      expect(result.responsible).toBeUndefined();
+      expect(result.agentErrorCode).toBeUndefined();
+    }
+  });
+
+  it("backward compat: rejected without error field synthesizes default and preserves extras", () => {
+    const result = parseSubmitPaymentResult({
+      accepted: false,
+      code: "INTERNAL_ERROR",
+      responsible: "sponsor",
+    });
+    expect(result.accepted).toBe(false);
+    if (!result.accepted) {
+      expect(result.error).toBe("Payment submission rejected by relay");
+      expect(result.responsible).toBe("sponsor");
+    }
+  });
+});
+
+describe("parseCheckPaymentResult — wire-field extraction", () => {
+  const { parseCheckPaymentResult } = __testUtils;
+
+  it("extracts nonceExpiresAt + sponsorNonceValidForMs from check response", () => {
+    const result = parseCheckPaymentResult({
+      paymentId: "pay_check_001",
+      status: "queued",
+      nonceExpiresAt: FUTURE_ISO,
+      sponsorNonceValidForMs: 600_000,
+    });
+    expect(result.paymentId).toBe("pay_check_001");
+    expect(result.nonceExpiresAt).toBe(FUTURE_ISO);
+    expect(result.sponsorNonceValidForMs).toBe(600_000);
+  });
+
+  it("extracts responsible + agentErrorCode from failed check arm", () => {
+    const result = parseCheckPaymentResult({
+      paymentId: "pay_check_002",
+      status: "failed",
+      errorCode: "BROADCAST_FAILED",
+      error: "tx rejected by mempool",
+      responsible: "sender",
+      agentErrorCode: "sender_nonce_confirmed",
+    });
+    expect(result.status).toBe("failed");
+    expect(result.responsible).toBe("sender");
+    expect(result.agentErrorCode).toBe("sender_nonce_confirmed");
+  });
+
+  it("backward compat: check response without wire fields parses cleanly", () => {
+    const result = parseCheckPaymentResult({
+      paymentId: "pay_check_003",
+      status: "confirmed",
+      txid: "a".repeat(64),
+    });
+    expect(result.status).toBe("confirmed");
+    expect(result.nonceExpiresAt).toBeUndefined();
+    expect(result.responsible).toBeUndefined();
+  });
+});
+
+describe("submitViaRPC — propagates wire fields to InboxPaymentVerification", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("propagates nonceExpiresAt + sponsorNonceValidForMs on pending-success (poll exhausted)", async () => {
+    const rpc: RelayRPC = {
+      submitPayment: vi.fn().mockResolvedValue({
+        accepted: true,
+        paymentId: "pay_pending_001",
+        status: "queued",
+        nonceExpiresAt: FUTURE_ISO,
+        sponsorNonceValidForMs: 600_000,
+      }),
+      // checkPayment always returns 'queued' so poll exhausts and we hit
+      // the pending-success arm.
+      checkPayment: vi.fn().mockResolvedValue({
+        paymentId: "pay_pending_001",
+        status: "queued",
+      }),
+    };
+
+    const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.paymentStatus).toBe("pending");
+    expect(result.nonceExpiresAt).toBe(FUTURE_ISO);
+    expect(result.sponsorNonceValidForMs).toBe(600_000);
+  });
+
+  it("propagates responsible + agentErrorCode on submitPayment rejection", async () => {
+    const rpc: RelayRPC = {
+      submitPayment: vi.fn().mockResolvedValue({
+        accepted: false,
+        error: "Sender nonce already confirmed on chain",
+        code: "SENDER_NONCE_STALE",
+        responsible: "sender",
+        agentErrorCode: "sender_nonce_confirmed",
+      }),
+      checkPayment: vi.fn(),
+    };
+
+    const result = await submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("SENDER_NONCE_STALE");
+    expect(result.responsible).toBe("sender");
+    expect(result.agentErrorCode).toBe("sender_nonce_confirmed");
+    expect(rpc.checkPayment).not.toHaveBeenCalled();
+  });
+
+  it("propagates nonceExpiresAt + sponsorNonceValidForMs on confirmed-success", async () => {
+    const rpc: RelayRPC = {
+      submitPayment: vi.fn().mockResolvedValue({
+        accepted: true,
+        paymentId: "pay_confirmed_001",
+        status: "queued",
+        nonceExpiresAt: FUTURE_ISO,
+        sponsorNonceValidForMs: 600_000,
+      }),
+      checkPayment: vi.fn().mockResolvedValue({
+        paymentId: "pay_confirmed_001",
+        status: "confirmed",
+        txid: "a".repeat(64),
+      }),
+    };
+
+    const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.paymentStatus).toBe("confirmed");
+    expect(result.nonceExpiresAt).toBe(FUTURE_ISO);
+    expect(result.sponsorNonceValidForMs).toBe(600_000);
+  });
+
+  it("propagates responsible + agentErrorCode on terminal failure (checkPayment status=failed)", async () => {
+    const rpc: RelayRPC = {
+      submitPayment: vi.fn().mockResolvedValue({
+        accepted: true,
+        paymentId: "pay_fail_attrib_001",
+        status: "queued",
+      }),
+      checkPayment: vi.fn().mockResolvedValue({
+        paymentId: "pay_fail_attrib_001",
+        status: "failed",
+        errorCode: "BROADCAST_FAILED",
+        error: "tx rejected by mempool",
+        responsible: "sender",
+        agentErrorCode: "sender_nonce_confirmed",
+      }),
+    };
+
+    const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(false);
+    expect(result.errorCode).toBe("BROADCAST_FAILED");
+    expect(result.responsible).toBe("sender");
+    expect(result.agentErrorCode).toBe("sender_nonce_confirmed");
+  });
+
+  it("backward compat: relay omitting wire fields → result has undefined extras, no parse error", async () => {
+    const rpc: RelayRPC = {
+      submitPayment: vi.fn().mockResolvedValue({
+        accepted: true,
+        paymentId: "pay_legacy_001",
+        status: "queued",
+      }),
+      checkPayment: vi.fn().mockResolvedValue({
+        paymentId: "pay_legacy_001",
+        status: "confirmed",
+        txid: "b".repeat(64),
+      }),
+    };
+
+    const resultPromise = submitViaRPC(rpc, baseTxHex, baseSettle, mockLogger);
+    await vi.runAllTimersAsync();
+    const result = await resultPromise;
+
+    expect(result.success).toBe(true);
+    expect(result.paymentStatus).toBe("confirmed");
+    expect(result.nonceExpiresAt).toBeUndefined();
+    expect(result.sponsorNonceValidForMs).toBeUndefined();
+    expect(result.responsible).toBeUndefined();
+    expect(result.agentErrorCode).toBeUndefined();
+  });
+});

--- a/lib/inbox/reconciliation-queue.ts
+++ b/lib/inbox/reconciliation-queue.ts
@@ -315,8 +315,16 @@ export async function processInboxReconciliationQueue(
 
       // Re-submission succeeded: update staged record with the new paymentId
       // and a fresh nonceExpiresAt, then re-enqueue for the next poll cycle.
+      //
+      // Phase 5.1 (relay PRs #379/#383): prefer the relay's authoritative
+      // nonceExpiresAt over LP local derivation.  When the relay version in
+      // deploy does not yet emit the field, fall back to `now +
+      // SPONSOR_NONCE_TTL_MS` (the legacy behavior).
       const newPaymentId = resubmitResult.paymentId;
-      const newNonceExpiresAt = new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
+      const newNonceExpiresAt =
+        typeof resubmitResult.nonceExpiresAt === "string" && resubmitResult.nonceExpiresAt.length > 0
+          ? resubmitResult.nonceExpiresAt
+          : new Date(Date.now() + SPONSOR_NONCE_TTL_MS).toISOString();
 
       try {
         await storeStagedInboxPayment(env.VERIFIED_AGENTS, {

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -211,11 +211,11 @@ function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
       ...raw,
       error: "Payment submission rejected by relay",
     });
-    return { ...parsed, ...extras } as RelaySubmitResult;
+    return { ...parsed, ...extras };
   }
 
   const parsed = RpcSubmitPaymentResultSchema.parse(raw);
-  return { ...parsed, ...extras } as RelaySubmitResult;
+  return { ...parsed, ...extras };
 }
 
 function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
@@ -234,13 +234,13 @@ function parseCheckPaymentResponse(raw: unknown): ParsedCheckPaymentResult {
   ) {
     const { errorCode, ...rest } = collapsed as Record<string, unknown>;
     return {
-      result: { ...RpcCheckPaymentResultSchema.parse(rest), ...extras } as RelayCheckResult,
+      result: { ...RpcCheckPaymentResultSchema.parse(rest), ...extras },
       ...(typeof errorCode === "string" && { rawErrorCode: errorCode }),
     };
   }
 
   return {
-    result: { ...RpcCheckPaymentResultSchema.parse(collapsed), ...extras } as RelayCheckResult,
+    result: { ...RpcCheckPaymentResultSchema.parse(collapsed), ...extras },
   };
 }
 export const __testUtils = {
@@ -374,6 +374,12 @@ export async function submitViaRPC(
         checkResult.checkStatusUrl,
         submitCheckStatusUrl
       );
+      // Surface the submit-time nonce TTL on the confirmed arm too: the
+      // nonce has already been consumed so the TTL is informational, but
+      // downstream telemetry/logging can correlate it with the staged
+      // record.  No fallback to `checkResult` here — once confirmed the
+      // sponsor never re-emits a fresh TTL, so `submitResult` is the only
+      // source.
       return {
         success: true,
         paymentTxid: checkResult.txid || "",

--- a/lib/inbox/relay-rpc.ts
+++ b/lib/inbox/relay-rpc.ts
@@ -29,12 +29,69 @@ import {
 
 export type RelaySettleOptions = z.infer<typeof RpcSettleOptionsSchema>;
 export type RelaySenderNonceInfo = z.infer<typeof RpcSenderNonceInfoSchema>;
-export type RelaySubmitResult = z.infer<typeof RpcSubmitPaymentResultSchema>;
-export type RelayCheckResult = z.infer<typeof RpcCheckPaymentResultSchema>;
+
+/**
+ * Wire fields surfaced by the x402-sponsor-relay alongside the canonical
+ * schema-defined fields.  These are NOT yet part of the
+ * `RpcSubmitPaymentResultSchema` in `@aibtc/tx-schemas` — `z.core.$strip` mode
+ * would strip them — so we extract them BEFORE the zod parse and re-attach
+ * after.  This keeps the LP forward-compatible: the moment the relay's RPC
+ * binding starts surfacing these fields, downstream consumers (staging,
+ * reconciliation, inbox UI) see them without further plumbing changes.
+ *
+ * Source contracts (merged 2026-05-19):
+ * - `nonceExpiresAt`, `sponsorNonceValidForMs` — relay PR#379 + #383 (`/sponsor`
+ *   success path).  Relay clock is authoritative; prefer over LP local
+ *   derivation from `SPONSOR_NONCE_TTL_MS`.
+ * - `responsible`, `agentErrorCode` — relay PR#381 (broadcast attribution
+ *   on the error arm).  `responsible` discriminates sender/sponsor/network
+ *   fault; `agentErrorCode` is the agent-facing reason code when
+ *   `responsible === "sender"`.
+ */
+export interface RelayWireExtras {
+  /** ISO 8601 UTC — relay-side TTL after which the sponsor nonce may be reclaimed. */
+  nonceExpiresAt?: string;
+  /** Duration in ms the sponsor nonce is valid (typically 600 000). */
+  sponsorNonceValidForMs?: number;
+  /** Attribution of a broadcast failure to sender, sponsor, or network. */
+  responsible?: "sender" | "sponsor" | "network";
+  /** Agent-facing reason code, set when `responsible === "sender"`. */
+  agentErrorCode?: string;
+}
+
+export type RelaySubmitResult = z.infer<typeof RpcSubmitPaymentResultSchema> & RelayWireExtras;
+export type RelayCheckResult = z.infer<typeof RpcCheckPaymentResultSchema> & RelayWireExtras;
 type ParsedCheckPaymentResult = {
   result: RelayCheckResult;
   rawErrorCode?: string;
 };
+
+const RESPONSIBLE_VALUES = new Set(["sender", "sponsor", "network"]);
+
+/**
+ * Extract the new wire fields from a raw RPC response.  Returns only the
+ * fields that are present and well-typed; unknown shapes (e.g. an old relay
+ * that omits these fields entirely) return an empty object — callers must
+ * treat all four fields as optional.
+ */
+function extractRelayWireExtras(raw: unknown): RelayWireExtras {
+  if (!raw || typeof raw !== "object") return {};
+  const r = raw as Record<string, unknown>;
+  const extras: RelayWireExtras = {};
+  if (typeof r.nonceExpiresAt === "string" && r.nonceExpiresAt.length > 0) {
+    extras.nonceExpiresAt = r.nonceExpiresAt;
+  }
+  if (typeof r.sponsorNonceValidForMs === "number" && Number.isFinite(r.sponsorNonceValidForMs)) {
+    extras.sponsorNonceValidForMs = r.sponsorNonceValidForMs;
+  }
+  if (typeof r.responsible === "string" && RESPONSIBLE_VALUES.has(r.responsible)) {
+    extras.responsible = r.responsible as RelayWireExtras["responsible"];
+  }
+  if (typeof r.agentErrorCode === "string" && r.agentErrorCode.length > 0) {
+    extras.agentErrorCode = r.agentErrorCode;
+  }
+  return extras;
+}
 
 /**
  * Typed interface for the X402_RELAY service binding RPC methods.
@@ -123,6 +180,8 @@ const TERMINAL_REASON_ERROR_CODE_MAP: Partial<Record<TerminalReason, InboxPaymen
 };
 
 function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
+  const extras = extractRelayWireExtras(raw);
+
   if (
     raw &&
     typeof raw === "object" &&
@@ -137,6 +196,7 @@ function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
       ...(typeof rawRecord.checkStatusUrl === "string" && {
         checkStatusUrl: rawRecord.checkStatusUrl,
       }),
+      ...extras,
     } as RelaySubmitResult;
   }
 
@@ -147,13 +207,15 @@ function parseSubmitPaymentResult(raw: unknown): RelaySubmitResult {
     (raw as { accepted?: unknown }).accepted === false &&
     !("error" in raw)
   ) {
-    return RpcSubmitPaymentResultSchema.parse({
+    const parsed = RpcSubmitPaymentResultSchema.parse({
       ...raw,
       error: "Payment submission rejected by relay",
     });
+    return { ...parsed, ...extras } as RelaySubmitResult;
   }
 
-  return RpcSubmitPaymentResultSchema.parse(raw);
+  const parsed = RpcSubmitPaymentResultSchema.parse(raw);
+  return { ...parsed, ...extras } as RelaySubmitResult;
 }
 
 function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
@@ -162,6 +224,8 @@ function parseCheckPaymentResult(raw: unknown): RelayCheckResult {
 
 function parseCheckPaymentResponse(raw: unknown): ParsedCheckPaymentResult {
   const collapsed = collapseSubmittedStatus(raw);
+  const extras = extractRelayWireExtras(collapsed);
+
   if (
     collapsed &&
     typeof collapsed === "object" &&
@@ -170,17 +234,19 @@ function parseCheckPaymentResponse(raw: unknown): ParsedCheckPaymentResult {
   ) {
     const { errorCode, ...rest } = collapsed as Record<string, unknown>;
     return {
-      result: RpcCheckPaymentResultSchema.parse(rest),
+      result: { ...RpcCheckPaymentResultSchema.parse(rest), ...extras } as RelayCheckResult,
       ...(typeof errorCode === "string" && { rawErrorCode: errorCode }),
     };
   }
 
   return {
-    result: RpcCheckPaymentResultSchema.parse(collapsed),
+    result: { ...RpcCheckPaymentResultSchema.parse(collapsed), ...extras } as RelayCheckResult,
   };
 }
 export const __testUtils = {
   parseCheckPaymentResult,
+  parseSubmitPaymentResult,
+  extractRelayWireExtras,
 };
 
 /**
@@ -253,6 +319,8 @@ export async function submitViaRPC(
       code: submitResult.code,
       errorCode,
       error: submitResult.error,
+      ...(submitResult.responsible && { responsible: submitResult.responsible }),
+      ...(submitResult.agentErrorCode && { agentErrorCode: submitResult.agentErrorCode }),
     });
     return {
       success: false,
@@ -260,6 +328,8 @@ export async function submitViaRPC(
       errorCode,
       ...(submitResult.code != null && { relayCode: submitResult.code }),
       ...(submitResult.error && { relayDetail: submitResult.error }),
+      ...(submitResult.responsible && { responsible: submitResult.responsible }),
+      ...(submitResult.agentErrorCode && { agentErrorCode: submitResult.agentErrorCode }),
     };
   }
 
@@ -311,6 +381,10 @@ export async function submitViaRPC(
         paymentId,
         ...(checkStatusUrl && { checkStatusUrl }),
         ...(checkResult.terminalReason && { terminalReason: checkResult.terminalReason }),
+        ...(submitResult.nonceExpiresAt && { nonceExpiresAt: submitResult.nonceExpiresAt }),
+        ...(submitResult.sponsorNonceValidForMs != null && {
+          sponsorNonceValidForMs: submitResult.sponsorNonceValidForMs,
+        }),
       };
     }
 
@@ -320,12 +394,16 @@ export async function submitViaRPC(
         submitCheckStatusUrl
       );
       const errorCode = mapTerminalOutcome(checkResult);
+      const responsible = checkResult.responsible ?? submitResult.responsible;
+      const agentErrorCode = checkResult.agentErrorCode ?? submitResult.agentErrorCode;
       log.warn("RPC: payment failed", {
         paymentId,
         status: checkResult.status,
         terminalReason: checkResult.terminalReason,
         errorCode: relayCode,
         error: checkResult.error,
+        ...(responsible && { responsible }),
+        ...(agentErrorCode && { agentErrorCode }),
       });
       return {
         success: false,
@@ -337,6 +415,8 @@ export async function submitViaRPC(
         ...(checkResult.txid && { paymentTxid: checkResult.txid }),
         ...(relayCode != null && { relayCode }),
         ...(checkResult.error && { relayDetail: checkResult.error }),
+        ...(responsible && { responsible }),
+        ...(agentErrorCode && { agentErrorCode }),
       };
     }
 
@@ -381,10 +461,14 @@ export async function submitViaRPC(
       lastCheckResult?.checkStatusUrl,
       submitCheckStatusUrl
     );
+    const nonceExpiresAt = submitResult.nonceExpiresAt ?? lastCheckResult?.nonceExpiresAt;
+    const sponsorNonceValidForMs =
+      submitResult.sponsorNonceValidForMs ?? lastCheckResult?.sponsorNonceValidForMs;
     log.info("RPC: poll exhausted after relay accepted — treating as pending success", {
       paymentId,
       lastStatus: lastStatus ?? "none",
       ...(lastCheckResult?.txid && { txid: lastCheckResult.txid }),
+      ...(nonceExpiresAt && { nonceExpiresAt }),
     });
     return {
       success: true,
@@ -392,6 +476,8 @@ export async function submitViaRPC(
       paymentId,
       ...(checkStatusUrl && { checkStatusUrl }),
       ...(lastCheckResult?.txid && { paymentTxid: lastCheckResult.txid }),
+      ...(nonceExpiresAt && { nonceExpiresAt }),
+      ...(sponsorNonceValidForMs != null && { sponsorNonceValidForMs }),
     };
   }
 

--- a/lib/inbox/x402-verify.ts
+++ b/lib/inbox/x402-verify.ts
@@ -155,6 +155,28 @@ export interface InboxPaymentVerification {
   retryAfterSeconds?: number;
   /** RPC payment ID for continued polling or log correlation. */
   paymentId?: string;
+  /**
+   * ISO 8601 UTC after which the relay may reclaim the sponsor nonce
+   * assigned to this payment.  When set, this is the relay's authoritative
+   * TTL — prefer over LP-side derivation from `SPONSOR_NONCE_TTL_MS`.
+   * Source: relay PR#379 (`/sponsor` + RPC submitPayment success).
+   */
+  nonceExpiresAt?: string;
+  /**
+   * Duration in ms the sponsor nonce is valid (typically 600 000).
+   * Source: relay PR#383 (`/sponsor` + RPC submitPayment success).
+   */
+  sponsorNonceValidForMs?: number;
+  /**
+   * Attribution of a broadcast failure: sender, sponsor, or network.
+   * Source: relay PR#381 (broadcast error arm).
+   */
+  responsible?: "sender" | "sponsor" | "network";
+  /**
+   * Agent-facing reason code; set when `responsible === "sender"`.
+   * Source: relay PR#381 (broadcast error arm).
+   */
+  agentErrorCode?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the LP-side `lib/inbox/relay-rpc.ts` parsers and downstream consumers to extract four new wire fields that the x402-sponsor-relay surfaces alongside the canonical schema-defined fields:

| Field | Type | Surfaces on | Source PR |
|---|---|---|---|
| `nonceExpiresAt` | ISO 8601 UTC string | `/sponsor` + RPC `submitPayment` success | aibtcdev/x402-sponsor-relay#379 |
| `sponsorNonceValidForMs` | number (typically 600 000) | `/sponsor` + RPC `submitPayment` success | aibtcdev/x402-sponsor-relay#383 |
| `responsible` | `"sender" \| "sponsor" \| "network"` | broadcast error arm | aibtcdev/x402-sponsor-relay#381 |
| `agentErrorCode` | string | broadcast error arm when `responsible === "sender"` | aibtcdev/x402-sponsor-relay#381 |

These fields are NOT in `@aibtc/tx-schemas@1.1.0`'s `RpcSubmitPaymentResultSchema` — that schema uses `z.core.$strip` mode which would strip them. The parsers extract the fields BEFORE the zod parse and re-attach after, keeping the LP forward-compatible with the relay's evolving wire contract.

## Why now

Relay quest stack merged today (2026-05-19 05:37-05:43Z), all five PRs landed in ~6 minutes:

- aibtcdev/x402-sponsor-relay#379 (nonceExpiresAt on `/sponsor` + `/relay`)
- aibtcdev/x402-sponsor-relay#381 (responsible + agentErrorCode attribution)
- aibtcdev/x402-sponsor-relay#383 (sponsorNonceValidForMs constant)
- aibtcdev/x402-sponsor-relay#385 (Hiro WS subscription pooling)
- aibtcdev/x402-sponsor-relay#386 (verification prep doc)

Mainnet `/sponsor` openapi confirmed to include the new fields (probed at `https://x402-relay.aibtc.com/openapi.json`). Without this PR, the entire wire contract goes unused on the consumer side — the LP parsers silently strip the relay's authoritative TTL and attribution data.

## Downstream wiring

1. **`lib/inbox/relay-rpc.ts`** — new `RelayWireExtras` interface; `RelaySubmitResult` and `RelayCheckResult` extended via intersection (preserves upstream `z.infer<...>` contract); `parseSubmitPaymentResult` + `parseCheckPaymentResponse` extract and re-attach extras around schema parse; `submitViaRPC` propagates the extras to `InboxPaymentVerification` on every return arm (rejection, confirmed-success, terminal-failure, pending-success).

2. **`lib/inbox/x402-verify.ts`** — `InboxPaymentVerification` extended with the four optional fields so route.ts can consume them.

3. **`app/api/inbox/[address]/route.ts`** (staging code, around line 1538) — uses `paymentResult.nonceExpiresAt ?? <local-fallback>` rather than always computing local. This fixes the dead branch flagged in [v421's lp#883 review (finding #1)](https://github.com/aibtcdev/landing-page/pull/883#pullrequestreview-4314947260): `isSponsorNonceExpired`'s relay-clock-authoritative branch was unreachable because `nonceExpiresAt` was never plumbed through.

4. **`lib/inbox/reconciliation-queue.ts`** (resubmit code, around line 320) — same treatment on the post-TTL re-`submitPayment` success path: record the relay's fresh authoritative `nonceExpiresAt` rather than LP local derivation.

Together this closes the loop for **both** the `/staging` and `/resubmit-after-TTL` paths. lp#883 just merged (~10 min before this PR) and intentionally retained the local-clock derivation since it shipped before this PR; this PR completes the contract.

## Backward compatibility

Older relay versions that omit the new fields parse cleanly; downstream consumers fall back to the LP-local `SPONSOR_NONCE_TTL_MS` derivation. No regression on the existing test suite — all 357 `lib/inbox` tests pass, 1 286 / 1 286 tests pass overall (5 skipped, unrelated).

## Tests

New file: `lib/inbox/__tests__/relay-rpc-wire-fields.test.ts` (26 cases, 417 LOC) covers:

- `extractRelayWireExtras` helper: rejects non-object input, validates types per field, ignores malformed values.
- `parseSubmitPaymentResult` success arm: extracts all four fields; backward compat when missing; preserves extras on the pre-paymentId short-circuit branch.
- `parseSubmitPaymentResult` error arm: extracts `responsible` for all three values (sender/sponsor/network); extracts `agentErrorCode` only when `responsible === "sender"`; backward compat with relay versions that omit attribution.
- `parseCheckPaymentResult`: extracts all four fields from check responses; backward compat.
- `submitViaRPC` end-to-end: propagates wire fields through `InboxPaymentVerification` on confirmed-success, pending-success (poll exhausted), submitPayment rejection, and terminal failure arms; backward compat when relay omits everything.

## Cross-references

- v421 lp#883 finding #1: \"isSponsorNonceExpired's relay clock authoritative branch is dead code\" — https://github.com/aibtcdev/landing-page/pull/883#pullrequestreview-4314947260
- v422 x402sr#381 finding #1: \"responsible + agentErrorCode not extracted on LP side\" — https://github.com/aibtcdev/x402-sponsor-relay/pull/381#pullrequestreview-4315000166
- v424 x402sr#386 cross-link offer: explicit Phase 5.1 LP PR commitment after relay quest merge — https://github.com/aibtcdev/x402-sponsor-relay/pull/386#issuecomment-4483698245
- v424 learning: \"LP RelayRPC parser systematically under-extracts new relay wire fields\" in secret-mars/drx4 `memory/learnings/active.md`

## Test plan

- [x] `npx vitest run lib/inbox/__tests__/relay-rpc-wire-fields.test.ts` — 26/26 pass
- [x] `npx vitest run lib/inbox/__tests__/relay-rpc.test.ts lib/inbox/__tests__/reconciliation-queue.test.ts` — 87/87 pass (no regressions)
- [x] `npx vitest run lib/inbox` — 357/357 pass
- [x] `npx vitest run` (full suite) — 1 286/1 286 pass (5 skipped, unrelated)
- [x] `npx tsc --noEmit` — net zero new errors (126 pre-existing test-file errors in `*-flip.test.ts` / `dual-write.test.ts` unrelated to this PR)