### PR TITLE
fix(d1): restore indexes dropped by migration 008 table rebuild

### DIFF
--- a/migrations/019_restore_dropped_indexes.sql
+++ b/migrations/019_restore_dropped_indexes.sql
@@ -1,0 +1,61 @@
+-- Migration 019: restore indexes silently dropped by migration 008.
+--
+-- ROOT CAUSE (2026-05-26 D1 attribution): migration 008 (nullable_btc_public_key)
+-- rebuilt agents/claims/inbox_messages/vouches/swaps/balances to drop a NOT NULL
+-- constraint. SQLite cannot ALTER COLUMN, so 008 did the table-rebuild dance:
+--   CREATE TEMP TABLE tmp_x AS SELECT * FROM x; DROP TABLE x; CREATE TABLE x (...);
+--   INSERT INTO x SELECT * FROM tmp_x;
+-- DROP TABLE removes a table's indexes along with it. Migration 008 recreated
+-- ONLY the `agents` indexes afterward (008 lines 254-257) and never restored the
+-- indexes defined in migrations 002-006 for the other five rebuilt tables.
+--
+-- IMPACT: every inbox listing became a full table scan. `wrangler d1 insights`
+-- showed inbox_messages SELECTs accounting for ~96% of all D1 rows-read
+-- (~4.5B rows/day, ~$100+/mo overage) at <1K agents. EXPLAIN QUERY PLAN confirmed
+-- `SCAN inbox_messages` + temp B-tree sort because idx_inbox_to_btc_sent_at and
+-- idx_inbox_reply_to were absent from the live DB. The indexes existed in the
+-- migration *files* but not in production (`wrangler d1 migrations list` reported
+-- "No migrations to apply"), so the prior cost campaign trusted the files and
+-- never ran EXPLAIN / checked live sqlite_master.
+--
+-- This migration is additive and idempotent (IF NOT EXISTS) — it only recreates
+-- the indexes 008 dropped. DDL is copied verbatim from migrations 002-006, with
+-- one deliberate change noted below.
+--
+-- NOTE on idx_inbox_payment_txid: originally a UNIQUE index (003 line 86). The
+-- live table accumulated 16 duplicate payment_txid groups while the unique
+-- constraint was absent (008 onward), so it is recreated here as NON-UNIQUE to
+-- keep this migration safe and unblocked. Restoring uniqueness requires a
+-- separate dedup data task — see follow-up issue. The non-unique index still
+-- serves payment_txid reconciliation lookups; it is not on the hot path.
+
+-- ── inbox_messages (the dominant cost driver) ──────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_inbox_to_btc_sent_at
+  ON inbox_messages(to_btc_address, sent_at DESC) WHERE is_reply = 0;
+CREATE INDEX IF NOT EXISTS idx_inbox_outbox_from_btc_sent_at
+  ON inbox_messages(from_btc_address, sent_at DESC) WHERE is_reply = 1;
+CREATE INDEX IF NOT EXISTS idx_inbox_unread
+  ON inbox_messages(to_btc_address) WHERE is_reply = 0 AND read_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_inbox_reply_to
+  ON inbox_messages(reply_to_message_id) WHERE reply_to_message_id IS NOT NULL;
+-- NON-UNIQUE (see note above; was UNIQUE in migration 003).
+CREATE INDEX IF NOT EXISTS idx_inbox_payment_txid
+  ON inbox_messages(payment_txid) WHERE payment_txid IS NOT NULL;
+
+-- ── claims ─────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_claims_status ON claims(status);
+CREATE INDEX IF NOT EXISTS idx_claims_claimed_at ON claims(claimed_at);
+
+-- ── vouches ────────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_vouches_referrer ON vouches(referrer_btc, registered_at DESC);
+CREATE INDEX IF NOT EXISTS idx_vouches_referee ON vouches(referee_btc);
+CREATE INDEX IF NOT EXISTS idx_vouches_paid_out ON vouches(paid_out, registered_at) WHERE paid_out = 0;
+
+-- ── balances ───────────────────────────────────────────────────────────────
+CREATE INDEX IF NOT EXISTS idx_balances_agent_token_time
+  ON balances(agent_address, token_id, captured_at DESC);
+
+-- ── swaps (010 re-added the token_in/out indexes; these three were not) ──────
+CREATE INDEX IF NOT EXISTS idx_swaps_sender_burn_time ON swaps(sender, burn_block_time DESC);
+CREATE INDEX IF NOT EXISTS idx_swaps_scored_at ON swaps(scored_at) WHERE scored_at IS NULL;
+CREATE INDEX IF NOT EXISTS idx_swaps_contract_burn_time ON swaps(contract_id, burn_block_time DESC);

--- a/migrations/019_restore_dropped_indexes.sql
+++ b/migrations/019_restore_dropped_indexes.sql
@@ -55,7 +55,7 @@ CREATE INDEX IF NOT EXISTS idx_vouches_paid_out ON vouches(paid_out, registered_
 CREATE INDEX IF NOT EXISTS idx_balances_agent_token_time
   ON balances(agent_address, token_id, captured_at DESC);
 
--- ── swaps (010 re-added the token_in/out indexes; these three were not) ──────
+-- ── swaps (010 added the token_in/out indexes; these three from 005 were not) ─
 CREATE INDEX IF NOT EXISTS idx_swaps_sender_burn_time ON swaps(sender, burn_block_time DESC);
 CREATE INDEX IF NOT EXISTS idx_swaps_scored_at ON swaps(scored_at) WHERE scored_at IS NULL;
 CREATE INDEX IF NOT EXISTS idx_swaps_contract_burn_time ON swaps(contract_id, burn_block_time DESC);


### PR DESCRIPTION
## Root cause

The unattributed steady-state ~190M/hr (~4.5B/day) landing-page **D1 rows-read** is **~96% full-table scans of `inbox_messages`**. Migration `008_nullable_btc_public_key` rebuilt six tables to drop a NOT NULL constraint (SQLite can't `ALTER COLUMN`) via `CREATE TEMP → DROP TABLE → CREATE → INSERT`. `DROP TABLE` drops a table's indexes with it — and 008 recreated **only the `agents` indexes** (008 lines 254-257), silently losing every index defined in migrations 002-006 for `inbox_messages`, `claims`, `vouches`, `balances`, and `swaps`.

The indexes exist in the migration **files** but not in the **live DB**, and `wrangler d1 migrations list` reports nothing pending — so the schema *looks* complete. The prior cost campaign trusted the files and never ran `EXPLAIN QUERY PLAN` / checked live `sqlite_master`.

## Evidence (live, 2026-05-26)

- `wrangler d1 insights landing-page --sort-by reads`: top query `SELECT … FROM inbox_messages WHERE to_btc_address=? AND is_reply=0 ORDER BY sent_at DESC LIMIT ? OFFSET ?` = **22.1B rows / 7d (60%)**; inbox SELECTs together ≈ **96%** of all D1 reads.
- `EXPLAIN QUERY PLAN`: `SCAN inbox_messages USING INDEX idx_inbox_sent_from_stx` + `USE TEMP B-TREE FOR ORDER BY` (full scan on the wrong index; `idx_inbox_to_btc_sent_at` is absent). Reply fetch = bare `SCAN`.
- Live `sqlite_master`: `inbox_messages` has only the PK autoindex + `idx_inbox_sent_from_stx` (018). All five 003 indexes missing; `claims`/`vouches`/`balances` have **zero** indexes live.
- Table is 8,012 rows; 22.1B ÷ 6,032 non-reply rows ≈ **3.7M full scans / 7d**.

## What this does

Migration 019 recreates every index dropped by 008, `IF NOT EXISTS` (additive, idempotent, reversible via `DROP INDEX`). DDL copied verbatim from migrations 002-006, one deliberate change:

- **`idx_inbox_payment_txid` restored NON-UNIQUE** (was UNIQUE in 003). 16 duplicate `payment_txid` groups accumulated while the constraint was absent, so a UNIQUE index would abort the migration. Restoring uniqueness needs a separate dedup task (follow-up issue to file). The non-unique index still serves reconciliation lookups and is not on the hot path.

## Cost & latency impact (expected)

Each inbox call goes from a ~6,032-row scan + temp-sort to an index seek of ~LIMIT rows. Projected **D1 rows-read 4.5B/day → <100M/day — inside the 25B/mo free tier (D1 read cost → ~$0)**, and a large wall-time drop on inbox routes (#1 query burned 5.5 hrs of cumulative D1 time / 7d).

## Apply (manual — CI/git-deploy does NOT apply D1 migrations)

```
npm run wrangler -- d1 migrations apply landing-page --remote
```

## Verify (post-apply, partial-hour settle discipline)

1. `wrangler d1 execute … "SELECT tbl_name,name FROM sqlite_master WHERE type='index'"` — confirm the 15 indexes present.
2. `EXPLAIN QUERY PLAN` on the inbox-list query — expect `SEARCH inbox_messages USING INDEX idx_inbox_to_btc_sent_at`, no temp B-tree.
3. `wrangler d1 insights` + GraphQL D1 rows-read — re-read the previous-previous settled hour; expect ≥95% drop on the inbox query.

## Follow-ups (separate)

- Data: dedup the 16 duplicate `payment_txid` groups, then restore the UNIQUE constraint.
- Guardrail: CI/recon check diffing live `sqlite_master` vs expected indexes so a future rebuild can't silently drop them again.
- Investigate the May 22-25 landing-page WARN/ERROR spike (0→954 errors/day after the feature wave).

Full attribution writeup: `~/.planning/active/2026-05-20-d1-attribution-traffic-shape/phases/P0-baseline/2026-05-26T1740Z-d1-attribution-FOUND.md`

cc @arc0btc @secret-mars

🤖 Generated with [Claude Code](https://claude.com/claude-code)