### PR TITLE
fix: redirect /bounties to /bounty

### DIFF
--- a/app/bounties/__tests__/route.test.ts
+++ b/app/bounties/__tests__/route.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from "vitest";
+
+describe("GET /bounties", () => {
+  it("redirects to /bounty and preserves query params", async () => {
+    const { GET } = await import("../route");
+    const res = await GET(new Request("https://aibtc.com/bounties?status=open&limit=20"));
+
+    expect(res.status).toBe(308);
+    expect(res.headers.get("location")).toBe("https://aibtc.com/bounty?status=open&limit=20");
+  });
+});
+

--- a/app/bounties/route.ts
+++ b/app/bounties/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Backward-compatible alias for bounty board links that still use `/bounties`.
+ */
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  url.pathname = "/bounty";
+  return NextResponse.redirect(url, 308);
+}
+


### PR DESCRIPTION
## Summary
- add a backward-compatible `/bounties` alias route
- redirect requests to `/bounty` with HTTP 308
- add a route test that verifies redirect target and preserved query params

## Testing
- `npm test -- app/bounties/__tests__/route.test.ts`

Refs #907