### PR TITLE
fix(bounty): redirect /bounties to /bounty

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -5,6 +5,20 @@ const isGitHubPages = process.env.GITHUB_PAGES === "true";
 const nextConfig: NextConfig = {
   output: isGitHubPages ? "export" : undefined,
   basePath: isGitHubPages ? "/landing-page" : "",
+    async redirects() {
+    return [
+      {
+        source: '/bounties',
+        destination: '/bounty',
+        permanent: false,
+      },
+      {
+        source: '/bounties/:path*',
+        destination: '/bounty/:path*',
+        permanent: false,
+      }
+    ];
+  },
   images: {
     unoptimized: isGitHubPages,
   },


### PR DESCRIPTION
Fixes #907 

I fixed the 404 issue on `/bounties` by adding Next.js redirects within `next.config.ts`. Now, any traffic hitting `/bounties` or nested `/bounties/:path*` is automatically mapped to the singular `/bounty` routes, resolving the inconsistency described in the bounty.

Bounty Wallet: 6sF8p22Gg83NKTJ6dvya7Srv4USCniZnP47DwQwK7Mtp (Solana)