### PR TITLE
Fix misleading Sent count on agent profile

### DIFF
--- a/app/components/InboxActivity.tsx
+++ b/app/components/InboxActivity.tsx
@@ -90,7 +90,9 @@ export default function InboxActivity({
 
   const { messages, replies = {}, unreadCount, totalCount, receivedCount = 0, sentCount = 0 } = data.inbox;
   const hasMessages = totalCount > 0;
-  const repliedCount = messages.filter((m) => m.repliedAt).length;
+  // `sentCount` is the maintained count of replies this agent has sent
+  // (is_reply=1) — NOT originated messages. Labeled "replied" so it isn't
+  // mistaken for a sent-message total the inbox doesn't cheaply track.
 
   return (
     <div className={className}>
@@ -101,12 +103,10 @@ export default function InboxActivity({
           {hasMessages && (
             <div className="flex items-center gap-2 text-[11px] text-white/40 sm:gap-3 sm:text-[12px]">
               <span>{receivedCount} received</span>
-              <span className="text-white/15">&middot;</span>
-              <span>{sentCount} sent</span>
-              {repliedCount > 0 && (
+              {sentCount > 0 && (
                 <>
                   <span className="text-white/15">&middot;</span>
-                  <span>{repliedCount} replied</span>
+                  <span>{sentCount} replied</span>
                 </>
               )}
             </div>


### PR DESCRIPTION
## What

The `/agents/[address]` profile page (via `InboxActivity`) showed `sentCount` labeled **"sent"**, but that counter is *replies sent* (`is_reply=1`). An agent that only sent originated messages — not replies — read **"0 sent"**, which is misleading next to a correct received count.

## How

Relabel it **"replied"** (it's the exact maintained reply counter) and drop the redundant approximate "replied" stat that was computed over only the loaded message page. The profile now shows `received` + `replied`, both exact.

## Cost

Zero added — both numbers come from the `agent_inbox_stats` row already fetched on load. No new query, no `COUNT(*)`, no maintained counter. Verified against D1's billing model (rows read/written): this adds no rows read.

## Note

Originated-message *totals* are intentionally not shown here — that would require either a per-load read or a per-send counter, both declined for cost. The inbox page's Sent tab (PR #919) already lets you browse originated messages and their recipients.