### PR TITLE
fix(scheduler): enable TENERO_REFRESH_ENABLED at top-level (closes #880)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -34,11 +34,16 @@
       "remote": true
     }
   ],
-  // Top-level vars: used by bare `wrangler deploy` (without --env). Keep
-  // Tenero refresh disabled here so a no-env deployment cannot consume the
-  // production Tenero key/quota even if the secret exists on the Worker name.
+  // Top-level vars: used by bare `wrangler deploy` (without --env), which is
+  // what the Cloudflare Workers Build pipeline runs. The prior "keep Tenero
+  // refresh disabled here" guard meant the SchedulerDO never populated the
+  // KV cache in prod (issue #880) — so the competition-finalize snapshot
+  // path can't fetch frozen prices. Enabling here is the resolution.
+  // env.preview below still omits TENERO_REFRESH_ENABLED, so a preview
+  // build cannot accidentally consume the production Tenero quota.
   "vars": {
-    "DEPLOY_ENV": "production"
+    "DEPLOY_ENV": "production",
+    "TENERO_REFRESH_ENABLED": "true"
   },
   // First-party rate limit bindings. Mirrors the agent-news pattern (agent-news#704/#705).
   // Top-level IDs are the local-dev defaults — they are overridden in each named env


### PR DESCRIPTION
## Summary

The Cloudflare Workers Build pipeline runs bare \`wrangler deploy\` (no \`--env\`), which reads the top-level \`vars\` block in \`wrangler.jsonc\`. The prior guard intentionally omitted \`TENERO_REFRESH_ENABLED\` there as a "no-env safety" measure — but the practical effect was that the SchedulerDO has been skipping every Tenero tick in prod since the env var was introduced, leaving the KV price cache empty (confirmed: \`wrangler kv key list\` returns zero \`tenero:*\` keys).

That blocks the snapshot action of the new competition-finalize flow (#822 / #897), which reads from the KV cache to freeze per-token prices. The new \`empty_price_cache\` pre-flight gate would return 503 on any real snapshot attempt.

Setting \`TENERO_REFRESH_ENABLED: "true"\` at the top level lets the scheduler populate the cache on its 5-minute tick.

\`env.preview\` is left without the var, so preview deploys still cannot consume the production Tenero quota.

Closes #880.

## Test plan
- [ ] CI green
- [ ] Post-merge: wait one scheduler tick (~5 min), confirm \`tenero:*\` KV keys exist
- [ ] Post-merge: \`POST /api/admin/competition/finalize?dry-run=true { action: "snapshot" }\` returns \`wouldCapture.priced > 0\` instead of 503

🤖 Generated with [Claude Code](https://claude.com/claude-code)