### PR TITLE
fix(deps): bump tmp to 0.2.6 (CVE-2026-44705)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12978,9 +12978,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
     "path-to-regexp": ">=8.4.0",
-    "axios": ">=1.15.0"
+    "axios": ">=1.15.0",
+    "tmp": ">=0.2.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- Bumps transitive dependency `tmp` from 0.2.5 → 0.2.6 via npm `overrides`
- Fixes GHSA-ph9p-34f9-6g65 / CVE-2026-44705: path traversal via unsanitized `prefix`/`postfix`/`dir` options
- `tmp` is pulled in by `patch-package` (devDependency only) — no runtime exposure

## Risk assessment

**Low** — `tmp` is a dev-only transitive dependency used by `patch-package` during `postinstall`. The landing-page app code never calls `tmp` directly with user-controlled input, so there is no runtime attack surface. The upgrade is a pure lock-file bump.

## Test plan

- [ ] CI build passes (`next build`)
- [ ] Dependabot alert #111 auto-dismisses after merge

Closes: https://github.com/aibtcdev/landing-page/security/dependabot/111

🤖 Generated with [Claude Code](https://claude.com/claude-code)