### PR TITLE
feat(d1): add agents.last_check_in_at for P2 heartbeat ratelimits work

### DIFF
--- a/migrations/015_last_check_in_at.sql
+++ b/migrations/015_last_check_in_at.sql
@@ -1,0 +1,24 @@
+-- Migration 015: add agents.last_check_in_at for P2 heartbeat ratelimits work.
+--
+-- Replaces the `checkin:{btcAddress}` KV key family (no-`{ expirationTtl }`
+-- bug confirmed at the predecessor retro and the 2026-05-18-kv-d1-pattern-finish
+-- quest P0 baseline — 696 lifetime keys, growing forever) with a durable D1
+-- column for the most-recent successful POST /api/heartbeat timestamp.
+--
+-- The enforcement window itself moves to the `RATE_LIMIT_CHECKIN` Cloudflare
+-- `ratelimits` binding (1 req / 60s), so this column is for display and
+-- analytics — not the rate-limit critical path. The response payload reads
+-- the value back to compute `nextCheckInAt`.
+--
+-- Semantically distinct from `last_active_at`: that column updates on any
+-- liveness signal (register, vouch, identity, challenge, ...); this one is
+-- specifically the most recent heartbeat POST. Both nullable.
+--
+-- Backfill: none. Column starts NULL; each agent's next successful POST
+-- /api/heartbeat populates it. P0 noted ~696 active agents with check-in
+-- records; on the 5-min heartbeat convention, ~95% population is reachable
+-- within ~30 min of normal traffic.
+--
+-- Forward-only. Rollback path is a follow-up DROP COLUMN migration.
+
+ALTER TABLE agents ADD COLUMN last_check_in_at TEXT;


### PR DESCRIPTION
## Summary

Migration-only PR: adds a nullable \`TEXT\` column \`last_check_in_at\` to the \`agents\` D1 table. This is the durable last-seen state half of P2 — the rate-limit window itself moves to a Cloudflare \`ratelimits\` binding in the follow-up code PR.

## Why

Retires the \`checkin:{btcAddress}\` KV key family. P0 baseline confirmed the no-\`{ expirationTtl }\` bug at \`lib/heartbeat/kv-helpers.ts:60\` is still live (696 lifetime keys, growing forever — original retro flag). The KV-RMW shape is also the largest remaining write surface after P1 closed (estimated ~8K writes/hr at active-agent steady state vs P0's measured 26.4K writes/24h total).

The new column is semantically distinct from \`last_active_at\`:
- \`last_active_at\` updates on any liveness signal (register, vouch, identity, challenge, ...).
- \`last_check_in_at\` is specifically the most recent successful POST \`/api/heartbeat\` — used by the response payload to compute \`nextCheckInAt\`.

Both nullable. No backfill — column starts NULL and each agent's next check-in populates it (~30 min to ~95% population at the 5-min heartbeat convention).

## Test plan

- [x] Migration parses; \`wrangler d1 migrations list --remote\` shows the new file as pending.
- [ ] **Post-merge operational gate**: I will run \`npm run wrangler -- d1 migrations apply landing-page --env production --remote\` from this repo and verify the column with \`SELECT name, type FROM pragma_table_info('agents') WHERE name = 'last_check_in_at'\`. Output captured in \`phases/P2/verify.md\` per the quest's D1 operational-gate discipline.
- [ ] After verification, the follow-up code PR (\`p2b-heartbeat-ratelimits-binding\`) is unblocked.

## Quest context

- Quest folder: \`~/.planning/active/2026-05-18-kv-d1-pattern-finish/\`
- Phase plan: \`phases/P2/plan.md\` (dated 2026-05-19T23:45Z)
- Phase spec: \`PHASES.md § Phase 2\`
- Predecessor: \`P1\` merged earlier today as \`c77f043e\` (#886)

## Reviewers

- @arc0btc @secret-mars — primary review (one-pass)
- @steel-yeti — dev-council, non-blocking
- Copilot — auto-attaches

🤖 Generated with [Claude Code](https://claude.com/claude-code)