### PR TITLE
feat(bounties): surface proof-of-flow and push open bounties on heartbeat

### DIFF
--- a/app/api/heartbeat/__tests__/route.test.ts
+++ b/app/api/heartbeat/__tests__/route.test.ts
@@ -37,6 +37,13 @@ vi.mock("@/lib/inbox/stats", () => ({
   }),
 }));
 
+// Open-bounties surfacing reads D1 via listBounties; mock it so this unit
+// test stays focused on the check-in write path (mirrors the inbox-stats
+// mock above) and prepare() reflects only the UPDATE.
+vi.mock("@/lib/bounty", () => ({
+  listBounties: vi.fn().mockResolvedValue({ bounties: [], total: 0 }),
+}));
+
 vi.mock("@/lib/levels", () => ({
   getAgentLevel: vi.fn().mockReturnValue({ level: 1, levelName: "Registered" }),
   getNextLevel: vi.fn().mockReturnValue(null),

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -58,6 +58,16 @@ function getOrientation(
  */
 const OPEN_BOUNTIES_CACHE_KEY = "https://cache.aibtc.local/heartbeat/open-bounties";
 const OPEN_BOUNTIES_CACHE_TTL_SECONDS = 120;
+/**
+ * How many open bounties we want to show vs. how many we prefetch before
+ * ranking. `listBounties` orders by `created_at DESC`, NOT reward, so we must
+ * pull a wider window and sort by reward ourselves — otherwise a high-reward
+ * but older bounty outside the newest N rows would be silently dropped. 25
+ * comfortably covers the realistic open-bounty volume; the query is indexed
+ * and edge-cached, so the wider prefetch is effectively free.
+ */
+const OPEN_BOUNTIES_SHOWN = 3;
+const OPEN_BOUNTIES_PREFETCH = 25;
 
 /**
  * Fetch a few currently-open bounties for the check-in payload. Highest
@@ -66,7 +76,7 @@ const OPEN_BOUNTIES_CACHE_TTL_SECONDS = 120;
  * Wrapped in the edge cache (see key/TTL above) so repeat check-ins skip the
  * D1 read entirely. Fails open (returns []) on missing DB or any error:
  * surfacing earning opportunities is a nice-to-have, never a reason to fail a
- * heartbeat. Capped at 3 to keep the payload small.
+ * heartbeat.
  */
 async function fetchOpenBounties(
   db: D1Database | undefined,
@@ -78,9 +88,14 @@ async function fetchOpenBounties(
       OPEN_BOUNTIES_CACHE_KEY,
       OPEN_BOUNTIES_CACHE_TTL_SECONDS,
       async () => {
-        const { bounties } = await listBounties(db, { status: "open", limit: 3, now });
+        const { bounties } = await listBounties(db, {
+          status: "open",
+          limit: OPEN_BOUNTIES_PREFETCH,
+          now,
+        });
         const list = bounties
           .sort((a, b) => b.rewardSats - a.rewardSats)
+          .slice(0, OPEN_BOUNTIES_SHOWN)
           .map((b) => ({
             id: b.id,
             title: b.title,
@@ -161,7 +176,7 @@ function getNextAction(
     const top = openBounties[0];
     return {
       step: "Take a Bounty",
-      description: `${openBounties.length} open bounty${openBounties.length === 1 ? "" : " (and more)"} you can earn sBTC on right now. Top reward: "${top.title}" — ${top.rewardSats.toLocaleString()} sats. Browse at ${top.url}, then submit work via POST /api/bounties/${top.id}/submit.`,
+      description: `${openBounties.length} open ${openBounties.length === 1 ? "bounty" : "bounties"} you can earn sBTC on right now. Top reward: "${top.title}" — ${top.rewardSats.toLocaleString()} sats. Browse at ${top.url}, then submit work via POST /api/bounties/${top.id}/submit.`,
       endpoint: `GET /api/bounties/${top.id}`,
     };
   }

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -9,6 +9,8 @@ import { ACTIVE_BEATS_LIST } from "@/lib/news-beats";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
 import { generateName } from "@/lib/name-generator";
 import { getAgentInboxStats } from "@/lib/inbox/stats";
+import { listBounties } from "@/lib/bounty";
+import { withEdgeCache } from "@/lib/edge-cache";
 import {
   CHECK_IN_MESSAGE_FORMAT,
   CHECK_IN_RATE_LIMIT_SECONDS,
@@ -24,13 +26,14 @@ import {
 function getOrientation(
   agent: AgentRecord,
   claim: ClaimStatus | null,
-  unreadCount: number
+  unreadCount: number,
+  openBounties: HeartbeatOrientation["openBounties"] = []
 ): HeartbeatOrientation {
   const levelInfo = getAgentLevel(agent, claim);
   const displayName = agent.displayName || generateName(agent.btcAddress);
 
   // Determine next action based on level and journey progress
-  const nextAction = getNextAction(levelInfo.level, agent, unreadCount);
+  const nextAction = getNextAction(levelInfo.level, agent, unreadCount, openBounties);
 
   return {
     btcAddress: agent.btcAddress,
@@ -40,7 +43,64 @@ function getOrientation(
     lastActiveAt: agent.lastActiveAt,
     unreadCount,
     nextAction,
+    ...(openBounties.length > 0 && { openBounties }),
   };
+}
+
+/**
+ * Global edge-cache key + TTL for the open-bounties lookup. The list is
+ * identical for every agent, so a single shared entry serves all check-ins —
+ * not keyed per-address. `caches.default` is per-colo, so the effective D1
+ * cost is ~one read per colo per TTL window instead of one per check-in
+ * (~13k/day across the active fleet collapses to a handful). Edge reads/writes
+ * are free. 120s staleness is harmless: a new bounty appears within 2 min, and
+ * a just-closed one is rejected at the submit endpoint regardless.
+ */
+const OPEN_BOUNTIES_CACHE_KEY = "https://cache.aibtc.local/heartbeat/open-bounties";
+const OPEN_BOUNTIES_CACHE_TTL_SECONDS = 120;
+
+/**
+ * Fetch a few currently-open bounties for the check-in payload. Highest
+ * reward first — the most attractive work surfaces at the top.
+ *
+ * Wrapped in the edge cache (see key/TTL above) so repeat check-ins skip the
+ * D1 read entirely. Fails open (returns []) on missing DB or any error:
+ * surfacing earning opportunities is a nice-to-have, never a reason to fail a
+ * heartbeat. Capped at 3 to keep the payload small.
+ */
+async function fetchOpenBounties(
+  db: D1Database | undefined,
+  now: Date = new Date()
+): Promise<NonNullable<HeartbeatOrientation["openBounties"]>> {
+  if (!db) return [];
+  try {
+    const res = await withEdgeCache(
+      OPEN_BOUNTIES_CACHE_KEY,
+      OPEN_BOUNTIES_CACHE_TTL_SECONDS,
+      async () => {
+        const { bounties } = await listBounties(db, { status: "open", limit: 3, now });
+        const list = bounties
+          .sort((a, b) => b.rewardSats - a.rewardSats)
+          .map((b) => ({
+            id: b.id,
+            title: b.title,
+            rewardSats: b.rewardSats,
+            expiresAt: b.expiresAt,
+            url: `https://aibtc.com/bounties/${b.id}`,
+          }));
+        return new Response(JSON.stringify(list), {
+          headers: {
+            "content-type": "application/json",
+            // s-maxage drives caches.default's own TTL (see withEdgeCache).
+            "cache-control": `s-maxage=${OPEN_BOUNTIES_CACHE_TTL_SECONDS}`,
+          },
+        });
+      }
+    );
+    return (await res.json()) as NonNullable<HeartbeatOrientation["openBounties"]>;
+  } catch {
+    return [];
+  }
 }
 
 /**
@@ -50,7 +110,8 @@ function getOrientation(
 function getNextAction(
   level: number,
   agent: AgentRecord,
-  unreadCount: number
+  unreadCount: number,
+  openBounties: HeartbeatOrientation["openBounties"] = []
 ): HeartbeatOrientation["nextAction"] {
   // Level 0: not registered yet
   if (level === 0) {
@@ -90,6 +151,18 @@ function getNextAction(
       step: "Check Inbox",
       description: `You have ${unreadCount} unread message${unreadCount === 1 ? "" : "s"}. Check your inbox at /api/inbox/${agent.btcAddress}`,
       endpoint: `GET /api/inbox/${agent.btcAddress}`,
+    };
+  }
+
+  // Caught up with an open bounty available — point at the highest-reward one
+  // so an active check-in converts straight into paid work. The full list
+  // rides along in `orientation.openBounties`.
+  if (openBounties.length > 0) {
+    const top = openBounties[0];
+    return {
+      step: "Take a Bounty",
+      description: `${openBounties.length} open bounty${openBounties.length === 1 ? "" : " (and more)"} you can earn sBTC on right now. Top reward: "${top.title}" — ${top.rewardSats.toLocaleString()} sats. Browse at ${top.url}, then submit work via POST /api/bounties/${top.id}/submit.`,
+      endpoint: `GET /api/bounties/${top.id}`,
     };
   }
 
@@ -139,9 +212,12 @@ export async function GET(request: NextRequest) {
     // Phase 2.5 Step 4 — unreadCount now served from D1 live SELECT COUNT(*).
     // Replaces the KV inbox:agent:{btcAddress} read that served a stale cached
     // counter. Closes aibtc-mcp-server#497 for the heartbeat orientation path.
-    const unreadCount = await fetchUnreadCount(db, agent.btcAddress);
+    const [unreadCount, openBounties] = await Promise.all([
+      fetchUnreadCount(db, agent.btcAddress),
+      fetchOpenBounties(db),
+    ]);
 
-    const orientation = getOrientation(agent, claim, unreadCount);
+    const orientation = getOrientation(agent, claim, unreadCount, openBounties);
 
     return NextResponse.json(
       {
@@ -194,6 +270,8 @@ export async function GET(request: NextRequest) {
                 description: "string",
                 endpoint: "string | undefined",
               },
+              openBounties:
+                "Array<{ id, title, rewardSats, expiresAt, url }> | undefined — a few open bounties you can earn sBTC on right now",
             },
           },
         },
@@ -408,11 +486,12 @@ export async function POST(request: NextRequest) {
     // not on every 5-min check-in. Identical JSON across both sides per
     // inventory, so this is data-lossless.
     // Phase 2.5 Step 4 — unreadCount served from D1 live SELECT COUNT(*).
-    const [, unreadCount] = await Promise.all([
+    const [, unreadCount, openBounties] = await Promise.all([
       kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent)),
       fetchUnreadCount(db, btcAddress),
+      fetchOpenBounties(db),
     ]);
-    const orientation = getOrientation(updatedAgent, claim, unreadCount);
+    const orientation = getOrientation(updatedAgent, claim, unreadCount, openBounties);
     const nextLevel = getNextLevel(orientation.level);
 
     return NextResponse.json({

--- a/app/bounties/BountyDirectory.tsx
+++ b/app/bounties/BountyDirectory.tsx
@@ -255,6 +255,7 @@ export default function BountyDirectory({
                     href={`https://explorer.hiro.so/txid/${b.paidTxid}?chain=mainnet`}
                     target="_blank"
                     rel="noopener noreferrer"
+                    aria-label={`View on-chain payment transaction for "${b.title}"`}
                     className="whitespace-nowrap text-[#7DA2FF]/70 hover:text-[#7DA2FF]"
                   >
                     tx &#8599;

--- a/app/bounties/BountyDirectory.tsx
+++ b/app/bounties/BountyDirectory.tsx
@@ -151,6 +151,39 @@ export default function BountyDirectory({
     });
   }, [initialBounties, statusFilter, searchFilter, sort]);
 
+  // Proof-of-flow stats — derived from the full set already in hand (no extra
+  // fetch). "Paid out" is the trust-critical number: every sat is backed by an
+  // on-chain, Hiro-verified sBTC transfer, so it's a claim the board can make
+  // honestly. Surfaces activity to a cold visitor before they touch a filter.
+  const stats = useMemo(() => {
+    const bounties = initialBounties ?? [];
+    let paidOutSats = 0;
+    let paidCount = 0;
+    let openCount = 0;
+    let submissionCount = 0;
+    for (const b of bounties) {
+      submissionCount += b.submissionCount;
+      if (b.status === "paid") {
+        paidCount += 1;
+        paidOutSats += b.rewardSats;
+      } else if (b.status === "open") {
+        openCount += 1;
+      }
+    }
+    return { paidOutSats, paidCount, openCount, submissionCount };
+  }, [initialBounties]);
+
+  // Recently-paid rail — the strongest "this board is alive" signal. Paid
+  // bounties stay visible forever (see page.tsx), so we surface the newest few
+  // with a link to the on-chain tx as proof.
+  const recentlyPaid = useMemo(() => {
+    const bounties = initialBounties ?? [];
+    return bounties
+      .filter((b) => b.status === "paid" && b.paidAt)
+      .sort((a, b) => new Date(b.paidAt!).getTime() - new Date(a.paidAt!).getTime())
+      .slice(0, 4);
+  }, [initialBounties]);
+
   return (
     <section className="space-y-8">
       <div className="flex flex-wrap items-start justify-between gap-4">
@@ -159,6 +192,30 @@ export default function BountyDirectory({
           <p className="mt-2 text-[15px] text-white/50 max-md:text-sm">
             Any registered agent can post tasks or submit work. Payment proven on-chain in sBTC.
           </p>
+          {(stats.paidCount > 0 || stats.openCount > 0) && (
+            <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-1 text-[12px] text-white/40">
+              <span>
+                <span className="font-medium text-[#F7931A]">&#8383;{formatSats(stats.paidOutSats)}</span> sats paid out
+              </span>
+              <span className="text-white/20">·</span>
+              <span>
+                <span className="font-medium text-white/70">{stats.paidCount}</span> paid
+              </span>
+              <span className="text-white/20">·</span>
+              <span>
+                <span className="font-medium text-emerald-400">{stats.openCount}</span> open
+              </span>
+              {stats.submissionCount > 0 && (
+                <>
+                  <span className="text-white/20">·</span>
+                  <span>
+                    <span className="font-medium text-white/70">{stats.submissionCount}</span> submission
+                    {stats.submissionCount !== 1 ? "s" : ""}
+                  </span>
+                </>
+              )}
+            </div>
+          )}
         </div>
         <Link
           href="/bounties/new"
@@ -167,6 +224,47 @@ export default function BountyDirectory({
           Post a bounty
         </Link>
       </div>
+
+      {recentlyPaid.length > 0 && (
+        <div className="rounded-xl border border-[#F7931A]/15 bg-[#F7931A]/[0.03] p-4">
+          <div className="mb-3 flex items-center gap-2 text-[11px] font-medium uppercase tracking-wide text-[#F7931A]/80">
+            <span className="inline-block size-1.5 rounded-full bg-[#F7931A]" aria-hidden="true" />
+            Recently paid &middot; verified on-chain
+          </div>
+          <ul className="flex flex-col divide-y divide-white/[0.04]">
+            {recentlyPaid.map((b) => (
+              <li
+                key={b.id}
+                className="flex items-center gap-3 py-2 text-[13px] first:pt-0 last:pb-0"
+              >
+                <span className="flex items-center gap-1 whitespace-nowrap font-semibold text-[#F7931A]">
+                  <span className="text-[#F7931A]/60">&#8383;</span>
+                  {formatSats(b.rewardSats)}
+                </span>
+                <Link
+                  href={`/bounties/${b.id}`}
+                  className="min-w-0 flex-1 truncate text-white/70 hover:text-white"
+                >
+                  {b.title}
+                </Link>
+                {b.paidAt && (
+                  <span className="whitespace-nowrap text-white/30">{relativeTime(b.paidAt)}</span>
+                )}
+                {b.paidTxid && (
+                  <a
+                    href={`https://explorer.hiro.so/txid/${b.paidTxid}?chain=mainnet`}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="whitespace-nowrap text-[#7DA2FF]/70 hover:text-[#7DA2FF]"
+                  >
+                    tx &#8599;
+                  </a>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
 
       <div className="flex flex-wrap items-center gap-2">
         <div

--- a/lib/heartbeat/types.ts
+++ b/lib/heartbeat/types.ts
@@ -37,4 +37,17 @@ export interface HeartbeatOrientation {
     description: string;
     endpoint?: string;
   };
+  /**
+   * A few currently-open bounties the agent can act on right now. Surfaced on
+   * every check-in so active agents see live earning opportunities without a
+   * second round-trip. Omitted when none are open or the lookup fails.
+   */
+  openBounties?: Array<{
+    id: string;
+    title: string;
+    rewardSats: number;
+    /** ISO. Submission window closes. */
+    expiresAt: string;
+    url: string;
+  }>;
 }


### PR DESCRIPTION
## What

Two changes that make the bounty board feel alive and feed it the active agents it already has.

### Bounties page (`BountyDirectory.tsx`)
- **Proof-of-flow stats bar** — `₿X sats paid out · N paid · N open · N submissions`. The "paid out" figure is backed by Hiro-verified on-chain sBTC transfers, so it's an honest activity signal.
- **"Recently paid · verified on-chain" rail** — the newest paid bounties, each linking to the on-chain tx as proof.

Both derive purely from the bounty data the page already loads — no new fetches.

### Heartbeat (`/api/heartbeat`)
- Orientation now carries `openBounties` (top 3 by reward) on **every** check-in (GET orientation + POST check-in).
- For a caught-up agent, `nextAction` upgrades from generic "Explore Ecosystem" to a concrete **"Take a Bounty"** pointing at the highest-reward open one with the exact submit endpoint.

"Active" = a signed heartbeat check-in, so this puts live earning opportunities in front of exactly the agents proving liveness — converting check-ins into bounty work.

## Cost

The open-bounties lookup is wrapped in the existing `withEdgeCache` (`caches.default`) under a single **global** key (the list is identical for all agents) with a 120s TTL. Effective D1 reads drop from ~1 per check-in (~13k/day) to ~1 per colo per 2 min; edge reads/writes are free. Fails open to `[]` — surfacing bounties never fails a heartbeat.

## Test
- `npm test` — heartbeat + bounty suites green (no new tests; behavior is additive).
- No new TypeScript errors (baseline unchanged).