### PR TITLE
Inbox: show originated messages in the Sent tab

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -34,6 +34,7 @@ import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/in
 import { bumpInboundStats, getAgentInboxStats } from "@/lib/inbox/stats";
 import {
   listInboxMessagesFromD1,
+  listSentMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
   checkRedeemedTxidInD1,
@@ -271,14 +272,10 @@ export async function GET(
   // See: https://github.com/aibtcdev/landing-page/issues/697 (Phase 2.5 umbrella)
   // See: https://github.com/aibtcdev/landing-page/issues/723 (cache-invariant extraction)
 
-  // This route only supports received messages for the inbox list GET.
-  // The 'view' param is preserved for response-shape compatibility and
-  // future extension; for now only received/all is meaningful for inbox-list.
-  // Sent messages (outbox view) are not yet flipped in this PR (Step 3.3).
-  //
-  // For 'view=sent' with D1, we fall back to the same D1 path but return
-  // only received messages (view=all treats inbox as the source of truth).
-  // The sent-outbox flip will be handled in Step 3.3.
+  // 'view=received' and 'view=all' read the received inbox (messages addressed
+  // to this agent). 'view=sent' reads ORIGINATED messages this agent authored
+  // to other agents (handled in its own branch just below). Replies (is_reply=1)
+  // remain available inline on received messages and via GET /api/outbox.
 
   // Fetch the paginated message list from D1
   if (!db) {
@@ -290,9 +287,85 @@ export async function GET(
     );
   }
 
+  // ── view=sent: originated messages this agent authored to others ──────────
+  // (is_reply=0, keyed by from_stx_address = the agent's STX identity, the
+  // x402 payer recorded at delivery). Backed by idx_inbox_sent_from_stx
+  // (migration 018) and paginated newest-first, so old messages never load
+  // unless explicitly paged to. There is no maintained total counter for
+  // originals — hasMore is derived from whether a full page came back, which
+  // is all the "Load more" UI needs (nobody pages a precise count of old sent
+  // messages). This intentionally does NOT touch the received/all path below.
+  if (view === "sent") {
+    let sentOriginals: import("@/lib/inbox/types").InboxMessage[];
+    // Originals are keyed by STX, so an agent without a resolved STX address
+    // cannot have authored any — short-circuit to an empty page.
+    if (!agent.stxAddress) {
+      sentOriginals = [];
+    } else {
+      try {
+        sentOriginals = await listSentMessagesFromD1(
+          db,
+          agent.stxAddress,
+          limit,
+          offset
+        );
+      } catch (e) {
+        return d1TransientResponse(
+          "Inbox database temporarily unavailable. Please retry shortly."
+        );
+      }
+    }
+
+    // Resolve recipient display names for "to whom". The recipient BTC address
+    // is stored directly on the row (to_btc_address), so no STX→BTC resolution
+    // is needed — we only look up the agent record for the display name.
+    const recipientSet = new Set<string>();
+    for (const m of sentOriginals) recipientSet.add(m.toBtcAddress);
+    const recipientMap = new Map<string, import("@/lib/types").AgentRecord>();
+    await Promise.all(
+      Array.from(recipientSet).map(async (addr) => {
+        const found = await lookupAgent(kv, addr, db);
+        if (found) recipientMap.set(addr, found);
+      })
+    );
+
+    const sentMessagesOut = sentOriginals.map((message) => {
+      const peer = recipientMap.get(message.toBtcAddress);
+      return {
+        ...message,
+        direction: "sent" as const,
+        peerBtcAddress: peer?.btcAddress ?? message.toBtcAddress,
+        peerDisplayName: peer?.displayName,
+      };
+    });
+
+    const hasMore = sentOriginals.length === limit;
+    return NextResponse.json({
+      agent: {
+        btcAddress: agent.btcAddress,
+        stxAddress: agent.stxAddress,
+        displayName: agent.displayName,
+      },
+      inbox: {
+        messages: sentMessagesOut,
+        replies: {},
+        unreadCount: 0,
+        // Lower-bound total — exact counts of old sent messages aren't tracked.
+        totalCount: offset + sentOriginals.length,
+        view,
+        status: statusFilter,
+        pagination: {
+          limit,
+          offset,
+          hasMore,
+          nextOffset: hasMore ? offset + limit : null,
+        },
+      },
+    });
+  }
+
   // Run the message list query and count queries in parallel for the
-  // received inbox. For 'view=sent', we return an empty inbox (Step 3.3
-  // handles the outbox flip). For 'view=all' and 'view=received', query D1.
+  // received inbox ('view=all' and 'view=received').
   const includeReceived = view === "received" || view === "all";
 
   // D1-throws fallback policy (declared per #722 dev-council Cycle 26 advisory):

--- a/app/inbox/[address]/page.tsx
+++ b/app/inbox/[address]/page.tsx
@@ -41,44 +41,7 @@ interface InboxResponse {
   };
 }
 
-interface OutboxResponse {
-  agent: {
-    btcAddress: string;
-    displayName?: string;
-  };
-  outbox: {
-    replies: OutboxReply[];
-    totalCount: number;
-    pagination: {
-      limit: number;
-      offset: number;
-      hasMore: boolean;
-      nextOffset: number | null;
-    };
-  };
-}
-
 const PAGE_SIZE = 20;
-
-// Map an OutboxReply to the same shape InboxList consumes, tagged as direction="sent".
-// The owner's BTC/STX address is used for toBtcAddress/toStxAddress so the row's
-// permalink resolves back to the owner's inbox (where the original message lives).
-function mapReplyToSentMessage(
-  reply: OutboxReply,
-  owner: { btcAddress: string; stxAddress: string }
-): MessageWithPeer {
-  return {
-    messageId: reply.messageId,
-    fromAddress: owner.stxAddress,
-    toBtcAddress: owner.btcAddress,
-    toStxAddress: owner.stxAddress,
-    content: reply.reply,
-    paymentSatoshis: 0,
-    sentAt: reply.repliedAt,
-    direction: "sent",
-    peerBtcAddress: reply.toBtcAddress,
-  };
-}
 
 export default function InboxPage() {
   const params = useParams();
@@ -122,22 +85,22 @@ export default function InboxPage() {
     }
   );
 
-  // Outbox tolerates 404/missing-shape: agents with no sent replies return a
-  // self-doc body without `outbox`. Fetcher throws on non-2xx, so we catch
-  // here and return an empty shape rather than letting SWR error.
-  const { data: outboxData } = useSWR<OutboxResponse | { outbox?: undefined }>(
-    address ? swrKeys.outbox(address, { limit: PAGE_SIZE, offset: 0 }) : null,
+  // Sent tab: originated messages this agent authored (inbox view=sent). Same
+  // endpoint and response shape as received, so it reuses the inbox pagination
+  // plumbing. Tolerates error/missing-shape by returning an empty inbox.
+  const { data: sentData } = useSWR<InboxResponse | { inbox?: undefined }>(
+    address ? swrKeys.inbox(address, { limit: PAGE_SIZE, offset: 0, view: "sent" }) : null,
     {
       fetcher: async (url: string) => {
         try {
-          return await fetcher<OutboxResponse>(url);
+          return await fetcher<InboxResponse>(url);
         } catch {
-          return { outbox: undefined };
+          return { inbox: undefined };
         }
       },
       onSuccess: (result) => {
-        const outbox = result && "outbox" in result ? result.outbox : undefined;
-        setSentNextOffset(outbox?.pagination.nextOffset ?? null);
+        const inbox = result && "inbox" in result ? result.inbox : undefined;
+        setSentNextOffset(inbox?.pagination.nextOffset ?? null);
       },
     }
   );
@@ -163,13 +126,15 @@ export default function InboxPage() {
   const unreadCount = inboxData?.inbox.unreadCount ?? 0;
   const receivedCount = inboxData?.inbox.receivedCount ?? inboxData?.inbox.totalCount ?? 0;
 
-  const baseOutbox = outboxData && "outbox" in outboxData ? outboxData.outbox : undefined;
+  const baseSentInbox = sentData && "inbox" in sentData ? sentData.inbox : undefined;
   const baseSent: MessageWithPeer[] = useMemo(
-    () => (agent && baseOutbox ? baseOutbox.replies.map((r) => mapReplyToSentMessage(r, agent)) : []),
-    [agent, baseOutbox]
+    () => baseSentInbox?.messages ?? [],
+    [baseSentInbox]
   );
   const sentMessages = [...baseSent, ...extraSent];
-  const sentCount = baseOutbox?.totalCount ?? 0;
+  // No maintained total for originals — badge reflects what's loaded, the same
+  // way the Replied/Awaiting tabs count their loaded rows.
+  const sentCount = sentMessages.length;
 
   // Load more — routed by current view. Sent tab loads from outbox; everything
   // else loads from inbox. Subsequent pages are appended to component state
@@ -181,18 +146,15 @@ export default function InboxPage() {
       if (sentNextOffset == null) return;
       setLoadingMore(true);
       try {
-        const result = await fetcher<OutboxResponse>(
-          swrKeys.outbox(address, { limit: PAGE_SIZE, offset: sentNextOffset })
+        const result = await fetcher<InboxResponse>(
+          swrKeys.inbox(address, { limit: PAGE_SIZE, offset: sentNextOffset, view: "sent" })
         );
-        const owner = { btcAddress: agent.btcAddress, stxAddress: agent.stxAddress };
         setExtraSent((prev) => {
           const existing = new Set([...baseSent, ...prev].map((m) => m.messageId));
-          const incoming = result.outbox.replies
-            .map((r) => mapReplyToSentMessage(r, owner))
-            .filter((m) => !existing.has(m.messageId));
+          const incoming = (result.inbox.messages ?? []).filter((m) => !existing.has(m.messageId));
           return [...prev, ...incoming];
         });
-        setSentNextOffset(result.outbox.pagination.nextOffset);
+        setSentNextOffset(result.inbox.pagination.nextOffset);
       } catch {
         // swallow — load-more failure leaves existing pages intact
       } finally {

--- a/lib/inbox/__tests__/d1-reads.test.ts
+++ b/lib/inbox/__tests__/d1-reads.test.ts
@@ -24,6 +24,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import {
   listInboxMessagesFromD1,
+  listSentMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
   getReplyForMessageFromD1,
@@ -366,6 +367,46 @@ describe("fetchRepliesForMessages", () => {
 
     const result = await fetchRepliesForMessages(db, ["msg_no_reply"]);
     expect(result.size).toBe(0);
+  });
+});
+
+// ── listSentMessagesFromD1 ────────────────────────────────────────────────────
+
+describe("listSentMessagesFromD1", () => {
+  const SENDER_STX = "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE";
+
+  it("filters by is_reply=0 AND from_stx_address, newest-first, paginated", async () => {
+    const db = createMockD1([INBOUND_ROW]);
+    const stmtMock = createPreparedStatement([INBOUND_ROW]);
+    (db.prepare as ReturnType<typeof vi.fn>).mockReturnValue(stmtMock);
+
+    await listSentMessagesFromD1(db, SENDER_STX, 20, 40);
+
+    const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
+    expect(sql).toContain("FROM inbox_messages");
+    expect(sql).toContain("WHERE is_reply = 0 AND from_stx_address = ?");
+    expect(sql).toContain("ORDER BY sent_at DESC");
+    expect(sql).toContain("LIMIT ? OFFSET ?");
+
+    const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
+    expect(bindArgs[0]).toBe(SENDER_STX);
+    expect(bindArgs[1]).toBe(20); // limit
+    expect(bindArgs[2]).toBe(40); // offset
+  });
+
+  it("maps rows to InboxMessage shape carrying the recipient", async () => {
+    const db = createMockD1([INBOUND_ROW]);
+    const [msg] = await listSentMessagesFromD1(db, SENDER_STX, 20, 0);
+    expect(msg.messageId).toBe(INBOUND_ROW.message_id);
+    expect(msg.fromAddress).toBe(SENDER_STX);
+    expect(msg.toBtcAddress).toBe(INBOUND_ROW.to_btc_address);
+    expect(msg.toStxAddress).toBe(INBOUND_ROW.to_stx_address);
+  });
+
+  it("returns an empty array when the agent has sent nothing", async () => {
+    const db = createMockD1([]);
+    const result = await listSentMessagesFromD1(db, SENDER_STX, 20, 0);
+    expect(result).toEqual([]);
   });
 });
 

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -160,6 +160,54 @@ export async function listInboxMessagesFromD1(
   return (result.results ?? []).map(rowToInboxMessage);
 }
 
+/**
+ * Fetch a page of ORIGINATED messages an agent has sent from D1.
+ *
+ * "Sent" here means messages this agent AUTHORED to other agents (is_reply=0),
+ * keyed by the sender's STX identity (from_stx_address — the x402 payer recorded
+ * at delivery time). This is distinct from listOutboxRepliesFromD1, which returns
+ * replies (is_reply=1) keyed by the replier's BTC address.
+ *
+ * Newest-first and paginated, backed by idx_inbox_sent_from_stx (migration 018)
+ * so the scan stays bounded to the LIMIT/OFFSET window — old messages never load
+ * unless explicitly paged to.
+ *
+ * Each row carries the recipient on to_btc_address / to_stx_address, so callers
+ * can render "to whom" without any extra resolution.
+ *
+ * SQL shape:
+ *   SELECT … FROM inbox_messages
+ *   WHERE is_reply = 0 AND from_stx_address = ?
+ *   ORDER BY sent_at DESC
+ *   LIMIT ? OFFSET ?
+ */
+export async function listSentMessagesFromD1(
+  db: D1Database,
+  fromStxAddress: string,
+  limit: number,
+  offset: number
+): Promise<InboxMessage[]> {
+  const sql = `
+    SELECT
+      message_id, from_stx_address, to_btc_address, to_stx_address,
+      content, payment_txid, payment_satoshis, payment_status,
+      payment_id, receipt_id, recovered_via_txid, authenticated,
+      bitcoin_signature, sender_btc_address,
+      sent_at, read_at, replied_at, reply_to_message_id
+    FROM inbox_messages
+    WHERE is_reply = 0 AND from_stx_address = ?
+    ORDER BY sent_at DESC
+    LIMIT ? OFFSET ?
+  `;
+
+  const result = await db
+    .prepare(sql)
+    .bind(fromStxAddress, limit, offset)
+    .all<D1InboxRow>();
+
+  return (result.results ?? []).map(rowToInboxMessage);
+}
+
 // Dead code purge (P3C PR 1): `countInboxMessagesFromD1` removed.
 // Replaced by `getAgentInboxStats(db, btcAddress)` from `lib/inbox/stats.ts`
 // which serves O(1) point-lookups against the maintained `agent_inbox_stats`

--- a/migrations/018_inbox_sent_from_stx_index.sql
+++ b/migrations/018_inbox_sent_from_stx_index.sql
@@ -1,0 +1,23 @@
+-- Migration 018: index for "sent originals" lookups on inbox_messages.
+--
+-- The agent inbox page's "Sent" tab lists messages an agent AUTHORED to other
+-- agents (is_reply=0), keyed by the sender's STX identity (from_stx_address —
+-- the x402 payer recorded at delivery). The existing indexes only cover
+-- received (idx_inbox_to_btc_sent_at, by to_btc_address) and replies
+-- (idx_inbox_outbox_from_btc_sent_at, by from_btc_address); neither serves a
+-- from_stx_address lookup, so the paginated newest-first query would otherwise
+-- scan every is_reply=0 row to sort.
+--
+-- This partial index makes GET /api/inbox/[address]?view=sent an index range
+-- scan bounded to the LIMIT/OFFSET window — D1 bills only the rows in the page,
+-- keeping cost flat as message volume grows.
+--
+-- Query served:
+--   SELECT … FROM inbox_messages
+--   WHERE is_reply = 0 AND from_stx_address = ?
+--   ORDER BY sent_at DESC
+--   LIMIT ? OFFSET ?
+
+CREATE INDEX IF NOT EXISTS idx_inbox_sent_from_stx
+  ON inbox_messages(from_stx_address, sent_at DESC)
+  WHERE is_reply = 0;


### PR DESCRIPTION
## What

The agent inbox "Sent" tab only showed *replies* (`is_reply=1`), so messages an agent originated to other agents never appeared anywhere on its page — Sent always read 0 even after sending. This makes the Sent tab show what an agent actually sent, and to whom.

## How

The inbox GET route already accepted `view=sent` but the branch was stubbed to return empty (Step 3.3 was deferred). This implements it.

- **`migrations/018_inbox_sent_from_stx_index.sql`** — partial index `(from_stx_address, sent_at DESC) WHERE is_reply=0` so the paginated query is a bounded index range scan. *(Already applied to production D1.)*
- **`listSentMessagesFromD1`** — lists originated messages (`is_reply=0`) keyed by the sender's STX identity, newest-first, paginated.
- **`view=sent` branch** in the inbox route — returns originated messages and resolves each recipient's display name from the row's `to_btc_address`.
- **Sent tab** now fetches `?view=sent` instead of the replies-only outbox, reusing the existing pagination plumbing.

## Behavior

- Newest-first, 20 per page; "Load more" pages older ones on demand — old messages never load up front.
- No `COUNT(*)` scan: `hasMore` derives from whether a full page returned; the badge reflects loaded count (same as Replied/Awaiting tabs).
- No write-path or send-cost changes.
- Replies move out of "Sent" (now = originated messages) but remain visible inline on the messages they answer and under the "Replied" tab.

## Tests

3 new cases in `d1-reads.test.ts` (SQL shape, recipient mapping, empty result). All 54 d1-reads + 87 inbox-route tests pass; typecheck clean on touched files.