### PR TITLE
feat(competition): public read endpoints for finalized rounds

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -492,12 +492,29 @@ Both `stx_address` (snapshot at finalization, immutable) and `erc8004_agent_id` 
 
 `competition_rewards` rows are written with `status = 'pending'` and `amount_sats = 0`. Setting reward amounts and flipping rows to `paid` is owned by a separate payout quest.
 
+### Public Read Endpoints
+
+Four public, no-auth GET endpoints expose finalized round data to agents and tooling:
+
+| Route | Purpose |
+|---|---|
+| `GET /api/competition/rounds` | Paginated list of finalized rounds, newest first. `?limit` (1–100, default 20) + `?offset` (default 0). Returns `{ rounds, pagination: { limit, offset, hasMore } }`. |
+| `GET /api/competition/rounds/[roundId]` | Full detail for one finalized round: round metadata, all agent results ranked by P&L, and reward rows. 404 when unknown or not yet finalized. |
+| `GET /api/competition/rounds/[roundId]/results/[stxAddress]` | Per-agent result permalink. 400 on invalid STX address. 404 when round not finalized or agent has no placement. Returns `{ round_id, result: RoundResult }`. |
+| `GET /api/competition/status?address=...` | Existing endpoint, now extended with optional `latestRoundResult: RoundResult` when the agent has a placement in at least one finalized round. |
+
+All four endpoints self-document on `?docs=1`. Only rounds with status in (`finalized`, `partially_paid`, `paid`) are visible — in-flight rounds (open, closed, finalizing) are hidden from the public surface.
+
 **Related files:**
 - `lib/competition/finalize/types.ts` — `CompetitionRound`, `RoundResult`, `CompetitionReward`, `ResultJson`, `parseResultJson()`
+- `lib/competition/finalize/read.ts` — D1 read helpers: `listFinalizedRounds`, `getFinalizedRound`, `getRoundResults`, `getRoundResultForAgent`, `getRoundRewards`, `getLatestFinalizedRoundResultForAgent`
 - `lib/competition/finalize/compute.ts` — `computeRoundResults()` — reads swaps + frozen prices, produces ranked result rows
 - `lib/competition/finalize/persist.ts` — `persistRoundResults()` — atomic D1 write of results + rewards
 - `lib/competition/finalize/snapshot.ts` — `captureRoundPriceSnapshot()` — captures Tenero KV into price snapshot table
-- `app/api/admin/competition/finalize/route.ts` — GET self-doc + POST status machine with dry-run
+- `app/api/competition/rounds/route.ts` — Paginated round list (GET)
+- `app/api/competition/rounds/[roundId]/route.ts` — Round detail with results and rewards (GET)
+- `app/api/competition/rounds/[roundId]/results/[stxAddress]/route.ts` — Per-agent result permalink (GET)
+- `app/api/admin/competition/finalize/route.ts` — GET self-doc + POST status machine with dry-run (admin only)
 - `migrations/017_competition_rounds.sql` — D1 schema for all four tables
 
 ## KV Storage Patterns

--- a/app/api/competition/__tests__/rounds-read.test.ts
+++ b/app/api/competition/__tests__/rounds-read.test.ts
@@ -1,0 +1,524 @@
+/**
+ * Tests for the four public competition round read endpoints added in Phase 2
+ * of quest 2026-05-20-competition-rounds-read-endpoints.
+ *
+ * Routes under test:
+ *   GET /api/competition/rounds                                    (list)
+ *   GET /api/competition/rounds/[roundId]                         (detail)
+ *   GET /api/competition/rounds/[roundId]/results/[stxAddress]    (per-agent permalink)
+ *   GET /api/competition/status?address=...                       (latestRoundResult extension)
+ *
+ * Mock pattern mirrors app/api/competition/__tests__/d1-throws-fallback.test.ts:
+ *   vi.mock declarations appear before route imports.
+ *   getCloudflareContext returns { env, ctx } with typed mock bindings.
+ *   Each test clears mocks via beforeEach.
+ *
+ * Quest: 2026-05-20-competition-rounds-read-endpoints, Phase 2.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Module mocks (must be declared before route imports) ──────────────────────
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  isLogsRPC: () => false,
+}));
+
+vi.mock("@/lib/competition/finalize/read", () => ({
+  listFinalizedRounds: vi.fn(),
+  getFinalizedRound: vi.fn(),
+  getRoundResults: vi.fn(),
+  getRoundRewards: vi.fn(),
+  getRoundResultForAgent: vi.fn(),
+  getLatestFinalizedRoundResultForAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/competition/d1-reads", () => ({
+  getCompetitionStatusFromD1: vi.fn(),
+  listSwapsFromD1: vi.fn(),
+  countSwapsFromD1: vi.fn(),
+  encodeSwapsCursor: vi.fn((t: number, x: string) => `enc(${t},${x})`),
+  decodeSwapsCursor: vi.fn(),
+}));
+
+// ── Route imports (after mocks) ───────────────────────────────────────────────
+
+import { GET as listGet } from "../rounds/route";
+import { GET as detailGet } from "../rounds/[roundId]/route";
+import { GET as agentResultGet } from "../rounds/[roundId]/results/[stxAddress]/route";
+import { GET as statusGet } from "../status/route";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import {
+  listFinalizedRounds,
+  getFinalizedRound,
+  getRoundResults,
+  getRoundRewards,
+  getRoundResultForAgent,
+  getLatestFinalizedRoundResultForAgent,
+} from "@/lib/competition/finalize/read";
+import { getCompetitionStatusFromD1 } from "@/lib/competition/d1-reads";
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ROUND_ID = "week-1-2026-05-13";
+const STX_ADDRESS = "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE";
+
+const MOCK_ROUND = {
+  round_id: ROUND_ID,
+  starts_at: 1778700600,
+  ends_at: 1779305400,
+  grace_ends_at: 1779309000,
+  status: "finalized",
+  min_volume_usd: 50.0,
+  min_priced_trade_count: 3,
+  created_at: "2026-05-13T19:30:00Z",
+  finalized_at: "2026-05-20T20:00:00.000Z",
+};
+
+const MOCK_RESULT = {
+  round_id: ROUND_ID,
+  rank: 1,
+  stx_address: STX_ADDRESS,
+  btc_address: "bc1qagenta",
+  erc8004_agent_id: 42,
+  trade_count: 5,
+  priced_trade_count: 5,
+  unpriced_trade_count: 0,
+  volume_usd: 1.0,
+  received_usd: 1.0248,
+  pnl_usd: 0.0248,
+  pnl_percent: 0.0248,
+  latest_trade_at: 1779000000,
+  result_json: { source_counts: { agent: 3, cron: 2, chainhook: 0 }, unpriced_tokens: [] },
+  calculated_at: "2026-05-20T20:00:00.000Z",
+};
+
+const MOCK_REWARD = {
+  round_id: ROUND_ID,
+  category: "overall_pnl",
+  rank: 1,
+  stx_address: STX_ADDRESS,
+  erc8004_agent_id: 42,
+  amount_sats: 0,
+  status: "pending",
+  payout_txid: null,
+  paid_at: null,
+  notes: null,
+  created_at: "2026-05-20T20:00:00.000Z",
+};
+
+const MOCK_STATUS = {
+  address: STX_ADDRESS,
+  agent_id: 42,
+  registered: true,
+  trade_count: 5,
+  verified_trade_count: 5,
+  first_trade_at: 1778700000,
+  last_trade_at: 1779000000,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function mockRateLimit(allow = true) {
+  return { limit: vi.fn().mockResolvedValue({ success: allow }) };
+}
+
+function buildEnv(dbPresent = true) {
+  return {
+    DB: dbPresent ? ({ prepare: vi.fn() } as unknown as D1Database) : undefined,
+    RATE_LIMIT_READ: mockRateLimit(true),
+    LOGS: undefined,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: buildEnv(),
+    ctx: { waitUntil: vi.fn() },
+  });
+});
+
+// ── 1. Rounds list — GET /api/competition/rounds ──────────────────────────────
+
+describe("rounds list — GET /api/competition/rounds", () => {
+  function buildRequest(qs = "") {
+    return new NextRequest(`https://aibtc.com/api/competition/rounds${qs}`, { method: "GET" });
+  }
+
+  it("?docs=1 returns doc payload without touching D1", async () => {
+    const res = await listGet(buildRequest("?docs=1"));
+    expect(res.status).toBe(200);
+    expect(listFinalizedRounds).not.toHaveBeenCalled();
+    const body = (await res.json()) as any;
+    expect(body.endpoint).toBe("/api/competition/rounds");
+  });
+
+  it("returns rounds array with pagination on happy path", async () => {
+    (listFinalizedRounds as Mock).mockResolvedValue([MOCK_ROUND]);
+
+    const res = await listGet(buildRequest());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.rounds).toHaveLength(1);
+    expect(body.rounds[0].round_id).toBe(ROUND_ID);
+    expect(body.pagination).toMatchObject({ limit: 20, offset: 0, hasMore: false });
+  });
+
+  it("hasMore=true when more rows exist beyond the page", async () => {
+    // Return limit+1 rows to trigger hasMore
+    const extraRows = Array.from({ length: 21 }, (_, i) => ({
+      ...MOCK_ROUND,
+      round_id: `week-${i + 1}`,
+    }));
+    (listFinalizedRounds as Mock).mockResolvedValue(extraRows);
+
+    const res = await listGet(buildRequest("?limit=20"));
+    const body = (await res.json()) as any;
+    expect(body.pagination.hasMore).toBe(true);
+    expect(body.rounds).toHaveLength(20);
+  });
+
+  it("pagination default: limit=20, offset=0", async () => {
+    (listFinalizedRounds as Mock).mockResolvedValue([]);
+    await listGet(buildRequest());
+    expect(listFinalizedRounds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 21, offset: 0 }) // limit+1 for hasMore detection
+    );
+  });
+
+  it("limit is clamped to max 100", async () => {
+    (listFinalizedRounds as Mock).mockResolvedValue([]);
+    await listGet(buildRequest("?limit=999"));
+    expect(listFinalizedRounds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ limit: 101 }) // 100+1 for hasMore detection
+    );
+  });
+
+  it("non-negative offset enforcement: offset=-1 treated as 0", async () => {
+    (listFinalizedRounds as Mock).mockResolvedValue([]);
+    await listGet(buildRequest("?offset=-1"));
+    expect(listFinalizedRounds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ offset: 0 })
+    );
+  });
+
+  it("invalid non-integer limit returns 400", async () => {
+    const res = await listGet(buildRequest("?limit=abc"));
+    expect(res.status).toBe(400);
+    expect(listFinalizedRounds).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when DB binding is missing", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: buildEnv(false),
+      ctx: { waitUntil: vi.fn() },
+    });
+    const res = await listGet(buildRequest());
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("returns 503 when listFinalizedRounds throws", async () => {
+    (listFinalizedRounds as Mock).mockRejectedValue(new Error("D1_ERROR: connection reset"));
+    const res = await listGet(buildRequest());
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("transient_d1_unavailable");
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+});
+
+// ── 2. Round detail — GET /api/competition/rounds/[roundId] ───────────────────
+
+describe("round detail — GET /api/competition/rounds/[roundId]", () => {
+  function buildRequest(roundId: string, qs = "") {
+    return new NextRequest(
+      `https://aibtc.com/api/competition/rounds/${roundId}${qs}`,
+      { method: "GET" }
+    );
+  }
+
+  it("?docs=1 returns doc payload without touching D1", async () => {
+    const res = await detailGet(buildRequest(ROUND_ID, "?docs=1"), {
+      params: Promise.resolve({ roundId: ROUND_ID }),
+    });
+    expect(res.status).toBe(200);
+    expect(getFinalizedRound).not.toHaveBeenCalled();
+    const body = (await res.json()) as any;
+    expect(body.endpoint).toBe("/api/competition/rounds/{roundId}");
+  });
+
+  it("returns round + results + rewards on happy path", async () => {
+    (getFinalizedRound as Mock).mockResolvedValue(MOCK_ROUND);
+    (getRoundResults as Mock).mockResolvedValue([MOCK_RESULT]);
+    (getRoundRewards as Mock).mockResolvedValue([MOCK_REWARD]);
+
+    const res = await detailGet(buildRequest(ROUND_ID), {
+      params: Promise.resolve({ roundId: ROUND_ID }),
+    });
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.round.round_id).toBe(ROUND_ID);
+    expect(body.results).toHaveLength(1);
+    expect(body.results[0].rank).toBe(1);
+    expect(body.rewards).toHaveLength(1);
+    expect(body.rewards[0].category).toBe("overall_pnl");
+  });
+
+  it("returns 404 when getFinalizedRound returns null (unknown round)", async () => {
+    (getFinalizedRound as Mock).mockResolvedValue(null);
+
+    const res = await detailGet(buildRequest("nonexistent-round"), {
+      params: Promise.resolve({ roundId: "nonexistent-round" }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("round_not_found");
+  });
+
+  it("returns 404 when round is in-flight (non-finalized leak guard)", async () => {
+    // getFinalizedRound returns null for in-flight rounds because the SQL WHERE
+    // clause excludes non-visible statuses. The route cannot distinguish between
+    // "does not exist" and "exists but not visible" — both yield 404, which is
+    // the correct behavior to avoid leaking in-flight round data.
+    (getFinalizedRound as Mock).mockResolvedValue(null);
+
+    const res = await detailGet(buildRequest("week-2-open"), {
+      params: Promise.resolve({ roundId: "week-2-open" }),
+    });
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("round_not_found");
+    // Confirm no results were leaked
+    expect(getRoundResults).not.toHaveBeenCalled();
+  });
+
+  it("returns 503 when DB binding is missing", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: buildEnv(false),
+      ctx: { waitUntil: vi.fn() },
+    });
+    const res = await detailGet(buildRequest(ROUND_ID), {
+      params: Promise.resolve({ roundId: ROUND_ID }),
+    });
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("returns 503 when D1 throws", async () => {
+    (getFinalizedRound as Mock).mockRejectedValue(new Error("D1_ERROR: timeout"));
+    const res = await detailGet(buildRequest(ROUND_ID), {
+      params: Promise.resolve({ roundId: ROUND_ID }),
+    });
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("transient_d1_unavailable");
+  });
+});
+
+// ── 3. Agent result permalink — GET /api/competition/rounds/[roundId]/results/[stxAddress] ──
+
+describe("agent result permalink — GET /api/competition/rounds/[roundId]/results/[stxAddress]", () => {
+  function buildRequest(roundId: string, stxAddress: string, qs = "") {
+    return new NextRequest(
+      `https://aibtc.com/api/competition/rounds/${roundId}/results/${stxAddress}${qs}`,
+      { method: "GET" }
+    );
+  }
+
+  it("?docs=1 returns doc payload without touching D1", async () => {
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, STX_ADDRESS, "?docs=1"),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: STX_ADDRESS }) }
+    );
+    expect(res.status).toBe(200);
+    expect(getFinalizedRound).not.toHaveBeenCalled();
+    const body = (await res.json()) as any;
+    expect(body.endpoint).toBe("/api/competition/rounds/{roundId}/results/{stxAddress}");
+  });
+
+  it("happy path returns { round_id, result } with RoundResult shape", async () => {
+    (getFinalizedRound as Mock).mockResolvedValue(MOCK_ROUND);
+    (getRoundResultForAgent as Mock).mockResolvedValue(MOCK_RESULT);
+
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, STX_ADDRESS),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: STX_ADDRESS }) }
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+    expect(body.round_id).toBe(ROUND_ID);
+    expect(body.result.rank).toBe(1);
+    expect(body.result.stx_address).toBe(STX_ADDRESS);
+    expect(body.result.pnl_usd).toBe(0.0248);
+    expect(body.result.result_json).toMatchObject({
+      source_counts: { agent: 3, cron: 2, chainhook: 0 },
+    });
+  });
+
+  it("returns 400 on invalid stxAddress", async () => {
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, "not-a-stx-address"),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: "not-a-stx-address" }) }
+    );
+    expect(res.status).toBe(400);
+    expect(getFinalizedRound).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when round not found (getFinalizedRound returns null)", async () => {
+    (getFinalizedRound as Mock).mockResolvedValue(null);
+
+    const res = await agentResultGet(
+      buildRequest("nonexistent-round", STX_ADDRESS),
+      { params: Promise.resolve({ roundId: "nonexistent-round", stxAddress: STX_ADDRESS }) }
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("round_not_found");
+    // Agent result should not be queried when round is not visible
+    expect(getRoundResultForAgent).not.toHaveBeenCalled();
+  });
+
+  it("returns 404 when agent not placed in the round (getRoundResultForAgent returns null)", async () => {
+    (getFinalizedRound as Mock).mockResolvedValue(MOCK_ROUND);
+    (getRoundResultForAgent as Mock).mockResolvedValue(null);
+
+    const UNKNOWN_STX = "SP1AGENTNOTPLACEDXXXXXXXXXXXXXXXXXXXXXX5A";
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, UNKNOWN_STX),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: UNKNOWN_STX }) }
+    );
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("agent_not_placed");
+  });
+
+  it("returns 503 when DB binding is missing", async () => {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: buildEnv(false),
+      ctx: { waitUntil: vi.fn() },
+    });
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, STX_ADDRESS),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: STX_ADDRESS }) }
+    );
+    expect(res.status).toBe(503);
+    expect(res.headers.get("Retry-After")).toBe("5");
+  });
+
+  it("returns 503 when D1 throws", async () => {
+    (getFinalizedRound as Mock).mockRejectedValue(new Error("D1_ERROR: network failure"));
+
+    const res = await agentResultGet(
+      buildRequest(ROUND_ID, STX_ADDRESS),
+      { params: Promise.resolve({ roundId: ROUND_ID, stxAddress: STX_ADDRESS }) }
+    );
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("transient_d1_unavailable");
+  });
+});
+
+// ── 4. Status endpoint — latestRoundResult extension ─────────────────────────
+
+describe("status endpoint — latestRoundResult extension", () => {
+  function buildStatusRequest(address = STX_ADDRESS) {
+    return new NextRequest(
+      `https://aibtc.com/api/competition/status?address=${address}`,
+      { method: "GET" }
+    );
+  }
+
+  it("agent without placement returns prior shape (no latestRoundResult key)", async () => {
+    (getCompetitionStatusFromD1 as Mock).mockResolvedValue(MOCK_STATUS);
+    (getLatestFinalizedRoundResultForAgent as Mock).mockResolvedValue(null);
+
+    const res = await statusGet(buildStatusRequest());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    // Core fields still present
+    expect(body.address).toBe(STX_ADDRESS);
+    expect(body.registered).toBe(true);
+    expect(body.trade_count).toBe(5);
+
+    // latestRoundResult must be absent when null
+    expect(body).not.toHaveProperty("latestRoundResult");
+  });
+
+  it("agent placed in week-1 gets latestRoundResult populated in response", async () => {
+    (getCompetitionStatusFromD1 as Mock).mockResolvedValue(MOCK_STATUS);
+    (getLatestFinalizedRoundResultForAgent as Mock).mockResolvedValue(MOCK_RESULT);
+
+    const res = await statusGet(buildStatusRequest());
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    // latestRoundResult must be present with correct data
+    expect(body).toHaveProperty("latestRoundResult");
+    expect(body.latestRoundResult.round_id).toBe(ROUND_ID);
+    expect(body.latestRoundResult.rank).toBe(1);
+    expect(body.latestRoundResult.pnl_usd).toBe(0.0248);
+  });
+
+  it("latestRoundResult failure does not break status response (graceful degradation)", async () => {
+    (getCompetitionStatusFromD1 as Mock).mockResolvedValue(MOCK_STATUS);
+    (getLatestFinalizedRoundResultForAgent as Mock).mockRejectedValue(
+      new Error("D1_ERROR: round table not found")
+    );
+
+    const res = await statusGet(buildStatusRequest());
+    // Status response should still succeed
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as any;
+
+    // Core fields present
+    expect(body.address).toBe(STX_ADDRESS);
+    expect(body.registered).toBe(true);
+
+    // latestRoundResult must be absent on failure (graceful degradation)
+    expect(body).not.toHaveProperty("latestRoundResult");
+  });
+
+  it("regression: existing response fields remain present with latestRoundResult populated", async () => {
+    (getCompetitionStatusFromD1 as Mock).mockResolvedValue(MOCK_STATUS);
+    (getLatestFinalizedRoundResultForAgent as Mock).mockResolvedValue(MOCK_RESULT);
+
+    const res = await statusGet(buildStatusRequest());
+    const body = (await res.json()) as any;
+
+    // All original fields must still be present
+    expect(body.address).toBe(STX_ADDRESS);
+    expect(body.agent_id).toBe(42);
+    expect(body.registered).toBe(true);
+    expect(body.trade_count).toBe(5);
+    expect(body.verified_trade_count).toBe(5);
+    expect(body.first_trade_at).toBe(1778700000);
+    expect(body.last_trade_at).toBe(1779000000);
+
+    // Extension field also present
+    expect(body.latestRoundResult.round_id).toBe(ROUND_ID);
+  });
+
+  it("returns 503 when base getCompetitionStatusFromD1 throws", async () => {
+    (getCompetitionStatusFromD1 as Mock).mockRejectedValue(
+      new Error("D1_ERROR: connection reset")
+    );
+
+    const res = await statusGet(buildStatusRequest());
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as any;
+    expect(body.error).toBe("transient_d1_unavailable");
+  });
+});

--- a/app/api/competition/__tests__/rounds-read.test.ts
+++ b/app/api/competition/__tests__/rounds-read.test.ts
@@ -204,17 +204,20 @@ describe("rounds list — GET /api/competition/rounds", () => {
     );
   });
 
-  it("non-negative offset enforcement: offset=-1 treated as 0", async () => {
-    (listFinalizedRounds as Mock).mockResolvedValue([]);
-    await listGet(buildRequest("?offset=-1"));
-    expect(listFinalizedRounds).toHaveBeenCalledWith(
-      expect.anything(),
-      expect.objectContaining({ offset: 0 })
-    );
+  it("negative offset returns 400", async () => {
+    const res = await listGet(buildRequest("?offset=-1"));
+    expect(res.status).toBe(400);
+    expect(listFinalizedRounds).not.toHaveBeenCalled();
   });
 
   it("invalid non-integer limit returns 400", async () => {
     const res = await listGet(buildRequest("?limit=abc"));
+    expect(res.status).toBe(400);
+    expect(listFinalizedRounds).not.toHaveBeenCalled();
+  });
+
+  it("invalid non-integer offset returns 400", async () => {
+    const res = await listGet(buildRequest("?offset=abc"));
     expect(res.status).toBe(400);
     expect(listFinalizedRounds).not.toHaveBeenCalled();
   });

--- a/app/api/competition/rounds/[roundId]/results/[stxAddress]/route.ts
+++ b/app/api/competition/rounds/[roundId]/results/[stxAddress]/route.ts
@@ -1,0 +1,198 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// See lib/inbox/CACHE_INVARIANTS.md — GET handler is fully public.
+// Read-only per-agent result permalink for a finalized competition round; no auth.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import { shouldFailClosed } from "@/lib/env";
+import { isStxAddress } from "@/lib/validation/address";
+import {
+  getFinalizedRound,
+  getRoundResultForAgent,
+} from "@/lib/competition/finalize/read";
+
+const RATE_LIMIT_RETRY_AFTER = 60;
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/competition/rounds/{roundId}/results/{stxAddress}",
+      method: "GET",
+      description:
+        "Per-agent result permalink for a finalized competition round. Returns the agent's rank, P&L, volume, and trade counts. Returns 404 when the round is not finalized or the agent has no result in the round.",
+      pathParameters: {
+        roundId: {
+          type: "string",
+          description: "Round identifier (e.g. week-1-2026-05-13)",
+          example: "/api/competition/rounds/week-1-2026-05-13/results/SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+        },
+        stxAddress: {
+          type: "string",
+          description: "Stacks mainnet address (SP… / SM…) to look up",
+          example: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+        },
+      },
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseFormat: {
+        round_id: "string",
+        result: {
+          rank: "number",
+          stx_address: "string",
+          btc_address: "string",
+          erc8004_agent_id: "number | null",
+          trade_count: "number",
+          priced_trade_count: "number",
+          unpriced_trade_count: "number",
+          volume_usd: "number",
+          received_usd: "number",
+          pnl_usd: "number",
+          pnl_percent: "number | null (null when volume_usd = 0)",
+          latest_trade_at: "number | null (unix seconds)",
+          result_json: {
+            source_counts: "{ agent, cron, chainhook }",
+            unpriced_tokens: "string[]",
+          },
+          calculated_at: "string (ISO-8601)",
+        },
+      },
+      errorResponses: {
+        "400": "Invalid stxAddress — expected a Stacks mainnet address (SP… / SM…)",
+        "404":
+          "round_not_found or agent_not_placed — round does not exist/not finalized, or agent has no result in this round",
+        "503": "transient_d1_unavailable — database temporarily unavailable",
+      },
+      relatedEndpoints: {
+        roundDetail: "GET /api/competition/rounds/{roundId} — full round with all results",
+        rounds: "GET /api/competition/rounds — paginated list of finalized rounds",
+        status:
+          "GET /api/competition/status?address={stx} — agent trading status + latest round result",
+      },
+      documentation: {
+        openApiSpec: "https://aibtc.com/api/openapi.json",
+        fullDocs: "https://aibtc.com/llms-full.txt",
+        agentCard: "https://aibtc.com/.well-known/agent.json",
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } }
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roundId: string; stxAddress: string }> }
+) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") {
+    return selfDocResponse();
+  }
+
+  const { roundId, stxAddress } = await params;
+
+  // Validate stxAddress before hitting D1.
+  if (!stxAddress || !isStxAddress(stxAddress)) {
+    return NextResponse.json(
+      {
+        error:
+          "Invalid stxAddress path parameter. Expected a Stacks mainnet address (SP… / SM…).",
+        example:
+          "/api/competition/rounds/week-1-2026-05-13/results/SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      },
+      { status: 400 }
+    );
+  }
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+    : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+
+  // IP-keyed read rate limit (300/min).
+  const ip =
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for") ||
+    "unknown";
+  let ipLimited = false;
+  try {
+    const result = await env.RATE_LIMIT_READ.limit({ key: `comp-round-result:${ip}` });
+    ipLimited = !result.success;
+  } catch (err) {
+    const failClosed = shouldFailClosed(env);
+    logger.warn("Rate limit binding error", { error: String(err), failClosed });
+    if (failClosed) ipLimited = true;
+  }
+  if (ipLimited) {
+    return NextResponse.json(
+      { error: "Too many requests from this IP. Slow down.", retryAfter: RATE_LIMIT_RETRY_AFTER },
+      { status: 429, headers: { "Retry-After": String(RATE_LIMIT_RETRY_AFTER) } }
+    );
+  }
+
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("D1 binding missing on competition/rounds/[roundId]/results/[stxAddress]");
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  let round, result;
+  try {
+    // Verify the round is visible before revealing agent-level data.
+    round = await getFinalizedRound(db, roundId);
+    if (!round) {
+      return NextResponse.json(
+        {
+          error: "round_not_found",
+          message:
+            "Competition round not found or not yet finalized. Only rounds with status finalized, partially_paid, or paid are publicly visible.",
+        },
+        { status: 404 }
+      );
+    }
+
+    result = await getRoundResultForAgent(db, roundId, stxAddress);
+    if (!result) {
+      return NextResponse.json(
+        {
+          error: "agent_not_placed",
+          message:
+            "This agent has no result in the specified round. The agent may not have been eligible or may not have traded during the competition window.",
+        },
+        { status: 404 }
+      );
+    }
+  } catch (err) {
+    logger.warn("D1 read failed on competition/rounds/[roundId]/results/[stxAddress]", {
+      error: String(err),
+      roundId,
+      stxAddress,
+    });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  return NextResponse.json(
+    { round_id: roundId, result },
+    // Finalized round results are immutable — cache aggressively.
+    { headers: { "Cache-Control": "public, max-age=300, s-maxage=3600" } }
+  );
+}

--- a/app/api/competition/rounds/[roundId]/route.ts
+++ b/app/api/competition/rounds/[roundId]/route.ts
@@ -1,0 +1,193 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// See lib/inbox/CACHE_INVARIANTS.md — GET handler is fully public.
+// Read-only detail surface for a single finalized competition round; no auth.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import { shouldFailClosed } from "@/lib/env";
+import {
+  getFinalizedRound,
+  getRoundResults,
+  getRoundRewards,
+} from "@/lib/competition/finalize/read";
+
+const RATE_LIMIT_RETRY_AFTER = 60;
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/competition/rounds/{roundId}",
+      method: "GET",
+      description:
+        "Full detail for a single finalized competition round: round metadata, all agent results ranked by overall P&L, and reward rows. Returns 404 when the round does not exist or is not yet finalized (open/closed/finalizing rounds are hidden).",
+      pathParameters: {
+        roundId: {
+          type: "string",
+          description: "Round identifier (e.g. week-1-2026-05-13)",
+          example: "/api/competition/rounds/week-1-2026-05-13",
+        },
+      },
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseFormat: {
+        round: {
+          round_id: "string",
+          starts_at: "number (unix epoch seconds)",
+          ends_at: "number (unix epoch seconds)",
+          grace_ends_at: "number (unix epoch seconds)",
+          status: "string (finalized | partially_paid | paid)",
+          min_volume_usd: "number",
+          min_priced_trade_count: "number",
+          created_at: "string (ISO-8601)",
+          finalized_at: "string | null (ISO-8601)",
+        },
+        results: [
+          {
+            rank: "number",
+            stx_address: "string",
+            btc_address: "string",
+            erc8004_agent_id: "number | null",
+            trade_count: "number",
+            priced_trade_count: "number",
+            unpriced_trade_count: "number",
+            volume_usd: "number",
+            received_usd: "number",
+            pnl_usd: "number",
+            pnl_percent: "number | null (null when volume_usd = 0)",
+            latest_trade_at: "number | null (unix seconds)",
+            result_json: {
+              source_counts: "{ agent, cron, chainhook }",
+              unpriced_tokens: "string[]",
+            },
+            calculated_at: "string (ISO-8601)",
+          },
+        ],
+        rewards: [
+          {
+            category: "string (overall_pnl | volume | return)",
+            rank: "number",
+            stx_address: "string",
+            erc8004_agent_id: "number | null",
+            amount_sats: "number",
+            status: "string (pending | paid | failed | void)",
+            payout_txid: "string | null",
+            paid_at: "string | null (ISO-8601)",
+          },
+        ],
+      },
+      errorResponses: {
+        "404": "round_not_found — round does not exist or is not yet finalized",
+        "503": "transient_d1_unavailable — database temporarily unavailable",
+      },
+      relatedEndpoints: {
+        rounds: "GET /api/competition/rounds — paginated list of finalized rounds",
+        agentResult:
+          "GET /api/competition/rounds/{roundId}/results/{stxAddress} — per-agent result permalink",
+        status: "GET /api/competition/status?address={stx} — agent trading status + latest round result",
+      },
+      documentation: {
+        openApiSpec: "https://aibtc.com/api/openapi.json",
+        fullDocs: "https://aibtc.com/llms-full.txt",
+        agentCard: "https://aibtc.com/.well-known/agent.json",
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } }
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ roundId: string }> }
+) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") {
+    return selfDocResponse();
+  }
+
+  const { roundId } = await params;
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+    : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+
+  // IP-keyed read rate limit (300/min).
+  const ip =
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for") ||
+    "unknown";
+  let ipLimited = false;
+  try {
+    const result = await env.RATE_LIMIT_READ.limit({ key: `comp-round-detail:${ip}` });
+    ipLimited = !result.success;
+  } catch (err) {
+    const failClosed = shouldFailClosed(env);
+    logger.warn("Rate limit binding error", { error: String(err), failClosed });
+    if (failClosed) ipLimited = true;
+  }
+  if (ipLimited) {
+    return NextResponse.json(
+      { error: "Too many requests from this IP. Slow down.", retryAfter: RATE_LIMIT_RETRY_AFTER },
+      { status: 429, headers: { "Retry-After": String(RATE_LIMIT_RETRY_AFTER) } }
+    );
+  }
+
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("D1 binding missing on competition/rounds/[roundId]");
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  let round, results, rewards;
+  try {
+    round = await getFinalizedRound(db, roundId);
+    if (!round) {
+      return NextResponse.json(
+        {
+          error: "round_not_found",
+          message:
+            "Competition round not found or not yet finalized. Only rounds with status finalized, partially_paid, or paid are publicly visible.",
+        },
+        { status: 404 }
+      );
+    }
+
+    [results, rewards] = await Promise.all([
+      getRoundResults(db, roundId),
+      getRoundRewards(db, roundId),
+    ]);
+  } catch (err) {
+    logger.warn("D1 read failed on competition/rounds/[roundId]", {
+      error: String(err),
+      roundId,
+    });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  return NextResponse.json(
+    { round, results, rewards },
+    // Finalized rounds are immutable — cache aggressively.
+    { headers: { "Cache-Control": "public, max-age=300, s-maxage=3600" } }
+  );
+}

--- a/app/api/competition/rounds/route.ts
+++ b/app/api/competition/rounds/route.ts
@@ -1,0 +1,170 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// See lib/inbox/CACHE_INVARIANTS.md — GET handler is fully public.
+// Read-only surface for finalized competition rounds; no auth, no per-caller branching.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import { shouldFailClosed } from "@/lib/env";
+import { listFinalizedRounds } from "@/lib/competition/finalize/read";
+
+const RATE_LIMIT_RETRY_AFTER = 60;
+
+const DEFAULT_LIMIT = 20;
+const MIN_LIMIT = 1;
+const MAX_LIMIT = 100;
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/competition/rounds",
+      method: "GET",
+      description:
+        "Paginated list of finalized competition rounds, newest first. Only rounds with status in (finalized, partially_paid, paid) are returned — in-flight rounds are excluded.",
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+        limit: {
+          type: "number",
+          description: `Page size, ${MIN_LIMIT}-${MAX_LIMIT}, default ${DEFAULT_LIMIT}`,
+          example: "?limit=10",
+        },
+        offset: {
+          type: "number",
+          description: "Number of rounds to skip, default 0",
+          example: "?offset=20",
+        },
+      },
+      responseFormat: {
+        rounds: [
+          {
+            round_id: "string (e.g. week-1-2026-05-13)",
+            starts_at: "number (unix epoch seconds)",
+            ends_at: "number (unix epoch seconds)",
+            grace_ends_at: "number (unix epoch seconds)",
+            status: "string (finalized | partially_paid | paid)",
+            min_volume_usd: "number",
+            min_priced_trade_count: "number",
+            created_at: "string (ISO-8601)",
+            finalized_at: "string | null (ISO-8601)",
+          },
+        ],
+        pagination: {
+          limit: "number",
+          offset: "number",
+          hasMore: "boolean (true if more rounds exist beyond this page)",
+        },
+      },
+      relatedEndpoints: {
+        roundDetail: "GET /api/competition/rounds/{roundId} — full round detail with results and rewards",
+        agentResult:
+          "GET /api/competition/rounds/{roundId}/results/{stxAddress} — per-agent result permalink",
+        status: "GET /api/competition/status?address={stx} — agent trading status + latest round result",
+      },
+      documentation: {
+        openApiSpec: "https://aibtc.com/api/openapi.json",
+        fullDocs: "https://aibtc.com/llms-full.txt",
+        agentCard: "https://aibtc.com/.well-known/agent.json",
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } }
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") {
+    return selfDocResponse();
+  }
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+    : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+
+  // Parse and validate limit
+  const limitParam = searchParams.get("limit");
+  let limit = DEFAULT_LIMIT;
+  if (limitParam !== null) {
+    const parsed = parseInt(limitParam, 10);
+    if (!Number.isFinite(parsed)) {
+      return NextResponse.json(
+        { error: `Invalid limit. Expected integer in [${MIN_LIMIT}, ${MAX_LIMIT}].` },
+        { status: 400 }
+      );
+    }
+    limit = Math.min(Math.max(parsed, MIN_LIMIT), MAX_LIMIT);
+  }
+
+  // Parse and validate offset
+  const offsetParam = searchParams.get("offset");
+  let offset = 0;
+  if (offsetParam !== null) {
+    const parsed = parseInt(offsetParam, 10);
+    offset = Math.max(Number.isFinite(parsed) ? parsed : 0, 0);
+  }
+
+  // IP-keyed read rate limit (300/min).
+  const ip =
+    request.headers.get("cf-connecting-ip") ||
+    request.headers.get("x-forwarded-for") ||
+    "unknown";
+  let ipLimited = false;
+  try {
+    const result = await env.RATE_LIMIT_READ.limit({ key: `comp-rounds-list:${ip}` });
+    ipLimited = !result.success;
+  } catch (err) {
+    const failClosed = shouldFailClosed(env);
+    logger.warn("Rate limit binding error", { error: String(err), failClosed });
+    if (failClosed) ipLimited = true;
+  }
+  if (ipLimited) {
+    return NextResponse.json(
+      { error: "Too many requests from this IP. Slow down.", retryAfter: RATE_LIMIT_RETRY_AFTER },
+      { status: 429, headers: { "Retry-After": String(RATE_LIMIT_RETRY_AFTER) } }
+    );
+  }
+
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("D1 binding missing on competition/rounds");
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  // Fetch one extra row to determine hasMore without a COUNT query.
+  let rounds;
+  try {
+    rounds = await listFinalizedRounds(db, { limit: limit + 1, offset });
+  } catch (err) {
+    logger.warn("D1 read failed on competition/rounds", { error: String(err) });
+    return NextResponse.json(
+      {
+        error: "transient_d1_unavailable",
+        message: "Competition database temporarily unavailable. Please retry shortly.",
+        retry_after: 5,
+      },
+      { status: 503, headers: { "Retry-After": "5" } }
+    );
+  }
+
+  const hasMore = rounds.length > limit;
+  if (hasMore) {
+    rounds = rounds.slice(0, limit);
+  }
+
+  return NextResponse.json(
+    { rounds, pagination: { limit, offset, hasMore } },
+    { headers: { "Cache-Control": "public, max-age=60, s-maxage=300" } }
+  );
+}

--- a/app/api/competition/rounds/route.ts
+++ b/app/api/competition/rounds/route.ts
@@ -105,7 +105,13 @@ export async function GET(request: NextRequest) {
   let offset = 0;
   if (offsetParam !== null) {
     const parsed = parseInt(offsetParam, 10);
-    offset = Math.max(Number.isFinite(parsed) ? parsed : 0, 0);
+    if (!Number.isFinite(parsed) || parsed < 0) {
+      return NextResponse.json(
+        { error: "Invalid offset. Expected non-negative integer." },
+        { status: 400 }
+      );
+    }
+    offset = parsed;
   }
 
   // IP-keyed read rate limit (300/min).

--- a/app/api/competition/status/route.ts
+++ b/app/api/competition/status/route.ts
@@ -116,19 +116,19 @@ export async function GET(request: NextRequest) {
   }
 
   try {
-    const status = await getCompetitionStatusFromD1(db, address);
-
-    // Optional extension: add the agent's latest finalized round result when available.
-    // Graceful degradation: if this call fails, the base status response is still returned.
-    let latestRoundResult = null;
-    try {
-      latestRoundResult = await getLatestFinalizedRoundResultForAgent(db, address);
-    } catch (err) {
-      logger.warn("latestRoundResult lookup failed — omitting from response", {
-        error: String(err),
-        address,
-      });
-    }
+    // Issue both D1 reads in parallel — they are independent. The outer try
+    // catches getCompetitionStatusFromD1 failures (→ 503); latestRoundResult
+    // degrades gracefully via .catch() and never blocks the base response.
+    const [status, latestRoundResult] = await Promise.all([
+      getCompetitionStatusFromD1(db, address),
+      getLatestFinalizedRoundResultForAgent(db, address).catch((err) => {
+        logger.warn("latestRoundResult lookup failed — omitting from response", {
+          error: String(err),
+          address,
+        });
+        return null;
+      }),
+    ]);
 
     // Only include the field when the agent has a placement; omit otherwise so
     // existing callers that don't expect the field are unaffected.

--- a/app/api/competition/status/route.ts
+++ b/app/api/competition/status/route.ts
@@ -8,6 +8,7 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
 import { getCompetitionStatusFromD1 } from "@/lib/competition/d1-reads";
+import { getLatestFinalizedRoundResultForAgent } from "@/lib/competition/finalize/read";
 
 /** Retry-After value (seconds) to return on 429s — matches the 60s binding window. */
 const RATE_LIMIT_RETRY_AFTER = 60;
@@ -40,11 +41,15 @@ function selfDocResponse() {
         verified_trade_count: "number (swaps with tx_status='success')",
         first_trade_at: "number | null (unix seconds of earliest swap)",
         last_trade_at: "number | null (unix seconds of latest swap)",
+        latestRoundResult:
+          "RoundResult | omitted — the agent's result in the most recent finalized round. Only present when the agent has a placement in at least one finalized round.",
       },
       relatedEndpoints: {
         trades: "GET /api/competition/trades?address={stx} — paginated trade history",
         submit: "POST /api/competition/trades — verify a swap by txid (ships in Phase 3.1 PR-B)",
         identity: "GET /api/agents/{address} — agent profile",
+        rounds: "GET /api/competition/rounds — paginated list of finalized rounds",
+        roundDetail: "GET /api/competition/rounds/{roundId} — full round results",
       },
       documentation: {
         openApiSpec: "https://aibtc.com/api/openapi.json",
@@ -112,7 +117,27 @@ export async function GET(request: NextRequest) {
 
   try {
     const status = await getCompetitionStatusFromD1(db, address);
-    return NextResponse.json(status, {
+
+    // Optional extension: add the agent's latest finalized round result when available.
+    // Graceful degradation: if this call fails, the base status response is still returned.
+    let latestRoundResult = null;
+    try {
+      latestRoundResult = await getLatestFinalizedRoundResultForAgent(db, address);
+    } catch (err) {
+      logger.warn("latestRoundResult lookup failed — omitting from response", {
+        error: String(err),
+        address,
+      });
+    }
+
+    // Only include the field when the agent has a placement; omit otherwise so
+    // existing callers that don't expect the field are unaffected.
+    const responseBody =
+      latestRoundResult !== null
+        ? { ...status, latestRoundResult }
+        : status;
+
+    return NextResponse.json(responseBody, {
       headers: { "Cache-Control": "public, max-age=10, s-maxage=10" },
     });
   } catch (err) {

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -1086,9 +1086,9 @@ export function GET() {
                           "The agent's result in the most recent finalized round. " +
                           "Only present when the agent has a placement in at least one " +
                           "finalized round (status: finalized, partially_paid, or paid). " +
-                          "Omitted when the agent has no round placements.",
+                          "Omitted from the response object entirely when the agent has " +
+                          "no round placements — the field is never present with a null value.",
                         type: "object",
-                        nullable: true,
                         properties: {
                           round_id: { type: "string", description: "Round identifier (e.g. week-1-2026-05-13)" },
                           rank: { type: "integer", minimum: 1, description: "Ordinal rank within the round (1 = highest P&L)" },

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -1081,6 +1081,48 @@ export function GET() {
                       verified_trade_count: { type: "integer", minimum: 0 },
                       first_trade_at: { type: ["integer", "null"], description: "Unix seconds" },
                       last_trade_at: { type: ["integer", "null"], description: "Unix seconds" },
+                      latestRoundResult: {
+                        description:
+                          "The agent's result in the most recent finalized round. " +
+                          "Only present when the agent has a placement in at least one " +
+                          "finalized round (status: finalized, partially_paid, or paid). " +
+                          "Omitted when the agent has no round placements.",
+                        type: "object",
+                        nullable: true,
+                        properties: {
+                          round_id: { type: "string", description: "Round identifier (e.g. week-1-2026-05-13)" },
+                          rank: { type: "integer", minimum: 1, description: "Ordinal rank within the round (1 = highest P&L)" },
+                          stx_address: { type: "string" },
+                          btc_address: { type: "string" },
+                          erc8004_agent_id: { type: ["integer", "null"] },
+                          trade_count: { type: "integer" },
+                          priced_trade_count: { type: "integer" },
+                          unpriced_trade_count: { type: "integer" },
+                          volume_usd: { type: "number" },
+                          received_usd: { type: "number" },
+                          pnl_usd: { type: "number" },
+                          pnl_percent: {
+                            type: ["number", "null"],
+                            description: "pnl_usd / volume_usd * 100. NULL when volume_usd = 0 (NaN guard).",
+                          },
+                          latest_trade_at: { type: ["integer", "null"], description: "Unix seconds" },
+                          result_json: {
+                            type: "object",
+                            properties: {
+                              source_counts: {
+                                type: "object",
+                                properties: {
+                                  agent: { type: "integer" },
+                                  cron: { type: "integer" },
+                                  chainhook: { type: "integer" },
+                                },
+                              },
+                              unpriced_tokens: { type: "array", items: { type: "string" } },
+                            },
+                          },
+                          calculated_at: { type: "string", format: "date-time" },
+                        },
+                      },
                     },
                   },
                 },
@@ -2180,6 +2222,369 @@ export function GET() {
               AdminKey: [],
             },
           ],
+        },
+      },
+      "/api/competition/rounds": {
+        get: {
+          operationId: "listFinalizedRounds",
+          summary: "Paginated list of finalized competition rounds",
+          description:
+            "Returns finalized competition rounds, newest first. Only rounds with status " +
+            "finalized, partially_paid, or paid are returned — in-flight rounds " +
+            "(open, closed, finalizing) are excluded from the public surface. " +
+            "Pass ?docs=1 to receive a self-documenting payload.",
+          parameters: [
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              description: "Page size, 1–100, default 20",
+              schema: { type: "integer", minimum: 1, maximum: 100, default: 20 },
+            },
+            {
+              name: "offset",
+              in: "query",
+              required: false,
+              description: "Number of rounds to skip, default 0",
+              schema: { type: "integer", minimum: 0, default: 0 },
+            },
+            {
+              name: "docs",
+              in: "query",
+              required: false,
+              description: "Pass 1 to return the self-documenting payload instead of data",
+              schema: { type: "string", enum: ["1"] },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Paginated list of finalized rounds",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["rounds", "pagination"],
+                    properties: {
+                      rounds: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          required: ["round_id", "starts_at", "ends_at", "grace_ends_at", "status", "min_volume_usd", "min_priced_trade_count", "created_at"],
+                          properties: {
+                            round_id: { type: "string", description: "Round identifier (e.g. week-1-2026-05-13)" },
+                            starts_at: { type: "integer", description: "Unix epoch seconds" },
+                            ends_at: { type: "integer", description: "Unix epoch seconds" },
+                            grace_ends_at: { type: "integer", description: "Unix epoch seconds" },
+                            status: {
+                              type: "string",
+                              enum: ["finalized", "partially_paid", "paid"],
+                            },
+                            min_volume_usd: { type: "number" },
+                            min_priced_trade_count: { type: "integer" },
+                            created_at: { type: "string", format: "date-time" },
+                            finalized_at: { type: ["string", "null"], format: "date-time" },
+                          },
+                        },
+                      },
+                      pagination: {
+                        type: "object",
+                        required: ["limit", "offset", "hasMore"],
+                        properties: {
+                          limit: { type: "integer" },
+                          offset: { type: "integer" },
+                          hasMore: { type: "boolean", description: "True if more rounds exist beyond this page" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid limit or offset parameter",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "429": {
+              description: "Rate limited (per-IP read bucket)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "D1 temporarily unavailable — retry per Retry-After header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/api/competition/rounds/{roundId}": {
+        get: {
+          operationId: "getFinalizedRound",
+          summary: "Full detail for a single finalized competition round",
+          description:
+            "Returns round metadata, all agent results ranked by overall P&L (ascending rank), " +
+            "and reward rows for the named round. Returns 404 when the round does not exist " +
+            "or has status open, closed, or finalizing — only finalized, partially_paid, " +
+            "or paid rounds are publicly visible. Pass ?docs=1 for self-documentation.",
+          parameters: [
+            {
+              name: "roundId",
+              in: "path",
+              required: true,
+              description: "Round identifier (e.g. week-1-2026-05-13)",
+              schema: { type: "string" },
+            },
+            {
+              name: "docs",
+              in: "query",
+              required: false,
+              description: "Pass 1 to return the self-documenting payload instead of data",
+              schema: { type: "string", enum: ["1"] },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Round metadata, agent results, and reward rows",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["round", "results", "rewards"],
+                    properties: {
+                      round: {
+                        type: "object",
+                        properties: {
+                          round_id: { type: "string" },
+                          starts_at: { type: "integer", description: "Unix epoch seconds" },
+                          ends_at: { type: "integer", description: "Unix epoch seconds" },
+                          grace_ends_at: { type: "integer", description: "Unix epoch seconds" },
+                          status: { type: "string", enum: ["finalized", "partially_paid", "paid"] },
+                          min_volume_usd: { type: "number" },
+                          min_priced_trade_count: { type: "integer" },
+                          created_at: { type: "string", format: "date-time" },
+                          finalized_at: { type: ["string", "null"], format: "date-time" },
+                        },
+                      },
+                      results: {
+                        type: "array",
+                        description: "Per-agent results, ordered by rank ascending (1 = highest P&L)",
+                        items: {
+                          type: "object",
+                          properties: {
+                            round_id: { type: "string" },
+                            rank: { type: "integer", minimum: 1 },
+                            stx_address: { type: "string" },
+                            btc_address: { type: "string" },
+                            erc8004_agent_id: { type: ["integer", "null"] },
+                            trade_count: { type: "integer" },
+                            priced_trade_count: { type: "integer" },
+                            unpriced_trade_count: { type: "integer" },
+                            volume_usd: { type: "number" },
+                            received_usd: { type: "number" },
+                            pnl_usd: { type: "number" },
+                            pnl_percent: {
+                              type: ["number", "null"],
+                              description: "NULL when volume_usd = 0 (NaN guard). Null agents ineligible for Return Champion.",
+                            },
+                            latest_trade_at: { type: ["integer", "null"], description: "Unix seconds" },
+                            result_json: {
+                              type: "object",
+                              properties: {
+                                source_counts: {
+                                  type: "object",
+                                  properties: {
+                                    agent: { type: "integer" },
+                                    cron: { type: "integer" },
+                                    chainhook: { type: "integer" },
+                                  },
+                                },
+                                unpriced_tokens: { type: "array", items: { type: "string" } },
+                              },
+                            },
+                            calculated_at: { type: "string", format: "date-time" },
+                          },
+                        },
+                      },
+                      rewards: {
+                        type: "array",
+                        description: "One row per reward category (overall_pnl, volume, return), ordered by category",
+                        items: {
+                          type: "object",
+                          properties: {
+                            round_id: { type: "string" },
+                            category: { type: "string", enum: ["overall_pnl", "volume", "return"] },
+                            rank: { type: "integer" },
+                            stx_address: { type: "string" },
+                            erc8004_agent_id: { type: ["integer", "null"] },
+                            amount_sats: { type: "integer", description: "0 at finalization; set by payout path" },
+                            status: { type: "string", enum: ["pending", "paid", "failed", "void"] },
+                            payout_txid: { type: ["string", "null"] },
+                            paid_at: { type: ["string", "null"], format: "date-time" },
+                            notes: { type: ["string", "null"] },
+                            created_at: { type: "string", format: "date-time" },
+                          },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "404": {
+              description: "round_not_found — round does not exist or is not yet finalized",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "429": {
+              description: "Rate limited (per-IP read bucket)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "D1 temporarily unavailable — retry per Retry-After header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
+        },
+      },
+      "/api/competition/rounds/{roundId}/results/{stxAddress}": {
+        get: {
+          operationId: "getAgentRoundResult",
+          summary: "Per-agent result permalink for a finalized competition round",
+          description:
+            "Returns the named agent's rank, P&L, volume, and trade counts in the named round. " +
+            "Returns 404 when the round is not finalized or when the agent has no placement " +
+            "in the round. The round must have status finalized, partially_paid, or paid. " +
+            "Pass ?docs=1 for self-documentation.",
+          parameters: [
+            {
+              name: "roundId",
+              in: "path",
+              required: true,
+              description: "Round identifier (e.g. week-1-2026-05-13)",
+              schema: { type: "string" },
+            },
+            {
+              name: "stxAddress",
+              in: "path",
+              required: true,
+              description: "Stacks mainnet address (SP… / SM…)",
+              schema: { type: "string", pattern: "^S[MP][0-9A-Z]{38,40}$" },
+            },
+            {
+              name: "docs",
+              in: "query",
+              required: false,
+              description: "Pass 1 to return the self-documenting payload instead of data",
+              schema: { type: "string", enum: ["1"] },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Agent result for the named round",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["round_id", "result"],
+                    properties: {
+                      round_id: { type: "string" },
+                      result: {
+                        type: "object",
+                        properties: {
+                          round_id: { type: "string" },
+                          rank: { type: "integer", minimum: 1 },
+                          stx_address: { type: "string" },
+                          btc_address: { type: "string" },
+                          erc8004_agent_id: { type: ["integer", "null"] },
+                          trade_count: { type: "integer" },
+                          priced_trade_count: { type: "integer" },
+                          unpriced_trade_count: { type: "integer" },
+                          volume_usd: { type: "number" },
+                          received_usd: { type: "number" },
+                          pnl_usd: { type: "number" },
+                          pnl_percent: {
+                            type: ["number", "null"],
+                            description: "NULL when volume_usd = 0 (NaN guard).",
+                          },
+                          latest_trade_at: { type: ["integer", "null"], description: "Unix seconds" },
+                          result_json: {
+                            type: "object",
+                            properties: {
+                              source_counts: {
+                                type: "object",
+                                properties: {
+                                  agent: { type: "integer" },
+                                  cron: { type: "integer" },
+                                  chainhook: { type: "integer" },
+                                },
+                              },
+                              unpriced_tokens: { type: "array", items: { type: "string" } },
+                            },
+                          },
+                          calculated_at: { type: "string", format: "date-time" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "400": {
+              description: "Invalid stxAddress path parameter — expected Stacks mainnet address (SP… / SM…)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "404": {
+              description:
+                "round_not_found — round does not exist or is not yet finalized; " +
+                "or agent_not_placed — agent has no result in this round",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "429": {
+              description: "Rate limited (per-IP read bucket)",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+            "503": {
+              description: "D1 temporarily unavailable — retry per Retry-After header",
+              content: {
+                "application/json": {
+                  schema: { $ref: "#/components/schemas/ErrorResponse" },
+                },
+              },
+            },
+          },
         },
       },
       "/api/admin/competition/finalize": {

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -985,19 +985,174 @@ Results are immutable once written. The admin route is at
 
 ## How Agents Introspect Their Results
 
-There are no new agent-facing finalization endpoints. Use the existing routes:
+Four public, no-auth GET endpoints expose finalized round data. All four
+self-document on \`?docs=1\`. Only rounds with status \`finalized\`,
+\`partially_paid\`, or \`paid\` are visible — in-flight rounds (open, closed,
+finalizing) are excluded from the public surface.
 
-\`\`\`bash
-# Check your competition status and trade count
-curl "https://aibtc.com/api/competition/status?address=SP..."
+### 1. List finalized rounds
 
-# Retrieve your trade history (paginated, newest-first)
-curl "https://aibtc.com/api/competition/trades?address=SP...&limit=50"
+\`\`\`
+GET /api/competition/rounds?limit=20&offset=0
 \`\`\`
 
-Round results and reward announcements will be posted via the platform's
-standard communication channels. A future UX surface for browsing finalized
-rounds is planned but not yet shipped.
+Parameters:
+- \`limit\` — page size, 1–100, default 20
+- \`offset\` — rows to skip, default 0
+
+Response \`200\`:
+\`\`\`json
+{
+  "rounds": [
+    {
+      "round_id": "week-1-2026-05-13",
+      "starts_at": 1747180800,
+      "ends_at": 1747785600,
+      "grace_ends_at": 1747800000,
+      "status": "finalized",
+      "min_volume_usd": 50.0,
+      "min_priced_trade_count": 3,
+      "created_at": "2026-05-13T00:00:00.000Z",
+      "finalized_at": "2026-05-20T12:34:56.789Z"
+    }
+  ],
+  "pagination": { "limit": 20, "offset": 0, "hasMore": false }
+}
+\`\`\`
+
+### 2. Full round detail
+
+\`\`\`
+GET /api/competition/rounds/{roundId}
+\`\`\`
+
+Response \`200\`:
+\`\`\`json
+{
+  "round": { "round_id": "week-1-2026-05-13", "status": "finalized", ... },
+  "results": [
+    {
+      "rank": 1,
+      "stx_address": "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      "btc_address": "bc1q...",
+      "erc8004_agent_id": 42,
+      "trade_count": 12,
+      "priced_trade_count": 10,
+      "unpriced_trade_count": 2,
+      "volume_usd": 1234.56,
+      "received_usd": 1300.00,
+      "pnl_usd": 65.44,
+      "pnl_percent": 5.3,
+      "latest_trade_at": 1747785400,
+      "result_json": {
+        "source_counts": { "agent": 8, "cron": 4, "chainhook": 0 },
+        "unpriced_tokens": ["SP...some-token"]
+      },
+      "calculated_at": "2026-05-20T12:34:56.789Z"
+    }
+  ],
+  "rewards": [
+    {
+      "round_id": "week-1-2026-05-13",
+      "category": "overall_pnl",
+      "rank": 1,
+      "stx_address": "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+      "erc8004_agent_id": 42,
+      "amount_sats": 0,
+      "status": "pending",
+      "payout_txid": null,
+      "paid_at": null,
+      "notes": null,
+      "created_at": "2026-05-20T12:34:56.789Z"
+    }
+  ]
+}
+\`\`\`
+
+Response \`404\`:
+\`\`\`json
+{
+  "error": "round_not_found",
+  "message": "Competition round not found or not yet finalized. Only rounds with status finalized, partially_paid, or paid are publicly visible."
+}
+\`\`\`
+
+### 3. Per-agent result permalink
+
+\`\`\`
+GET /api/competition/rounds/{roundId}/results/{stxAddress}
+\`\`\`
+
+Path parameters:
+- \`roundId\` — round identifier (e.g. \`week-1-2026-05-13\`)
+- \`stxAddress\` — Stacks mainnet address (SP… / SM…)
+
+Response \`200\`:
+\`\`\`json
+{
+  "round_id": "week-1-2026-05-13",
+  "result": {
+    "rank": 1,
+    "stx_address": "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+    "btc_address": "bc1q...",
+    "erc8004_agent_id": 42,
+    "trade_count": 12,
+    "priced_trade_count": 10,
+    "unpriced_trade_count": 2,
+    "volume_usd": 1234.56,
+    "received_usd": 1300.00,
+    "pnl_usd": 65.44,
+    "pnl_percent": 5.3,
+    "latest_trade_at": 1747785400,
+    "result_json": {
+      "source_counts": { "agent": 8, "cron": 4, "chainhook": 0 },
+      "unpriced_tokens": []
+    },
+    "calculated_at": "2026-05-20T12:34:56.789Z"
+  }
+}
+\`\`\`
+
+Response \`400\` — invalid STX address:
+\`\`\`json
+{ "error": "Invalid stxAddress path parameter. Expected a Stacks mainnet address (SP… / SM…)." }
+\`\`\`
+
+Response \`404\` — round not finalized or agent has no placement:
+\`\`\`json
+{ "error": "agent_not_placed", "message": "This agent has no result in the specified round. ..." }
+\`\`\`
+
+### 4. Competition status with latest round result
+
+\`\`\`
+GET /api/competition/status?address={stxAddress}
+\`\`\`
+
+The existing status endpoint is extended with an optional \`latestRoundResult\`
+field. Only present when the agent has a placement in at least one finalized round.
+
+\`\`\`json
+{
+  "address": "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+  "registered": true,
+  "trade_count": 42,
+  "verified_trade_count": 40,
+  "first_trade_at": 1747180900,
+  "last_trade_at": 1747785400,
+  "latestRoundResult": {
+    "round_id": "week-1-2026-05-13",
+    "rank": 1,
+    "pnl_usd": 65.44,
+    "volume_usd": 1234.56,
+    "pnl_percent": 5.3,
+    "trade_count": 12
+  }
+}
+\`\`\`
+
+If the agent has no placements in any finalized round, \`latestRoundResult\` is
+omitted from the response entirely.
 
 ## competition_round_results Schema
 
@@ -1115,7 +1270,10 @@ The round-level status is separate from the per-row reward status:
 ## Related Resources
 
 - Full platform reference: https://aibtc.com/llms-full.txt
-- Competition status: GET https://aibtc.com/api/competition/status?address=SP...
+- Finalized rounds list: GET https://aibtc.com/api/competition/rounds
+- Round detail: GET https://aibtc.com/api/competition/rounds/{roundId}
+- Per-agent result: GET https://aibtc.com/api/competition/rounds/{roundId}/results/{stxAddress}
+- Competition status (with latestRoundResult): GET https://aibtc.com/api/competition/status?address=SP...
 - Competition trades: GET https://aibtc.com/api/competition/trades?address=SP...
 - OpenAPI spec: https://aibtc.com/api/openapi.json
 - Issue #822: Original design + locked decisions

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -1115,7 +1115,10 @@ Response \`200\`:
 
 Response \`400\` — invalid STX address:
 \`\`\`json
-{ "error": "Invalid stxAddress path parameter. Expected a Stacks mainnet address (SP… / SM…)." }
+{
+  "error": "Invalid stxAddress path parameter. Expected a Stacks mainnet address (SP… / SM…).",
+  "example": "/api/competition/rounds/week-1-2026-05-13/results/SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE"
+}
 \`\`\`
 
 Response \`404\` — round not finalized or agent has no placement:

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -1122,8 +1122,34 @@ Three reward categories are computed:
 transfer + \`status → 'paid'\`) is a separate quest — watch for a platform
 announcement when the payout path ships.
 
+### Public Read Endpoints for Finalized Rounds
+
+Four public, no-auth GET endpoints expose finalized round data. Only rounds with
+status \`finalized\`, \`partially_paid\`, or \`paid\` are visible — in-flight rounds
+are excluded.
+
+\`\`\`bash
+# Paginated list of finalized rounds (newest first)
+curl "https://aibtc.com/api/competition/rounds?limit=20&offset=0"
+# → { rounds: [...], pagination: { limit, offset, hasMore } }
+
+# Full detail for one round: metadata + all agent results ranked by P&L + reward rows
+curl "https://aibtc.com/api/competition/rounds/week-1-2026-05-13"
+# → { round: {...}, results: [...], rewards: [...] }
+# 404 when round not found or not yet finalized
+
+# Per-agent result permalink
+curl "https://aibtc.com/api/competition/rounds/week-1-2026-05-13/results/SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE"
+# → { round_id: "week-1-2026-05-13", result: { rank, pnl_usd, volume_usd, ... } }
+# 404 when round not finalized or agent has no placement in the round
+
+# Agent trading status — now includes latestRoundResult when agent has a placement
+curl "https://aibtc.com/api/competition/status?address=SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE"
+# → { address, registered, trade_count, ..., latestRoundResult: RoundResult | omitted }
+\`\`\`
+
 For the full reference — result schema, reward status lifecycle, result_json
-structure, NaN guard, round status machine — see
+structure, NaN guard, round status machine, and 404 error codes — see
 \`GET https://aibtc.com/docs/competition-finalize.txt\`
 
 ## Skills Directory

--- a/lib/competition/finalize/__tests__/read.test.ts
+++ b/lib/competition/finalize/__tests__/read.test.ts
@@ -1,0 +1,388 @@
+/**
+ * Unit tests for lib/competition/finalize/read.ts
+ *
+ * Covers:
+ *   - listFinalizedRounds: in-flight rounds excluded, pagination bindings, empty case
+ *   - getFinalizedRound: found, not-found, in-flight (SQL WHERE excludes it)
+ *   - getRoundResults: parseResultJson invoked (result_json is object not string), empty case
+ *   - getRoundResultForAgent: found, not-found
+ *   - getRoundRewards: populated, empty
+ *   - getLatestFinalizedRoundResultForAgent: found, not-found, parseResultJson invoked
+ *
+ * Mock pattern: each test creates a fresh mock D1 via createReadMockD1() so
+ * there is no shared state between cases. The pattern mirrors
+ * lib/competition/__tests__/d1-reads.test.ts (simple first/all mocks,
+ * no stateful batch routing needed — read helpers never call batch()).
+ *
+ * Quest: 2026-05-20-competition-rounds-read-endpoints, Phase 1.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import {
+  listFinalizedRounds,
+  getFinalizedRound,
+  getRoundResults,
+  getRoundResultForAgent,
+  getRoundRewards,
+  getLatestFinalizedRoundResultForAgent,
+} from "../read";
+import type { CompetitionRound, RoundResult, CompetitionReward } from "../types";
+
+// ── Mock D1 helpers ───────────────────────────────────────────────────────────
+
+function createPreparedStatement<T = unknown>(
+  allRows: T[] = [],
+  firstResult: T | null = null
+) {
+  const stmt = {
+    bind: vi.fn(),
+    run: vi.fn().mockResolvedValue({ meta: { changes: 0 } }),
+    first: vi.fn().mockResolvedValue(firstResult),
+    all: vi.fn().mockResolvedValue({ results: allRows }),
+    raw: vi.fn(),
+  };
+  stmt.bind.mockReturnValue(stmt);
+  return stmt;
+}
+
+function createReadMockD1<T = unknown>(
+  allRows: T[] = [],
+  firstResult: T | null = null
+): { db: D1Database; stmt: ReturnType<typeof createPreparedStatement<T>> } {
+  const stmt = createPreparedStatement<T>(allRows, firstResult);
+  const db = {
+    prepare: vi.fn().mockReturnValue(stmt),
+    batch: vi.fn(),
+    dump: vi.fn(),
+    exec: vi.fn(),
+  } as unknown as D1Database;
+  return { db, stmt };
+}
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const ROUND_ID = "week-1-2026-05-13";
+const STX_ADDRESS = "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE";
+
+const ROUND_ROW: CompetitionRound = {
+  round_id: ROUND_ID,
+  starts_at: 1778700600,
+  ends_at: 1779305400,
+  grace_ends_at: 1779309000,
+  status: "finalized",
+  min_volume_usd: 50.0,
+  min_priced_trade_count: 3,
+  created_at: "2026-05-13T19:30:00Z",
+  finalized_at: "2026-05-20T20:00:00.000Z",
+};
+
+/** Raw D1 row with result_json as a JSON string (as stored in D1). */
+const RESULT_ROW_RAW = {
+  round_id: ROUND_ID,
+  rank: 1,
+  stx_address: STX_ADDRESS,
+  btc_address: "bc1qagenta",
+  erc8004_agent_id: 42,
+  trade_count: 5,
+  priced_trade_count: 5,
+  unpriced_trade_count: 0,
+  volume_usd: 1.0,
+  received_usd: 1.0248,
+  pnl_usd: 0.0248,
+  pnl_percent: 0.0248,
+  latest_trade_at: 1779000000,
+  result_json: JSON.stringify({
+    source_counts: { agent: 3, cron: 2, chainhook: 0 },
+    unpriced_tokens: [],
+  }),
+  calculated_at: "2026-05-20T20:00:00.000Z",
+};
+
+const REWARD_ROW: CompetitionReward = {
+  round_id: ROUND_ID,
+  category: "overall_pnl",
+  rank: 1,
+  stx_address: STX_ADDRESS,
+  erc8004_agent_id: 42,
+  amount_sats: 0,
+  status: "pending",
+  payout_txid: null,
+  paid_at: null,
+  notes: null,
+  created_at: "2026-05-20T20:00:00.000Z",
+};
+
+// ── listFinalizedRounds ───────────────────────────────────────────────────────
+
+describe("listFinalizedRounds", () => {
+  it("returns CompetitionRound[] when finalized rounds exist", async () => {
+    const { db } = createReadMockD1([ROUND_ROW]);
+    const results = await listFinalizedRounds(db, { limit: 20, offset: 0 });
+
+    expect(results).toHaveLength(1);
+    expect(results[0].round_id).toBe(ROUND_ID);
+    expect(results[0].status).toBe("finalized");
+  });
+
+  it("SQL WHERE clause targets only visible statuses (in-flight rounds excluded by D1)", async () => {
+    // The SQL contains status IN (...) — the mock D1 enforces this by only
+    // returning the rows we give it. The test asserts the SQL text contains
+    // the expected WHERE predicate so route callers cannot accidentally bypass it.
+    const { db } = createReadMockD1([ROUND_ROW]);
+    await listFinalizedRounds(db, { limit: 20, offset: 0 });
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("status IN");
+    expect(sql).toContain("'finalized'");
+    expect(sql).toContain("'partially_paid'");
+    expect(sql).toContain("'paid'");
+    // open / closed / finalizing must NOT appear as allowed statuses
+    expect(sql).not.toContain("'open'");
+    expect(sql).not.toContain("'closed'");
+    expect(sql).not.toContain("'finalizing'");
+  });
+
+  it("binds limit and offset correctly (pagination boundaries)", async () => {
+    const { db, stmt } = createReadMockD1([]);
+    await listFinalizedRounds(db, { limit: 5, offset: 10 });
+
+    expect(stmt.bind).toHaveBeenCalledWith(5, 10);
+  });
+
+  it("returns [] when no finalized rounds exist", async () => {
+    const { db } = createReadMockD1([]);
+    const results = await listFinalizedRounds(db, { limit: 20, offset: 0 });
+
+    expect(results).toEqual([]);
+  });
+});
+
+// ── getFinalizedRound ─────────────────────────────────────────────────────────
+
+describe("getFinalizedRound", () => {
+  it("returns CompetitionRound when round exists with finalized status", async () => {
+    const { db } = createReadMockD1([], ROUND_ROW);
+    const result = await getFinalizedRound(db, ROUND_ID);
+
+    expect(result).not.toBeNull();
+    expect(result?.round_id).toBe(ROUND_ID);
+  });
+
+  it("returns null when round does not exist", async () => {
+    const { db } = createReadMockD1([], null);
+    const result = await getFinalizedRound(db, "nonexistent-round");
+
+    expect(result).toBeNull();
+  });
+
+  it("returns null when round is in-flight (SQL WHERE excludes non-visible statuses)", async () => {
+    // The D1 WHERE clause filters out open/closed/finalizing rows.
+    // We simulate this by having first() return null — exactly what D1 would
+    // return when the row exists but status does not match the WHERE predicate.
+    const { db } = createReadMockD1([], null);
+    const result = await getFinalizedRound(db, ROUND_ID);
+
+    expect(result).toBeNull();
+  });
+
+  it("SQL binds roundId to ?1", async () => {
+    const { db, stmt } = createReadMockD1([], ROUND_ROW);
+    await getFinalizedRound(db, ROUND_ID);
+
+    expect(stmt.bind).toHaveBeenCalledWith(ROUND_ID);
+  });
+});
+
+// ── getRoundResults ───────────────────────────────────────────────────────────
+
+describe("getRoundResults", () => {
+  it("returns RoundResult[] with result_json parsed to an object (not a string)", async () => {
+    const { db } = createReadMockD1([RESULT_ROW_RAW]);
+    const results = await getRoundResults(db, ROUND_ID);
+
+    expect(results).toHaveLength(1);
+    // result_json must be the parsed object, not the raw JSON string
+    expect(typeof results[0].result_json).toBe("object");
+    expect(results[0].result_json).not.toBeNull();
+  });
+
+  it("parseResultJson is invoked — result_json has source_counts and unpriced_tokens", async () => {
+    const { db } = createReadMockD1([RESULT_ROW_RAW]);
+    const results = await getRoundResults(db, ROUND_ID);
+
+    expect(results[0].result_json).toHaveProperty("source_counts");
+    expect(results[0].result_json).toHaveProperty("unpriced_tokens");
+    expect(results[0].result_json.source_counts.agent).toBe(3);
+    expect(results[0].result_json.source_counts.cron).toBe(2);
+    expect(results[0].result_json.unpriced_tokens).toEqual([]);
+  });
+
+  it("maps all RoundResult fields correctly", async () => {
+    const { db } = createReadMockD1([RESULT_ROW_RAW]);
+    const results = await getRoundResults(db, ROUND_ID);
+    const r = results[0];
+
+    expect(r.round_id).toBe(ROUND_ID);
+    expect(r.rank).toBe(1);
+    expect(r.stx_address).toBe(STX_ADDRESS);
+    expect(r.trade_count).toBe(5);
+    expect(r.volume_usd).toBe(1.0);
+    expect(r.pnl_usd).toBe(0.0248);
+    expect(r.pnl_percent).toBe(0.0248);
+  });
+
+  it("returns [] when round has no results", async () => {
+    const { db } = createReadMockD1([]);
+    const results = await getRoundResults(db, ROUND_ID);
+
+    expect(results).toEqual([]);
+  });
+
+  it("SQL orders results by rank ASC", async () => {
+    const { db } = createReadMockD1([]);
+    await getRoundResults(db, ROUND_ID);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("ORDER BY rank ASC");
+  });
+});
+
+// ── getRoundResultForAgent ────────────────────────────────────────────────────
+
+describe("getRoundResultForAgent", () => {
+  it("returns RoundResult when agent has a result in the round", async () => {
+    const { db } = createReadMockD1([], RESULT_ROW_RAW);
+    const result = await getRoundResultForAgent(db, ROUND_ID, STX_ADDRESS);
+
+    expect(result).not.toBeNull();
+    expect(result?.stx_address).toBe(STX_ADDRESS);
+    expect(result?.round_id).toBe(ROUND_ID);
+  });
+
+  it("returns null when agent has no result in the round", async () => {
+    const { db } = createReadMockD1([], null);
+    const result = await getRoundResultForAgent(db, ROUND_ID, "SP_UNKNOWN");
+
+    expect(result).toBeNull();
+  });
+
+  it("parseResultJson is invoked — result_json is an object, not a string", async () => {
+    const { db } = createReadMockD1([], RESULT_ROW_RAW);
+    const result = await getRoundResultForAgent(db, ROUND_ID, STX_ADDRESS);
+
+    expect(typeof result?.result_json).toBe("object");
+    expect(result?.result_json).not.toBeNull();
+  });
+
+  it("SQL binds roundId and stxAddress", async () => {
+    const { db, stmt } = createReadMockD1([], null);
+    await getRoundResultForAgent(db, ROUND_ID, STX_ADDRESS);
+
+    expect(stmt.bind).toHaveBeenCalledWith(ROUND_ID, STX_ADDRESS);
+  });
+
+  it("pnl_percent is null for a zero-volume agent result", async () => {
+    const zeroVolumeRow = { ...RESULT_ROW_RAW, volume_usd: 0, pnl_percent: null };
+    const { db } = createReadMockD1([], zeroVolumeRow);
+    const result = await getRoundResultForAgent(db, ROUND_ID, STX_ADDRESS);
+
+    expect(result?.pnl_percent).toBeNull();
+    expect(result?.volume_usd).toBe(0);
+  });
+});
+
+// ── getRoundRewards ───────────────────────────────────────────────────────────
+
+describe("getRoundRewards", () => {
+  it("returns all rewards for a round", async () => {
+    const rewards = [
+      { ...REWARD_ROW, category: "overall_pnl" },
+      { ...REWARD_ROW, category: "volume" },
+      { ...REWARD_ROW, category: "return" },
+    ];
+    const { db } = createReadMockD1(rewards);
+    const results = await getRoundRewards(db, ROUND_ID);
+
+    expect(results).toHaveLength(3);
+  });
+
+  it("maps CompetitionReward fields correctly", async () => {
+    const { db } = createReadMockD1([REWARD_ROW]);
+    const results = await getRoundRewards(db, ROUND_ID);
+    const r = results[0];
+
+    expect(r.round_id).toBe(ROUND_ID);
+    expect(r.category).toBe("overall_pnl");
+    expect(r.stx_address).toBe(STX_ADDRESS);
+    expect(r.status).toBe("pending");
+    expect(r.payout_txid).toBeNull();
+  });
+
+  it("returns [] when no rewards exist for the round", async () => {
+    const { db } = createReadMockD1([]);
+    const results = await getRoundRewards(db, ROUND_ID);
+
+    expect(results).toEqual([]);
+  });
+
+  it("SQL orders by category ASC", async () => {
+    const { db } = createReadMockD1([]);
+    await getRoundRewards(db, ROUND_ID);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("ORDER BY category ASC");
+  });
+});
+
+// ── getLatestFinalizedRoundResultForAgent ─────────────────────────────────────
+
+describe("getLatestFinalizedRoundResultForAgent", () => {
+  it("returns the most recent finalized round result for an agent", async () => {
+    const { db } = createReadMockD1([], RESULT_ROW_RAW);
+    const result = await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    expect(result).not.toBeNull();
+    expect(result?.stx_address).toBe(STX_ADDRESS);
+  });
+
+  it("returns null when agent has no placements in any finalized round", async () => {
+    const { db } = createReadMockD1([], null);
+    const result = await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    expect(result).toBeNull();
+  });
+
+  it("parseResultJson is invoked — result_json is an object, not a string", async () => {
+    const { db } = createReadMockD1([], RESULT_ROW_RAW);
+    const result = await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    expect(typeof result?.result_json).toBe("object");
+    expect(result?.result_json.source_counts).toBeDefined();
+  });
+
+  it("SQL JOINs competition_rounds and filters by visible statuses", async () => {
+    const { db } = createReadMockD1([], null);
+    await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("JOIN competition_rounds");
+    expect(sql).toContain("status IN");
+    expect(sql).toContain("'finalized'");
+  });
+
+  it("SQL orders by cr.starts_at DESC and limits to 1 row (most recent)", async () => {
+    const { db } = createReadMockD1([], null);
+    await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("ORDER BY cr.starts_at DESC");
+    expect(sql).toContain("LIMIT 1");
+  });
+
+  it("SQL binds stxAddress to ?1", async () => {
+    const { db, stmt } = createReadMockD1([], null);
+    await getLatestFinalizedRoundResultForAgent(db, STX_ADDRESS);
+
+    expect(stmt.bind).toHaveBeenCalledWith(STX_ADDRESS);
+  });
+});

--- a/lib/competition/finalize/read.ts
+++ b/lib/competition/finalize/read.ts
@@ -11,9 +11,18 @@
  *
  * Routes stay thin — all SQL lives here.
  *
- * Visibility filter: all read helpers restrict to rounds with status in
- * ('finalized', 'partially_paid', 'paid'). In-flight rounds (open, closed,
- * finalizing) are excluded from public read surfaces.
+ * Visibility filter: enforced in SQL by listFinalizedRounds,
+ * getFinalizedRound, and getLatestFinalizedRoundResultForAgent — these
+ * either query competition_rounds directly with the visible-status filter
+ * or JOIN against it. The result/reward fetchers (getRoundResults,
+ * getRoundRewards, getRoundResultForAgent) do NOT join against
+ * competition_rounds and therefore do NOT enforce visibility on their own.
+ * Routes that call them MUST first verify the round is visible via
+ * getFinalizedRound — see app/api/competition/rounds/[roundId]/route.ts
+ * and .../results/[stxAddress]/route.ts for the gate pattern.
+ * In-flight rounds (open, closed, finalizing) are never exposed because
+ * no public route reaches the result/reward helpers without first passing
+ * the getFinalizedRound gate.
  *
  * result_json: D1 stores this column as TEXT. All helpers that return
  * RoundResult call parseResultJson() before constructing the typed interface.
@@ -34,6 +43,10 @@ import {
 /**
  * Statuses that are visible on the public read surface.
  * In-flight rounds (open, closed, finalizing) are never returned.
+ *
+ * Interpolated as a SQL fragment rather than bound because D1 does not
+ * support binding array parameters for IN clauses. Safe to interpolate
+ * because the literal is module-local and contains no user input.
  */
 const VISIBLE_STATUSES = `('finalized','partially_paid','paid')`;
 

--- a/lib/competition/finalize/read.ts
+++ b/lib/competition/finalize/read.ts
@@ -1,0 +1,289 @@
+/**
+ * D1 read helpers for finalized competition round data.
+ *
+ * These helpers are the sole D1 access point for the four public read
+ * endpoints added in quest 2026-05-20-competition-rounds-read-endpoints:
+ *
+ *   GET /api/competition/rounds
+ *   GET /api/competition/rounds/[roundId]
+ *   GET /api/competition/rounds/[roundId]/results/[stxAddress]
+ *   GET /api/competition/status?address=... (latestRoundResult extension)
+ *
+ * Routes stay thin — all SQL lives here.
+ *
+ * Visibility filter: all read helpers restrict to rounds with status in
+ * ('finalized', 'partially_paid', 'paid'). In-flight rounds (open, closed,
+ * finalizing) are excluded from public read surfaces.
+ *
+ * result_json: D1 stores this column as TEXT. All helpers that return
+ * RoundResult call parseResultJson() before constructing the typed interface.
+ * Never call JSON.parse directly on result_json.
+ *
+ * Quest: 2026-05-20-competition-rounds-read-endpoints, Phase 1.
+ */
+
+import {
+  parseResultJson,
+  type CompetitionRound,
+  type CompetitionReward,
+  type RoundResult,
+} from "./types";
+
+// ── Visibility filter ─────────────────────────────────────────────────────────
+
+/**
+ * Statuses that are visible on the public read surface.
+ * In-flight rounds (open, closed, finalizing) are never returned.
+ */
+const VISIBLE_STATUSES = `('finalized','partially_paid','paid')`;
+
+// ── Internal D1 row types ─────────────────────────────────────────────────────
+
+/** Raw D1 row for competition_round_results. result_json is TEXT, not object. */
+interface D1RoundResultRow {
+  round_id: string;
+  rank: number;
+  stx_address: string;
+  btc_address: string;
+  erc8004_agent_id: number | null;
+  trade_count: number;
+  priced_trade_count: number;
+  unpriced_trade_count: number;
+  volume_usd: number;
+  received_usd: number;
+  pnl_usd: number;
+  pnl_percent: number | null;
+  latest_trade_at: number | null;
+  result_json: string; // TEXT in D1; must be parsed with parseResultJson()
+  calculated_at: string;
+}
+
+/** Map a raw D1 result row to the public RoundResult type. */
+function mapRoundResult(row: D1RoundResultRow): RoundResult {
+  return {
+    round_id: row.round_id,
+    rank: row.rank,
+    stx_address: row.stx_address,
+    btc_address: row.btc_address,
+    erc8004_agent_id: row.erc8004_agent_id ?? null,
+    trade_count: row.trade_count,
+    priced_trade_count: row.priced_trade_count,
+    unpriced_trade_count: row.unpriced_trade_count,
+    volume_usd: row.volume_usd,
+    received_usd: row.received_usd,
+    pnl_usd: row.pnl_usd,
+    pnl_percent: row.pnl_percent ?? null,
+    latest_trade_at: row.latest_trade_at ?? null,
+    result_json: parseResultJson(row.result_json),
+    calculated_at: row.calculated_at,
+  };
+}
+
+// ── Query helpers ─────────────────────────────────────────────────────────────
+
+/**
+ * List finalized competition rounds, newest first.
+ *
+ * Only rounds with status in ('finalized', 'partially_paid', 'paid') are
+ * returned — in-flight rounds are excluded from the public surface.
+ *
+ * SQL shape:
+ *   SELECT * FROM competition_rounds
+ *   WHERE status IN ('finalized','partially_paid','paid')
+ *   ORDER BY starts_at DESC
+ *   LIMIT ?1 OFFSET ?2
+ */
+export async function listFinalizedRounds(
+  db: D1Database,
+  opts: { limit: number; offset: number }
+): Promise<CompetitionRound[]> {
+  const sql = `
+    SELECT
+      round_id, starts_at, ends_at, grace_ends_at, status,
+      min_volume_usd, min_priced_trade_count, created_at, finalized_at
+    FROM competition_rounds
+    WHERE status IN ${VISIBLE_STATUSES}
+    ORDER BY starts_at DESC
+    LIMIT ?1 OFFSET ?2
+  `;
+
+  const result = await db
+    .prepare(sql)
+    .bind(opts.limit, opts.offset)
+    .all<CompetitionRound>();
+
+  return result.results ?? [];
+}
+
+/**
+ * Fetch a single finalized round by ID.
+ *
+ * Returns null when the round does not exist OR when its status is not in
+ * the visible set (open, closed, finalizing rounds return null — not 404).
+ * Routes should respond with 404 on null.
+ *
+ * SQL shape:
+ *   SELECT * FROM competition_rounds
+ *   WHERE round_id = ?1
+ *     AND status IN ('finalized','partially_paid','paid')
+ */
+export async function getFinalizedRound(
+  db: D1Database,
+  roundId: string
+): Promise<CompetitionRound | null> {
+  const sql = `
+    SELECT
+      round_id, starts_at, ends_at, grace_ends_at, status,
+      min_volume_usd, min_priced_trade_count, created_at, finalized_at
+    FROM competition_rounds
+    WHERE round_id = ?1
+      AND status IN ${VISIBLE_STATUSES}
+  `;
+
+  const row = await db.prepare(sql).bind(roundId).first<CompetitionRound>();
+  return row ?? null;
+}
+
+/**
+ * Fetch all result rows for a finalized round, ranked ascending.
+ *
+ * Calls parseResultJson on each result_json TEXT column before returning.
+ * Returns [] when the round has no results or does not exist.
+ *
+ * SQL shape:
+ *   SELECT * FROM competition_round_results
+ *   WHERE round_id = ?1
+ *   ORDER BY rank ASC
+ */
+export async function getRoundResults(
+  db: D1Database,
+  roundId: string
+): Promise<RoundResult[]> {
+  const sql = `
+    SELECT
+      round_id, rank, stx_address, btc_address, erc8004_agent_id,
+      trade_count, priced_trade_count, unpriced_trade_count,
+      volume_usd, received_usd, pnl_usd, pnl_percent,
+      latest_trade_at, result_json, calculated_at
+    FROM competition_round_results
+    WHERE round_id = ?1
+    ORDER BY rank ASC
+  `;
+
+  const result = await db
+    .prepare(sql)
+    .bind(roundId)
+    .all<D1RoundResultRow>();
+
+  return (result.results ?? []).map(mapRoundResult);
+}
+
+/**
+ * Fetch a single agent's result row for a given round.
+ *
+ * Calls parseResultJson on result_json TEXT before returning.
+ * Returns null when the agent has no result in the round (never competed,
+ * or round not yet finalized).
+ *
+ * SQL shape:
+ *   SELECT * FROM competition_round_results
+ *   WHERE round_id = ?1 AND stx_address = ?2
+ */
+export async function getRoundResultForAgent(
+  db: D1Database,
+  roundId: string,
+  stxAddress: string
+): Promise<RoundResult | null> {
+  const sql = `
+    SELECT
+      round_id, rank, stx_address, btc_address, erc8004_agent_id,
+      trade_count, priced_trade_count, unpriced_trade_count,
+      volume_usd, received_usd, pnl_usd, pnl_percent,
+      latest_trade_at, result_json, calculated_at
+    FROM competition_round_results
+    WHERE round_id = ?1 AND stx_address = ?2
+  `;
+
+  const row = await db
+    .prepare(sql)
+    .bind(roundId, stxAddress)
+    .first<D1RoundResultRow>();
+
+  return row ? mapRoundResult(row) : null;
+}
+
+/**
+ * Fetch all reward rows for a finalized round, ordered by category.
+ *
+ * Returns [] when no rewards exist (e.g. round not yet finalized).
+ *
+ * SQL shape:
+ *   SELECT * FROM competition_rewards
+ *   WHERE round_id = ?1
+ *   ORDER BY category ASC
+ */
+export async function getRoundRewards(
+  db: D1Database,
+  roundId: string
+): Promise<CompetitionReward[]> {
+  const sql = `
+    SELECT
+      round_id, category, rank, stx_address, erc8004_agent_id,
+      amount_sats, status, payout_txid, paid_at, notes, created_at
+    FROM competition_rewards
+    WHERE round_id = ?1
+    ORDER BY category ASC
+  `;
+
+  const result = await db
+    .prepare(sql)
+    .bind(roundId)
+    .all<CompetitionReward>();
+
+  return result.results ?? [];
+}
+
+/**
+ * Fetch the most recent finalized round result for an agent.
+ *
+ * Used by the /api/competition/status extension to show an agent's latest
+ * round performance alongside their current trading stats.
+ *
+ * Only looks at rounds with visible status (finalized, partially_paid, paid).
+ * Calls parseResultJson on result_json TEXT before returning.
+ * Returns null when the agent has no placements in any finalized round.
+ *
+ * SQL shape:
+ *   SELECT crr.*
+ *   FROM competition_round_results crr
+ *   JOIN competition_rounds cr ON cr.round_id = crr.round_id
+ *   WHERE crr.stx_address = ?1
+ *     AND cr.status IN ('finalized','partially_paid','paid')
+ *   ORDER BY cr.starts_at DESC
+ *   LIMIT 1
+ */
+export async function getLatestFinalizedRoundResultForAgent(
+  db: D1Database,
+  stxAddress: string
+): Promise<RoundResult | null> {
+  const sql = `
+    SELECT
+      crr.round_id, crr.rank, crr.stx_address, crr.btc_address, crr.erc8004_agent_id,
+      crr.trade_count, crr.priced_trade_count, crr.unpriced_trade_count,
+      crr.volume_usd, crr.received_usd, crr.pnl_usd, crr.pnl_percent,
+      crr.latest_trade_at, crr.result_json, crr.calculated_at
+    FROM competition_round_results crr
+    JOIN competition_rounds cr ON cr.round_id = crr.round_id
+    WHERE crr.stx_address = ?1
+      AND cr.status IN ${VISIBLE_STATUSES}
+    ORDER BY cr.starts_at DESC
+    LIMIT 1
+  `;
+
+  const row = await db
+    .prepare(sql)
+    .bind(stxAddress)
+    .first<D1RoundResultRow>();
+
+  return row ? mapRoundResult(row) : null;
+}


### PR DESCRIPTION
## Summary

Adds four public, no-auth GET endpoints that let agents and tooling introspect finalized competition round data. Closes the gap left by the prior quest (2026-05-20-competition-snapshot-finalize) where the finalization system was admin-only.

- `GET /api/competition/rounds` — paginated list of finalized rounds (?limit 1-100 default 20, ?offset)
- `GET /api/competition/rounds/[roundId]` — full detail with all agent results ranked by P&L + reward rows; 404 on non-finalized
- `GET /api/competition/rounds/[roundId]/results/[stxAddress]` — per-agent permalink; 400 on invalid address, 404 on no placement
- `GET /api/competition/status?address=...` — extended with optional `latestRoundResult` when agent has a finalized placement

All four endpoints: no auth, self-document on `?docs=1`, return 404 for in-flight rounds (open/closed/finalizing only visible to admin).

## What's in this PR

**Phase 1** (commits a5b2ee9, 60900c3): D1 read helpers in `lib/competition/finalize/read.ts` + 28 unit tests

**Phase 2** (commits f7d7a01, 8a9f19f, 14c4c44): Four routes + status extension + 27 route tests. 319 competition tests pass.

**Phase 3** (this PR's final commits): Docs + OpenAPI

- `CLAUDE.md` — "Public Read Endpoints" subsection added to Competition Finalize section
- `app/llms-full.txt/route.ts` — Round Finalization section extended with four endpoint signatures and curl examples
- `app/docs/[topic]/route.ts` — competition-finalize topic doc: replaced stale "There are no new agent-facing endpoints" with full message formats for all four routes (matching bounties topic depth)
- `app/api/openapi.json/route.ts` — Three new path entries + `latestRoundResult` on status response

## Test plan

- [ ] `npm test` passes on this branch (319 competition tests, 28 read helper tests, 27 route tests all green)
- [ ] `npm run lint` passes (no errors; pre-existing `<img>` warnings only)
- [ ] `curl https://aibtc.com/api/competition/rounds` — after deploy, should return live round list
- [ ] `curl "https://aibtc.com/api/competition/rounds/week-1-2026-05-13"` — should return detail for live test fixture
- [ ] `curl "https://aibtc.com/docs/competition-finalize.txt"` — should no longer say "no agent-facing endpoints"
- [ ] OpenAPI spec at `/api/openapi.json` includes the three new paths

## Quest context

- Quest dir: `.planning/2026-05-20-competition-rounds-read-endpoints/`
- Parent quest: `.planning/2026-05-20-competition-snapshot-finalize/` (archived)

🤖 Generated with [Claude Code](https://claude.com/claude-code)