### PR TITLE
fix(bounty): reject multi-winner wording in create validation

### DIFF
--- a/lib/bounty/__tests__/validation-create.test.ts
+++ b/lib/bounty/__tests__/validation-create.test.ts
@@ -14,15 +14,33 @@ function validCreateBody(description: string) {
 }
 
 describe("validateCreateBounty multi-winner copy guard", () => {
-  it("rejects descriptions that suggest multi-winner payout semantics", () => {
-    const result = validateCreateBounty(
-      validCreateBody("Up to 3 winners. First-come first-paid within the 3-slot cap.")
-    );
+  function expectDescriptionRejected(description: string) {
+    const result = validateCreateBounty(validCreateBody(description));
     expect("errors" in result).toBe(true);
     if ("errors" in result) {
       expect(result.errors.some((e) => e.field === "description")).toBe(true);
-      expect(result.errors[0]?.message).toContain("multi-winner support");
+      expect(result.errors.some((e) => e.message.includes("multi-winner support"))).toBe(true);
     }
+  }
+
+  it("rejects 'up to N winners' phrasing", () => {
+    expectDescriptionRejected("Up to 3 winners. First report accepted wins.");
+  });
+
+  it("rejects 'multiple winners' phrasing", () => {
+    expectDescriptionRejected("Multiple winners possible if submissions are distinct.");
+  });
+
+  it("rejects first-come first-paid phrasing", () => {
+    expectDescriptionRejected("First-come, first-paid until all payouts are used.");
+  });
+
+  it("rejects slot-cap phrasing", () => {
+    expectDescriptionRejected("This bounty has a 3-slot cap for accepted submissions.");
+  });
+
+  it("rejects slots-remaining phrasing", () => {
+    expectDescriptionRejected("2 slots remaining for this payout.");
   });
 
   it("accepts descriptions that do not imply multiple winners", () => {

--- a/lib/bounty/__tests__/validation-create.test.ts
+++ b/lib/bounty/__tests__/validation-create.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from "vitest";
+import { validateCreateBounty } from "../validation";
+
+function validCreateBody(description: string) {
+  return {
+    posterBtcAddress: "bc1qq9vpsra2cjmuvlx623ltsnw04cfxl2xevuahw3",
+    title: "Improve bounty submission filters",
+    description,
+    rewardSats: 5000,
+    expiresAt: new Date(Date.now() + 48 * 60 * 60 * 1000).toISOString(),
+    signedAt: new Date().toISOString(),
+    signature: "/".repeat(88),
+  };
+}
+
+describe("validateCreateBounty multi-winner copy guard", () => {
+  it("rejects descriptions that suggest multi-winner payout semantics", () => {
+    const result = validateCreateBounty(
+      validCreateBody("Up to 3 winners. First-come first-paid within the 3-slot cap.")
+    );
+    expect("errors" in result).toBe(true);
+    if ("errors" in result) {
+      expect(result.errors.some((e) => e.field === "description")).toBe(true);
+      expect(result.errors[0]?.message).toContain("multi-winner support");
+    }
+  });
+
+  it("accepts descriptions that do not imply multiple winners", () => {
+    const result = validateCreateBounty(
+      validCreateBody("Single winner bounty. Submit one implementation with tests and PR.")
+    );
+    expect("data" in result).toBe(true);
+    if ("data" in result) {
+      expect(result.data.description).toContain("Single winner bounty");
+    }
+  });
+});

--- a/lib/bounty/validation.ts
+++ b/lib/bounty/validation.ts
@@ -29,6 +29,8 @@ export interface ValidationHint {
 }
 
 type FieldError = { message: string; hint: ValidationHint };
+// Narrow guard for observed unsupported multi-winner copy from #908. This is not
+// a semantic classifier; extend with new phrases only when real false negatives appear.
 const MULTI_WINNER_COPY_PATTERN =
   /\b(up to \d+ winners?|multiple winners?|first[-\s]come[,\s]+first[-\s]paid|\d+[-\s]slot cap|\d+ slots? remain(?:ing)?)\b/i;
 

--- a/lib/bounty/validation.ts
+++ b/lib/bounty/validation.ts
@@ -29,6 +29,8 @@ export interface ValidationHint {
 }
 
 type FieldError = { message: string; hint: ValidationHint };
+const MULTI_WINNER_COPY_PATTERN =
+  /\b(up to \d+ winners?|multiple winners?|first[-\s]come[,\s]+first[-\s]paid|\d+[-\s]slot cap|\d+ slots? remain(?:ing)?)\b/i;
 
 function pushBtcAddressError(errors: FieldError[], value: unknown, field: string) {
   if (typeof value !== "string") {
@@ -191,6 +193,18 @@ export function validateCreateBounty(body: unknown):
         hint: `Trim to ${DESCRIPTION_MAX} or fewer. Current: ${b.description.length}.`,
       },
     });
+  } else {
+    const multiWinnerMatch = b.description.match(MULTI_WINNER_COPY_PATTERN);
+    if (multiWinnerMatch) {
+      errors.push({
+        message: "description suggests multi-winner support which is not currently available",
+        hint: {
+          field: "description",
+          message: "description suggests multi-winner support which is not currently available",
+          hint: `Detected phrase: "${multiWinnerMatch[0]}". Bounties currently support only a single winner. Rewrite without multi-winner/slot language or split into multiple bounties.`,
+        },
+      });
+    }
   }
 
   if (typeof b.rewardSats !== "number" || !Number.isInteger(b.rewardSats) || b.rewardSats <= 0) {


### PR DESCRIPTION
Fixes #908 by implementing the low-risk guardrail (option 1): reject multi-winner wording in bounty descriptions at create time.

## What changed
- Added a multi-winner pattern check in `validateCreateBounty` to reject phrases like `up to N winners`, `multiple winners`, `first-come first-paid`, and `N-slot cap`.
- Returns a structured validation hint explaining the single-winner constraint.
- Added focused tests for rejected and accepted description cases.

## Validation
- `npm test -- lib/bounty/__tests__/validation-create.test.ts`

/claim #908