### PR TITLE
perf(competition): O(1) swap stats via agent_swap_stats counter table

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -44,6 +44,8 @@
         "lib/agent-lookup.ts",
         "lib/bitcoin-verify.ts",
         "lib/d1/agents-mirror.ts",
+        "lib/competition/d1-reads.ts",
+        "lib/competition/stats.ts",
         "lib/challenge.ts",
         "lib/achievements/kv.ts",
         "lib/heartbeat/kv-helpers.ts",

--- a/lib/competition/__tests__/d1-reads.test.ts
+++ b/lib/competition/__tests__/d1-reads.test.ts
@@ -87,25 +87,33 @@ const SWAP_ROW = {
 // ── getCompetitionStatusFromD1 ───────────────────────────────────────────────
 
 describe("getCompetitionStatusFromD1", () => {
-  it("issues a JOIN over registered_wallets + agents + swaps with sender filter", async () => {
+  it("issues a JOIN over registered_wallets + agents + agent_swap_stats with sender filter (P3B PR 2)", async () => {
     const { db, stmt } = createMockD1([], STATUS_ROW);
     await getCompetitionStatusFromD1(db, STX_ADDRESS);
 
     const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
     expect(sql).toContain("FROM registered_wallets rw");
     expect(sql).toContain("JOIN agents a ON a.stx_address = rw.stx_address");
-    expect(sql).toContain("LEFT JOIN swaps s ON s.sender = rw.stx_address");
+    // P3B PR 2: replaces the per-request `LEFT JOIN swaps + COUNT/SUM/MIN/MAX`
+    // scan with an O(1) lookup on the maintained-counter table.
+    expect(sql).toContain("LEFT JOIN agent_swap_stats s ON s.stx_address = rw.stx_address");
+    expect(sql).not.toContain("LEFT JOIN swaps");
     expect(sql).toContain("WHERE rw.stx_address = ?1");
-    expect(sql).toContain("GROUP BY");
+    // No GROUP BY needed now — the source table is one-row-per-sender.
+    expect(sql).not.toContain("GROUP BY");
 
     expect(stmt.bind.mock.calls[0][0]).toBe(STX_ADDRESS);
   });
 
-  it("counts success-status trades into verified_trade_count via SUM CASE", async () => {
+  it("reads pre-aggregated verified_count from agent_swap_stats instead of SUM(CASE...)", async () => {
     const { db } = createMockD1([], STATUS_ROW);
     await getCompetitionStatusFromD1(db, STX_ADDRESS);
     const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("SUM(CASE WHEN s.tx_status = 'success' THEN 1 ELSE 0 END)");
+    // No SUM/COUNT/MIN/MAX over swaps any more — the helper writes them.
+    expect(sql).not.toContain("SUM(CASE WHEN");
+    expect(sql).not.toContain("COUNT(s.txid)");
+    expect(sql).toContain("COALESCE(s.verified_count, 0)");
+    expect(sql).toContain("COALESCE(s.trade_count, 0)");
   });
 
   it("maps a populated row to CompetitionStatusRow with registered=true", async () => {
@@ -235,19 +243,23 @@ describe("listSwapsFromD1", () => {
 // ── countSwapsFromD1 ─────────────────────────────────────────────────────────
 
 describe("countSwapsFromD1", () => {
-  it("issues SELECT COUNT(*) FROM swaps WHERE sender = ?1", async () => {
+  it("reads trade_count from agent_swap_stats (P3B PR 2 — was SELECT COUNT(*) FROM swaps)", async () => {
     const { db, stmt } = createMockD1([], { cnt: 7 });
     const count = await countSwapsFromD1(db, STX_ADDRESS);
 
     expect(count).toBe(7);
     const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("SELECT COUNT(*)");
-    expect(sql).toContain("FROM swaps");
-    expect(sql).toContain("WHERE sender = ?1");
+    // P3B PR 2: O(1) point-lookup on the maintained-counter table.
+    // The prior `SELECT COUNT(*) FROM swaps` was the textbook D1
+    // COUNT(*) anti-pattern called out in `feedback_d1_count_antipattern`.
+    expect(sql).toContain("FROM agent_swap_stats");
+    expect(sql).toContain("WHERE stx_address = ?1");
+    expect(sql).not.toContain("FROM swaps");
+    expect(sql).not.toContain("COUNT(*)");
     expect(stmt.bind.mock.calls[0][0]).toBe(STX_ADDRESS);
   });
 
-  it("returns 0 when first() returns null", async () => {
+  it("returns 0 when the agent has no agent_swap_stats row (never traded)", async () => {
     const { db } = createMockD1([], null);
     const count = await countSwapsFromD1(db, STX_ADDRESS);
     expect(count).toBe(0);

--- a/lib/competition/__tests__/stats.test.ts
+++ b/lib/competition/__tests__/stats.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Unit tests for `lib/competition/stats.ts`.
+ *
+ * Asserts the SQL shape + bind contract for `getSwapStats`,
+ * `recordSwapInsert`, and `rebuildSwapStats`. The shape is pinned
+ * here so a schema rename or column reorder is caught in CI before
+ * it ships to production.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { getSwapStats, recordSwapInsert, rebuildSwapStats } from "../stats";
+
+const STX_ADDRESS = "SP1TESTADDRESS1234";
+const BURN_BLOCK_TIME = 1762547890;
+
+interface CapturedRun {
+  sql: string;
+  binds: unknown[];
+}
+
+function createMockD1(opts?: {
+  firstResult?: unknown;
+  runError?: Error;
+}): { db: D1Database; runs: CapturedRun[] } {
+  const runs: CapturedRun[] = [];
+  const db = {
+    prepare: vi.fn((sql: string) => ({
+      bind: vi.fn((...binds: unknown[]) => ({
+        first: vi.fn(async () => {
+          runs.push({ sql, binds });
+          return opts?.firstResult ?? null;
+        }),
+        run: vi.fn(async () => {
+          runs.push({ sql, binds });
+          if (opts?.runError) throw opts.runError;
+          return { meta: { changes: 1 } };
+        }),
+      })),
+      // For statements without bind() (rebuildSwapStats DELETE)
+      first: vi.fn(async () => {
+        runs.push({ sql, binds: [] });
+        return null;
+      }),
+      run: vi.fn(async () => {
+        runs.push({ sql, binds: [] });
+        return { meta: { changes: 1 } };
+      }),
+    })),
+  } as unknown as D1Database;
+  return { db, runs };
+}
+
+// ── getSwapStats ─────────────────────────────────────────────────────────────
+
+describe("getSwapStats", () => {
+  it("issues a point-lookup on agent_swap_stats keyed by stx_address", async () => {
+    const { db, runs } = createMockD1({
+      firstResult: {
+        stx_address: STX_ADDRESS,
+        trade_count: 12,
+        verified_count: 10,
+        first_trade_at: 1700000000,
+        last_trade_at: 1762547890,
+        updated_at: "2026-05-20T00:00:00.000Z",
+      },
+    });
+
+    const row = await getSwapStats(db, STX_ADDRESS);
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].sql).toContain("FROM agent_swap_stats");
+    expect(runs[0].sql).toContain("WHERE stx_address = ?1");
+    expect(runs[0].binds).toEqual([STX_ADDRESS]);
+    expect(row?.trade_count).toBe(12);
+    expect(row?.verified_count).toBe(10);
+  });
+
+  it("returns null when the sender has no stats row", async () => {
+    const { db } = createMockD1({ firstResult: null });
+    const row = await getSwapStats(db, STX_ADDRESS);
+    expect(row).toBeNull();
+  });
+});
+
+// ── recordSwapInsert ─────────────────────────────────────────────────────────
+
+describe("recordSwapInsert", () => {
+  it("INSERTs with trade_count=1 + ON CONFLICT bumps counters monotonically", async () => {
+    const { db, runs } = createMockD1();
+    await recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "success");
+
+    expect(runs).toHaveLength(1);
+    expect(runs[0].sql).toContain("INSERT INTO agent_swap_stats");
+    expect(runs[0].sql).toContain("ON CONFLICT(stx_address) DO UPDATE SET");
+    expect(runs[0].sql).toContain("trade_count    = trade_count + 1");
+    // verified_delta is the second bind (= 1 for success).
+    expect(runs[0].binds[0]).toBe(STX_ADDRESS);
+    expect(runs[0].binds[1]).toBe(1);
+    expect(runs[0].binds[2]).toBe(BURN_BLOCK_TIME);
+  });
+
+  it("does NOT bump verified_count when tx_status is not 'success'", async () => {
+    const { db, runs } = createMockD1();
+    await recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "abort_by_response");
+    // verified_delta is the second bind (= 0 for non-success).
+    expect(runs[0].binds[1]).toBe(0);
+  });
+
+  it("uses min()/max() so first/last_trade_at stay monotonic against clock skew", async () => {
+    const { db, runs } = createMockD1();
+    await recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "success");
+    expect(runs[0].sql).toMatch(/first_trade_at\s*=\s*min\s*\(/);
+    expect(runs[0].sql).toMatch(/last_trade_at\s*=\s*max\s*\(/);
+  });
+
+  it("swallows D1 errors so a stats failure never breaks swap persistence", async () => {
+    const { db } = createMockD1({
+      runError: new Error("FOREIGN KEY constraint failed"),
+    });
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    await expect(
+      recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "success")
+    ).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[agent-swap-stats]")
+    );
+    warnSpy.mockRestore();
+  });
+});
+
+// ── rebuildSwapStats ─────────────────────────────────────────────────────────
+
+describe("rebuildSwapStats", () => {
+  it("DELETEs then re-INSERTs from a swaps GROUP BY scan", async () => {
+    const { db, runs } = createMockD1();
+    await rebuildSwapStats(db);
+
+    expect(runs).toHaveLength(2);
+    expect(runs[0].sql).toContain("DELETE FROM agent_swap_stats");
+    expect(runs[1].sql).toContain("INSERT INTO agent_swap_stats");
+    expect(runs[1].sql).toContain("FROM swaps");
+    expect(runs[1].sql).toContain("GROUP BY sender");
+  });
+});

--- a/lib/competition/d1-reads.ts
+++ b/lib/competition/d1-reads.ts
@@ -124,19 +124,25 @@ function mapSwapRow(row: D1SwapRow): SwapRow {
 /**
  * Fetch the trading-comp status row for a given STX address.
  *
- * Joins registered_wallets (membership) + agents (agent_id) + swaps (counts).
- * Returns a synthesized "unregistered" row when the address is not in
- * registered_wallets — do NOT 404 from the route on this case.
+ * Joins registered_wallets (membership) + agents (agent_id) +
+ * agent_swap_stats (counts, maintained counter table — P3B PR 2 /
+ * migration 016). Returns a synthesized "unregistered" row when the
+ * address is not in registered_wallets — do NOT 404 from the route
+ * on this case.
  *
- * SQL shape (locked, per PHASE-3.1-HANDOFF.md):
+ * SQL shape:
  *   SELECT rw.stx_address, a.erc8004_agent_id, 1 AS registered,
- *          COUNT(s.txid), SUM(... success ...),
- *          MIN(burn_block_time), MAX(burn_block_time)
+ *          COALESCE(s.trade_count, 0), COALESCE(s.verified_count, 0),
+ *          s.first_trade_at, s.last_trade_at
  *   FROM registered_wallets rw
  *   JOIN agents a ON a.stx_address = rw.stx_address
- *   LEFT JOIN swaps s ON s.sender = rw.stx_address
+ *   LEFT JOIN agent_swap_stats s ON s.stx_address = rw.stx_address
  *   WHERE rw.stx_address = ?1
- *   GROUP BY rw.stx_address, a.erc8004_agent_id
+ *
+ * Pre-PR-2 shape used `LEFT JOIN swaps + COUNT/SUM/MIN/MAX + GROUP BY`
+ * which walked every matching row per request. See PHASE-3.1-HANDOFF.md
+ * for the original "locked" shape (now superseded) and
+ * `feedback_d1_count_antipattern` for the cost driver.
  */
 export async function getCompetitionStatusFromD1(
   db: D1Database,
@@ -275,9 +281,29 @@ export async function countSwapsFromD1(
   // P3B PR 2: was `SELECT COUNT(*) FROM swaps WHERE sender = ?1`
   // (textbook D1 COUNT(*) anti-pattern — pay-per-row-scanned).
   // Now an O(1) point-lookup on `agent_swap_stats.trade_count`
-  // (migration 016). Missing-row case → 0, matching the prior
-  // empty-COUNT behavior.
+  // (migration 016, seeded atomically; maintained by
+  // recordSwapInsert in lib/competition/stats.ts).
   const sql = `SELECT trade_count AS cnt FROM agent_swap_stats WHERE stx_address = ?1`;
   const row = await db.prepare(sql).bind(stxAddress).first<{ cnt: number }>();
-  return row?.cnt ?? 0;
+  if (row) return row.cnt;
+
+  // Miss case: either the agent has never traded, OR the stats row
+  // is missing due to a write-path failure / un-backfilled environment.
+  // Disambiguate with a single bounded COUNT(*) so we never silently
+  // undercount a real trader (Copilot PR #892 feedback). The fallback
+  // is O(N rows for this sender) — bounded by the agent's swap volume,
+  // not the whole table. Triggers a warn log when the fallback finds
+  // actual rows so the drift is operator-visible.
+  const fallback = await db
+    .prepare("SELECT COUNT(*) AS cnt FROM swaps WHERE sender = ?1")
+    .bind(stxAddress)
+    .first<{ cnt: number }>();
+  const count = fallback?.cnt ?? 0;
+  if (count > 0) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `[agent-swap-stats] miss for sender ${stxAddress} fell back to COUNT(*) and found ${count} — possible un-backfilled or stale stats row`
+    );
+  }
+  return count;
 }

--- a/lib/competition/d1-reads.ts
+++ b/lib/competition/d1-reads.ts
@@ -142,20 +142,28 @@ export async function getCompetitionStatusFromD1(
   db: D1Database,
   stxAddress: string
 ): Promise<CompetitionStatusRow> {
+  // P3B PR 2: aggregate fields come from agent_swap_stats (O(1)
+  // point-lookup) instead of a per-request `LEFT JOIN swaps +
+  // COUNT/SUM/MIN/MAX` scan. `agent_swap_stats` is maintained on
+  // every swap INSERT by `lib/competition/stats.ts:recordSwapInsert`;
+  // see migration 016 + phases/P3B/pr2-plan.md.
+  //
+  // The COALESCE pattern serves agents who are registered but have
+  // never traded (LEFT JOIN miss on agent_swap_stats) — counts go
+  // to zero, first/last_trade_at stay null.
   const sql = `
     SELECT
       rw.stx_address AS address,
       a.erc8004_agent_id AS agent_id,
       1 AS registered,
-      COUNT(s.txid) AS trade_count,
-      SUM(CASE WHEN s.tx_status = 'success' THEN 1 ELSE 0 END) AS verified_trade_count,
-      MIN(s.burn_block_time) AS first_trade_at,
-      MAX(s.burn_block_time) AS last_trade_at
+      COALESCE(s.trade_count, 0)     AS trade_count,
+      COALESCE(s.verified_count, 0)  AS verified_trade_count,
+      s.first_trade_at               AS first_trade_at,
+      s.last_trade_at                AS last_trade_at
     FROM registered_wallets rw
     JOIN agents a ON a.stx_address = rw.stx_address
-    LEFT JOIN swaps s ON s.sender = rw.stx_address
+    LEFT JOIN agent_swap_stats s ON s.stx_address = rw.stx_address
     WHERE rw.stx_address = ?1
-    GROUP BY rw.stx_address, a.erc8004_agent_id
   `;
 
   const row = await db.prepare(sql).bind(stxAddress).first<D1StatusRow>();
@@ -264,7 +272,12 @@ export async function countSwapsFromD1(
   db: D1Database,
   stxAddress: string
 ): Promise<number> {
-  const sql = `SELECT COUNT(*) AS cnt FROM swaps WHERE sender = ?1`;
+  // P3B PR 2: was `SELECT COUNT(*) FROM swaps WHERE sender = ?1`
+  // (textbook D1 COUNT(*) anti-pattern — pay-per-row-scanned).
+  // Now an O(1) point-lookup on `agent_swap_stats.trade_count`
+  // (migration 016). Missing-row case → 0, matching the prior
+  // empty-COUNT behavior.
+  const sql = `SELECT trade_count AS cnt FROM agent_swap_stats WHERE stx_address = ?1`;
   const row = await db.prepare(sql).bind(stxAddress).first<{ cnt: number }>();
   return row?.cnt ?? 0;
 }

--- a/lib/competition/stats.ts
+++ b/lib/competition/stats.ts
@@ -1,0 +1,138 @@
+/**
+ * Maintained-counter helpers for the `agent_swap_stats` table
+ * (migration 016).
+ *
+ * The table mirrors `agent_inbox_stats` (migration 012) — single
+ * row per `stx_address` carrying aggregates that would otherwise
+ * require a full-row scan of `swaps` per request. See
+ * `phases/P3B/pr2-plan.md` for the cost-driver attribution.
+ *
+ * Write path: `recordSwapInsert` is called by
+ * `lib/competition/verify.ts:insertSwap` after every successful
+ * INSERT (meta.changes === 1). Failures are caught + logged but
+ * never propagated — a stats-write failure must not break swap
+ * persistence (the live `swaps` row remains authoritative).
+ *
+ * Read path: `getSwapStats` is the O(1) point-lookup used by
+ * `lib/competition/d1-reads.ts:countSwapsFromD1` and
+ * `getCompetitionStatusFromD1`. Returns null on miss; callers
+ * coalesce to zero/null as appropriate for their response shape.
+ */
+
+import type { Logger } from "@/lib/logging";
+
+/** Shape returned by `getSwapStats`; matches the `agent_swap_stats` columns. */
+export interface SwapStatsRow {
+  stx_address: string;
+  trade_count: number;
+  verified_count: number;
+  first_trade_at: number | null;
+  last_trade_at: number | null;
+  updated_at: string;
+}
+
+/**
+ * Point-lookup for an agent's swap stats. Returns null when the
+ * agent has no row in `agent_swap_stats` (no swaps yet, or the
+ * row was never seeded). Callers should treat null as zero counts.
+ */
+export async function getSwapStats(
+  db: D1Database,
+  stxAddress: string
+): Promise<SwapStatsRow | null> {
+  const sql = `
+    SELECT stx_address, trade_count, verified_count,
+           first_trade_at, last_trade_at, updated_at
+    FROM agent_swap_stats
+    WHERE stx_address = ?1
+  `;
+  const row = await db.prepare(sql).bind(stxAddress).first<SwapStatsRow>();
+  return row ?? null;
+}
+
+/**
+ * UPSERT-increment the swap stats for a sender. Called on every
+ * successful `swaps` INSERT. The first call for a sender inserts
+ * a new row with `trade_count = 1`; subsequent calls bump the
+ * counters and refresh first/last_trade_at via MIN/MAX so the
+ * function is monotonic against clock skew on `burn_block_time`.
+ *
+ * Errors are caught and logged via the passed Logger (or console
+ * fallback) — the caller is in the swap-persist hot path and a
+ * stats-maintenance hiccup must not surface as a swap failure.
+ */
+export async function recordSwapInsert(
+  db: D1Database,
+  stxAddress: string,
+  burnBlockTime: number,
+  txStatus: string,
+  logger?: Logger
+): Promise<void> {
+  const verifiedDelta = txStatus === "success" ? 1 : 0;
+  const updatedAt = new Date().toISOString();
+  // SQLite scalar `min(a, b)` / `max(a, b)` are NULL-aware:
+  // `min(NULL, x)` returns NULL. The COALESCE wrappers ensure the
+  // first INSERT (no existing row) and the UPSERT path treat NULL
+  // as "no opinion" and let the incoming value win.
+  const sql = `
+    INSERT INTO agent_swap_stats
+      (stx_address, trade_count, verified_count, first_trade_at, last_trade_at, updated_at)
+    VALUES (?1, 1, ?2, ?3, ?3, ?4)
+    ON CONFLICT(stx_address) DO UPDATE SET
+      trade_count    = trade_count + 1,
+      verified_count = verified_count + ?2,
+      first_trade_at = min(COALESCE(first_trade_at, ?3), ?3),
+      last_trade_at  = max(COALESCE(last_trade_at, ?3), ?3),
+      updated_at     = ?4
+  `;
+  try {
+    await db
+      .prepare(sql)
+      .bind(stxAddress, verifiedDelta, burnBlockTime, updatedAt)
+      .run();
+  } catch (e) {
+    const msg = `[agent-swap-stats] recordSwapInsert failed for ${stxAddress}: ${(e as Error).message}`;
+    if (logger) {
+      logger.error("agent_swap_stats.record_failed", {
+        stxAddress,
+        error: (e as Error).message,
+      });
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(msg);
+    }
+  }
+}
+
+/**
+ * Recompute every row of `agent_swap_stats` from a full
+ * `swaps` GROUP BY scan. Idempotent — wipes existing rows and
+ * re-inserts. Use only for:
+ *   - Initial seed after migration apply.
+ *   - Operator-triggered repair after admin mutations to `swaps`.
+ *
+ * NOT for hot-path use — this is the expensive query the rest of
+ * the file exists to avoid.
+ */
+export async function rebuildSwapStats(db: D1Database): Promise<void> {
+  const updatedAt = new Date().toISOString();
+  // Single statement: clear + re-seed inside one prepared
+  // batch. D1's executeMulti would let us do this in one round
+  // trip, but a sequential pair is simpler to reason about and
+  // the function is admin-only.
+  await db.prepare("DELETE FROM agent_swap_stats").run();
+  const sql = `
+    INSERT INTO agent_swap_stats
+      (stx_address, trade_count, verified_count, first_trade_at, last_trade_at, updated_at)
+    SELECT
+      sender                                                     AS stx_address,
+      COUNT(*)                                                   AS trade_count,
+      SUM(CASE WHEN tx_status = 'success' THEN 1 ELSE 0 END)     AS verified_count,
+      MIN(burn_block_time)                                       AS first_trade_at,
+      MAX(burn_block_time)                                       AS last_trade_at,
+      ?1                                                         AS updated_at
+    FROM swaps
+    GROUP BY sender
+  `;
+  await db.prepare(sql).bind(updatedAt).run();
+}

--- a/lib/competition/stats.ts
+++ b/lib/competition/stats.ts
@@ -91,15 +91,21 @@ export async function recordSwapInsert(
       .bind(stxAddress, verifiedDelta, burnBlockTime, updatedAt)
       .run();
   } catch (e) {
-    const msg = `[agent-swap-stats] recordSwapInsert failed for ${stxAddress}: ${(e as Error).message}`;
+    // Warn (not error) — a stats-maintenance failure is data drift, not
+    // a hot bug: the authoritative `swaps` row was already INSERTed by
+    // the caller, and the next successful recordSwapInsert for this
+    // sender will reconcile via the ON CONFLICT branch. The fallback
+    // path in countSwapsFromD1 also surfaces the drift if it persists.
     if (logger) {
-      logger.error("agent_swap_stats.record_failed", {
+      logger.warn("agent_swap_stats.record_failed", {
         stxAddress,
         error: (e as Error).message,
       });
     } else {
       // eslint-disable-next-line no-console
-      console.warn(msg);
+      console.warn(
+        `[agent-swap-stats] recordSwapInsert failed for ${stxAddress}: ${(e as Error).message}`
+      );
     }
   }
 }

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -441,8 +441,9 @@ export async function verifyAndPersistSwap(
   } else {
     // P3B PR 2: maintain agent_swap_stats so countSwapsFromD1 and
     // getCompetitionStatusFromD1 can serve O(1) reads. Errors are
-    // swallowed inside recordSwapInsert — a stats hiccup must not
-    // surface as a swap-persist failure.
+    // caught + warn-logged inside recordSwapInsert (via logger.warn
+    // when a Logger is provided, console.warn otherwise) — a stats
+    // hiccup must not surface as a swap-persist failure.
     await recordSwapInsert(
       db,
       persistArgs.sender,

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -26,6 +26,7 @@ import { isAllowedSwap } from "./allowlist";
 import { COMP_START_TIMESTAMP } from "./constants";
 import { parseSwapFromTx, type HiroTxForSwap } from "./parse";
 import type { SwapRow } from "./d1-reads";
+import { recordSwapInsert } from "./stats";
 
 /** The Stacks tx_status values that mean "still in flight; no row should be written". */
 const PENDING_STATUSES = new Set<string>(["pending"]);
@@ -437,6 +438,18 @@ export async function verifyAndPersistSwap(
     // Should never happen — log + return the row we attempted to write so
     // the caller still gets a useful payload.
     logger?.warn?.("competition.verify.insert_skip_no_existing", { txid });
+  } else {
+    // P3B PR 2: maintain agent_swap_stats so countSwapsFromD1 and
+    // getCompetitionStatusFromD1 can serve O(1) reads. Errors are
+    // swallowed inside recordSwapInsert — a stats hiccup must not
+    // surface as a swap-persist failure.
+    await recordSwapInsert(
+      db,
+      persistArgs.sender,
+      persistArgs.burn_block_time,
+      persistArgs.tx_status,
+      logger
+    );
   }
 
   return {

--- a/migrations/016_agent_swap_stats.sql
+++ b/migrations/016_agent_swap_stats.sql
@@ -46,3 +46,33 @@ CREATE TABLE IF NOT EXISTS agent_swap_stats (
   last_trade_at   INTEGER,
   updated_at      TEXT NOT NULL
 );
+
+-- Atomic seed: populate the new table from every existing sender in
+-- one statement, inside the same migration transaction as the CREATE.
+-- This closes the correctness window where a deploy applies the
+-- migration but the operator hasn't yet run the backfill SQL: without
+-- this seed, every historical trader would report trade_count=0 on
+-- /api/competition/status and /api/competition/trades until the manual
+-- backfill ran (Codex PR #892 P1 feedback).
+--
+-- INSERT OR REPLACE keeps the seed re-runnable; in normal operation
+-- this runs once at migration-apply time and is a no-op thereafter
+-- (the maintained write path in lib/competition/stats.ts owns updates
+-- from this point forward). The `2026-05-20T06:30:00Z` timestamp is
+-- the migration-author time; updated_at gets refreshed on the next
+-- recordSwapInsert per sender.
+--
+-- The standalone phases/P3B/backfill-swap-stats-2026-05-20.sql file
+-- remains as an operator artifact for manual repair (e.g. after admin
+-- mutations to swaps) and historical reference.
+INSERT OR REPLACE INTO agent_swap_stats
+  (stx_address, trade_count, verified_count, first_trade_at, last_trade_at, updated_at)
+SELECT
+  sender                                                     AS stx_address,
+  COUNT(*)                                                   AS trade_count,
+  SUM(CASE WHEN tx_status = 'success' THEN 1 ELSE 0 END)     AS verified_count,
+  MIN(burn_block_time)                                       AS first_trade_at,
+  MAX(burn_block_time)                                       AS last_trade_at,
+  '2026-05-20T06:30:00Z'                                     AS updated_at
+FROM swaps
+GROUP BY sender;

--- a/migrations/016_agent_swap_stats.sql
+++ b/migrations/016_agent_swap_stats.sql
@@ -1,0 +1,48 @@
+-- Migration 016: agent_swap_stats maintained-counter table.
+--
+-- Replaces the live `SELECT COUNT(*) FROM swaps WHERE sender = ?` +
+-- per-agent aggregate JOIN in `lib/competition/d1-reads.ts` with O(1)
+-- point-lookups on this single-row-per-sender table.
+--
+-- This is the same anti-pattern + same fix shape as migration 012
+-- (`agent_inbox_stats`). The cost-driver root-cause is documented in
+-- `feedback_d1_count_antipattern`: D1 is pay-per-row-scanned; COUNT(*)
+-- and aggregate JOINs over a wide table walk every matching row on
+-- every request, even when the route has `s-maxage=10` (the cache
+-- expires every 10s for hot agents → D1 hit / 10s / agent).
+--
+-- Columns:
+--   stx_address     — primary key, matches swaps.sender
+--   trade_count     — total swaps with this sender
+--   verified_count  — subset where tx_status = 'success' (renamed
+--                     from "verified_trade_count" in the API for
+--                     internal brevity; the API field name is
+--                     preserved in lib/competition/d1-reads.ts)
+--   first_trade_at  — MIN(burn_block_time) (unix int, matches schema)
+--   last_trade_at   — MAX(burn_block_time)
+--   updated_at      — ISO-8601 of last counter update
+--
+-- Write-path maintenance (see lib/competition/stats.ts):
+--   On `insertSwap` success (meta.changes === 1):
+--     recordSwapInsert(db, sender, burn_block_time, tx_status) UPSERTs
+--     with `trade_count = trade_count + 1`, `verified_count = ... + 1
+--     when status='success'`, `first/last_trade_at` via MIN/MAX.
+--
+-- Repair: rebuildSwapStats() in lib/competition/stats.ts recomputes
+-- from `swaps` GROUP BY sender. Run after admin mutations to swaps
+-- (none exist today, but documented per the inbox_stats pattern).
+--
+-- Backfill: a one-shot INSERT OR REPLACE seed runs once after the
+-- migration applies, populating one row per existing sender. Captured
+-- in `phases/P3B/backfill-swap-stats-2026-05-20.sql`.
+--
+-- Quest: 2026-05-18-kv-d1-pattern-finish, P3B PR 2.
+
+CREATE TABLE IF NOT EXISTS agent_swap_stats (
+  stx_address     TEXT PRIMARY KEY,
+  trade_count     INTEGER NOT NULL DEFAULT 0,
+  verified_count  INTEGER NOT NULL DEFAULT 0,
+  first_trade_at  INTEGER,
+  last_trade_at   INTEGER,
+  updated_at      TEXT NOT NULL
+);


### PR DESCRIPTION
## Summary

P3B PR 2. After PR 1 (#891) cached the leaderboard SSR aggregate (−32% D1 rows-read), the remaining ~3B/day surface attributes to the two competition aggregate queries in `lib/competition/d1-reads.ts`:

- **`countSwapsFromD1`**: `SELECT COUNT(*) FROM swaps WHERE sender = ?` — textbook D1 COUNT(*) walk-every-row anti-pattern.
- **`getCompetitionStatusFromD1`**: per-agent `COUNT(s.txid) + SUM(CASE...) + MIN/MAX(burn_block_time)` JOIN over `swaps`, same scan cost.

Both routes are `s-maxage=10` cached, so hot agents still hit D1 every 10s. This exactly matches `feedback_d1_count_antipattern` ("D1 hot-path COUNT(*) is an anti-pattern — D1 is pay-per-row-scanned; COUNT(*) walks every matching row; use maintained counter tables instead"). The May 13/14 spike to 32B/20B rows-read days was almost certainly this pattern under traffic.

Mirrors the migration 012 (`agent_inbox_stats`) fix exactly.

Plan: [`phases/P3B/pr2-plan.md`](.planning/active/2026-05-18-kv-d1-pattern-finish/phases/P3B/pr2-plan.md). Quest: [P3B](.planning/active/2026-05-18-kv-d1-pattern-finish).

## What changed

- **`migrations/016_agent_swap_stats.sql`** — single-row-per-sender table: `stx_address` PK, `trade_count`, `verified_count`, `first_trade_at`, `last_trade_at`, `updated_at`.
- **`lib/competition/stats.ts`** (new) — `getSwapStats` (O(1) lookup), `recordSwapInsert` (UPSERT-increment with `min()/max()` for monotonic timestamps), `rebuildSwapStats` (admin/repair). Write errors are caught + warn-logged so a stats hiccup never breaks swap persistence.
- **`lib/competition/verify.ts:insertSwap`** — after `meta.changes === 1`, calls `recordSwapInsert(db, sender, burn_block_time, tx_status, logger)`.
- **`lib/competition/d1-reads.ts`** — both queries flipped:
  - `countSwapsFromD1` → `SELECT trade_count FROM agent_swap_stats WHERE stx_address = ?` (O(1)).
  - `getCompetitionStatusFromD1` → `LEFT JOIN agent_swap_stats` instead of `LEFT JOIN swaps + GROUP BY`. COALESCE handles never-traded agents (registered but no swap row yet).

## Operational gate (per QUEST.md D1 discipline)

After merge:

1. `npm run wrangler -- d1 migrations apply landing-page --env production --remote`
2. Verify column: `SELECT name FROM sqlite_master WHERE type='table' AND name='agent_swap_stats'` returns 1.
3. Run backfill: `npm run wrangler -- d1 execute landing-page --env production --remote --file=.planning/active/2026-05-18-kv-d1-pattern-finish/phases/P3B/backfill-swap-stats-2026-05-20.sql`
4. Spot-check 3–5 senders: `SELECT trade_count FROM agent_swap_stats WHERE stx_address = ? UNION ALL SELECT COUNT(*) FROM swaps WHERE sender = ?` should return matching pairs.
5. Monitor D1 rows-read trend over the next 1–4h. Expected: further 30–50% drop on top of PR 1's reduction (target rate ≤70M/hr ≈ 1.7B/day).

Steps captured in the verify section to be appended to `phases/P3B/verify.md` after merge.

## Backfill SQL

`INSERT OR REPLACE` one row per existing sender via a `swaps GROUP BY` scan. Idempotent — safe to re-run. Functionally equivalent to `rebuildSwapStats()` but expressed as a single SQL statement so it can be applied via `wrangler d1 execute --remote --file=...` without a worker request.

The query reads the entire `swaps` table once (~ size-of-swaps rows). At current swap volume this is well below the per-request budget; happens once.

## Tests

- New `lib/competition/__tests__/stats.test.ts` covers `getSwapStats` (point-lookup shape + null return), `recordSwapInsert` (INSERT-on-first/UPSERT-on-subsequent, verified_delta=1/0 by status, `min()/max()` for monotonic timestamps, swallow-on-D1-error), and `rebuildSwapStats` (DELETE-then-INSERT shape).
- Updated `lib/competition/__tests__/d1-reads.test.ts`:
  - `getCompetitionStatusFromD1` now asserts the new `LEFT JOIN agent_swap_stats` shape + `COALESCE(s.trade_count, 0)` / `COALESCE(s.verified_count, 0)`; asserts absence of the old `SUM/COUNT/GROUP BY` shapes.
  - `countSwapsFromD1` now asserts the new `FROM agent_swap_stats WHERE stx_address = ?` shape; asserts absence of `FROM swaps` and `COUNT(*)`.
- Local: `npm test -- lib/competition` → **151 passed (10 files)**. `npm run lint`, `npm run build` clean. `npm run deploy:dry-run` not run — schema-only migration + library/route changes, no binding changes.

## Trade-offs / risks

- **Stats writes are best-effort.** A D1 outage during a swap submit could cause `agent_swap_stats` to lag the live `swaps` row by 1 record. Operator can `rebuildSwapStats()` on demand. The discrepancy bound is small (single-digit rows during the outage window) since each successful swap INSERT triggers one UPSERT. P3C will revisit if this matters under load.
- **First-page response shape unchanged.** `CompetitionStatusRow` field names + types are exactly preserved — no API consumer change.
- **Migration is forward-only.** Rollback path = revert PR + drop table migration. Same shape as P2 migration 015.

## Reviewers

`@arc0btc @secret-mars` (Copilot auto-attaches). `@steel-yeti` non-blocking shadow council.

## Test plan

- [ ] CI green
- [ ] After merge: apply migration + backfill per operational gate
- [ ] Spot-check 5 senders match between `agent_swap_stats.trade_count` and `SELECT COUNT(*) FROM swaps WHERE sender = ?`
- [ ] Pull D1 hourly rows-read trend at T+1h and T+4h — expect further reduction on top of PR 1's −32%
- [ ] Capture in `phases/P3B/verify.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)