### PR TITLE
fix(inbox): derive unread totalCount from live rows

### DIFF
--- a/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/agent-lookup", () => ({
 
 vi.mock("@/lib/inbox/d1-reads", () => ({
   listInboxMessagesFromD1: vi.fn(),
+  countInboxMessagesByStatusFromD1: vi.fn(),
   // countInboxMessagesFromD1 was deleted in P3C PR 1 — counts come from
   // getAgentInboxStats (lib/inbox/stats.ts) per migration 012's
   // agent_inbox_stats table.
@@ -103,6 +104,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import {
   listInboxMessagesFromD1,
+  countInboxMessagesByStatusFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
 } from "@/lib/inbox/d1-reads";
@@ -174,6 +176,7 @@ function setupDefaultMocks() {
   });
   (lookupAgent as Mock).mockResolvedValue(TEST_AGENT);
   (listInboxMessagesFromD1 as Mock).mockResolvedValue([RECEIVED_MESSAGE]);
+  (countInboxMessagesByStatusFromD1 as Mock).mockResolvedValue(1);
   (fetchRepliesForMessages as Mock).mockResolvedValue(new Map());
   (listOutboxRepliesFromD1 as Mock).mockResolvedValue([]);
   // countOutboxRepliesFromD1 is no longer called (perf/d1-inbox-count-4to2)
@@ -214,6 +217,34 @@ describe("Phase 2.5 Step 3.3 — sentCount derivation in inbox-list GET", () => 
     expect(res.status).toBe(200);
     const body = await res.json();
     expect(body.inbox.sentCount).toBe(0);
+  });
+
+  it("uses live filtered count for status=unread when stats drift", async () => {
+    (listInboxMessagesFromD1 as Mock).mockResolvedValue([]);
+    (getAgentInboxStats as Mock).mockResolvedValue({
+      receivedCount: 17,
+      unreadCount: 1,
+      sentCount: 0,
+      lastMessageAt: null,
+      lastSentAt: null,
+    });
+    (countInboxMessagesByStatusFromD1 as Mock).mockResolvedValue(0);
+
+    const res = await GET(
+      buildGetRequest(AGENT_ADDR, "?status=unread"),
+      buildContext(AGENT_ADDR)
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(countInboxMessagesByStatusFromD1).toHaveBeenCalledWith(
+      expect.anything(),
+      AGENT_ADDR,
+      "unread"
+    );
+    expect(body.inbox.totalCount).toBe(0);
+    expect(body.inbox.unreadCount).toBe(1);
+    expect(body.inbox.messages).toEqual([]);
   });
 
   it("includes sentCount in economics.satsSent calculation", async () => {

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -33,6 +33,7 @@ import {
 import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/inbox/d1-dual-write";
 import { bumpInboundStats, getAgentInboxStats } from "@/lib/inbox/stats";
 import {
+  countInboxMessagesByStatusFromD1,
   listInboxMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
@@ -328,16 +329,24 @@ export async function GET(
   const unreadCount = agentStats.unreadCount;
   const receivedCount = agentStats.receivedCount;
 
-  // Derive totalCount from stats counters — no extra COUNT(*) needed.
+  // Derive totalCount from stats counters on the fast path.
   // statusFilter="all"   → totalCount equals receivedCount (same predicate)
-  // statusFilter="unread" → totalCount equals unreadCount (same predicate)
+  // statusFilter="unread" → fallback to live filtered count if stats drift
   // statusFilter="read"   → totalCount equals received minus unread
-  const totalCount: number =
+  let totalCount: number =
     statusFilter === "unread"
       ? unreadCount
       : statusFilter === "read"
         ? Math.max(0, receivedCount - unreadCount)
         : receivedCount; // "all"
+
+  if (includeReceived && statusFilter !== "all") {
+    try {
+      totalCount = await countInboxMessagesByStatusFromD1(db, agent.btcAddress, statusFilter);
+    } catch (_e) {
+      return d1TransientResponse("Inbox database temporarily unavailable. Please retry shortly.");
+    }
+  }
 
   // sentCount: prefer stats table for accuracy. Fall back to sentMessages.length
   // when include=partners (already fetched for the partner graph). If includePartners
@@ -518,7 +527,7 @@ export async function GET(
   // AND no sent replies), return the self-documenting response. An agent that
   // has only sent replies (sentCount > 0, totalCount === 0) falls through to
   // the normal envelope so sentCount/economics/partners are exposed.
-  if (totalCount === 0 && sentCount === 0) {
+  if (totalCount === 0 && sentCount === 0 && unreadCount === 0 && receivedCount === 0) {
     return NextResponse.json({
       endpoint: "/api/inbox/[address]",
       description:

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -160,12 +160,32 @@ export async function listInboxMessagesFromD1(
   return (result.results ?? []).map(rowToInboxMessage);
 }
 
-// Dead code purge (P3C PR 1): `countInboxMessagesFromD1` removed.
-// Replaced by `getAgentInboxStats(db, btcAddress)` from `lib/inbox/stats.ts`
-// which serves O(1) point-lookups against the maintained `agent_inbox_stats`
-// table (migration 012). The prior `SELECT COUNT(*) FROM inbox_messages
-// WHERE to_btc_address = ?` was the textbook D1 COUNT(*) anti-pattern
-// (cf. `feedback_d1_count_antipattern`).
+/**
+ * Count inbox rows for a status filter using the same predicates as the list query.
+ *
+ * Used as a narrow reconciliation fallback when status-filter counters drift from
+ * the underlying row set (for example unread counter skew).
+ */
+export async function countInboxMessagesByStatusFromD1(
+  db: D1Database,
+  btcAddress: string,
+  status: StatusFilter
+): Promise<number> {
+  let sql = `
+    SELECT COUNT(*) AS count
+    FROM inbox_messages
+    WHERE to_btc_address = ? AND is_reply = 0
+  `;
+
+  if (status === "unread") {
+    sql += " AND read_at IS NULL";
+  } else if (status === "read") {
+    sql += " AND read_at IS NOT NULL";
+  }
+
+  const row = await db.prepare(sql).bind(btcAddress).first<{ count: number | string }>();
+  return Number(row?.count ?? 0);
+}
 
 /**
  * Fetch reply rows for a set of parent message IDs.


### PR DESCRIPTION
Refs #906

## Summary
- Derive filtered inbox `totalCount` from the live D1 row count when status is `read` or `unread`.
- Keep the `agent_inbox_stats` fast path for `status=all`.
- Prevent the unread counter from reporting a phantom count when the maintained stat drifts from the row set.

## Verification
- `npm test -- app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts lib/inbox/__tests__/d1-reads.test.ts`

No secrets, wallet material, deployment values, private context, or price claims included.