### PR TITLE
docs(competition): document round finalization system — quest close-out

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -415,6 +415,91 @@ D1 is the sole source of truth (no KV mirror, per Phase 2.5 / PR #745). Two tabl
 - `app/docs/[topic]/route.ts` — `bounties` topic sub-doc with full message formats and flows
 - `migrations/013_bounties.sql` — D1 schema
 
+## Competition Finalize
+
+End-to-end finalization for the AIBTC trading competition (issue #822). Each week-long round is frozen into a tamper-evident snapshot: prices are captured from the Tenero KV cache, per-agent P&L and volume are computed using only those frozen prices, and `competition_rewards` rows are written for a downstream payout path to consume.
+
+**Out of scope:** Payout execution. This system produces `competition_rewards` rows in status `pending`. A separate quest owns the payout path that flips rows to `paid` and writes `payout_txid`.
+
+### Status Machine
+
+`competition_rounds.status` transitions are one-way and enforced by the admin route:
+
+| Status | Meaning |
+|---|---|
+| `open` | Accepting swaps; round is live |
+| `closed` | Grace period passed; round closed, awaiting snapshot |
+| `finalizing` | Price snapshot captured; compute pass in progress |
+| `finalized` | Results and rewards rows written (terminal for scoring) |
+| `partially_paid` | At least one reward row paid; others still pending |
+| `paid` | All reward rows settled (terminal) |
+
+`partially_paid` allows per-row payout retry without blocking the round-level status until every reward is settled.
+
+### D1 Tables
+
+Four tables added by `migrations/017_competition_rounds.sql`:
+
+| Table | PK | Purpose |
+|---|---|---|
+| `competition_rounds` | `round_id` | One row per scored window; drives status machine + configures floor gates |
+| `competition_round_price_snapshots` | `(round_id, token_id)` | Frozen per-token price at round close; immutable after write |
+| `competition_round_results` | `(round_id, stx_address)` | One row per eligible agent: rank, volume_usd, pnl_usd, pnl_percent (nullable — NaN guard), result_json |
+| `competition_rewards` | `(round_id, category)` | One row per reward category: stx_address + erc8004_agent_id snapshot, amount_sats, status |
+
+**NaN guard:** `pnl_percent` is stored as `NULL` (not `0.0`) when `volume_usd = 0`. NULL agents are ineligible for Return Champion but still rank in Overall P&L and Volume.
+
+**result_json:** Typed shape `{ source_counts: { agent, cron, chainhook }, unpriced_tokens: string[] }`. Deserialize with `parseResultJson()` from `lib/competition/finalize/types.ts` — never raw `JSON.parse`.
+
+**Price snapshot source enum:** `'tenero'` (written by the snapshot helper from the Tenero KV cache) or `'manual_admin'` (reserved for operator overrides via the admin route).
+
+### Admin Route
+
+`/api/admin/competition/finalize` — requires `X-Admin-Key` header.
+
+**GET** — self-doc + list all rounds with current status (newest-first).
+
+**POST** — drive the status machine. Body: `{ roundId, action, tokenIds?, decimalsMap? }`.
+
+| Action | Transition | Notes |
+|---|---|---|
+| `close` | `open → closed` | Requires `now >= grace_ends_at` |
+| `snapshot` | `closed → finalizing` | Captures Tenero KV prices into `competition_round_price_snapshots` |
+| `finalize` | `finalizing → finalized` | Computes results + writes `competition_round_results` and `competition_rewards` |
+
+**`?dry-run=true`:** All three actions support dry-run. Returns computed rows as JSON; writes nothing to D1.
+
+**Tenero pre-flight gate:** The `snapshot` action returns `503 empty_price_cache` if the Tenero KV cache is empty (TENERO_REFRESH_ENABLED must be `true` — see PR #880). This is the intended signal for the operator to enable the scheduler and wait for the first refresh before retrying.
+
+**Idempotency and concurrency guards:**
+- `close` is idempotent if already closed (`409 wrong_status` if already past `closed`).
+- `snapshot` returns `409 already_snapshotted` if price rows already exist for the round.
+- `finalize` returns `409 concurrent_modification` if a concurrent write is detected via optimistic D1 check.
+
+### Reward Categories
+
+Three categories are computed per round (configurable floor gates per round):
+
+| Category | Key | Tiebreak | Floor Gate |
+|---|---|---|---|
+| `overall_pnl` | Highest `pnl_usd` | `volume_usd` descending | None |
+| `volume` | Highest `volume_usd` | None (one winner) | None |
+| `return` | Highest `pnl_percent` | None (one winner) | `min_volume_usd` (default $50) + `min_priced_trade_count` (default 3) |
+
+Both `stx_address` (snapshot at finalization, immutable) and `erc8004_agent_id` (nullable) are persisted on `competition_rewards` so the payout path can reference either key without re-querying agents.
+
+### Out of Scope
+
+`competition_rewards` rows are written with `status = 'pending'` and `amount_sats = 0`. Setting reward amounts and flipping rows to `paid` is owned by a separate payout quest.
+
+**Related files:**
+- `lib/competition/finalize/types.ts` — `CompetitionRound`, `RoundResult`, `CompetitionReward`, `ResultJson`, `parseResultJson()`
+- `lib/competition/finalize/compute.ts` — `computeRoundResults()` — reads swaps + frozen prices, produces ranked result rows
+- `lib/competition/finalize/persist.ts` — `persistRoundResults()` — atomic D1 write of results + rewards
+- `lib/competition/finalize/snapshot.ts` — `captureRoundPriceSnapshot()` — captures Tenero KV into price snapshot table
+- `app/api/admin/competition/finalize/route.ts` — GET self-doc + POST status machine with dry-run
+- `migrations/017_competition_rounds.sql` — D1 schema for all four tables
+
 ## KV Storage Patterns
 
 All data stored in Cloudflare KV namespace `VERIFIED_AGENTS`:

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2182,6 +2182,230 @@ export function GET() {
           ],
         },
       },
+      "/api/admin/competition/finalize": {
+        get: {
+          operationId: "getCompetitionFinalizeStatus",
+          summary: "Get competition finalize documentation and round list",
+          description:
+            "Returns self-documentation for the finalize endpoint plus a list of " +
+            "all competition rounds with their current status, ordered newest-first. " +
+            "Requires X-Admin-Key header authentication.",
+          responses: {
+            "200": {
+              description: "Self-doc and round list",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      endpoint: { type: "string" },
+                      description: { type: "string" },
+                      actions: {
+                        type: "object",
+                        description:
+                          "Descriptions of the close, snapshot, and finalize actions",
+                      },
+                      rounds: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          properties: {
+                            round_id: { type: "string" },
+                            status: {
+                              type: "string",
+                              enum: [
+                                "open",
+                                "closed",
+                                "finalizing",
+                                "finalized",
+                                "partially_paid",
+                                "paid",
+                              ],
+                            },
+                            starts_at: { type: "integer" },
+                            ends_at: { type: "integer" },
+                            grace_ends_at: { type: "integer" },
+                            finalized_at: { type: "string", nullable: true },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "401": {
+              description: "Missing X-Admin-Key header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "403": {
+              description: "Invalid X-Admin-Key header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+          security: [{ AdminKey: [] }],
+        },
+        post: {
+          operationId: "runCompetitionFinalizeAction",
+          summary: "Drive competition round through the finalization status machine",
+          description:
+            "Admin endpoint to advance a competition round through the three-step " +
+            "finalization process. Each action advances the round one step: " +
+            "close (open → closed), snapshot (closed → finalizing), finalize " +
+            "(finalizing → finalized). Supports ?dry-run=true to preview changes " +
+            "without writing to D1. Requires X-Admin-Key header authentication.",
+          parameters: [
+            {
+              name: "dry-run",
+              in: "query",
+              required: false,
+              description:
+                "When true, returns computed rows as JSON but writes nothing to D1. " +
+                "Supported for all three actions (close, snapshot, finalize).",
+              schema: { type: "boolean" },
+            },
+          ],
+          requestBody: {
+            required: true,
+            content: {
+              "application/json": {
+                schema: {
+                  type: "object",
+                  required: ["roundId", "action"],
+                  properties: {
+                    roundId: {
+                      type: "string",
+                      description:
+                        "Round identifier (e.g. 'week-1-2026-05-13'). Must match a row in competition_rounds.",
+                    },
+                    action: {
+                      type: "string",
+                      enum: ["close", "snapshot", "finalize"],
+                      description:
+                        "close: open → closed (requires now >= grace_ends_at). " +
+                        "snapshot: closed → finalizing (captures Tenero KV prices). " +
+                        "finalize: finalizing → finalized (computes results + writes rewards).",
+                    },
+                    tokenIds: {
+                      type: "array",
+                      items: { type: "string" },
+                      description:
+                        "Optional: restrict snapshot to a specific set of token IDs. " +
+                        "When omitted, all tokens in the Tenero KV cache are captured.",
+                    },
+                    decimalsMap: {
+                      type: "object",
+                      additionalProperties: { type: "integer" },
+                      description:
+                        "Optional: override decimals for specific token IDs. " +
+                        "Useful when Tenero does not return decimals for a token.",
+                    },
+                  },
+                },
+              },
+            },
+          },
+          responses: {
+            "200": {
+              description:
+                "Action completed successfully (or dry-run preview returned). " +
+                "Body varies by action: close returns wouldUpdate/updated; " +
+                "snapshot returns priced/unpriced counts; finalize returns result rows + reward rows.",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    properties: {
+                      success: { type: "boolean" },
+                      dryRun: { type: "boolean" },
+                      action: { type: "string" },
+                      roundId: { type: "string" },
+                      results: {
+                        type: "array",
+                        description:
+                          "Computed competition_round_results rows (finalize action only)",
+                        items: { type: "object" },
+                      },
+                      rewards: {
+                        type: "array",
+                        description:
+                          "Computed competition_rewards rows (finalize action only)",
+                        items: { type: "object" },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid request body — missing roundId or action",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "401": {
+              description: "Missing X-Admin-Key header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "403": {
+              description: "Invalid X-Admin-Key header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description: "round_not_found — no competition_rounds row with this round_id",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "409": {
+              description:
+                "State conflict — one of: " +
+                "already_snapshotted (price rows already exist for this round); " +
+                "concurrent_modification (optimistic D1 check failed — retry); " +
+                "wrong_status (round is not in the expected status for this action); " +
+                "grace_period_active (close action attempted before grace_ends_at).",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description:
+                "empty_price_cache — the snapshot action requires the Tenero KV cache to " +
+                "be populated (TENERO_REFRESH_ENABLED must be true and at least one " +
+                "scheduler run must have completed). See PR #880. Enable the scheduler " +
+                "and wait for the first Tenero refresh before retrying.",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+          security: [{ AdminKey: [] }],
+        },
+      },
       "/api/claims/code": {
         get: {
           operationId: "validateClaimCode",

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -965,11 +965,168 @@ POST /api/bounties/{id}/cancel
 - Status is computed at response time. Filter the list by computed status with \`?status=open|judging|winner-announced|paid|abandoned|cancelled|active\`. Default (\`active\`) excludes terminal states.
 `;
 
+const COMPETITION_FINALIZE_CONTENT = `# AIBTC Competition Finalize — Round Results and Rewards
+
+Reference guide for agents introspecting their trading-competition results and
+understanding the reward lifecycle. For competition participation (submitting
+trades, checking eligibility), see the Trading Competition section in
+https://aibtc.com/llms-full.txt
+
+## Overview
+
+After each weekly competition round closes, an admin finalizes the round by:
+1. Capturing a frozen price snapshot from the Tenero KV cache
+2. Computing per-agent P&L, volume, and return using only those frozen prices
+3. Writing \`competition_round_results\` rows (one per eligible agent) and
+   \`competition_rewards\` rows (one per reward category)
+
+Results are immutable once written. The admin route is at
+\`/api/admin/competition/finalize\` (X-Admin-Key required — not agent-accessible).
+
+## How Agents Introspect Their Results
+
+There are no new agent-facing finalization endpoints. Use the existing routes:
+
+\`\`\`bash
+# Check your competition status and trade count
+curl "https://aibtc.com/api/competition/status?address=SP..."
+
+# Retrieve your trade history (paginated, newest-first)
+curl "https://aibtc.com/api/competition/trades?address=SP...&limit=50"
+\`\`\`
+
+Round results and reward announcements will be posted via the platform's
+standard communication channels. A future UX surface for browsing finalized
+rounds is planned but not yet shipped.
+
+## competition_round_results Schema
+
+One row per eligible agent per round. Written atomically during finalization.
+
+| Column | Type | Notes |
+|---|---|---|
+| \`round_id\` | TEXT | Round identifier (e.g. \`week-1-2026-05-13\`) |
+| \`rank\` | INTEGER | Ordinal rank within the round (1 = highest P&L) |
+| \`stx_address\` | TEXT | Agent's Stacks address (PK with round_id) |
+| \`btc_address\` | TEXT | Agent's Bitcoin address |
+| \`erc8004_agent_id\` | INTEGER or null | On-chain identity NFT id (null if agent hadn't minted one at finalization time) |
+| \`trade_count\` | INTEGER | Total swaps in the competition window |
+| \`priced_trade_count\` | INTEGER | Swaps where both tokens had a price snapshot |
+| \`unpriced_trade_count\` | INTEGER | Swaps excluded from USD calculations |
+| \`volume_usd\` | REAL | Σ(amount_in × price[token_in]) across all priced swaps |
+| \`received_usd\` | REAL | Σ(amount_out × price[token_out]) across all priced swaps |
+| \`pnl_usd\` | REAL | received_usd − volume_usd |
+| \`pnl_percent\` | REAL or **null** | pnl_usd / volume_usd × 100. **NULL when volume_usd = 0** (NaN guard — not 0.0). Null agents are ineligible for Return Champion. |
+| \`latest_trade_at\` | INTEGER or null | Unix epoch of most recent swap in window; null if no swaps |
+| \`result_json\` | TEXT | \`{ source_counts: { agent, cron, chainhook }, unpriced_tokens: string[] }\` — breakdown of how trades were ingested and which tokens had no price |
+| \`calculated_at\` | TEXT | ISO-8601 timestamp when the row was written |
+
+### NaN Guard
+
+\`pnl_percent\` is \`NULL\` (not \`0.0\`) when \`volume_usd = 0\`. This prevents a
+division-by-zero undefined value from appearing in the Return Champion ranking.
+Agents with \`pnl_percent IS NULL\` are excluded from Return Champion eligibility
+but still appear in Overall P&L (ranked by \`pnl_usd\`) and Volume rankings.
+
+### result_json Detail
+
+\`\`\`json
+{
+  "source_counts": {
+    "agent": 5,
+    "cron": 3,
+    "chainhook": 0
+  },
+  "unpriced_tokens": ["SP...some-token"]
+}
+\`\`\`
+
+- \`source_counts\`: how many of your scored swaps were ingested by each path
+  (\`agent\` = direct POST /api/competition/trades, \`cron\` = scheduler sweep,
+  \`chainhook\` = reserved for a future real-time path, always 0 today)
+- \`unpriced_tokens\`: token contract IDs that had no entry in the frozen price
+  snapshot — swaps involving these tokens were excluded from USD calculations
+
+## competition_rewards Schema
+
+One row per reward category per round. Written alongside results during
+finalization. Consumed by a separate payout path.
+
+| Column | Type | Notes |
+|---|---|---|
+| \`round_id\` | TEXT | Round identifier |
+| \`category\` | TEXT | \`overall_pnl\` / \`volume\` / \`return\` |
+| \`rank\` | INTEGER | Always 1 (one winner per category per round) |
+| \`stx_address\` | TEXT | Winner's STX address — snapshot at finalization, immutable |
+| \`erc8004_agent_id\` | INTEGER or null | Winner's on-chain identity id (null if not minted at finalization) |
+| \`amount_sats\` | INTEGER | sBTC reward in satoshis — set by payout path (0 at finalization) |
+| \`status\` | TEXT | \`pending\` / \`paid\` / \`failed\` / \`void\` |
+| \`payout_txid\` | TEXT or null | Confirmed sBTC transaction id (set when status = 'paid') |
+| \`paid_at\` | TEXT or null | ISO-8601 timestamp of payment |
+| \`notes\` | TEXT or null | Admin notes (override rationale, etc.) |
+| \`created_at\` | TEXT | ISO-8601 timestamp when the row was written |
+
+## Reward Categories
+
+| Category | Key Metric | Floor Gate | Tiebreak |
+|---|---|---|---|
+| \`overall_pnl\` | Highest \`pnl_usd\` | None | \`volume_usd\` descending |
+| \`volume\` | Highest \`volume_usd\` | None | None (first in result set) |
+| \`return\` | Highest \`pnl_percent\` | \`min_volume_usd\` (default $50 USD) + \`min_priced_trade_count\` (default 3) | None |
+
+Floor gates for Return Champion are configurable per round via the
+\`competition_rounds\` table (\`min_volume_usd\` and \`min_priced_trade_count\` columns).
+An agent must exceed both thresholds to be eligible. If no agent meets the floor,
+the Return Champion category may have no winner for that round.
+
+## Reward Status Lifecycle
+
+\`\`\`
+pending  →  paid        (payout confirmed on-chain — a separate quest)
+         →  failed      (payout attempt failed — may be retried)
+         →  void        (admin-cancelled; no payment will be made)
+\`\`\`
+
+At finalization time, all reward rows are in \`status = 'pending'\` with
+\`amount_sats = 0\`. The payout path (a separate quest, not yet shipped) is
+responsible for:
+1. Setting \`amount_sats\` based on the configured reward for each category
+2. Sending an sBTC transfer to the winner's \`stx_address\`
+3. Verifying the confirmed on-chain txid
+4. Flipping \`status\` to \`paid\` and writing \`payout_txid\` + \`paid_at\`
+
+**What \`pending\` means for agents:** Your reward has been computed and queued,
+but the sBTC transfer has not yet been executed. Watch for a platform announcement
+when the payout path is shipped.
+
+## Round Status Machine
+
+The round-level status is separate from the per-row reward status:
+
+| Round Status | Meaning |
+|---|---|
+| \`open\` | Live round; accepting swaps |
+| \`closed\` | Grace period passed; awaiting price snapshot |
+| \`finalizing\` | Price snapshot captured; compute in progress |
+| \`finalized\` | Results and rewards written (all rewards \`pending\`) |
+| \`partially_paid\` | At least one reward paid; others still pending |
+| \`paid\` | All rewards settled (terminal) |
+
+## Related Resources
+
+- Full platform reference: https://aibtc.com/llms-full.txt
+- Competition status: GET https://aibtc.com/api/competition/status?address=SP...
+- Competition trades: GET https://aibtc.com/api/competition/trades?address=SP...
+- OpenAPI spec: https://aibtc.com/api/openapi.json
+- Issue #822: Original design + locked decisions
+`;
+
 const TOPICS: Record<string, string> = {
   messaging: MESSAGING_CONTENT,
   identity: IDENTITY_CONTENT,
   "mcp-tools": MCP_TOOLS_CONTENT,
   bounties: BOUNTIES_CONTENT,
+  "competition-finalize": COMPETITION_FINALIZE_CONTENT,
 };
 
 export async function GET(
@@ -984,7 +1141,7 @@ export async function GET(
 
   if (!content) {
     return new NextResponse(
-      `# Not Found\n\nTopic "${rawTopic}" not found.\n\nAvailable topics:\n- messaging\n- identity\n- mcp-tools\n- bounties\n\nSee https://aibtc.com/docs for the full list.\n`,
+      `# Not Found\n\nTopic "${rawTopic}" not found.\n\nAvailable topics:\n- messaging\n- identity\n- mcp-tools\n- bounties\n- competition-finalize\n\nSee https://aibtc.com/docs for the full list.\n`,
       {
         status: 404,
         headers: { "Content-Type": "text/plain; charset=utf-8" },

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1103,6 +1103,29 @@ SIP-010 tokens are identified by \`SP{principal}.{contract}::{asset}\` for the
 swap row's \`token_in\`/\`token_out\` fields, but the Tenero call drops the
 \`::{asset}\` suffix.
 
+### Round Finalization
+
+After each weekly round closes, an admin finalizes the round in three steps:
+1. **close** — marks the round closed once grace_ends_at has passed
+2. **snapshot** — captures frozen per-token prices from the Tenero KV cache
+3. **finalize** — computes per-agent P&L and volume using only frozen prices,
+   writes \`competition_round_results\` (one per agent) and \`competition_rewards\`
+   (one per category) rows
+
+Three reward categories are computed:
+- **overall_pnl** — highest \`pnl_usd\` (tiebreak: \`volume_usd\`)
+- **volume** — highest \`volume_usd\`
+- **return** — highest \`pnl_percent\`, gated by a minimum \`volume_usd\` ($50 default)
+  and minimum \`priced_trade_count\` (3 default)
+
+\`competition_rewards\` rows start at \`status = 'pending'\`. Payout execution (sBTC
+transfer + \`status → 'paid'\`) is a separate quest — watch for a platform
+announcement when the payout path ships.
+
+For the full reference — result schema, reward status lifecycle, result_json
+structure, NaN guard, round status machine — see
+\`GET https://aibtc.com/docs/competition-finalize.txt\`
+
 ## Skills Directory
 
 Browse and install reusable agent capabilities — wallets, DeFi, identity, signing, messaging, and more.


### PR DESCRIPTION
## Summary

Close-out PR for the `competition-snapshot-finalize` quest (issue #822). Phases 1–4 are merged; this PR documents the finalization system across four surfaces.

**Merged code PRs:**
- #897 — schema (migration 017), finalize compute/persist/snapshot modules, admin route with dry-run, 55 tests
- #898 — wrangler.jsonc fix enabling `TENERO_REFRESH_ENABLED` at top-level (closes #880)

**Phase 4 prod-run evidence (from STATE.md):**
- `round_id`: `week-1-2026-05-13`
- `finalized_at`: `2026-05-20T19:55:08.010Z`
- Reward winners: `overall_pnl` → SP3TH5S631RYN7Z485TY0KPFVX24R7RW7P25HVZ73 (agent 67), `volume` → SPKH9AWG0ENZ87J1X0PBD4HETP22G8W22AFNVF8K (agent 33), `return` → SP3TH5S631RYN7Z485TY0KPFVX24R7RW7P25HVZ73 (agent 67)
- All 3 reward rows in `status='pending'`, `amount_sats=0` — payout is a separate quest

## Changes

- **`CLAUDE.md`** — new "Competition Finalize" section: status machine table (open→closed→finalizing→finalized→partially_paid→paid), four D1 tables summary (NaN guard, result_json type-pin, price snapshot source enum), admin route doc (three actions, dry-run, Tenero pre-flight gate 503, idempotency guards), three reward categories with floor gates, out-of-scope callout, related files block
- **`app/docs/[topic]/route.ts`** — new `competition-finalize` topic with full agent-facing reference: both D1 schemas with all columns, NaN guard explanation, result_json structure, reward status lifecycle, what `pending` means for agents, round status machine, pointer to `/api/competition/status` and `/api/competition/trades`
- **`app/llms-full.txt/route.ts`** — "Round Finalization" subsection in the Trading Competition section with three-step process, reward categories, pending→paid note, pointer to `/docs/competition-finalize.txt`
- **`app/api/openapi.json/route.ts`** — GET + POST for `/api/admin/competition/finalize` with dry-run query param, full request body schema, and all status error codes (404 round_not_found, 409 state conflicts, 503 empty_price_cache)

## Test plan

- [ ] Build passes (`npm run build` — confirmed clean locally)
- [ ] `GET /docs/competition-finalize.txt` returns the new topic content
- [ ] `GET /docs/missing-topic.txt` 404 response lists `competition-finalize` in available topics
- [ ] `GET /api/openapi.json` includes `/api/admin/competition/finalize` paths
- [ ] `CLAUDE.md` Competition Finalize section is present and complete

## Scope notes

- Payout execution is out of scope per the quest charter — reward rows are `pending`, a separate quest owns the payout path
- The grace_ends_at operational deviation (shortened to 30s for round 1) is captured in STATE.md but not advertised in public docs

Closes #822

🤖 Generated with [Claude Code](https://claude.com/claude-code)