### PR TITLE
fix(inbox): derive status=unread totalCount from live COUNT(*) to fix phantom unread (#906)

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -34,6 +34,7 @@ import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/in
 import { bumpInboundStats, getAgentInboxStats } from "@/lib/inbox/stats";
 import {
   listInboxMessagesFromD1,
+  countInboxMessagesFromD1,
   listSentMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
@@ -378,12 +379,16 @@ export async function GET(
   //   [0] stats row — receivedCount, unreadCount from maintained counters
   //   [1] paginated message list (the page the caller asked for)
   //   [2] sentMessages — outbox replies for partner graph (only when includePartners)
+  //   [3] live unread count — only when status=unread, bypasses stale denormalized counter
+  //       (#906: agent_inbox_stats.unread_count can drift above live row count,
+  //       producing totalCount=1 + messages=[] phantom unread)
   let receivedMessages: import("@/lib/inbox/types").InboxMessage[];
   let agentStats: Awaited<ReturnType<typeof getAgentInboxStats>>;
   let sentMessages: import("@/lib/inbox/types").OutboxReply[];
+  let liveUnreadCount: number | null = null;
   try {
-    [agentStats, receivedMessages, sentMessages] = await Promise.all([
-      // Stats O(1) point-lookup — replaces two countInboxMessagesFromD1 scans
+    [agentStats, receivedMessages, sentMessages, liveUnreadCount] = await Promise.all([
+      // Stats O(1) point-lookup — receivedCount and sentCount remain accurate
       getAgentInboxStats(db, agent.btcAddress),
       // Paginated message list (still needed for message content)
       includeReceived
@@ -393,18 +398,23 @@ export async function GET(
       includePartners
         ? listOutboxRepliesFromD1(db, agent.btcAddress, 100, 0)
         : Promise.resolve([] as import("@/lib/inbox/types").OutboxReply[]),
+      // Live count for status=unread only — avoids phantom unread from counter drift
+      statusFilter === "unread"
+        ? countInboxMessagesFromD1(db, agent.btcAddress, "unread")
+        : Promise.resolve(null),
     ]);
   } catch (e) {
     return d1TransientResponse("Inbox database temporarily unavailable. Please retry shortly.");
   }
 
-  const unreadCount = agentStats.unreadCount;
+  const unreadCount = liveUnreadCount ?? agentStats.unreadCount;
   const receivedCount = agentStats.receivedCount;
 
-  // Derive totalCount from stats counters — no extra COUNT(*) needed.
-  // statusFilter="all"   → totalCount equals receivedCount (same predicate)
-  // statusFilter="unread" → totalCount equals unreadCount (same predicate)
-  // statusFilter="read"   → totalCount equals received minus unread
+  // Derive totalCount from counters.
+  // statusFilter="all"    → totalCount equals receivedCount (maintained counter, accurate)
+  // statusFilter="unread" → totalCount comes from live COUNT(*) WHERE read_at IS NULL
+  //                         (liveUnreadCount), not the denormalized counter that can drift
+  // statusFilter="read"   → totalCount equals received minus live unread
   const totalCount: number =
     statusFilter === "unread"
       ? unreadCount

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -161,6 +161,40 @@ export async function listInboxMessagesFromD1(
 }
 
 /**
+ * Count inbound messages for an agent with the given status filter.
+ *
+ * Restored to serve as the source-of-truth for totalCount when
+ * statusFilter === "unread", bypassing the denormalized agent_inbox_stats
+ * counter which can drift when a mark-read update misses decrementUnreadStats.
+ * Hits idx_inbox_unread (partial index on read_at IS NULL) for the unread
+ * case — O(log n) not O(n). See: https://github.com/aibtcdev/landing-page/issues/906
+ */
+export async function countInboxMessagesFromD1(
+  db: D1Database,
+  btcAddress: string,
+  status: StatusFilter
+): Promise<number> {
+  let sql = `
+    SELECT COUNT(*) AS cnt
+    FROM inbox_messages
+    WHERE to_btc_address = ? AND is_reply = 0
+  `;
+
+  if (status === "unread") {
+    sql += " AND read_at IS NULL";
+  } else if (status === "read") {
+    sql += " AND read_at IS NOT NULL";
+  }
+
+  const row = await db
+    .prepare(sql)
+    .bind(btcAddress)
+    .first<{ cnt: number }>();
+
+  return row?.cnt ?? 0;
+}
+
+/**
  * Fetch a page of ORIGINATED messages an agent has sent from D1.
  *
  * "Sent" here means messages this agent AUTHORED to other agents (is_reply=0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -12978,9 +12978,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
     "path-to-regexp": ">=8.4.0",
-    "axios": ">=1.15.0"
+    "axios": ">=1.15.0",
+    "tmp": ">=0.2.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

Fixes the phantom unread bug reported in #906: `GET /api/inbox/{address}?status=unread` returns `totalCount: 1` + `messages: []`.

**Root cause**: `totalCount` for `status=unread` was derived from `agent_inbox_stats.unread_count` (denormalized counter). When a mark-read update doesn't call `decrementUnreadStats`, the counter drifts above the live row count. The row-fetch query (`WHERE read_at IS NULL`) returns zero rows, but `totalCount` stays at 1 — a phantom unread no consumer can enumerate or mark read.

**Fix (Option 1 from #906)**:
- Restore `countInboxMessagesFromD1` in `lib/inbox/d1-reads.ts` (removed in #893 in favor of the stats table)
- For `status=unread` requests, run a live `COUNT(*) WHERE read_at IS NULL` in parallel with the existing stats/message-list queries
- Use the live count as `totalCount` and `unreadCount` for `status=unread`, bypassing the stale denormalized counter
- `status=read` totalCount is also corrected as a side effect (derives from `receivedCount - liveUnreadCount`)
- `status=all` still uses the O(1) maintained `receivedCount` — no regression there

**Performance**: The live count hits `idx_inbox_unread` (partial index on `read_at IS NULL`, added in an earlier migration) — O(log n) scan, not a full table scan. Only executes when `status=unread`, so the common `status=all` path is unaffected.

**Operational context**: Arc runs this inbox API in production as the primary agent-to-agent messaging path. The polling pattern `?status=unread` → enumerate → PATCH mark-read is exactly how agents drive replyable threads. A phantom unread silently breaks the loop — the agent sees "1 unread" but can never process it.

## Test plan

- [ ] `GET /api/inbox/{address}?status=unread` with a known-clean agent: `totalCount` and `messages.length` agree
- [ ] After marking all messages read, `?status=unread` returns `totalCount: 0` + `messages: []`
- [ ] `?status=all` still returns correct `totalCount` (unchanged path)
- [ ] Manually verify against Quasar Garuda's address `SP20GPDS5RYB2DV03KG4W08EG6HD11KYPK6FQJE1` from #906 — phantom unread should resolve

## Related

- Closes #906
- Related: #724 (route-level GET integration tests — this is exactly the regression class those tests would catch)
- Related: aibtc-mcp-server#497 (original unreadCount drift tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)