### PR TITLE
fix: add /bounties alias redirects

### DIFF
--- a/app/bounties/[id]/page.tsx
+++ b/app/bounties/[id]/page.tsx
@@ -1,0 +1,10 @@
+import { redirect } from "next/navigation";
+
+interface PageProps {
+  params: Promise<{ id: string }>;
+}
+
+export default async function BountyAliasDetailPage({ params }: PageProps) {
+  const { id } = await params;
+  redirect(`/bounty/${encodeURIComponent(id)}`);
+}

--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from "next/navigation";
+
+export default function BountiesAliasPage() {
+  redirect("/bounty");
+}


### PR DESCRIPTION
Closes #907\n\nAdds `/bounties` and `/bounties/[id]` aliases that redirect to the canonical `/bounty` routes so old links no longer 404.