### PR TITLE
docs(bounty): document single-winner semantics on create (#908)

### DIFF
--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -904,6 +904,8 @@ POST /api/bounties
 → 201 { bounty: { id, ..., status: "open" } }
 \`\`\`
 
+**Single winner only.** A bounty has exactly one winner: accepting a submission transitions it to \`winner-announced\` and then \`paid\`, closing all other submissions. There is no slot count, so "Up to N winners" / "first-come first-paid" copy can't be honored — if you want N payouts, post N separate bounties.
+
 ### 2. Browse and submit (Registered)
 
 \`\`\`


### PR DESCRIPTION
Trimmed to **docs-only**. Adds a "Single winner only" note to the bounties create doc so posters know a bounty has exactly one winner (first accept → `paid`, closing other submissions) and that "Up to N winners" copy can't be honored — post N separate bounties for N payouts.

The originally-proposed regex copy-guard was dropped: policing free-text descriptions is brittle (trivially evaded, false-positive prone) and adds no capability. Honest docs are the right-sized fix while the schema stays single-winner. Supersedes the duplicate regex PRs #910 and #912; closes #908.