### PR TITLE
perf(activity): replace KV mutex with caches.default single-flight

### DIFF
--- a/app/api/activity/__tests__/route.test.ts
+++ b/app/api/activity/__tests__/route.test.ts
@@ -215,19 +215,40 @@ describe("GET /api/activity", () => {
     // resolved. If inFlight was cleared on response-ready instead of put-settled,
     // a second request arriving in that window would see both a cache miss
     // and an empty inFlight and trigger a duplicate rebuild.
+    //
+    // Deterministic barrier strategy (steel-yeti cycle 4 residual):
+    // - `putStarted` fires when the leader's cache.put enters — i.e. response
+    //   is built and the inFlight slot is at the at-risk window.
+    // - `secondReachedMatch` fires when the second GET's cache.match runs —
+    //   i.e. the second caller has progressed far enough to consult inFlight
+    //   on its next step. No empirical microtask drains.
     const store = new Map<string, Response>();
     let releasePut!: () => void;
     const putGate = new Promise<void>((resolve) => {
       releasePut = resolve;
     });
+
+    let matchCalls = 0;
+    let signalSecondReached!: () => void;
+    const secondReachedMatch = new Promise<void>((resolve) => {
+      signalSecondReached = resolve;
+    });
+    let signalPutStarted!: () => void;
+    const putStarted = new Promise<void>((resolve) => {
+      signalPutStarted = resolve;
+    });
+
     const cache = {
       match: vi.fn(async (req: Request) => {
+        matchCalls += 1;
+        if (matchCalls === 2) signalSecondReached();
         const stored = store.get(req.url);
         if (!stored) return undefined;
         return new Response(stored.clone().body, stored);
       }),
       put: vi.fn(async (req: Request, res: Response) => {
-        await putGate; // hold the put open
+        signalPutStarted();
+        await putGate;
         store.set(req.url, res);
       }),
       delete: vi.fn(async () => true),
@@ -236,42 +257,26 @@ describe("GET /api/activity", () => {
       default: cache,
     };
 
-    // Signal fired the moment the leader's cache.put begins — at that point
-    // buildActivityData has returned and the put is awaiting `putGate`.
-    let signalPutStarted!: () => void;
-    const putStarted = new Promise<void>((resolve) => {
-      signalPutStarted = resolve;
-    });
-    cache.put = vi.fn(async (req: Request, res: Response) => {
-      signalPutStarted();
-      await putGate;
-      store.set(req.url, res);
-    });
-
     const { GET } = await import("../route");
 
     const first = GET(
       new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
     );
 
-    // Deterministic: wait until the leader has actually entered cache.put.
-    // At this point the response is built and the inFlight slot is at risk
-    // of being cleared if the implementation released it on response-ready.
+    // Wait until leader has built the response and is now blocked inside cache.put.
+    // This is exactly the at-risk window for the race.
     await putStarted;
 
-    // Second request enters the response-ready → put-settled window. With
-    // the fix it sees the populated inFlight slot and does NOT trigger
-    // a second buildActivityData call.
+    // Second request enters that window. With the fix it sees the populated
+    // inFlight slot via inFlight.get and does NOT trigger a second
+    // buildActivityData call.
     const second = GET(
       new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
     );
-    // Let second progress through cache.match + inFlight lookup before
-    // we release the put. A small microtask drain here is sufficient
-    // and bounded — we only need second past inFlight.get, which is two
-    // awaits deep from GET entry.
-    for (let i = 0; i < 10; i += 1) {
-      await Promise.resolve();
-    }
+
+    // Wait deterministically until second's cache.match has run — at that point
+    // second is one step from inFlight.get and we can safely release the put.
+    await secondReachedMatch;
 
     releasePut();
     await Promise.all([first, second]);

--- a/app/api/activity/__tests__/route.test.ts
+++ b/app/api/activity/__tests__/route.test.ts
@@ -70,7 +70,7 @@ describe("GET /api/activity", () => {
     uninstallMockCache();
   });
 
-  it("returns docs payload without calling buildActivityData or touching the cache", async () => {
+  it("returns docs payload without calling buildActivityData or touching the cache, and does not leak the internal cache URL", async () => {
     const { store, stats } = installMockCache();
     const { GET } = await import("../route");
 
@@ -83,8 +83,13 @@ describe("GET /api/activity", () => {
     expect(stats.matches).toBe(0);
     expect(stats.puts).toBe(0);
     expect(store.size).toBe(0);
-    const body = (await res.json()) as { endpoint: string };
+    const bodyText = await res.text();
+    const body = JSON.parse(bodyText) as { endpoint: string };
     expect(body.endpoint).toBe("/api/activity");
+    // Public docs payload must not expose the worker-internal pseudo-host
+    // used for caches.default keys (steel-yeti S3).
+    expect(bodyText).not.toContain("cache.aibtc.local");
+    expect(bodyText).not.toContain("cacheKeyUrl");
   });
 
   it("on cache miss, runs buildActivityData once and populates caches.default", async () => {
@@ -132,39 +137,46 @@ describe("GET /api/activity", () => {
   });
 
   it("dedupes concurrent cache-miss requests to a single buildActivityData call", async () => {
-    installMockCache();
-
-    // Hold buildActivityData open until all concurrent GETs have entered the in-flight dedup branch.
-    let release!: (value: {
-      events: never[];
-      stats: { totalAgents: number; activeAgents: number; totalMessages: number; totalSatsTransacted: number };
-    }) => void;
-    const gate = new Promise<{
-      events: never[];
-      stats: { totalAgents: number; activeAgents: number; totalMessages: number; totalSatsTransacted: number };
-    }>((resolve) => {
+    // Deterministic barrier: install a cache.match shim that counts callers and
+    // resolves them only after all N have arrived. By the time cache.match
+    // unblocks each caller, the leader has set the inFlight slot and the
+    // others see it via inFlight.get on their next step — no microtask-drain
+    // guesswork (steel-yeti cycle-2 nit).
+    const TOTAL = 5;
+    const store = new Map<string, Response>();
+    let arrived = 0;
+    let release!: () => void;
+    const allArrived = new Promise<void>((resolve) => {
       release = resolve;
     });
-    buildActivityDataMock.mockImplementationOnce(() => gate);
+    const cache = {
+      match: vi.fn(async (req: Request) => {
+        arrived += 1;
+        if (arrived === TOTAL) release();
+        await allArrived;
+        return store.get(req.url);
+      }),
+      put: vi.fn(async (req: Request, res: Response) => {
+        store.set(req.url, res);
+      }),
+      delete: vi.fn(async (req: Request) => store.delete(req.url)),
+    };
+    (globalThis as unknown as { caches: { default: typeof cache } }).caches = {
+      default: cache,
+    };
+
+    buildActivityDataMock.mockResolvedValue({
+      events: [],
+      stats: { totalAgents: 7, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 },
+    });
 
     const { GET } = await import("../route");
 
-    const reqs = Array.from({ length: 5 }, () =>
-      GET(new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0]),
+    const results = await Promise.all(
+      Array.from({ length: TOTAL }, () =>
+        GET(new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0]),
+      ),
     );
-
-    // Yield enough microtasks for all five GETs to enter the inFlight dedup branch
-    // (cache.match is async, getCloudflareContext is async, etc.). 20 is empirical:
-    // ~3-4 awaits per GET before reaching inFlight under the current async stack.
-    // If this test flaps after an upstream async-stack change, raise the count
-    // rather than tightening it — over-draining is harmless, under-draining
-    // releases the gate before all GETs reach dedup.
-    for (let i = 0; i < 20; i += 1) {
-      await Promise.resolve();
-    }
-    release({ events: [], stats: { totalAgents: 7, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 } });
-
-    const results = await Promise.all(reqs);
 
     expect(buildActivityDataMock).toHaveBeenCalledTimes(1);
     for (const r of results) {
@@ -224,26 +236,40 @@ describe("GET /api/activity", () => {
       default: cache,
     };
 
+    // Signal fired the moment the leader's cache.put begins — at that point
+    // buildActivityData has returned and the put is awaiting `putGate`.
+    let signalPutStarted!: () => void;
+    const putStarted = new Promise<void>((resolve) => {
+      signalPutStarted = resolve;
+    });
+    cache.put = vi.fn(async (req: Request, res: Response) => {
+      signalPutStarted();
+      await putGate;
+      store.set(req.url, res);
+    });
+
     const { GET } = await import("../route");
 
-    // First request kicks off the build; with the bug it would resolve and clear inFlight before put settled.
     const first = GET(
       new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
     );
 
-    // Drain enough microtasks that the leader has finished building (buildActivityData resolved)
-    // and is now waiting on cache.put.
-    for (let i = 0; i < 30; i += 1) {
-      await Promise.resolve();
-    }
+    // Deterministic: wait until the leader has actually entered cache.put.
+    // At this point the response is built and the inFlight slot is at risk
+    // of being cleared if the implementation released it on response-ready.
+    await putStarted;
 
-    // Now fire a second request. With the fix, inFlight is still populated,
-    // so this should NOT trigger a second buildActivityData call.
+    // Second request enters the response-ready → put-settled window. With
+    // the fix it sees the populated inFlight slot and does NOT trigger
+    // a second buildActivityData call.
     const second = GET(
       new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
     );
-
-    for (let i = 0; i < 30; i += 1) {
+    // Let second progress through cache.match + inFlight lookup before
+    // we release the put. A small microtask drain here is sufficient
+    // and bounded — we only need second past inFlight.get, which is two
+    // awaits deep from GET entry.
+    for (let i = 0; i < 10; i += 1) {
       await Promise.resolve();
     }
 

--- a/app/api/activity/__tests__/route.test.ts
+++ b/app/api/activity/__tests__/route.test.ts
@@ -154,7 +154,11 @@ describe("GET /api/activity", () => {
     );
 
     // Yield enough microtasks for all five GETs to enter the inFlight dedup branch
-    // (cache.match is async, getCloudflareContext is async, etc.).
+    // (cache.match is async, getCloudflareContext is async, etc.). 20 is empirical:
+    // ~3-4 awaits per GET before reaching inFlight under the current async stack.
+    // If this test flaps after an upstream async-stack change, raise the count
+    // rather than tightening it — over-draining is harmless, under-draining
+    // releases the gate before all GETs reach dedup.
     for (let i = 0; i < 20; i += 1) {
       await Promise.resolve();
     }
@@ -192,6 +196,31 @@ describe("GET /api/activity", () => {
     );
     expect(ok.status).toBe(200);
     expect(buildActivityDataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns the built response even if cache.put rejects", async () => {
+    // Steel-yeti S1: a failed cache.put must not fail an otherwise successful build.
+    const store = new Map<string, Response>();
+    const cache = {
+      match: vi.fn(async () => undefined),
+      put: vi.fn(async () => {
+        throw new Error("simulated cache.put failure");
+      }),
+      delete: vi.fn(async () => true),
+    };
+    (globalThis as unknown as { caches: { default: typeof cache } }).caches = {
+      default: cache,
+    };
+
+    const { GET } = await import("../route");
+    const res = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    expect(cache.put).toHaveBeenCalledTimes(1);
+    expect(store.size).toBe(0);
   });
 
   it("falls through to building (no cache reads/writes) when caches.default is unavailable", async () => {

--- a/app/api/activity/__tests__/route.test.ts
+++ b/app/api/activity/__tests__/route.test.ts
@@ -198,6 +198,61 @@ describe("GET /api/activity", () => {
     expect(buildActivityDataMock).toHaveBeenCalledTimes(2);
   });
 
+  it("holds the in-flight slot until cache.put settles (Codex race)", async () => {
+    // Codex P2: with ctx.waitUntil, buildAndCache returned before cache.put
+    // resolved. If inFlight was cleared on response-ready instead of put-settled,
+    // a second request arriving in that window would see both a cache miss
+    // and an empty inFlight and trigger a duplicate rebuild.
+    const store = new Map<string, Response>();
+    let releasePut!: () => void;
+    const putGate = new Promise<void>((resolve) => {
+      releasePut = resolve;
+    });
+    const cache = {
+      match: vi.fn(async (req: Request) => {
+        const stored = store.get(req.url);
+        if (!stored) return undefined;
+        return new Response(stored.clone().body, stored);
+      }),
+      put: vi.fn(async (req: Request, res: Response) => {
+        await putGate; // hold the put open
+        store.set(req.url, res);
+      }),
+      delete: vi.fn(async () => true),
+    };
+    (globalThis as unknown as { caches: { default: typeof cache } }).caches = {
+      default: cache,
+    };
+
+    const { GET } = await import("../route");
+
+    // First request kicks off the build; with the bug it would resolve and clear inFlight before put settled.
+    const first = GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    // Drain enough microtasks that the leader has finished building (buildActivityData resolved)
+    // and is now waiting on cache.put.
+    for (let i = 0; i < 30; i += 1) {
+      await Promise.resolve();
+    }
+
+    // Now fire a second request. With the fix, inFlight is still populated,
+    // so this should NOT trigger a second buildActivityData call.
+    const second = GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    for (let i = 0; i < 30; i += 1) {
+      await Promise.resolve();
+    }
+
+    releasePut();
+    await Promise.all([first, second]);
+
+    expect(buildActivityDataMock).toHaveBeenCalledTimes(1);
+  });
+
   it("returns the built response even if cache.put rejects", async () => {
     // Steel-yeti S1: a failed cache.put must not fail an otherwise successful build.
     const store = new Map<string, Response>();

--- a/app/api/activity/__tests__/route.test.ts
+++ b/app/api/activity/__tests__/route.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: async () => ({
+    env: { VERIFIED_AGENTS: {}, DB: undefined },
+    ctx: undefined,
+  }),
+}));
+
+// Default mock for buildActivityData — each test can override via mockResolvedValueOnce/mockRejectedValueOnce.
+const buildActivityDataMock = vi.fn(async () => ({
+  events: [],
+  stats: { totalAgents: 0, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 },
+}));
+
+vi.mock("@/lib/activity", () => ({
+  buildActivityData: (...args: unknown[]) => buildActivityDataMock(...args),
+}));
+
+interface MockCacheStats {
+  matches: number;
+  puts: number;
+}
+
+function installMockCache(): { store: Map<string, Response>; stats: MockCacheStats } {
+  const store = new Map<string, Response>();
+  const stats: MockCacheStats = { matches: 0, puts: 0 };
+  const cache = {
+    match: vi.fn(async (req: Request) => {
+      stats.matches += 1;
+      const stored = store.get(req.url);
+      if (!stored) return undefined;
+      // Return a fresh clone so the test code can consume the body without
+      // exhausting the stored stream.
+      return new Response(stored.clone().body, stored);
+    }),
+    put: vi.fn(async (req: Request, res: Response) => {
+      stats.puts += 1;
+      store.set(req.url, res);
+    }),
+    delete: vi.fn(async (req: Request) => store.delete(req.url)),
+  };
+  (globalThis as unknown as { caches: { default: typeof cache } }).caches = { default: cache };
+  return { store, stats };
+}
+
+function uninstallMockCache() {
+  (globalThis as unknown as { caches?: unknown }).caches = undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("GET /api/activity", () => {
+  beforeEach(() => {
+    buildActivityDataMock.mockClear();
+    buildActivityDataMock.mockImplementation(async () => ({
+      events: [],
+      stats: { totalAgents: 1, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 },
+    }));
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    uninstallMockCache();
+  });
+
+  it("returns docs payload without calling buildActivityData or touching the cache", async () => {
+    const { store, stats } = installMockCache();
+    const { GET } = await import("../route");
+
+    const res = await GET(
+      new Request("https://aibtc.com/api/activity?docs=1") as unknown as Parameters<typeof GET>[0],
+    );
+
+    expect(res.status).toBe(200);
+    expect(buildActivityDataMock).not.toHaveBeenCalled();
+    expect(stats.matches).toBe(0);
+    expect(stats.puts).toBe(0);
+    expect(store.size).toBe(0);
+    const body = (await res.json()) as { endpoint: string };
+    expect(body.endpoint).toBe("/api/activity");
+  });
+
+  it("on cache miss, runs buildActivityData once and populates caches.default", async () => {
+    const { store, stats } = installMockCache();
+    const { GET } = await import("../route");
+
+    const res = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("MISS");
+    expect(buildActivityDataMock).toHaveBeenCalledTimes(1);
+    expect(stats.puts).toBe(1);
+    expect(store.has("https://cache.aibtc.local/api/activity")).toBe(true);
+  });
+
+  it("on cache hit, short-circuits the build and returns X-Cache: HIT", async () => {
+    const { store, stats } = installMockCache();
+    // Pre-populate the cache with a response carrying its own headers.
+    store.set(
+      "https://cache.aibtc.local/api/activity",
+      new Response(JSON.stringify({ events: [], stats: { totalAgents: 42 } }), {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=60, s-maxage=120",
+          "Content-Type": "application/json",
+          "X-Cache": "MISS",
+        },
+      }),
+    );
+
+    const { GET } = await import("../route");
+    const res = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("X-Cache")).toBe("HIT");
+    expect(buildActivityDataMock).not.toHaveBeenCalled();
+    expect(stats.matches).toBe(1);
+    expect(stats.puts).toBe(0);
+    const body = (await res.json()) as { stats: { totalAgents: number } };
+    expect(body.stats.totalAgents).toBe(42);
+  });
+
+  it("dedupes concurrent cache-miss requests to a single buildActivityData call", async () => {
+    installMockCache();
+
+    // Hold buildActivityData open until all concurrent GETs have entered the in-flight dedup branch.
+    let release!: (value: {
+      events: never[];
+      stats: { totalAgents: number; activeAgents: number; totalMessages: number; totalSatsTransacted: number };
+    }) => void;
+    const gate = new Promise<{
+      events: never[];
+      stats: { totalAgents: number; activeAgents: number; totalMessages: number; totalSatsTransacted: number };
+    }>((resolve) => {
+      release = resolve;
+    });
+    buildActivityDataMock.mockImplementationOnce(() => gate);
+
+    const { GET } = await import("../route");
+
+    const reqs = Array.from({ length: 5 }, () =>
+      GET(new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0]),
+    );
+
+    // Yield enough microtasks for all five GETs to enter the inFlight dedup branch
+    // (cache.match is async, getCloudflareContext is async, etc.).
+    for (let i = 0; i < 20; i += 1) {
+      await Promise.resolve();
+    }
+    release({ events: [], stats: { totalAgents: 7, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 } });
+
+    const results = await Promise.all(reqs);
+
+    expect(buildActivityDataMock).toHaveBeenCalledTimes(1);
+    for (const r of results) {
+      expect(r.status).toBe(200);
+      const body = (await r.json()) as { stats: { totalAgents: number } };
+      expect(body.stats.totalAgents).toBe(7);
+    }
+  });
+
+  it("clears the in-flight entry on build failure so the next request retries", async () => {
+    installMockCache();
+
+    buildActivityDataMock.mockRejectedValueOnce(new Error("boom"));
+
+    const { GET } = await import("../route");
+
+    const failed = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+    expect(failed.status).toBe(500);
+
+    // Second call must retry (in-flight entry was cleared in the finally block).
+    buildActivityDataMock.mockResolvedValueOnce({
+      events: [],
+      stats: { totalAgents: 1, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 },
+    });
+    const ok = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+    expect(ok.status).toBe(200);
+    expect(buildActivityDataMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("falls through to building (no cache reads/writes) when caches.default is unavailable", async () => {
+    uninstallMockCache();
+    const { GET } = await import("../route");
+
+    const res = await GET(
+      new Request("https://aibtc.com/api/activity") as unknown as Parameters<typeof GET>[0],
+    );
+
+    expect(res.status).toBe(200);
+    expect(buildActivityDataMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -24,6 +24,8 @@ function getDefaultCache(): Cache | null {
   return c?.default ?? null;
 }
 
+// `kv` and `db` are forwarded to `buildActivityData` — this layer owns only
+// `caches.default` and does not perform any direct KV reads or writes.
 async function buildAndCache(
   kv: KVNamespace,
   db: D1Database | undefined,
@@ -42,7 +44,12 @@ async function buildAndCache(
   if (cache) {
     const cacheKey = new Request(CACHE_KEY_URL, { method: "GET" });
     const cachedClone = new Response(response.clone().body, response);
-    const stash = cache.put(cacheKey, cachedClone);
+    // Best-effort: a failed cache.put must not fail an otherwise successful
+    // build — TTL/freshness costs are bounded by RESPONSE_S_MAXAGE and the
+    // next request will rebuild and retry the cache write.
+    const stash = cache.put(cacheKey, cachedClone).catch((err) => {
+      console.error("Failed to populate caches.default for /api/activity:", err);
+    });
     if (ctx) {
       ctx.waitUntil(stash);
     } else {
@@ -60,8 +67,13 @@ async function buildAndCache(
  * and aggregate statistics (total agents, active agents, messages, sats).
  *
  * Cached in `caches.default` for 120s via s-maxage. Concurrent rebuild
- * requests inside one isolate are deduplicated through `inFlight`;
- * cross-isolate coherence comes from `caches.default` itself.
+ * requests inside one isolate are deduplicated through `inFlight`.
+ *
+ * Cache coherence scope: `caches.default` is **per-colo** — Cloudflare
+ * does not replicate cached entries across data centers, so first hits
+ * are expected per-colo rather than once-globally. The combination of
+ * a 120s s-maxage TTL and bounded colo count gives O(colos)
+ * rebuilds-per-TTL globally, which is fine for this route.
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -100,9 +112,9 @@ export async function GET(request: NextRequest) {
         },
       },
       cachingStrategy: {
-        description: "Response is cached in caches.default (the Cloudflare edge cache) for 2 minutes via s-maxage. Stats derived from shared agent-list cache (no independent O(N) scan). Only event detail fetches for top 20 active agents remain as targeted KV reads.",
+        description: "Response is cached in caches.default (the Cloudflare edge cache) for 2 minutes via s-maxage. Cache scope is per-colo, not global. Stats derived from shared agent-list cache (no independent O(N) scan). Only event detail fetches for top 20 active agents remain as targeted KV reads.",
+        ttl: RESPONSE_S_MAXAGE,
         sMaxAgeSeconds: RESPONSE_S_MAXAGE,
-        cacheKeyUrl: CACHE_KEY_URL,
       },
       relatedEndpoints: {
         agents: "/api/agents - List all agents with pagination",

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -13,11 +13,11 @@ const RESPONSE_MAX_AGE = 60;
 const RESPONSE_S_MAXAGE = 120;
 
 // Module-level in-flight map collapses concurrent rebuilds inside one
-// isolate to a single buildActivityData() call. Combined with
-// caches.default (coherent across isolates inside a colo) this gives an
-// effective single-flight without the KV-RMW mutex that previously lived
-// at `cache:activity:building`.
-const inFlight = new Map<string, Promise<Response>>();
+// isolate to a single buildActivityData() call. The slot is held until
+// the caches.default put settles — not just until the response is built
+// — so a request arriving in the gap can't slip past both the cache
+// miss and an empty inFlight and trigger a duplicate rebuild.
+const inFlight = new Map<string, Promise<{ response: Response }>>();
 
 function getDefaultCache(): Cache | null {
   const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;
@@ -26,11 +26,16 @@ function getDefaultCache(): Cache | null {
 
 // `kv` and `db` are forwarded to `buildActivityData` — this layer owns only
 // `caches.default` and does not perform any direct KV reads or writes.
+//
+// Returns both the live response (which the leader serves immediately and
+// concurrent waiters clone) and the `stash` promise that resolves when the
+// cache.default put has settled. The caller uses `stash` to know when it's
+// safe to clear the inFlight slot.
 async function buildAndCache(
   kv: KVNamespace,
   db: D1Database | undefined,
   ctx: { waitUntil(p: Promise<unknown>): void } | undefined,
-): Promise<Response> {
+): Promise<{ response: Response; stash: Promise<unknown> }> {
   const data: ActivityResponse = await buildActivityData(kv, db);
   const response = NextResponse.json(data, {
     headers: {
@@ -41,23 +46,18 @@ async function buildAndCache(
   });
 
   const cache = getDefaultCache();
-  if (cache) {
-    const cacheKey = new Request(CACHE_KEY_URL, { method: "GET" });
-    const cachedClone = new Response(response.clone().body, response);
-    // Best-effort: a failed cache.put must not fail an otherwise successful
-    // build — TTL/freshness costs are bounded by RESPONSE_S_MAXAGE and the
-    // next request will rebuild and retry the cache write.
-    const stash = cache.put(cacheKey, cachedClone).catch((err) => {
-      console.error("Failed to populate caches.default for /api/activity:", err);
-    });
-    if (ctx) {
-      ctx.waitUntil(stash);
-    } else {
-      await stash;
-    }
-  }
+  if (!cache) return { response, stash: Promise.resolve() };
 
-  return response;
+  const cacheKey = new Request(CACHE_KEY_URL, { method: "GET" });
+  const cachedClone = new Response(response.clone().body, response);
+  // Best-effort: a failed cache.put must not fail an otherwise successful
+  // build — TTL/freshness costs are bounded by RESPONSE_S_MAXAGE and the
+  // next request will rebuild and retry the cache write.
+  const stash = cache.put(cacheKey, cachedClone).catch((err) => {
+    console.error("Failed to populate caches.default for /api/activity:", err);
+  });
+  if (ctx) ctx.waitUntil(stash);
+  return { response, stash };
 }
 
 /**
@@ -150,18 +150,25 @@ export async function GET(request: NextRequest) {
 
     let promise = inFlight.get(CACHE_KEY_URL);
     if (!promise) {
-      promise = buildAndCache(kv, db, ctx).finally(() => {
-        inFlight.delete(CACHE_KEY_URL);
-      });
+      promise = buildAndCache(kv, db, ctx);
       inFlight.set(CACHE_KEY_URL, promise);
+      // Hold the inFlight slot until the cache.default put settles — not
+      // just until buildActivityData() returns. Otherwise a request arriving
+      // in the window between response-ready and cache.put-settled would see
+      // both a cache miss and an empty inFlight and trigger a duplicate
+      // rebuild, defeating single-flight.
+      promise.then(
+        ({ stash }) => stash.finally(() => inFlight.delete(CACHE_KEY_URL)),
+        () => inFlight.delete(CACHE_KEY_URL),
+      );
     }
 
-    const result = await promise;
+    const { response } = await promise;
     // Concurrent awaiters can't share a single Response body stream;
     // clone for this request so each caller has its own readable copy.
-    return new Response(result.clone().body, {
-      status: result.status,
-      headers: result.headers,
+    return new Response(response.clone().body, {
+      status: response.status,
+      headers: response.headers,
     });
   } catch (error) {
     console.error("Failed to fetch activity:", error);

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -66,14 +66,18 @@ async function buildAndCache(
  * Returns recent network activity (messages, registrations)
  * and aggregate statistics (total agents, active agents, messages, sats).
  *
- * Cached in `caches.default` for 120s via s-maxage. Concurrent rebuild
- * requests inside one isolate are deduplicated through `inFlight`.
+ * **Cache scope: per-colo, not global single-flight.** `caches.default`
+ * does not replicate cached entries across Cloudflare data centers, so
+ * first hits are expected per-colo rather than once-globally. The 120s
+ * `s-maxage` TTL plus bounded colo count gives O(colos) rebuilds-per-TTL
+ * globally — fine for this route, but read this constraint before
+ * reusing the pattern elsewhere.
  *
- * Cache coherence scope: `caches.default` is **per-colo** — Cloudflare
- * does not replicate cached entries across data centers, so first hits
- * are expected per-colo rather than once-globally. The combination of
- * a 120s s-maxage TTL and bounded colo count gives O(colos)
- * rebuilds-per-TTL globally, which is fine for this route.
+ * Pattern: `caches.default` for cross-isolate coherence inside a colo,
+ * plus a module-level `inFlight` Map for in-isolate single-flight
+ * dedup. The inFlight slot is held until `cache.put` settles so a
+ * request arriving in the response-ready → put-settled window cannot
+ * trigger a duplicate rebuild.
  */
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -17,7 +17,7 @@ const RESPONSE_S_MAXAGE = 120;
 // the caches.default put settles — not just until the response is built
 // — so a request arriving in the gap can't slip past both the cache
 // miss and an empty inFlight and trigger a duplicate rebuild.
-const inFlight = new Map<string, Promise<{ response: Response }>>();
+const inFlight = new Map<string, Promise<{ response: Response; stash: Promise<unknown> }>>();
 
 function getDefaultCache(): Cache | null {
   const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;

--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -3,23 +3,55 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { buildActivityData } from "@/lib/activity";
 import type { ActivityResponse } from "@/app/components/activity-shared";
 
-/**
- * Cached activity data stored at `cache:activity` in KV.
- */
-interface CachedActivity {
-  data: ActivityResponse;
-  cachedAt: string;
-}
-
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, OPTIONS",
 };
 
-const CACHE_KEY = "cache:activity";
-const BUILDING_KEY = "cache:activity:building";
-const CACHE_TTL_SECONDS = 120; // 2 minutes
-const BUILDING_TTL_SECONDS = 30;
+const CACHE_KEY_URL = "https://cache.aibtc.local/api/activity";
+const RESPONSE_MAX_AGE = 60;
+const RESPONSE_S_MAXAGE = 120;
+
+// Module-level in-flight map collapses concurrent rebuilds inside one
+// isolate to a single buildActivityData() call. Combined with
+// caches.default (coherent across isolates inside a colo) this gives an
+// effective single-flight without the KV-RMW mutex that previously lived
+// at `cache:activity:building`.
+const inFlight = new Map<string, Promise<Response>>();
+
+function getDefaultCache(): Cache | null {
+  const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;
+  return c?.default ?? null;
+}
+
+async function buildAndCache(
+  kv: KVNamespace,
+  db: D1Database | undefined,
+  ctx: { waitUntil(p: Promise<unknown>): void } | undefined,
+): Promise<Response> {
+  const data: ActivityResponse = await buildActivityData(kv, db);
+  const response = NextResponse.json(data, {
+    headers: {
+      "Cache-Control": `public, max-age=${RESPONSE_MAX_AGE}, s-maxage=${RESPONSE_S_MAXAGE}`,
+      "X-Cache": "MISS",
+      ...CORS_HEADERS,
+    },
+  });
+
+  const cache = getDefaultCache();
+  if (cache) {
+    const cacheKey = new Request(CACHE_KEY_URL, { method: "GET" });
+    const cachedClone = new Response(response.clone().body, response);
+    const stash = cache.put(cacheKey, cachedClone);
+    if (ctx) {
+      ctx.waitUntil(stash);
+    } else {
+      await stash;
+    }
+  }
+
+  return response;
+}
 
 /**
  * GET /api/activity
@@ -27,11 +59,11 @@ const BUILDING_TTL_SECONDS = 30;
  * Returns recent network activity (messages, registrations)
  * and aggregate statistics (total agents, active agents, messages, sats).
  *
- * Caches result in KV for 2 minutes. Uses the shared agent-list cache
- * to derive stats and identify top active agents — no independent O(N) scan.
+ * Cached in `caches.default` for 120s via s-maxage. Concurrent rebuild
+ * requests inside one isolate are deduplicated through `inFlight`;
+ * cross-isolate coherence comes from `caches.default` itself.
  */
 export async function GET(request: NextRequest) {
-  // Self-documenting: return usage docs when explicitly requested via ?docs=1
   const { searchParams } = new URL(request.url);
   if (searchParams.get("docs") === "1") {
     return NextResponse.json({
@@ -68,9 +100,9 @@ export async function GET(request: NextRequest) {
         },
       },
       cachingStrategy: {
-        description: "Response is cached in KV for 2 minutes. Stats derived from shared agent-list cache (no independent O(N) scan). Only event detail fetches for top 20 active agents remain as targeted KV reads.",
-        ttl: CACHE_TTL_SECONDS,
-        key: CACHE_KEY,
+        description: "Response is cached in caches.default (the Cloudflare edge cache) for 2 minutes via s-maxage. Stats derived from shared agent-list cache (no independent O(N) scan). Only event detail fetches for top 20 active agents remain as targeted KV reads.",
+        sMaxAgeSeconds: RESPONSE_S_MAXAGE,
+        cacheKeyUrl: CACHE_KEY_URL,
       },
       relatedEndpoints: {
         agents: "/api/agents - List all agents with pagination",
@@ -90,85 +122,34 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const db = env.DB as D1Database | undefined;
 
-    // Check cache first
-    const cached = await kv.get<CachedActivity>(CACHE_KEY, "json");
-    if (cached && cached.data) {
-      const cachedAge = Date.now() - new Date(cached.cachedAt).getTime();
-      if (cachedAge < CACHE_TTL_SECONDS * 1000) {
-        return NextResponse.json(cached.data, {
-          headers: {
-            "Cache-Control": "public, max-age=60, s-maxage=120",
-            "X-Cache": "HIT",
-            "X-Cache-Age": Math.floor(cachedAge / 1000).toString(),
-            ...CORS_HEADERS,
-          },
-        });
+    const cache = getDefaultCache();
+    if (cache) {
+      const cached = await cache.match(new Request(CACHE_KEY_URL, { method: "GET" }));
+      if (cached) {
+        const headers = new Headers(cached.headers);
+        headers.set("X-Cache", "HIT");
+        return new Response(cached.body, { status: cached.status, headers });
       }
     }
 
-    // Cache miss — check if another request is already rebuilding (thundering herd guard)
-    const building = await kv.get(BUILDING_KEY);
-    if (building) {
-      // Return stale data if available, otherwise a minimal fallback
-      if (cached && cached.data) {
-        return NextResponse.json(cached.data, {
-          headers: {
-            "Cache-Control": "public, max-age=30, s-maxage=60",
-            "X-Cache": "STALE",
-            ...CORS_HEADERS,
-          },
-        });
-      }
-      return NextResponse.json(
-        { events: [], stats: { totalAgents: 0, activeAgents: 0, totalMessages: 0, totalSatsTransacted: 0 } },
-        {
-          headers: {
-            "Cache-Control": "no-store",
-            "X-Cache": "MISS-BUILDING",
-            ...CORS_HEADERS,
-          },
-        }
-      );
-    }
-
-    // Claim rebuild with sentinel (best-effort)
-    try {
-      await kv.put(BUILDING_KEY, "1", { expirationTtl: BUILDING_TTL_SECONDS });
-    } catch {
-      // Proceed anyway — worst case is a duplicate rebuild
-    }
-
-    let response: ActivityResponse;
-    try {
-      response = await buildActivityData(kv, db);
-
-      // Cache the response
-      const cacheData: CachedActivity = {
-        data: response,
-        cachedAt: new Date().toISOString(),
-      };
-      await kv.put(CACHE_KEY, JSON.stringify(cacheData), {
-        expirationTtl: CACHE_TTL_SECONDS,
+    let promise = inFlight.get(CACHE_KEY_URL);
+    if (!promise) {
+      promise = buildAndCache(kv, db, ctx).finally(() => {
+        inFlight.delete(CACHE_KEY_URL);
       });
-    } catch (buildError) {
-      // Clear sentinel and re-throw so the outer catch returns a structured error
-      await kv.delete(BUILDING_KEY).catch(() => {});
-      throw buildError;
+      inFlight.set(CACHE_KEY_URL, promise);
     }
 
-    // Clear sentinel after successful rebuild
-    await kv.delete(BUILDING_KEY).catch(() => {});
-
-    return NextResponse.json(response, {
-      headers: {
-        "Cache-Control": "public, max-age=60, s-maxage=120",
-        "X-Cache": "MISS",
-        ...CORS_HEADERS,
-      },
+    const result = await promise;
+    // Concurrent awaiters can't share a single Response body stream;
+    // clone for this request so each caller has its own readable copy.
+    return new Response(result.clone().body, {
+      status: result.status,
+      headers: result.headers,
     });
   } catch (error) {
     console.error("Failed to fetch activity:", error);


### PR DESCRIPTION
## Summary

- Retires the `cache:activity` KV cache blob and `cache:activity:building` KV mutex on the `/api/activity` hot read path.
- Replaces them with `caches.default` (cross-isolate cache, TTL via `s-maxage`) plus a module-level `inFlight` Map for in-isolate single-flight dedup.
- Adds `app/api/activity/__tests__/route.test.ts` covering docs branch, cache hit, cache miss + populate, concurrent miss dedup, build-failure clears in-flight, and the `caches.default`-unavailable fall-through.

## Why

P0 baseline of the [`2026-05-18-kv-d1-pattern-finish` quest](https://github.com/aibtcdev/landing-page/issues/762) flagged `cache:activity:building` as the highest-traffic KV-RMW antipattern shape carried over from the predecessor `2026-05-14-kv-write-bill-stop` retro — a KV read-modify-write on every cold-cache `/api/activity` request, with `kv.put` on the mutex claim and two `kv.delete` calls on the cleanup paths. `caches.default` is already coherent inside a colo, so once the cache layer moves there a separate mutex sentinel is no longer needed; the in-isolate Map covers the residual concurrent-rebuild case.

This is the highest-traffic KV-RMW shape in the quest, so it lands first. After merge, both `cache:activity` and `cache:activity:building` should be at 0 ops/day in KV GraphQL (verification in the post-merge `phases/P1/verify.md`).

## Pattern

Two layers:

1. `caches.default` for cross-isolate coherence — honors `s-maxage=120` for its own TTL.
2. Module-level `inFlight: Map<string, Promise<Response>>` collapses concurrent requests inside one isolate to a single `buildActivityData()` call. Entry is cleared in a `finally` block so a rejected build doesn't pin the slot.

The dropped KV "stale fallback" path is no longer needed: with `caches.default` holding the response for 120s and the in-flight dedup covering the cold-cache spike, concurrent readers await the rebuild instead of returning stale data. If post-merge wall time on `/api/activity` regresses in worker-logs, the rollback path is straightforward.

## Test plan

- [x] `npm run test -- app/api/activity` — 6 tests pass
- [x] `npm run lint` — only pre-existing image warnings, no new findings
- [x] `npm run deploy:dry-run` — OpenNext bundle builds clean
- [ ] Post-merge: confirm `cache:activity:building` + `cache:activity` KV write rate at 0 ops/day via GraphQL
- [ ] Post-merge: no new error class for `/api/activity` in `logs.aibtc.com`
- [ ] Post-merge: script-level wall p99 no worse than P0 baseline (2.89s across all routes)

## Quest context

- Quest folder: `~/.planning/active/2026-05-18-kv-d1-pattern-finish/`
- Phase plan: `phases/P1/plan.md` (dated 2026-05-19T19:55Z)
- Phase spec: `PHASES.md § Phase 1`
- Discipline references: `feedback_pr_review_one_pass`, `feedback_no_loose_ends`, `feedback_resolve_addressed_review_threads`

## Reviewers

- @arc0btc @secret-mars — primary review (one-pass)
- @steel-yeti — dev-council, non-blocking; ok to land post-merge follow-ups as issues
- Copilot — auto-attaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)