### PR TITLE
chore(inbox): delete dead count*FromD1 helpers (replaced by stats table)

### DIFF
--- a/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
@@ -32,7 +32,9 @@ vi.mock("@/lib/agent-lookup", () => ({
 
 vi.mock("@/lib/inbox/d1-reads", () => ({
   listInboxMessagesFromD1: vi.fn(),
-  countInboxMessagesFromD1: vi.fn(),
+  // countInboxMessagesFromD1 was deleted in P3C PR 1 — counts come from
+  // getAgentInboxStats (lib/inbox/stats.ts) per migration 012's
+  // agent_inbox_stats table.
   fetchRepliesForMessages: vi.fn(),
   listOutboxRepliesFromD1: vi.fn(),
 }));
@@ -101,7 +103,6 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
   listInboxMessagesFromD1,
-  countInboxMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
 } from "@/lib/inbox/d1-reads";
@@ -173,7 +174,6 @@ function setupDefaultMocks() {
   });
   (lookupAgent as Mock).mockResolvedValue(TEST_AGENT);
   (listInboxMessagesFromD1 as Mock).mockResolvedValue([RECEIVED_MESSAGE]);
-  (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
   (fetchRepliesForMessages as Mock).mockResolvedValue(new Map());
   (listOutboxRepliesFromD1 as Mock).mockResolvedValue([]);
   // countOutboxRepliesFromD1 is no longer called (perf/d1-inbox-count-4to2)
@@ -318,7 +318,6 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
   it("partners includes both received senders AND sent reply targets when both exist", async () => {
     // Mock received messages (partner = sender)
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([RECEIVED_MESSAGE]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
     // Mock sent replies (partner = toBtcAddress) — sentCount derives from this list
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([SENT_REPLY]);
 
@@ -342,7 +341,6 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
   it("partners from sent-only direction have direction='sent'", async () => {
     // Only sent replies, no received messages — sentCount=1 derived from this list
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(0);
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([SENT_REPLY]);
 
     const res = await GET(
@@ -376,7 +374,6 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
     };
 
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([receivedMsgFromDualPartner]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([sentReplyToDualPartner]);
 
     const res = await GET(
@@ -510,7 +507,6 @@ describe("Phase 2.5 Step 3.3 — partners-with-sent in inbox-list GET", () => {
 
   it("partners only from received when no sent replies (received-only path still works)", async () => {
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([RECEIVED_MESSAGE]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(1);
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([]); // no sent replies — sentCount=0
 
     const res = await GET(
@@ -556,7 +552,6 @@ describe("D1-throws fallback still works after COUNT reduction", () => {
 
   it("returns 503 when listOutboxRepliesFromD1 throws (partners requested)", async () => {
     (listInboxMessagesFromD1 as Mock).mockResolvedValue([]);
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(0);
     (listOutboxRepliesFromD1 as Mock).mockRejectedValue(
       new Error("D1_ERROR: schema mismatch")
     );

--- a/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
@@ -27,7 +27,8 @@ vi.mock("@/lib/agent-lookup", () => ({
 
 vi.mock("@/lib/inbox/d1-reads", () => ({
   listInboxMessagesFromD1: vi.fn(),
-  countInboxMessagesFromD1: vi.fn(),
+  // countInboxMessagesFromD1 was deleted in P3C PR 1 — counts come from
+  // getAgentInboxStats per the migration-012 agent_inbox_stats table.
   fetchRepliesForMessages: vi.fn(),
 }));
 
@@ -95,7 +96,6 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
   listInboxMessagesFromD1,
-  countInboxMessagesFromD1,
   fetchRepliesForMessages,
 } from "@/lib/inbox/d1-reads";
 import { getAgentInboxStats } from "@/lib/inbox/stats";
@@ -140,7 +140,6 @@ describe("Phase 2.5 Step 3.1 — D1-throws fallback policy", () => {
     (listInboxMessagesFromD1 as Mock).mockRejectedValue(
       new Error("D1_ERROR: connection reset")
     );
-    (countInboxMessagesFromD1 as Mock).mockResolvedValue(0);
     (fetchRepliesForMessages as Mock).mockResolvedValue(new Map());
 
     const res = await GET(buildRequest(), buildContext());

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -85,7 +85,7 @@ vi.mock("@/lib/inbox/d1-reads", () => ({
   getInboxMessageFromD1: vi.fn(),
   getReplyForMessageFromD1: vi.fn(),
   listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
-  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
+  // countOutboxRepliesFromD1 was deleted in P3C PR 1.
 }));
 
 vi.mock("@/lib/bitcoin-verify", () => ({

--- a/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
+++ b/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
@@ -73,10 +73,9 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
 vi.mock("@/lib/inbox/d1-reads", () => ({
   checkRedeemedTxidInD1: vi.fn(),
   listInboxMessagesFromD1: vi.fn().mockResolvedValue([]),
-  countInboxMessagesFromD1: vi.fn().mockResolvedValue(0),
+  // countInboxMessagesFromD1 / countOutboxRepliesFromD1 deleted in P3C PR 1.
   fetchRepliesForMessages: vi.fn().mockResolvedValue(new Map()),
   listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
-  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
 }));
 
 // P3: inbox POST and GET now import from @/lib/inbox/stats

--- a/app/api/outbox/[address]/__tests__/d1-reads-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/d1-reads-flip.test.ts
@@ -36,7 +36,8 @@ vi.mock("@/lib/agent-lookup", () => ({
 
 vi.mock("@/lib/inbox/d1-reads", () => ({
   listOutboxRepliesFromD1: vi.fn(),
-  countOutboxRepliesFromD1: vi.fn(),
+  // countOutboxRepliesFromD1 was deleted in P3C PR 1 — sentCount now
+  // comes from getAgentInboxStats() per the migration-012 stats table.
 }));
 
 vi.mock("@/lib/inbox", () => ({
@@ -91,7 +92,7 @@ vi.mock("@/lib/validation/address", () => ({
 import { GET } from "../route";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
-import { listOutboxRepliesFromD1, countOutboxRepliesFromD1 } from "@/lib/inbox/d1-reads";
+import { listOutboxRepliesFromD1 } from "@/lib/inbox/d1-reads";
 import { getAgentInboxStats } from "@/lib/inbox/stats";
 
 // ---- shared fixtures --------------------------------------------------------
@@ -239,8 +240,8 @@ describe("Phase 2.5 Step 3.3 — GET /api/outbox/[address] D1 flip", () => {
     expect(listOutboxRepliesFromD1).toHaveBeenCalledOnce();
     const [, listCalledAddress] = (listOutboxRepliesFromD1 as Mock).mock.calls[0];
     expect(listCalledAddress).toBe(ADDR_B);
-    // P3: countOutboxRepliesFromD1 is no longer called; replaced by getAgentInboxStats
-    expect(countOutboxRepliesFromD1).not.toHaveBeenCalled();
+    // P3: totalCount comes from getAgentInboxStats (the legacy
+    // countOutboxRepliesFromD1 helper was deleted in P3C PR 1).
     expect(getAgentInboxStats).toHaveBeenCalledOnce();
   });
 
@@ -249,8 +250,6 @@ describe("Phase 2.5 Step 3.3 — GET /api/outbox/[address] D1 flip", () => {
     (listOutboxRepliesFromD1 as Mock).mockRejectedValue(
       new Error("D1_ERROR: connection reset")
     );
-    (countOutboxRepliesFromD1 as Mock).mockResolvedValue(1);
-
     const res = await GET(buildGetRequest(ADDR_A), buildContext(ADDR_A));
 
     expect(res.status).toBe(503);
@@ -378,7 +377,6 @@ describe("Phase 2.5 Step 3.3 — query param validation (NaN guard)", () => {
     expect(body.error).toBe("invalid_query_param");
     // D1 helpers must never be invoked for invalid input
     expect(listOutboxRepliesFromD1).not.toHaveBeenCalled();
-    expect(countOutboxRepliesFromD1).not.toHaveBeenCalled();
   });
 
   it("rejects out-of-range ?limit=0 with 400", async () => {
@@ -430,7 +428,6 @@ describe("Phase 2.5 Step 3.3 — query param validation (NaN guard)", () => {
   it("accepts ?limit=100 and ?offset=0 (boundary)", async () => {
     (lookupAgent as Mock).mockResolvedValue(AGENT_A);
     (listOutboxRepliesFromD1 as Mock).mockResolvedValue([REPLY_FROM_A]);
-    (countOutboxRepliesFromD1 as Mock).mockResolvedValue(1);
 
     const res = await GET(
       buildGetRequestWithQuery(ADDR_A, "?limit=100&offset=0"),

--- a/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
@@ -42,7 +42,7 @@ vi.mock("@/lib/inbox/d1-reads", () => ({
   getInboxMessageFromD1: vi.fn(),
   getReplyForMessageFromD1: vi.fn(),
   listOutboxRepliesFromD1: vi.fn().mockResolvedValue([]),
-  countOutboxRepliesFromD1: vi.fn().mockResolvedValue(0),
+  // countOutboxRepliesFromD1 was deleted in P3C PR 1.
 }));
 
 vi.mock("@/lib/inbox/d1-dual-write", () => ({

--- a/lib/inbox/__tests__/d1-reads.test.ts
+++ b/lib/inbox/__tests__/d1-reads.test.ts
@@ -7,8 +7,6 @@
  * Verifies:
  *   - listInboxMessagesFromD1: correct SQL shape, status filter variants,
  *     ORDER BY sent_at DESC, pagination bindings, InboxMessage mapping
- *   - countInboxMessagesFromD1: unread/read/all variants, the live
- *     SELECT COUNT(*) that closes aibtc-mcp-server#497
  *   - fetchRepliesForMessages: IN-clause construction, OutboxReply mapping,
  *     empty-input guard
  *   - getReplyForMessageFromD1: tenant-discriminator gate, hit/miss, SQL shape
@@ -26,16 +24,13 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   listInboxMessagesFromD1,
-  countInboxMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
-  countOutboxRepliesFromD1,
   getReplyForMessageFromD1,
   getAgentInboxFromD1,
   getSentIndexFromD1,
   getRecentInboxEventsFromD1,
   checkRedeemedTxidInD1,
-  type StatusFilter,
 } from "../d1-reads";
 
 // ── D1 mock helpers ───────────────────────────────────────────────────────────
@@ -281,104 +276,6 @@ describe("listInboxMessagesFromD1", () => {
   });
 });
 
-// ── countInboxMessagesFromD1 ──────────────────────────────────────────────────
-
-describe("countInboxMessagesFromD1", () => {
-  it("queries SELECT COUNT(*) from inbox_messages for status=all (no read_at filter)", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 5 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countInboxMessagesFromD1(db, BTC_ADDRESS, "all");
-
-    expect(count).toBe(5);
-    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("SELECT COUNT(*)");
-    expect(sql).toContain("FROM inbox_messages");
-    expect(sql).toContain("is_reply = 0");
-    expect(sql).not.toContain("read_at IS NULL");
-    expect(sql).not.toContain("read_at IS NOT NULL");
-  });
-
-  it("adds AND read_at IS NULL for status=unread (the live counter that closes aibtc-mcp-server#497)", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 2 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countInboxMessagesFromD1(db, BTC_ADDRESS, "unread");
-
-    expect(count).toBe(2);
-    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("AND read_at IS NULL");
-  });
-
-  it("adds AND read_at IS NOT NULL for status=read", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 3 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countInboxMessagesFromD1(db, BTC_ADDRESS, "read");
-
-    expect(count).toBe(3);
-    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("AND read_at IS NOT NULL");
-  });
-
-  it("binds the btcAddress as the first positional param", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 0 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    await countInboxMessagesFromD1(db, BTC_ADDRESS, "all");
-
-    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
-    expect(bindArgs[0]).toBe(BTC_ADDRESS);
-  });
-
-  it("returns 0 when db.first() returns null", async () => {
-    const stmtMock = createPreparedStatement([], null);
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countInboxMessagesFromD1(db, BTC_ADDRESS, "unread");
-    expect(count).toBe(0);
-  });
-
-  it("correctly distinguishes unreadCount=2 vs totalCount=2 (the acceptance test signal)", async () => {
-    // Simulates the §1.4 acceptance test:
-    // Pre-flip KV had unreadCount=3 (stale) / totalCount=2.
-    // Post-flip D1 should return unreadCount=2 / totalCount=2 (truthful).
-    const stmtUnread = createPreparedStatement([], { cnt: 2 });
-    const stmtTotal = createPreparedStatement([], { cnt: 2 });
-
-    let callCount = 0;
-    const db = {
-      prepare: vi.fn().mockImplementation(() => {
-        callCount++;
-        return callCount === 1 ? stmtUnread : stmtTotal;
-      }),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const unreadCount = await countInboxMessagesFromD1(db, BTC_ADDRESS, "unread");
-    const totalCount = await countInboxMessagesFromD1(db, BTC_ADDRESS, "all");
-
-    // Post-flip: both should be 2 (no drift)
-    expect(unreadCount).toBe(2);
-    expect(totalCount).toBe(2);
-    expect(unreadCount).toBe(totalCount); // drift=0 proves the stale-counter is fixed
-  });
-});
 
 // ── fetchRepliesForMessages ───────────────────────────────────────────────────
 
@@ -561,66 +458,6 @@ describe("listOutboxRepliesFromD1 (Phase 2.5 Step 3.3)", () => {
   });
 });
 
-// ── countOutboxRepliesFromD1 ──────────────────────────────────────────────────
-
-describe("countOutboxRepliesFromD1 (Phase 2.5 Step 3.3 — sentCount restoration)", () => {
-  const REPLIER_BTC = "bc1qp66jvxe765wgwpzqk8kcrmgh2mucyxg540mtzv";
-
-  it("queries SELECT COUNT(*) WHERE is_reply=1 AND from_btc_address=?", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 3 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countOutboxRepliesFromD1(db, REPLIER_BTC);
-
-    expect(count).toBe(3);
-    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("SELECT COUNT(*)");
-    expect(sql).toContain("FROM inbox_messages");
-    expect(sql).toContain("is_reply = 1");
-    expect(sql).toContain("from_btc_address = ?");
-  });
-
-  it("returns 0 when db.first() returns null", async () => {
-    const stmtMock = createPreparedStatement([], null);
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countOutboxRepliesFromD1(db, REPLIER_BTC);
-    expect(count).toBe(0);
-  });
-
-  it("sentCount restoration: returns > 0 for known-replier address (Step 3.3 acceptance signal)", async () => {
-    // This test represents the acceptance signal for Step 3.3:
-    // POST-flip, countOutboxRepliesFromD1 must return > 0 for an address that has sent replies.
-    // Was stubbed to 0 in Step 3.1 ("const sentCount = 0;").
-    const stmtMock = createPreparedStatement([], { cnt: 5 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    const count = await countOutboxRepliesFromD1(db, REPLIER_BTC);
-    expect(count).toBeGreaterThan(0); // Step 3.3 acceptance signal: sentCount > 0
-  });
-
-  it("binds from_btc_address as the first positional param", async () => {
-    const stmtMock = createPreparedStatement([], { cnt: 0 });
-    const db = {
-      prepare: vi.fn().mockReturnValue(stmtMock),
-      batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
-    } as unknown as D1Database;
-
-    await countOutboxRepliesFromD1(db, REPLIER_BTC);
-
-    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
-    expect(bindArgs[0]).toBe(REPLIER_BTC);
-  });
-});
 
 // ── getReplyForMessageFromD1 ──────────────────────────────────────────────────
 
@@ -988,18 +825,16 @@ describe("checkRedeemedTxidInD1 (Phase 2.5 Step 4 — double-redemption guard)",
 
 describe("cache-key invariants (structural verification)", () => {
   it("Invariant 1: the helpers accept no auth/session parameters — public branch only", () => {
-    // listInboxMessagesFromD1 and countInboxMessagesFromD1 take only
-    // (db, btcAddress, ...) — no authToken, no sessionId, no signature.
-    // This proves the public-only code path does not accidentally mix
-    // auth'd and public queries from the same parameter set.
+    // The d1-reads helpers take only (db, btcAddress, ...) — no authToken,
+    // no sessionId, no signature. This proves the public-only code path
+    // does not accidentally mix auth'd and public queries from the same
+    // parameter set.
     //
     // A future auth'd branch MUST pass an additional verified-owner parameter
     // AND use a different cache key (or no caching at all — Cache-Control: private, no-store).
     expect(listInboxMessagesFromD1.length).toBe(5); // (db, btcAddress, limit, offset, status)
-    expect(countInboxMessagesFromD1.length).toBe(3); // (db, btcAddress, status)
     expect(fetchRepliesForMessages.length).toBe(2);  // (db, parentMessageIds)
     expect(listOutboxRepliesFromD1.length).toBe(4);  // (db, btcAddress, limit, offset)
-    expect(countOutboxRepliesFromD1.length).toBe(2); // (db, btcAddress)
     expect(getReplyForMessageFromD1.length).toBe(3); // (db, parentMessageId, fromBtcAddress)
     // Phase 2.5 #746 enrichment helpers (db is optional — fail-open when undefined)
     expect(getAgentInboxFromD1.length).toBe(2);       // (db, btcAddress)

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -160,36 +160,12 @@ export async function listInboxMessagesFromD1(
   return (result.results ?? []).map(rowToInboxMessage);
 }
 
-/**
- * Count inbound messages for an agent, optionally filtered to unread.
- *
- * This is the live SELECT COUNT(*) that replaces the stale KV cached counter
- * and closes aibtc-mcp-server#497.
- */
-export async function countInboxMessagesFromD1(
-  db: D1Database,
-  btcAddress: string,
-  status: StatusFilter
-): Promise<number> {
-  let sql = `
-    SELECT COUNT(*) AS cnt
-    FROM inbox_messages
-    WHERE to_btc_address = ? AND is_reply = 0
-  `;
-
-  if (status === "unread") {
-    sql += " AND read_at IS NULL";
-  } else if (status === "read") {
-    sql += " AND read_at IS NOT NULL";
-  }
-
-  const row = await db
-    .prepare(sql)
-    .bind(btcAddress)
-    .first<{ cnt: number }>();
-
-  return row?.cnt ?? 0;
-}
+// Dead code purge (P3C PR 1): `countInboxMessagesFromD1` removed.
+// Replaced by `getAgentInboxStats(db, btcAddress)` from `lib/inbox/stats.ts`
+// which serves O(1) point-lookups against the maintained `agent_inbox_stats`
+// table (migration 012). The prior `SELECT COUNT(*) FROM inbox_messages
+// WHERE to_btc_address = ?` was the textbook D1 COUNT(*) anti-pattern
+// (cf. `feedback_d1_count_antipattern`).
 
 /**
  * Fetch reply rows for a set of parent message IDs.
@@ -311,33 +287,13 @@ export async function listOutboxRepliesFromD1(
   return (result.results ?? []).map(replyRowToOutboxReply);
 }
 
-/**
- * Count outbox replies sent by an agent from D1.
- *
- * Used to restore the `sentCount` dimension in GET /api/inbox/[address] that
- * was stubbed to 0 in Step 3.1.
- *
- * SQL shape:
- *   SELECT COUNT(*) FROM inbox_messages
- *   WHERE is_reply = 1 AND from_btc_address = ?
- */
-export async function countOutboxRepliesFromD1(
-  db: D1Database,
-  btcAddress: string
-): Promise<number> {
-  const sql = `
-    SELECT COUNT(*) AS cnt
-    FROM inbox_messages
-    WHERE is_reply = 1 AND from_btc_address = ?
-  `;
-
-  const row = await db
-    .prepare(sql)
-    .bind(btcAddress)
-    .first<{ cnt: number }>();
-
-  return row?.cnt ?? 0;
-}
+// Dead code purge (P3C PR 1): `countOutboxRepliesFromD1` removed.
+// Replaced by `getAgentInboxStats(db, btcAddress).sentCount` from
+// `lib/inbox/stats.ts` which serves O(1) point-lookups against the
+// maintained `agent_inbox_stats` table (migration 012). The prior
+// `SELECT COUNT(*) FROM inbox_messages WHERE is_reply = 1 AND
+// from_btc_address = ?` was the textbook D1 COUNT(*) anti-pattern
+// (cf. `feedback_d1_count_antipattern`).
 
 /**
  * Fetch a single reply for a parent message, filtered by the replier's BTC address.


### PR DESCRIPTION
## Summary

P3C PR 1 — dead-code purge. Net **−218 lines** (245 removed, 27 added — mostly comments and a few mock-cleanup lines).

`countInboxMessagesFromD1` and `countOutboxRepliesFromD1` in `lib/inbox/d1-reads.ts` have **no production callers**. Both were superseded by O(1) point-lookups against the `agent_inbox_stats` table (migration 012) via `getAgentInboxStats(db, btcAddress)` from `lib/inbox/stats.ts` in PR #745 / Phase 2.5. The route-level comments confirm:

- `app/api/inbox/[address]/route.ts:313` — "Stats O(1) point-lookup — replaces two countInboxMessagesFromD1 scans"
- `app/api/outbox/[address]/route.ts:627` — "(O(1) point-lookup) instead of countOutboxRepliesFromD1 (O(N rows))"

The functions stayed in the codebase as historical regression guards (test files asserting `not.toHaveBeenCalled()`), but were never used by production code post-Phase 2.5. Deleting them removes one place a future caller could re-introduce the textbook D1 COUNT(*) anti-pattern documented in `feedback_d1_count_antipattern`.

Plan: [`phases/P3C/plan.md`](.planning/active/2026-05-18-kv-d1-pattern-finish/phases/P3C/plan.md). Quest: [P3C](.planning/active/2026-05-18-kv-d1-pattern-finish).

## What changed

- `lib/inbox/d1-reads.ts` — both functions removed. Brief comment in their place pointing to the replacement (`getAgentInboxStats`) and the cost-driver memory (`feedback_d1_count_antipattern`).
- Tests updated to drop imports, mock fixtures, `mockResolvedValue` setups, and `not.toHaveBeenCalled()` regression guards for the deleted functions:
  - `lib/inbox/__tests__/d1-reads.test.ts` — removed the two `describe` blocks; updated cache-key invariant test.
  - `app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts` — removed 2 mock fixtures.
  - `app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts` — removed import + mock fixture + 6 `mockResolvedValue` setups.
  - `app/api/outbox/[address]/__tests__/d1-reads-flip.test.ts` — removed import + mock fixture + 1 `not.toHaveBeenCalled()` + 1 `mockResolvedValue`.
  - `app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts` — removed 1 mock fixture.

## Tests

`npm test -- lib/inbox app/api/inbox app/api/outbox` in main repo → **1,570 passed** (51 failures all in `.claude/worktrees/...`, stale local worktrees unrelated to this PR). `npm run build` clean. `npm run lint` clean.

The deleted functions had 10 unit tests in `lib/inbox/__tests__/d1-reads.test.ts`. Those test the SQL shape of a function that no longer exists, so they're removed alongside.

## Scope (and what's NOT in this PR)

PHASES.md § P3C calls for a larger scope (authority flip + dead-code purge across `kvFallbackKey`, `lib/agents-index.ts`, P4.3 comments, etc.). This PR is just the truly-dead targets that need no behavioral change.

The **authority-flip portion** (PR 2 of P3C) is deferred to a follow-up wake because it requires an operator decision on the ~708 KV `btc:`-only "partial agent" records (no `stxAddress`, never D1-inserted by `insertAgentToD1`'s partial-skip guard). Removing `kvFallbackKey` without a destination for them would 404 their profile views. Plan documents three options; recommendation is to keep `kvFallbackKey` as an intentional "legacy partial-records fallback" with the comment updated to reflect that it's no longer transitional scaffolding. Awaiting operator input.

## Reviewers

`@arc0btc @secret-mars` (Copilot auto-attaches). `@steel-yeti` non-blocking shadow council.

## Test plan

- [ ] CI green
- [ ] After merge: grep `countInboxMessagesFromD1\|countOutboxRepliesFromD1` returns zero hits in production code (only test-file mock-cleanup comments remain)
- [ ] No worker-logs error class introduced (no behavioral change expected — these were dead functions)
- [ ] Operator pings for the partial-agents decision so PR 2 can ship

🤖 Generated with [Claude Code](https://claude.com/claude-code)