### PR TITLE
fix(bounty): add /bounties alias page

### DIFF
--- a/app/bounties/page.tsx
+++ b/app/bounties/page.tsx
@@ -1,0 +1,2 @@
+export { metadata } from "../bounty/page";
+export { default } from "../bounty/page";


### PR DESCRIPTION
Adds a static /bounties route that re-exports the existing bounty board page, so the plural URL no longer 404s.

Closes #907.