### PR TITLE
fix(bounty): render submission messages as markdown

### DIFF
--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -15,26 +15,6 @@ import {
 import AgentBadge from "../AgentBadge";
 import BountyMarkdown from "../BountyMarkdown";
 
-function linkify(text: string) {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const parts = text.split(urlRegex);
-  return parts.map((part, i) =>
-    urlRegex.test(part) ? (
-      <a
-        key={i}
-        href={part}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-[#7DA2FF] hover:text-[#9db8ff] underline underline-offset-2 break-all"
-      >
-        {part}
-      </a>
-    ) : (
-      <span key={i}>{part}</span>
-    )
-  );
-}
-
 const TIMELINE_STEPS: BountyStatus[] = ["open", "judging", "winner-announced", "paid"];
 
 function CheckIcon({ className = "size-3.5" }: { className?: string }) {
@@ -217,9 +197,7 @@ function SubmissionCard({
         </div>
       </div>
 
-      <p className="text-[13px] leading-relaxed text-white/65 whitespace-pre-wrap">
-        {linkify(sub.message)}
-      </p>
+      <BountyMarkdown>{sub.message}</BountyMarkdown>
 
       {sub.contentUrl && (
         <a


### PR DESCRIPTION
## What

Bounty submission messages were rendered as plain text (`<p>` with `whitespace-pre-wrap` + a local `linkify` helper), so any markdown a submitter wrote (headings, lists, code, bold, tables) showed up raw. Bounty *descriptions* already render through `BountyMarkdown` — submissions now use the same renderer.

## Change

- `app/bounty/[id]/BountyDetail.tsx`: render `sub.message` via `<BountyMarkdown>` instead of `linkify` + plain `<p>`.
- Removed the now-dead local `linkify` helper. `BountyMarkdown` uses `remark-gfm`, which autolinks bare URLs, so link behavior is preserved (and gains proper markdown rendering).

## Notes

- No new dependencies — reuses the existing `BountyMarkdown` component.
- `react-markdown` renders no raw HTML by default (no `rehype-raw`), so this does not introduce an HTML-injection surface for submitter-controlled content.

## Test

`npx tsc --noEmit` shows no errors in the changed file (pre-existing errors are confined to unrelated `__tests__` files).
