### PR TITLE
docs(earning.md): add Inspect line to §7 Paid x402 Endpoints (#931)

### DIFF
--- a/app/earning.md/route.ts
+++ b/app/earning.md/route.ts
@@ -114,6 +114,7 @@ stake in the draw.
 
 **Earn:** per-call STX/sBTC payments from agents that call an API you deploy.
 
+- Inspect: \`list_x402_endpoints\` · \`probe_x402_endpoint\`
 - Scaffold: \`scaffold_x402_endpoint\` · \`scaffold_x402_ai_endpoint\`
 
 Notes: you build and deploy the endpoint; the x402 relay handles payment settlement so


### PR DESCRIPTION
## Summary

Adds the missing `Inspect:` line to §7 of `/earning.md` so it mirrors the **Inspect + Act** (§2–§6) and **Inspect + Scaffold** patterns the rest of the document uses.

```diff
 ## 7. Paid x402 Endpoints

 **Earn:** per-call STX/sBTC payments from agents that call an API you deploy.

+- Inspect: `list_x402_endpoints` · `probe_x402_endpoint`
 - Scaffold: `scaffold_x402_endpoint` · `scaffold_x402_ai_endpoint`
```

Two MCP tools fit the Inspect slot:
- `list_x402_endpoints` — enumerate already-deployed endpoints on the network
- `probe_x402_endpoint` — discover the 402 payment requirements / pricing for any URL

## Why

An agent considering deploying their own x402 endpoint benefits from first surveying what already exists — to avoid duplicating effort, identify pricing gaps, or find composable upstream services. The §7 framing (\"you build and deploy the endpoint\") quietly assumes the agent already has full ecosystem context, while §2–§6 bridge that gap explicitly via Inspect tools.

## Scope

- 1 file, +1/-0 lines (`app/earning.md/route.ts`)
- Pure content addition; no logic touched
- No tests required — `app/earning.md/route.ts` has no tests for content (the file is a static markdown response)
- Lint clean (no behavior change)

## Closes

Closes #931.

## Test plan

- [ ] Visual diff matches the inline diff in #931 body
- [ ] After merge, `curl -s https://aibtc.com/earning.md | sed -n '/## 7/,/^---$/p'` should show the new Inspect line between **Earn:** and Scaffold:

🤖 Generated with [Claude Code](https://claude.com/claude-code)