### PR TITLE
inbox/payment: add machine-readable resolution hints for pending + nonce flows

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -1273,6 +1273,7 @@ export async function POST(
         {
           error: `Nonce conflict: another transaction from your wallet is pending. Retry after ${retryAfterSeconds}s.`,
           code: errorCode,
+          resolution: "wait_for_queued_tx",
           retryable: true,
           retryAfter: retryAfterSeconds,
           nextSteps: "Retry the payment — the relay had a transient nonce collision",
@@ -1448,6 +1449,7 @@ export async function POST(
         {
           error: nonceError.error,
           code: errorCode,
+          resolution: nonceAction,
           retryable: true,
           retryAfter: nonceError.retryAfter,
           nextSteps: nonceError.nextSteps,
@@ -1615,6 +1617,9 @@ export async function POST(
         {
           success: true,
           message: "Payment accepted. Inbox delivery is staged until the relay reports confirmed.",
+          resolution: "poll_payment_status",
+          warning:
+            "Do not sign or submit a replacement payment while this payment remains pending.",
           inbox: {
             fromAddress,
             toBtcAddress,

--- a/app/api/payment-status/[paymentId]/route.ts
+++ b/app/api/payment-status/[paymentId]/route.ts
@@ -18,7 +18,8 @@ import {
  *
  * Use this endpoint after receiving `paymentStatus: "pending"` + `paymentId`
  * in a POST /api/inbox/[address] response. Pending means the message is staged
- * locally and not yet delivered. Poll every 10–30 seconds until the status is
+ * locally and not yet delivered. Treat that 202 response as success. Poll every
+ * 10–30 seconds until the status is
  * "confirmed" or a terminal failure state. When the relay includes a
  * `checkStatusUrl`, that canonical hint is returned unchanged; otherwise this
  * route falls back to its local poll URL.
@@ -57,6 +58,10 @@ export async function GET(
         },
         usage: "GET /api/payment-status/{paymentId}",
         example: "GET /api/payment-status/pay_abc123def456",
+        stateMachine:
+          "402 payment challenge -> sign payment -> POST /api/inbox/[address] -> if 202 pending, poll this endpoint -> only resubmit on terminal failure",
+        pendingSuccessRule:
+          "Treat POST /api/inbox/[address] returning 202 + paymentStatus='pending' as success. Do not sign a replacement payment while the current payment remains pending.",
         pollingAdvice: "Poll every 10–30 seconds until status is 'confirmed', 'failed', 'replaced', or 'not_found'",
         checkStatusUrlSemantics:
           "Relay-provided checkStatusUrl is preferred when present; otherwise this route returns its local polling URL.",

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -291,6 +291,8 @@ describe("inbox POST canonical staged-payment semantics", () => {
     });
     const body = (await response.json()) as {
       message: string;
+      resolution?: string;
+      warning?: string;
       inbox: { paymentStatus: string; paymentId?: string };
       checkStatusUrl?: string;
     };
@@ -299,6 +301,8 @@ describe("inbox POST canonical staged-payment semantics", () => {
     expect(body.message).toBe(
       "Payment accepted. Inbox delivery is staged until the relay reports confirmed."
     );
+    expect(body.resolution).toBe("poll_payment_status");
+    expect(body.warning).toContain("Do not sign or submit a replacement payment");
     expect(body.message).not.toContain("Message sent successfully");
     expect(body.inbox.paymentStatus).toBe("pending");
     expect(body.inbox.paymentId).toBe("pay_staged_case");


### PR DESCRIPTION
## What
Implements issue #580 by making pending and nonce retry paths explicit in API responses.

## Changes
- Add `resolution: "poll_payment_status"` and a pending warning in `POST /api/inbox/[address]` 202 responses
- Add `resolution` to nonce-related 409 responses (`wait_for_queued_tx`, `refetch_nonce_and_resign`, etc.)
- Expand `GET /api/payment-status/[paymentId]` self-doc response with a concise state machine + pending-success rule

## Why
Client integrations can now infer the next step from structured fields instead of string parsing, and pending 202 is clearly framed as success.

## Validation
- `npm test -- lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts`
- `npm test -- lib/inbox/__tests__/payment-status-route.test.ts`

Closes #580
