### PR TITLE
fix(inbox): repair agent_inbox_stats write-path drift (received #945 + unread #906)

### DIFF
--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
   insertInboundMessageToD1: vi.fn().mockResolvedValue({ changes: 1 }),
   insertReplyToD1: vi.fn().mockResolvedValue({ changes: 1 }),
   updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+  markMessageReadIfUnread: vi.fn().mockResolvedValue({ changes: 1 }),
   isPaymentTxidUniqueViolation: (err: unknown): boolean => {
     const msg = err instanceof Error ? err.message : String(err);
     return msg.includes("UNIQUE constraint failed: inbox_messages.payment_txid");
@@ -71,6 +72,7 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
 vi.mock("@/lib/inbox/stats", () => ({
   bumpInboundStats: vi.fn().mockResolvedValue(undefined),
   bumpSentStats: vi.fn().mockResolvedValue(undefined),
+  decrementUnreadStats: vi.fn().mockResolvedValue(undefined),
   getAgentInboxStats: vi.fn().mockResolvedValue({
     receivedCount: 0,
     unreadCount: 0,
@@ -148,7 +150,7 @@ import {
   getInboxMessageFromD1,
   getReplyForMessageFromD1,
 } from "@/lib/inbox/d1-reads";
-import { insertInboundMessageToD1, insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
+import { insertInboundMessageToD1, insertReplyToD1, updateMessageStateD1, markMessageReadIfUnread } from "@/lib/inbox/d1-dual-write";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 import { POST as inboxPOST } from "../route";
 import { POST as outboxPOST } from "../.././../outbox/[address]/route";
@@ -617,10 +619,11 @@ describe("POST /api/outbox/[address] — parent message D1 state update (still b
     const resp = await outboxPOST(req, { params: Promise.resolve({ address: AGENT.btcAddress }) });
 
     expect(resp.status).toBe(201);
-    // P3: waitUntil called twice:
-    //   1. best-effort parent-state updateMessageStateD1
-    //   2. bumpSentStats (changes === 1 from insertReplyToD1)
-    expect(waitUntilFn).toHaveBeenCalledTimes(2);
+    // P3 + #945 twin: waitUntil called three times for an unread parent:
+    //   1. best-effort parent-state updateMessageStateD1 (replied_at)
+    //   2. guarded mark-read + unread_count decrement (markMessageReadIfUnread)
+    //   3. bumpSentStats (changes === 1 from insertReplyToD1)
+    expect(waitUntilFn).toHaveBeenCalledTimes(3);
     expect(updateMessageStateD1).toHaveBeenCalledOnce();
 
     const [calledDb, calledMessageId, calledUpdates] = (
@@ -629,11 +632,18 @@ describe("POST /api/outbox/[address] — parent message D1 state update (still b
     expect(calledDb).toBe(db);
     // Must target the PARENT message_id directly (not the derived reply PK)
     expect(calledMessageId).toBe(MESSAGE_ID);
-    // Message was unread → both fields should be set
+    // replied_at is set here; read_at now goes through the guarded mark-read.
     expect(calledUpdates).toHaveProperty("repliedAt");
-    expect(calledUpdates).toHaveProperty("readAt");
+    expect(calledUpdates).not.toHaveProperty("readAt");
     expect(typeof calledUpdates.repliedAt).toBe("string");
-    expect(typeof calledUpdates.readAt).toBe("string");
+
+    // The unread parent is marked read via the guarded UPDATE, keyed by the
+    // parent recipient (the replying agent), which drives the unread_count
+    // decrement (#945 twin — previously this decrement was missing).
+    expect(markMessageReadIfUnread).toHaveBeenCalledOnce();
+    const [, markMsgId, markAddr] = (markMessageReadIfUnread as Mock).mock.calls[0];
+    expect(markMsgId).toBe(MESSAGE_ID);
+    expect(markAddr).toBe(AGENT.btcAddress);
   });
 
   it("sets only repliedAt (not readAt) when parent message was already read", async () => {

--- a/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
@@ -49,11 +49,15 @@ vi.mock("@/lib/inbox/d1-dual-write", () => ({
   // P3: insertReplyToD1 returns D1WriteResult {changes}
   insertReplyToD1: vi.fn().mockResolvedValue({ changes: 1 }),
   updateMessageStateD1: vi.fn().mockResolvedValue(undefined),
+  // #945 twin: replying to an unread message marks it read via this guarded
+  // UPDATE; changes === 1 signals a real unread→read transition.
+  markMessageReadIfUnread: vi.fn().mockResolvedValue({ changes: 1 }),
 }));
 
 // P3: outbox POST now calls bumpSentStats from @/lib/inbox/stats
 vi.mock("@/lib/inbox/stats", () => ({
   bumpSentStats: vi.fn().mockResolvedValue(undefined),
+  decrementUnreadStats: vi.fn().mockResolvedValue(undefined),
   getAgentInboxStats: vi.fn().mockResolvedValue({
     receivedCount: 0,
     unreadCount: 0,
@@ -96,6 +100,8 @@ import {
   getInboxMessageFromD1,
   getReplyForMessageFromD1,
 } from "@/lib/inbox/d1-reads";
+import { markMessageReadIfUnread } from "@/lib/inbox/d1-dual-write";
+import { decrementUnreadStats } from "@/lib/inbox/stats";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
 
 // ---- shared fixtures --------------------------------------------------------
@@ -381,5 +387,55 @@ describe("Phase 2.5 Step 3.5 — POST outbox write-path D1 flip", () => {
     expect(body.error).toBe("transient_d1_unavailable");
     expect(body.retry_after).toBe(5);
     expect(res.headers.get("Retry-After")).toBe("5");
+  });
+});
+
+describe("#945 twin — unread_count decrement on implicit mark-read (reply)", () => {
+  // The mark-read + decrement run inside ctx.waitUntil (a vi.fn here), so the
+  // promise chain executes but isn't awaited by the route. Flush a macrotask
+  // before asserting so the chained decrement has run.
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+
+  it("replying to an UNREAD message marks it read and decrements unread_count once", async () => {
+    // INBOX_MESSAGE has no readAt → wasUnread. markMessageReadIfUnread returns
+    // {changes: 1} (default mock) — a real unread→read transition.
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+    expect(res.status).toBe(201);
+    await flush();
+
+    expect(markMessageReadIfUnread).toHaveBeenCalledOnce();
+    const [, mId, mAddr] = (markMessageReadIfUnread as Mock).mock.calls[0];
+    expect(mId).toBe(MSG_ID);
+    expect(mAddr).toBe(ADDR_A); // parent recipient = the replying agent
+
+    expect(decrementUnreadStats).toHaveBeenCalledOnce();
+    expect((decrementUnreadStats as Mock).mock.calls[0][1]).toBe(ADDR_A);
+  });
+
+  it("replying to an ALREADY-READ message neither marks read nor decrements", async () => {
+    (getInboxMessageFromD1 as Mock).mockResolvedValue({
+      ...INBOX_MESSAGE,
+      readAt: "2026-05-08T06:30:00.000Z",
+    });
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+    expect(res.status).toBe(201);
+    await flush();
+
+    expect(markMessageReadIfUnread).not.toHaveBeenCalled();
+    expect(decrementUnreadStats).not.toHaveBeenCalled();
+  });
+
+  it("does not decrement when the guarded mark-read finds the row already read (changes === 0)", async () => {
+    // wasUnread at fetch, but a concurrent reader marked it read first: the
+    // guarded UPDATE (WHERE read_at IS NULL) matches no rows → no decrement.
+    (markMessageReadIfUnread as Mock).mockResolvedValueOnce({ changes: 0 });
+
+    const res = await POST(buildPostRequest(ADDR_A), buildContext(ADDR_A));
+    expect(res.status).toBe(201);
+    await flush();
+
+    expect(markMessageReadIfUnread).toHaveBeenCalledOnce();
+    expect(decrementUnreadStats).not.toHaveBeenCalled();
   });
 });

--- a/app/api/outbox/[address]/route.ts
+++ b/app/api/outbox/[address]/route.ts
@@ -13,8 +13,12 @@ import {
 } from "@/lib/inbox";
 import { isStxAddress } from "@/lib/validation/address";
 import { shouldFailClosed } from "@/lib/env";
-import { insertReplyToD1, updateMessageStateD1 } from "@/lib/inbox/d1-dual-write";
-import { bumpSentStats } from "@/lib/inbox/stats";
+import {
+  insertReplyToD1,
+  updateMessageStateD1,
+  markMessageReadIfUnread,
+} from "@/lib/inbox/d1-dual-write";
+import { bumpSentStats, decrementUnreadStats } from "@/lib/inbox/stats";
 import {
   listOutboxRepliesFromD1,
   getInboxMessageFromD1,
@@ -438,7 +442,10 @@ export async function POST(
   };
 
   // D1 is now the sole write path (Phase 2.5 Step 4 — KV writes removed).
-  // unreadCount is now a live SELECT COUNT(*) so no KV decrement is needed.
+  // When this reply marks the parent read, the maintained unread_count is
+  // decremented below (via markMessageReadIfUnread + decrementUnreadStats).
+  // (The old "unreadCount is a live COUNT so no decrement needed" assumption
+  // stopped holding once #845 made status=all read from agent_inbox_stats.)
   //
   // insertReplyToD1 is synchronous + failure-propagating: failure returns 503
   // + Retry-After: 5 so the sender retries rather than losing the reply.
@@ -468,21 +475,44 @@ export async function POST(
     );
   }
 
-  // Best-effort: update parent message's replied_at (and read_at if unread).
-  // The reply row is already committed; this is metadata only.
+  // Best-effort: update parent message's replied_at, and mark it read if this
+  // reply is the first acknowledgement. The reply row is already committed, so
+  // these are metadata-only updates.
   const wasUnread = !message.readAt;
-  const parentUpdates: { readAt?: string; repliedAt?: string } = {
-    repliedAt: now,
-    ...(wasUnread && { readAt: now }),
-  };
+
+  // Always stamp replied_at on the parent.
   ctx.waitUntil(
-    updateMessageStateD1(db, messageId, parentUpdates).catch((err) =>
+    updateMessageStateD1(db, messageId, { repliedAt: now }).catch((err) =>
       logger.error("outbox.d1_parent_state_failed", {
         messageId,
         error: String(err),
       })
     )
   );
+
+  // Replying to an unread message implicitly marks it read. Route this through
+  // the guarded atomic UPDATE (WHERE read_at IS NULL) — mirroring the PATCH
+  // mark-read path — so we both stamp read_at and learn whether this was a real
+  // unread→read transition, then decrement the maintained unread_count only on
+  // changes === 1. Previously this path set read_at but never decremented
+  // unread_count, leaving it inflated above the live unread row count — the
+  // phantom-unread root cause behind #906 / #942.
+  if (wasUnread) {
+    ctx.waitUntil(
+      markMessageReadIfUnread(db, messageId, agent.btcAddress, now)
+        .then((res) =>
+          res.changes === 1
+            ? decrementUnreadStats(db, agent.btcAddress).catch(() => {})
+            : undefined
+        )
+        .catch((err) =>
+          logger.error("outbox.d1_mark_read_failed", {
+            messageId,
+            error: String(err),
+          })
+        )
+    );
+  }
 
   // Bump sent stats only on a real insert (changes === 1), not on recovery replay.
   // fromAddress is the agent's BTC address (message.toBtcAddress resolved above).

--- a/lib/inbox/__tests__/kv-helpers.test.ts
+++ b/lib/inbox/__tests__/kv-helpers.test.ts
@@ -46,9 +46,17 @@ function createMockD1(opts?: {
   insertError?: Error;
   /** Pre-populate rows. */
   seedRows?: InboxRow[];
-}): { db: D1Database; rows: InboxRow[]; insertCalls: { sql: string; binds: unknown[] }[] } {
+}): {
+  db: D1Database;
+  rows: InboxRow[];
+  insertCalls: { sql: string; binds: unknown[] }[];
+  statsBumps: { binds: unknown[] }[];
+} {
   const rows: InboxRow[] = opts?.seedRows ? [...opts.seedRows] : [];
   const insertCalls: { sql: string; binds: unknown[] }[] = [];
+  // Records every agent_inbox_stats received-count bump (bumpInboundStats) so
+  // tests can assert the staged → confirmed delivery path maintains the counter.
+  const statsBumps: { binds: unknown[] }[] = [];
 
   const db = {
     prepare: (sql: string) => {
@@ -59,6 +67,10 @@ function createMockD1(opts?: {
           return stmt;
         },
         run: async () => {
+          if (sql.includes("agent_inbox_stats")) {
+            statsBumps.push({ binds });
+            return { success: true, meta: { changes: 1 } };
+          }
           if (sql.includes("INSERT INTO inbox_messages")) {
             insertCalls.push({ sql, binds });
             if (opts?.insertError) throw opts.insertError;
@@ -161,7 +173,7 @@ function createMockD1(opts?: {
     },
   } as unknown as D1Database;
 
-  return { db, rows, insertCalls };
+  return { db, rows, insertCalls, statsBumps };
 }
 
 describe("decrementUnreadCount", () => {
@@ -352,7 +364,7 @@ describe("staged inbox payment helpers", () => {
 
   it("finalizes a staged inbox payment by inserting into D1 and clearing the staged KV record (#760)", async () => {
     const kv = createMockKV();
-    const { db, rows, insertCalls } = createMockD1();
+    const { db, rows, insertCalls, statsBumps } = createMockD1();
     const now = new Date().toISOString();
     const stagedMessage: InboxMessage = {
       messageId: "msg_stage_confirmed",
@@ -393,6 +405,14 @@ describe("staged inbox payment helpers", () => {
     expect(rows[0]?.payment_status).toBe("confirmed");
     expect(rows[0]?.to_btc_address).toBe("bc1recipient");
 
+    // #945: the staged → confirmed delivery is the ONLY place the row is first
+    // written for a pending payment, so it must bump received_count/unread_count
+    // here — exactly once, for the recipient. Without this the counter silently
+    // drifts below the live inbox row count.
+    expect(statsBumps).toHaveLength(1);
+    expect(statsBumps[0]?.binds[0]).toBe("bc1recipient"); // btc_address
+    expect(statsBumps[0]?.binds[1]).toBe(now); // last_message_at = sentAt
+
     // Critically: NO legacy KV writes happened — the inbox:message / inbox:agent
     // / inbox:sent keys must stay empty. This is the regression the fix prevents.
     expect(await getMessage(kv, "msg_stage_confirmed")).toBeNull();
@@ -401,7 +421,7 @@ describe("staged inbox payment helpers", () => {
 
   it("is idempotent: re-finalize after staged record was cleared returns null without a second INSERT (#760)", async () => {
     const kv = createMockKV();
-    const { db, insertCalls } = createMockD1();
+    const { db, insertCalls, statsBumps } = createMockD1();
     const now = new Date().toISOString();
     const stagedMessage: InboxMessage = {
       messageId: "msg_idempotent",
@@ -435,6 +455,9 @@ describe("staged inbox payment helpers", () => {
     });
     expect(second).toBeNull();
     expect(insertCalls).toHaveLength(1);
+    // #945: only the first finalize (the real insert) bumped the counter — the
+    // re-finalize is a noop and must not double-count.
+    expect(statsBumps).toHaveLength(1);
   });
 
   it("returns the canonical D1 row when the staged record exists but D1 already has the message (queue retry race) (#760)", async () => {
@@ -461,7 +484,7 @@ describe("staged inbox payment helpers", () => {
       read_at: null,
       replied_at: null,
     };
-    const { db, insertCalls } = createMockD1({ seedRows: [seededRow] });
+    const { db, insertCalls, statsBumps } = createMockD1({ seedRows: [seededRow] });
     const now = new Date().toISOString();
 
     await storeStagedInboxPayment(kv, {
@@ -491,6 +514,9 @@ describe("staged inbox payment helpers", () => {
 
     // No INSERT attempted — the existing-row branch short-circuits.
     expect(insertCalls).toHaveLength(0);
+    // #945: the row already existed (a prior finalize owns the increment), so
+    // this short-circuit must not bump the counter.
+    expect(statsBumps).toHaveLength(0);
   });
 
   it("treats UNIQUE-violation on payment_txid as idempotent success and returns the canonical row (#760)", async () => {
@@ -524,7 +550,7 @@ describe("staged inbox payment helpers", () => {
 
     // Force INSERT to throw the UNIQUE constraint error, but pre-populate the
     // row so the post-violation re-query finds it.
-    const { db, insertCalls } = createMockD1({
+    const { db, insertCalls, statsBumps } = createMockD1({
       insertError: new Error(
         "D1_ERROR: UNIQUE constraint failed: inbox_messages.payment_txid"
       ),
@@ -562,6 +588,9 @@ describe("staged inbox payment helpers", () => {
     expect(insertCalls).toHaveLength(1);
     expect(finalized).toBeNull();
     expect(await getStagedInboxPayment(kv, "pay_unique_race")).toBeNull();
+    // #945: the INSERT lost the UNIQUE race (no row written by us), so the catch
+    // branch must not bump — the finalize that won the race owns the increment.
+    expect(statsBumps).toHaveLength(0);
   });
 
   it("propagates non-UNIQUE D1 errors so the queue retries (#760)", async () => {

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -15,6 +15,7 @@ import type {
 } from "./types";
 import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "./d1-dual-write";
 import { getInboxMessageFromD1 } from "./d1-reads";
+import { bumpInboundStats } from "./stats";
 
 /**
  * Build KV key for an individual inbox message.
@@ -406,12 +407,14 @@ export async function finalizeStagedInboxPayment(
     paymentId,
   };
 
+  let insertResult: { changes: number };
   try {
-    await insertInboundMessageToD1(db, finalizedMessage);
+    insertResult = await insertInboundMessageToD1(db, finalizedMessage);
   } catch (err) {
     if (isPaymentTxidUniqueViolation(err)) {
       // A parallel finalize already inserted the row under the same payment_txid.
       // Re-query D1 for the canonical row, clear the staged record, and return it.
+      // No stats bump here — the finalize that won the race owns the increment.
       const canonical = await getInboxMessageFromD1(
         db,
         staged.message.toBtcAddress,
@@ -421,6 +424,24 @@ export async function finalizeStagedInboxPayment(
       return canonical;
     }
     throw err;
+  }
+
+  // Bump received_count/unread_count for the staged → confirmed delivery.
+  // Pending payments return 202 from POST /api/inbox/[address] WITHOUT inserting
+  // the row, so the synchronous bump on that path never runs for them — the row
+  // is first written here, when the confirmed payment finalizes. Omitting this
+  // is the systematic source of agent_inbox_stats received-count drift (#945):
+  // every pending→confirmed message landed in inbox_messages but was never
+  // counted. Bump only on a real insert (changes === 1) — a parallel finalize
+  // that lost the ON CONFLICT race returns 0 and must not double-count. Best-
+  // effort to mirror the synchronous delivery path; any residual drift stays
+  // reconcilable via /api/admin/reconcile?target=inbox_stats.
+  if (insertResult.changes === 1) {
+    await bumpInboundStats(
+      db,
+      finalizedMessage.toBtcAddress,
+      finalizedMessage.sentAt
+    ).catch(() => {});
   }
 
   await deleteStagedInboxPayment(kv, paymentId);


### PR DESCRIPTION
## Summary

Two sibling bugs in the same class: a write path mutated `inbox_messages` but failed to maintain the denormalized `agent_inbox_stats` counter. Fixed at the source (no read-side workarounds, no new machinery).

### 1. received_count drifted too LOW — #945
Pending x402 payments return `202` from `POST /api/inbox/[address]` **without** inserting the row — the row is first written later, when the confirmed payment finalizes in `finalizeStagedInboxPayment`. That function inserted the row but never called `bumpInboundStats`, so every pending→confirmed message landed in the inbox yet was never counted. This explains the asymmetry in #945: replies bump synchronously (so `sentCount` stayed correct) while `receivedCount` silently undercounted.

**Fix:** after a real insert (`changes === 1`), bump received/unread for the recipient — mirroring the synchronous delivery path. The change-guard + existing-row / UNIQUE-race short-circuits ensure exactly-once, no double-count.

> Note: the "−82 sentCount drift" in #945 is a non-bug — `sentCount` counts replies (`is_reply=1`) while `view=sent` lists originated messages (`is_reply=0`). Different quantities, both correct.

### 2. unread_count drifted too HIGH — #906 (twin)
Replying to an unread message implicitly marks the parent read, but the outbox POST path set `read_at` **without** calling `decrementUnreadStats` — so `unread_count` inflated above the live unread row count (the phantom-unread root cause). `status=all` reads `unread_count` from the counter, so it was user-visible there.

**Fix:** route the implicit mark-read through the guarded atomic UPDATE (`markMessageReadIfUnread`, `WHERE read_at IS NULL`) — mirroring the PATCH mark-read path — and decrement only on a real unread→read transition (`changes === 1`). `replied_at` is still stamped via `updateMessageStateD1`.

## Relationship to #942
#942 fixes the same phantom-unread symptom (#906) on the **read side**, by deriving `status=unread` `totalCount` from a live `COUNT(*)` and bypassing the counter. This PR fixes the **write-side cause**, which also corrects `status=all` (which #942 leaves on the maintained counter). They overlap — #942's read-side workaround becomes unnecessary once the counter is maintained correctly.

## Follow-up (not in this PR)
Existing accumulated drift still needs a one-time `POST /api/admin/reconcile?target=inbox_stats` to recompute the counters from live rows.

## Tests
Full suite green (1442 passed, 5 skipped). New assertions cover exactly-once bump on staged delivery (no double-count on retries/races) and exactly-once unread decrement on a real mark-read transition (none on already-read or a lost race).