### PR TITLE
fix(bounty): render submission messages as Markdown

### DIFF
--- a/app/bounty/BountyMarkdown.tsx
+++ b/app/bounty/BountyMarkdown.tsx
@@ -6,7 +6,7 @@ import remarkBreaks from "remark-breaks";
 import type { Components } from "react-markdown";
 
 /**
- * Markdown renderer for bounty descriptions.
+ * Markdown renderer for bounty descriptions and submission messages.
  *
  * Defaults are safe: react-markdown does not render raw HTML by default, so
  * we do not pass rehype-raw. Custom link renderer opens in a new tab and

--- a/app/bounty/[id]/BountyDetail.tsx
+++ b/app/bounty/[id]/BountyDetail.tsx
@@ -15,26 +15,6 @@ import {
 import AgentBadge from "../AgentBadge";
 import BountyMarkdown from "../BountyMarkdown";
 
-function linkify(text: string) {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const parts = text.split(urlRegex);
-  return parts.map((part, i) =>
-    urlRegex.test(part) ? (
-      <a
-        key={i}
-        href={part}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="text-[#7DA2FF] hover:text-[#9db8ff] underline underline-offset-2 break-all"
-      >
-        {part}
-      </a>
-    ) : (
-      <span key={i}>{part}</span>
-    )
-  );
-}
-
 const TIMELINE_STEPS: BountyStatus[] = ["open", "judging", "winner-announced", "paid"];
 
 function CheckIcon({ className = "size-3.5" }: { className?: string }) {
@@ -217,9 +197,7 @@ function SubmissionCard({
         </div>
       </div>
 
-      <p className="text-[13px] leading-relaxed text-white/65 whitespace-pre-wrap">
-        {linkify(sub.message)}
-      </p>
+      <BountyMarkdown>{sub.message}</BountyMarkdown>
 
       {sub.contentUrl && (
         <a


### PR DESCRIPTION
Bounty **descriptions** render as Markdown (#903), but submission **messages** were still shown as plain text (`whitespace-pre-wrap` + a local `linkify`) — so Markdown in a submission appeared raw/unformatted.

## Fix

- Route submission messages through the same `<BountyMarkdown>` renderer used for descriptions (`app/bounty/[id]/BountyDetail.tsx`).
- Remove the now-redundant local `linkify` helper — `BountyMarkdown` uses `remark-gfm`, which autolinks bare URLs, so link behavior is preserved.
- Update the `BountyMarkdown` doc comment to note it renders submissions too.

Styling is unchanged: the renderer's `text-[13px] leading-relaxed text-white/70` matches what the submission block already used. Lint clean.