### PR TITLE
fix(bns): shorten confirmed-negative cache TTL from 7d to 6h (#946)

### DIFF
--- a/lib/__tests__/bns.test.ts
+++ b/lib/__tests__/bns.test.ts
@@ -282,7 +282,7 @@ describe("lookupBnsName", () => {
       const result = await lookupBnsName(
         "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
       );
-      // 7d TTL stored in D1 — confirmed "no primary name" per three-state model.
+      // 6h TTL stored in D1 — confirmed "no primary name" per three-state model.
       // ERR-NO-PRIMARY-NAME is the real BNS-V2 response for nameless addresses.
       expect(result).toBeNull();
     });
@@ -293,13 +293,13 @@ describe("lookupBnsName", () => {
       const result = await lookupBnsName(
         "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7"
       );
-      // 7d TTL stored in D1. Defense-in-depth branch.
+      // 6h TTL stored in D1. Defense-in-depth branch.
       expect(result).toBeNull();
     });
 
     it("returns null on unexpected err code (lookup-failed state, 60s D1 TTL)", async () => {
       // ERR-UNWRAP (u101) or any other non-u131 error is treated as a
-      // genuine malformed response — short-TTL defer rather than 7d pin.
+      // genuine malformed response — short-TTL defer rather than 6h pin.
       mockFetch.mockResolvedValue(mockV2ErrOther(101));
 
       const result = await lookupBnsName(

--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -24,7 +24,8 @@ const BNS_V2_NAME = "BNS-V2";
 
 // BNS-V2 error code returned by `get-primary` when the address has no
 // primary name. Treated as an authoritative "no name" signal and cached
-// with the confirmed-negative (7d) TTL.
+// with the confirmed-negative TTL (6h — see BNS_CONFIRMED_NEGATIVE_CACHE_TTL
+// in lib/identity/kv-cache.ts; short because a primary name is mutable).
 const BNS_ERR_NO_PRIMARY_NAME = "131";
 
 /**
@@ -122,7 +123,7 @@ export async function lookupBnsNameWithOutcome(
     if (!json.success) {
       const errCode = json.value?.value;
       if (errCode === BNS_ERR_NO_PRIMARY_NAME) {
-        // Authoritative "no primary name" — cache as confirmed-negative (7d).
+        // Authoritative "no primary name" — cache as confirmed-negative (6h).
         await setCachedBnsNegative(stxAddress, kv, logger);
         return { state: "confirmed-negative", name: null };
       }

--- a/lib/identity/kv-cache.ts
+++ b/lib/identity/kv-cache.ts
@@ -39,11 +39,23 @@ import { samplingFor } from "../logging";
 
 const BNS_CACHE_TTL = 24 * 60 * 60; // 24 hours (confirmed positive)
 /**
- * "Confirmed no name" — Hiro returned `(ok none)`. A state change requires
- * an on-chain BNS registration tx; we bust this cache on registration/update
- * write paths and via the explicit refresh endpoint.
+ * "Confirmed no name" — Hiro returned `(ok none)` / `ERR-NO-PRIMARY-NAME`.
+ *
+ * Kept deliberately short (6h, not 7d) because a BNS primary name is *mutable*:
+ * an agent can call `set-primary-name` at any time after registering, and
+ * nothing on the write side busts this entry. With a 7d TTL an agent who
+ * registers before owning a name (the common case) stays `bnsName: null` for
+ * up to a week — the lazy refresh in `/api/agents/[address]` reads *through*
+ * this cache (`lookupBnsName` → `getCachedBnsName`) and so can never re-hit
+ * Hiro until the entry expires. 6h bounds that staleness while still absorbing
+ * a profile-view hammer. This is the asymmetry with identity NFTs below: an
+ * NFT can't be un-minted, so its negative is safe to cache for 7d; a primary
+ * name can appear (and change) with no event we observe. See issue #946.
+ *
+ * The `POST /api/identity/:address/refresh` endpoint remains the instant
+ * manual escape hatch (it calls `invalidateBnsCache` before re-looking up).
  */
-const BNS_CONFIRMED_NEGATIVE_CACHE_TTL = 7 * 24 * 60 * 60; // 7 days
+const BNS_CONFIRMED_NEGATIVE_CACHE_TTL = 6 * 60 * 60; // 6 hours
 /**
  * "Lookup failed" — Hiro 429/5xx, malformed response, timeout. Short TTL so
  * a transient upstream blip doesn't pin an address as name-less; long enough
@@ -594,8 +606,8 @@ export function setCachedBnsName(
 
 /**
  * Cache a "confirmed no BNS name" response (Hiro returned `(ok none)`).
- * Uses the long {@link BNS_CONFIRMED_NEGATIVE_CACHE_TTL} (7d) because state
- * change requires an on-chain BNS registration tx.
+ * Uses {@link BNS_CONFIRMED_NEGATIVE_CACHE_TTL} (6h) — kept short because a
+ * BNS primary name is mutable and nothing on the write side busts this entry.
  */
 export function setCachedBnsNegative(
   address: string,
@@ -657,7 +669,7 @@ export function setCachedBnsContractError(
 /**
  * Delete the cached BNS entry for an address (both positive and negative).
  * Use on write paths (registration completed, manual refresh) so the next
- * lookup re-hits Hiro instead of serving a stale 7d confirmed-negative.
+ * lookup re-hits Hiro instead of serving a stale confirmed-negative entry.
  */
 export function invalidateBnsCache(
   address: string,


### PR DESCRIPTION
Agents who register before setting a BNS primary name were stuck on `bnsName: null` for up to 7 days even after `set-primary-name` confirmed on-chain. The lazy refresh in /api/agents/[address] calls `lookupBnsName`, which reads *through* the cache (`getCachedBnsName` returns NONE_SENTINEL) and never re-hits Hiro — so it can't bypass its own poisoned negative entry.

A BNS primary name is mutable and nothing on the write side busts this cache, unlike an identity NFT (immutable once minted, kept at 7d). 6h bounds the staleness while still absorbing a profile-view hammer; once the entry expires the lazy refresh self-heals automatically.

POST /api/identity/:address/refresh remains the instant manual escape hatch.