### PR TITLE
[OpenAI Codex] Add /bounties redirects for bounty board

### DIFF
--- a/app/bounties/[id]/page.tsx
+++ b/app/bounties/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { permanentRedirect } from "next/navigation";
+
+type BountiesAliasDetailPageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function BountiesAliasDetailPage({ params }: BountiesAliasDetailPageProps) {
+  const { id } = await params;
+  permanentRedirect(`/bounty/${id}`);
+}

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,0 +1,5 @@
+import { permanentRedirect } from "next/navigation";
+
+export default function BountiesAliasPage() {
+  permanentRedirect("/bounty");
+}


### PR DESCRIPTION
Fixes issue #907 by adding permanent redirects from `/bounties` and `/bounties/{id}` to the live `/bounty` routes.

Validation:
- `npm run typecheck` (repo has pre-existing TS errors unrelated to this change)
