### PR TITLE
perf(leaderboard): cache SSR aggregate in caches.default + emit rebuild metric

### DIFF
--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -49,6 +49,17 @@ function getDefaultCache(): Cache | null {
   return c?.default ?? null;
 }
 
+/**
+ * In-flight singleflight for the leaderboard rebuild. Keyed by the
+ * cache URL so a future second cached surface in this file would not
+ * share the gate. Prevents N concurrent isolates-in-this-colo from all
+ * running LEADERBOARD_AGGREGATE_SQL when the cache misses — only the
+ * first miss runs the scan; the rest await the same Promise and then
+ * read from the warmed cache. Same shape as `app/api/activity/route.ts`
+ * (P1 caches.default + inFlight singleflight pattern).
+ */
+const inFlightRebuild = new Map<string, Promise<LeaderboardRow[]>>();
+
 export const metadata: Metadata = {
   title: "Trading Leaderboard - AIBTC",
   description:
@@ -112,12 +123,34 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   const { env, ctx } = await getCloudflareContext();
   const db = env.DB as D1Database | undefined;
 
+  // Opportunistic SchedulerDO kick — runs on EVERY visit, including
+  // cache hits, because a DO instance doesn't exist until something
+  // calls a method on it. Skipping the kick on cache hits would let
+  // alarm re-arming/recovery stall for up to the cache TTL after a DO
+  // reset or deploy (Codex PR #891 feedback). Idempotent on warm DOs.
+  // ctx may be undefined in non-Workers test runtimes — the catch
+  // below handles that path.
+  try {
+    if (env.SCHEDULER) {
+      const kick = env.SCHEDULER.get(env.SCHEDULER.idFromName(SCHEDULER_INSTANCE_NAME))
+        .status()
+        .then(() => undefined)
+        .catch(() => undefined);
+      if (ctx?.waitUntil) {
+        ctx.waitUntil(kick);
+      } else {
+        // No ctx (test runtime) — drop the kick rather than block the response.
+        void kick;
+      }
+    }
+  } catch {
+    // Binding access threw — render proceeds without the kick.
+  }
+
   // P3B cache layer — short-circuit the LEADERBOARD_AGGREGATE_SQL scan +
-  // per-sender rollup on cache hit. The page itself stays
-  // force-dynamic (the SchedulerDO kick below has its own side effect
-  // we want to run every visit), so this cache is *data-level*, not
-  // page-level. ctx.waitUntil persists the write past the response
-  // teardown so the next request in this colo gets the warm copy.
+  // per-sender rollup on cache hit. The cache is *data-level*, not
+  // page-level: the page itself stays force-dynamic so the scheduler
+  // kick above runs every visit.
   const cache = getDefaultCache();
   if (cache) {
     const cacheKey = new Request(LEADERBOARD_CACHE_URL, { method: "GET" });
@@ -132,26 +165,37 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
     }
   }
 
-  // Opportunistic SchedulerDO kick. A DO instance doesn't exist until
-  // something calls a method on it — the constructor (which arms the
-  // first alarm) only runs on first invocation. Fire-and-forget here so
-  // SSR isn't blocked; `ctx.waitUntil` keeps the RPC alive past response
-  // teardown. Idempotent — subsequent renders just touch a live instance.
-  // Wrapped in a guard so a missing/misbehaving DO binding never blocks
-  // the leaderboard render path.
-  try {
-    if (env.SCHEDULER) {
-      ctx.waitUntil(
-        env.SCHEDULER.get(env.SCHEDULER.idFromName(SCHEDULER_INSTANCE_NAME))
-          .status()
-          .then(() => undefined)
-          .catch(() => undefined)
-      );
-    }
-  } catch {
-    // Binding access threw — render proceeds without the kick.
-  }
+  // Cache miss — funnel concurrent miss-traffic through a single
+  // in-flight Promise so only one isolate-thread runs the expensive
+  // aggregate per TTL window. Mirrors the inFlight map in
+  // app/api/activity/route.ts (P1). Cleared in a finally block on the
+  // computeFn so a failed rebuild doesn't pin an exception forever.
+  const existing = inFlightRebuild.get(LEADERBOARD_CACHE_URL);
+  if (existing) return existing;
 
+  const rebuild = (async (): Promise<LeaderboardRow[]> => {
+    try {
+      return await rebuildLeaderboard(db, cache, ctx);
+    } finally {
+      inFlightRebuild.delete(LEADERBOARD_CACHE_URL);
+    }
+  })();
+  inFlightRebuild.set(LEADERBOARD_CACHE_URL, rebuild);
+  return rebuild;
+}
+
+/**
+ * The expensive rebuild path — exists separately from `fetchLeaderboard`
+ * so the singleflight gate can wrap it cleanly. Caches both populated
+ * results and the legitimate empty case so an early-competition empty
+ * leaderboard doesn't run the full scan on every visit (Copilot PR #891
+ * feedback). Returns `[]` when DB binding is missing (local dev).
+ */
+async function rebuildLeaderboard(
+  db: D1Database | undefined,
+  cache: Cache | null,
+  ctx: { waitUntil?: (p: Promise<unknown>) => void } | undefined
+): Promise<LeaderboardRow[]> {
   if (!db) return [];
 
   // Cache miss path — run the aggregate scan. Capture meta.rows_read so
@@ -186,7 +230,14 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
     totalMs: Date.now() - rebuildStart,
   });
 
-  if (rows.length === 0) return [];
+  // Legitimate empty leaderboard (pre-first-trade, off-season, etc.) —
+  // still cache `[]` so the next request in this colo skips the scan
+  // for the TTL window. Without this, the empty case would run the
+  // full aggregate on every visit (Copilot PR #891 feedback).
+  if (rows.length === 0) {
+    await writeLeaderboardCache(cache, ctx, []);
+    return [];
+  }
 
   // Roll up per (sender, pair) rows into per-sender state. For each pair we
   // bump:
@@ -266,28 +317,38 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
       return b.latestTradeAt - a.latestTradeAt;
     });
 
-  // Stash the rebuilt payload in caches.default. The cache write is
-  // detached via ctx.waitUntil so it doesn't block the response — the
-  // next request in this colo will short-circuit at the cache.match
-  // above for up to LEADERBOARD_CACHE_TTL_SECONDS.
-  if (cache) {
-    const payload = JSON.stringify(ranked);
-    const cachedResponse = new Response(payload, {
-      headers: {
-        "Cache-Control": `public, max-age=${LEADERBOARD_CACHE_TTL_SECONDS}, s-maxage=${LEADERBOARD_CACHE_TTL_SECONDS}`,
-        "Content-Type": "application/json",
-      },
-    });
-    const cacheKey = new Request(LEADERBOARD_CACHE_URL, { method: "GET" });
-    try {
-      ctx.waitUntil(cache.put(cacheKey, cachedResponse));
-    } catch {
-      // ctx may be unavailable in non-Workers test runtimes; the cache
-      // write is best-effort, so a missing ctx silently drops the put.
-    }
-  }
-
+  await writeLeaderboardCache(cache, ctx, ranked);
   return ranked;
+}
+
+/**
+ * Persist a leaderboard payload to `caches.default`. Mirrors the
+ * lib/edge-cache.ts pattern: if `ctx.waitUntil` is available, detach
+ * the write so it doesn't block the response. If `ctx` is missing
+ * (some test runtimes), `await` the put inline so the cache actually
+ * lands — silently dropping would cause perpetual cache misses
+ * (Copilot PR #891 feedback).
+ */
+async function writeLeaderboardCache(
+  cache: Cache | null,
+  ctx: { waitUntil?: (p: Promise<unknown>) => void } | undefined,
+  payload: LeaderboardRow[]
+): Promise<void> {
+  if (!cache) return;
+  const body = JSON.stringify(payload);
+  const cachedResponse = new Response(body, {
+    headers: {
+      "Cache-Control": `public, max-age=${LEADERBOARD_CACHE_TTL_SECONDS}, s-maxage=${LEADERBOARD_CACHE_TTL_SECONDS}`,
+      "Content-Type": "application/json",
+    },
+  });
+  const cacheKey = new Request(LEADERBOARD_CACHE_URL, { method: "GET" });
+  const put = cache.put(cacheKey, cachedResponse);
+  if (ctx?.waitUntil) {
+    ctx.waitUntil(put);
+  } else {
+    await put;
+  }
 }
 
 export default async function LeaderboardPage() {

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -15,6 +15,40 @@ export const dynamic = "force-dynamic";
 
 const SCHEDULER_INSTANCE_NAME = "v2";
 
+/**
+ * Leaderboard SSR cache TTL — 5 minutes. Matches the scheduler's
+ * ALARM_TICK_MS / TENERO_INTERVAL_MS = 5*60*1000 (`worker.ts:55,57`).
+ * Competition sweep cadence is 15min (`COMPETITION_INTERVAL_MS`) so
+ * 5-min TTL is more responsive than the slowest data path; chainhook
+ * can deliver between sweeps and that surfaces on the next rebuild.
+ *
+ * P3B target: collapses ~625K leaderboard renders/day into ≤288 D1
+ * aggregate rebuilds/day (1 per cache window, per-colo). The
+ * LEADERBOARD_AGGREGATE_SQL scan is the largest known steady-state
+ * D1 read surface; see `phases/P3B/plan.md` for attribution.
+ */
+const LEADERBOARD_CACHE_TTL_SECONDS = 300;
+
+/**
+ * Cache key for the leaderboard SSR data. Synthetic `cache.aibtc.local`
+ * host (matches the pattern in `lib/edge-cache.ts`) keeps these entries
+ * out of the live domain's HTTP cache namespace. Global key (no
+ * per-request variation) — the leaderboard is a public ranking and the
+ * SSR payload is identical for all visitors. Version-suffixed so a
+ * future shape change can ship without manual cache busting.
+ */
+const LEADERBOARD_CACHE_URL = "https://cache.aibtc.local/leaderboard/ssr:v1";
+
+/**
+ * Get the `caches.default` namespace if running on the Cloudflare
+ * Workers runtime. Null in Node / `next dev` — callers fall through
+ * to the uncached path.
+ */
+function getDefaultCache(): Cache | null {
+  const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;
+  return c?.default ?? null;
+}
+
 export const metadata: Metadata = {
   title: "Trading Leaderboard - AIBTC",
   description:
@@ -78,6 +112,26 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   const { env, ctx } = await getCloudflareContext();
   const db = env.DB as D1Database | undefined;
 
+  // P3B cache layer — short-circuit the LEADERBOARD_AGGREGATE_SQL scan +
+  // per-sender rollup on cache hit. The page itself stays
+  // force-dynamic (the SchedulerDO kick below has its own side effect
+  // we want to run every visit), so this cache is *data-level*, not
+  // page-level. ctx.waitUntil persists the write past the response
+  // teardown so the next request in this colo gets the warm copy.
+  const cache = getDefaultCache();
+  if (cache) {
+    const cacheKey = new Request(LEADERBOARD_CACHE_URL, { method: "GET" });
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      try {
+        return (await cached.json()) as LeaderboardRow[];
+      } catch {
+        // Malformed cache entry — fall through and rebuild. The bad
+        // entry will be overwritten by the put below.
+      }
+    }
+  }
+
   // Opportunistic SchedulerDO kick. A DO instance doesn't exist until
   // something calls a method on it — the constructor (which arms the
   // first alarm) only runs on first invocation. Fire-and-forget here so
@@ -100,15 +154,37 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
 
   if (!db) return [];
 
+  // Cache miss path — run the aggregate scan. Capture meta.rows_read so
+  // worker-logs can attribute leaderboard's contribution to the D1 read
+  // budget (one log line per rebuild; cache hits skip this entirely).
+  // See phases/P3B/plan.md for the attribution methodology.
+  const rebuildStart = Date.now();
   let rows: LeaderboardJoinedRow[] = [];
+  let scanMeta: { rowsRead?: number; durationMs?: number } | undefined;
   try {
     const result = await db
       .prepare(LEADERBOARD_AGGREGATE_SQL)
       .all<LeaderboardJoinedRow>();
     rows = result.results ?? [];
+    // D1 result.meta exposes rowsRead, duration, etc. Pluck only what
+    // we log; ignore the rest so we don't leak driver internals.
+    const m = (result as unknown as { meta?: { rows_read?: number; duration?: number } }).meta;
+    scanMeta = { rowsRead: m?.rows_read, durationMs: m?.duration };
   } catch {
     return [];
   }
+
+  // P3B observability: emit one log line per cache rebuild with the
+  // D1 read cost. Frequency of this event = cache miss rate; sum over
+  // 24h × rowsRead = leaderboard's daily contribution to the read
+  // budget. Cleaned up after P3B verify when the attribution is
+  // archived in `phases/P3B/verify.md`.
+  console.log("leaderboard.rebuild", {
+    rowCount: rows.length,
+    rowsRead: scanMeta?.rowsRead,
+    d1DurationMs: scanMeta?.durationMs,
+    totalMs: Date.now() - rebuildStart,
+  });
 
   if (rows.length === 0) return [];
 
@@ -189,6 +265,27 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
       if (b.tradeCount !== a.tradeCount) return b.tradeCount - a.tradeCount;
       return b.latestTradeAt - a.latestTradeAt;
     });
+
+  // Stash the rebuilt payload in caches.default. The cache write is
+  // detached via ctx.waitUntil so it doesn't block the response — the
+  // next request in this colo will short-circuit at the cache.match
+  // above for up to LEADERBOARD_CACHE_TTL_SECONDS.
+  if (cache) {
+    const payload = JSON.stringify(ranked);
+    const cachedResponse = new Response(payload, {
+      headers: {
+        "Cache-Control": `public, max-age=${LEADERBOARD_CACHE_TTL_SECONDS}, s-maxage=${LEADERBOARD_CACHE_TTL_SECONDS}`,
+        "Content-Type": "application/json",
+      },
+    });
+    const cacheKey = new Request(LEADERBOARD_CACHE_URL, { method: "GET" });
+    try {
+      ctx.waitUntil(cache.put(cacheKey, cachedResponse));
+    } catch {
+      // ctx may be unavailable in non-Workers test runtimes; the cache
+      // write is best-effort, so a missing ctx silently drops the put.
+    }
+  }
 
   return ranked;
 }


### PR DESCRIPTION
## Summary

P3B PR 1 — D1 read-load cleanup, starting with the largest known steady-state reader.

`/leaderboard` was `force-dynamic` with no cache. Every visit ran `LEADERBOARD_AGGREGATE_SQL` (full swaps-table scan + agents JOIN — see `lib/competition/leaderboard-query.ts`). Quest baseline: D1 rows-read averaging ~5.6B/day, well above Workers Paid's included pace of ~833M/day. Static review (PHASES.md § P3B) flagged this as the only large reader; this PR validates the hypothesis empirically by both fixing it and emitting a per-rebuild observability log.

PR for **P3B** of the [KV/D1 Pattern Finish quest](.planning/active/2026-05-18-kv-d1-pattern-finish). See `phases/P3B/plan.md` for the attribution and the full sequencing rationale.

## What changed

Wrap `fetchLeaderboard()` in a `caches.default` lookup/put with a 5-min TTL keyed globally:

- **Cache key:** `https://cache.aibtc.local/leaderboard/ssr:v1` — synthetic host (matches the pattern from `lib/edge-cache.ts`) so these entries don't pollute the live domain's HTTP cache. Global key (no per-request variation) — the leaderboard is a public ranking; LeaderboardClient pulls Tenero prices + avatars client-side, so the SSR payload is identical for all visitors.
- **TTL: 5 minutes.** Matches `ALARM_TICK_MS = TENERO_INTERVAL_MS = 5*60*1000` (`worker.ts:55,57`). Competition sweep cadence is 15 min (`COMPETITION_INTERVAL_MS`), so 5 min is more responsive than the slowest data path.
- **Cache hit:** skip the D1 scan + per-sender rollup entirely; return cached `LeaderboardRow[]`.
- **Cache miss:** run the existing scan + transform, then `ctx.waitUntil(cache.put)` so the next request in this colo gets the warm copy without blocking.
- **Page stays `force-dynamic`** — the `SchedulerDO` opportunistic kick at the top of `fetchLeaderboard()` needs to run every visit; only the expensive D1+transform tail is cached.

## Observability

One `console.log("leaderboard.rebuild", {rowCount, rowsRead, d1DurationMs, totalMs})` on each cache miss. Two purposes:

1. **Confirm the hypothesis empirically.** Sum 24h of `rows_read * rebuilds_count` = leaderboard's actual contribution to the D1 read budget. Plan estimated this at ~99% of steady-state load; this validates whether that's right or if PR 2+ needs to target a different path.
2. **Cache-miss-rate signal.** Worst-case miss rate at 5-min TTL is 1 / 5 min / colo. Sustained higher misses would indicate either too-low TTL or `caches.default` eviction pressure — either way actionable.

Cleaned up after P3B verify when the attribution is archived in `phases/P3B/verify.md`.

## Math (pre-merge estimate; will be refined post-merge from log data)

- **Pre:** every render runs the aggregate. Assume ~1 render/sec during competition = 86,400 renders/day. Each scan touches ~50K rows × full sweep + JOIN ≈ ~60K rows/query → ~5.2B rows/day from this path alone.
- **Post:** at 5-min TTL with 1 cache key, ≤288 rebuilds/day per-colo. With N≤6 active colos that's ≤~1,700 rebuilds/day globally × ~60K = ~100M rows/day. **~98% reduction projected.**
- Combined with no other large readers, the quest's first target (≤2B/day 7-day average) becomes reachable from this single PR.

## Trade-offs

- **`caches.default` is per-colo, not global.** At 5-min TTL with N colos, worst case is N × (1 rebuild / 5min). Still a 10-100× cut from current. Same trade-off accepted for `cache:activity:*` in P1 (see `phases/P1/retro.md`).
- **Stale-data perception.** The competition leaderboard is a live ranking surface. 5min is acceptable per the data source's slowest cadence (Tenero/SchedulerDO at 5min). If operators receive feedback about staleness, shorten to 60s (still a ~98% cut from baseline).
- **No bypass mechanism.** Could add `?bypass=1` for ops debugging, but that opens a DOS-of-the-cache vector. Skipped for now; if needed, an admin-gated cache-purge endpoint is the right shape.

## Tests

No unit tests for the cache wrapper — single-file change, exercised by build typecheck + `npm run deploy:dry-run`. The `LeaderboardRow` type guards serialization (a non-JSON-serializable field would fail typecheck). If reviewers want explicit cache-hit / cache-miss / malformed-payload coverage, happy to add in a fix-up commit.

`npm run lint`, `npm run build`, `npm run deploy:dry-run` all clean locally.

## Stop-here-if (per PHASES.md)

- p99 on `/leaderboard` regresses post-merge.
- `leaderboard.rebuild` log shows the cache miss rate >> expected (1 / 5min / colo).
- 7-day rolling D1 rows-read avg doesn't drop after this PR — pause; the hypothesis was wrong, attribute via PR 2+ before more cache work.
- Stale-data complaints surface — shorten TTL to 60s in a follow-up; only revert if even that isn't enough.

## Reviewers

`@arc0btc @secret-mars` (Copilot auto-attaches). `@steel-yeti` non-blocking shadow council.

## Test plan

- [ ] CI green
- [ ] After merge: monitor worker-logs for `leaderboard.rebuild` events (`https://logs.aibtc.com` with `X-Admin-Key`). Capture the per-rebuild `rows_read` distribution.
- [ ] After 24h: re-pull 7-day D1 rows-read trend via `phases/P0/baseline.md § Method appendix`. Expect a step-down on the merge day.
- [ ] After 24h: spot-check `/leaderboard` rendering — no stale-data complaints, p99 unchanged.
- [ ] Archive attribution in `phases/P3B/verify.md` + remove the observability log line in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)