### PR TITLE
fix(identity): stop amplifying Hiro egress throttling into 25s lookup-failed (#939)

### DIFF
--- a/lib/bns.ts
+++ b/lib/bns.ts
@@ -15,7 +15,7 @@ import {
   type LookupOutcomeState,
 } from "./identity/kv-cache";
 import { buildHiroHeaders } from "./identity/stacks-api";
-import { stacksApiFetch } from "./stacks-api-fetch";
+import { stacksApiFetch, SYNC_PER_ATTEMPT_TIMEOUT_MS } from "./stacks-api-fetch";
 import { STACKS_API_BASE } from "./identity/constants";
 import type { Logger } from "./logging";
 
@@ -76,7 +76,8 @@ export async function lookupBnsNameWithOutcome(
     headers["Content-Type"] = "application/json";
 
     // BNS lookup runs on request paths (register, verify, SSR). Use a reduced
-    // retry budget so a degraded Hiro cannot block requests for tens of seconds.
+    // retry budget AND a short per-attempt timeout so a degraded/throttled Hiro
+    // egress cannot block the request for tens of seconds (#939).
     const res = await stacksApiFetch(
       `${STACKS_API_BASE}/v2/contracts/call-read/${BNS_V2_CONTRACT}/${BNS_V2_NAME}/get-primary`,
       {
@@ -87,7 +88,12 @@ export async function lookupBnsNameWithOutcome(
           arguments: [`0x${serialized}`],
         }),
       },
-      { retries: 2, retries429: 1, logger }
+      {
+        retries: 1,
+        retries429: 1,
+        perAttemptTimeoutMs: SYNC_PER_ATTEMPT_TIMEOUT_MS,
+        logger,
+      }
     );
 
     if (!res.ok) {

--- a/lib/identity/__tests__/detection.test.ts
+++ b/lib/identity/__tests__/detection.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { detectAgentIdentityWithOutcome } from "../detection";
+
+// detection.ts calls Hiro via stacksApiFetch → global fetch. The BNS/identity
+// KV-cache helpers degrade to a miss/no-op when there is no Workers runtime
+// (getCloudflareContext throws → getDb() returns null), so no mocking needed
+// for them — same pattern as lib/__tests__/bns.test.ts.
+const mockFetch = vi.fn();
+global.fetch = mockFetch as unknown as typeof fetch;
+
+/** Minimal headers mock satisfying extractRateLimitInfo / detect429. */
+function mockHeaders(): Headers {
+  return { get: () => null } as unknown as Headers;
+}
+
+function mockResponse(status: number, body: unknown = {}) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: mockHeaders(),
+    json: async () => body,
+  };
+}
+
+const STX = "SP1KVZTZCTCN9TNA1H5MHQ3H0225JGN1RJHY4HA9W";
+
+const urlsHit = (): string[] => mockFetch.mock.calls.map((c) => String(c[0]));
+const isHoldings = (u: string) => u.includes("/extended/v1/tokens/nft/holdings");
+const isCallRead = (u: string) => u.includes("/v2/contracts/call-read/");
+
+describe("detectAgentIdentityWithOutcome — #939 throttle hardening", () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+  });
+  afterEach(() => {
+    vi.clearAllTimers();
+  });
+
+  it("429 on holdings → fails fast as lookup-failed WITHOUT firing the legacy scan", async () => {
+    // A 429 means Hiro is throttling our CF egress. The old code treated this as
+    // "holdings unavailable" and fired the O(N) legacy scan (5+ more call-read
+    // requests at the same throttled upstream) — the #939 25s amplification.
+    mockFetch.mockImplementation((url: string) =>
+      Promise.resolve(
+        isHoldings(url) ? mockResponse(429) : mockResponse(200, { okay: false })
+      )
+    );
+
+    const outcome = await detectAgentIdentityWithOutcome(STX);
+
+    expect(outcome).toEqual({ state: "lookup-failed", identity: null });
+    // The core fix: a 429 must NOT trigger the legacy call-read scan.
+    expect(urlsHit().some(isCallRead)).toBe(false);
+    // retries429 = 1 → exactly one holdings attempt, no in-band retry storm.
+    expect(urlsHit().filter(isHoldings)).toHaveLength(1);
+  });
+
+  it("5xx on holdings → also fails fast without the legacy scan", async () => {
+    mockFetch.mockImplementation((url: string) =>
+      Promise.resolve(
+        isHoldings(url) ? mockResponse(503) : mockResponse(200, { okay: false })
+      )
+    );
+
+    const outcome = await detectAgentIdentityWithOutcome(STX);
+
+    expect(outcome.state).toBe("lookup-failed");
+    expect(urlsHit().some(isCallRead)).toBe(false);
+  });
+
+  it("404 on holdings → still falls back to the legacy scan (genuine unavailability)", async () => {
+    // 404 = the holdings endpoint genuinely can't serve this lookup; the legacy
+    // scan is the right fallback there. call-read returns 400 so the scan fails
+    // fast without a real chain walk — we only assert the scan was entered.
+    mockFetch.mockImplementation((url: string) =>
+      Promise.resolve(isHoldings(url) ? mockResponse(404) : mockResponse(400))
+    );
+
+    await detectAgentIdentityWithOutcome(STX);
+
+    // The 404 branch is the only non-2xx path that should reach call-read.
+    expect(urlsHit().some(isCallRead)).toBe(true);
+  });
+
+  it("200 holdings hit → positive, no legacy scan", async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (isHoldings(url)) {
+        return Promise.resolve(
+          mockResponse(200, {
+            total: 1,
+            results: [
+              {
+                asset_identifier: "x::agent-identity",
+                value: { repr: "u122", hex: "0x" },
+                tx_id: "0x",
+              },
+            ],
+          })
+        );
+      }
+      // get-token-uri: benign non-clarity body → uri resolves to "" (best-effort)
+      return Promise.resolve(mockResponse(200, { okay: false }));
+    });
+
+    const outcome = await detectAgentIdentityWithOutcome(STX);
+
+    expect(outcome.state).toBe("positive");
+    expect(outcome.identity?.agentId).toBe(122);
+  });
+});

--- a/lib/identity/detection.ts
+++ b/lib/identity/detection.ts
@@ -5,7 +5,7 @@
 import { uintCV } from "@stacks/transactions";
 import { IDENTITY_REGISTRY_CONTRACT, STACKS_API_BASE } from "./constants";
 import { callReadOnly, parseClarityValue, buildHiroHeaders } from "./stacks-api";
-import { stacksApiFetch } from "../stacks-api-fetch";
+import { stacksApiFetch, SYNC_PER_ATTEMPT_TIMEOUT_MS } from "../stacks-api-fetch";
 import type { AgentIdentity } from "./types";
 import {
   getCachedIdentity,
@@ -65,27 +65,43 @@ export async function detectAgentIdentityWithOutcome(
     const holdingsUrl = `${STACKS_API_BASE}/extended/v1/tokens/nft/holdings?principal=${stxAddress}&asset_identifiers=${encodeURIComponent(assetId)}&limit=1`;
 
     const headers = buildHiroHeaders(hiroApiKey);
-    // Reduced retry budget for synchronous profile lookups: worst-case ~13s
-    // instead of default ~71s. Primary NFT holdings call gets retries429=1 (1s max
-    // 429 delay) and retries=2 (1.5s max 5xx delay).
+    // Synchronous profile lookup: keep the worst case to a few seconds so the
+    // request never blows a consumer's ~3s budget (#939). One attempt each for
+    // 429 and 5xx, with a 3.5s per-attempt timeout — a hung CF→Hiro call fails
+    // fast and is short-TTL negative-cached rather than retried in-band.
     const response = await stacksApiFetch(holdingsUrl, { headers }, {
-      retries: 2,
+      retries: 1,
       retries429: 1,
+      perAttemptTimeoutMs: SYNC_PER_ATTEMPT_TIMEOUT_MS,
       logger,
     });
 
     if (!response.ok) {
-      // Fallback to legacy scan if holdings API fails (e.g. 404, 500)
-      logger?.warn("identity.holdings_api_failed_falling_back", {
+      // Only fall back to the O(N) legacy scan when the holdings endpoint
+      // genuinely cannot serve this lookup (404 — e.g. asset path unknown).
+      // A 429 or 5xx means Hiro is throttling/erroring our egress, and the
+      // legacy scan fires 5+ MORE call-read requests against the same throttled
+      // upstream — turning one rate-limited call into a multi-second storm that
+      // still ends in lookup-failed (the #939 25s symptom). Fail fast instead,
+      // with a short-TTL negative cache so the next request retries cleanly.
+      if (response.status === 404) {
+        logger?.warn("identity.holdings_api_failed_falling_back", {
+          stxAddress,
+          status: response.status,
+        });
+        return await detectAgentIdentityLegacyWithOutcome(
+          stxAddress,
+          hiroApiKey,
+          kv,
+          logger
+        );
+      }
+      logger?.warn("identity.holdings_api_unavailable", {
         stxAddress,
         status: response.status,
       });
-      return await detectAgentIdentityLegacyWithOutcome(
-        stxAddress,
-        hiroApiKey,
-        kv,
-        logger
-      );
+      await setCachedIdentityLookupFailed(stxAddress, kv, logger);
+      return { state: "lookup-failed", identity: null };
     }
 
     const data = await response.json() as {
@@ -123,7 +139,8 @@ export async function detectAgentIdentityWithOutcome(
         "get-token-uri",
         [uintCV(agentId)],
         hiroApiKey,
-        logger
+        logger,
+        SYNC_PER_ATTEMPT_TIMEOUT_MS
       );
       uri = parseClarityValue(uriResult, logger) || "";
     } catch (error) {

--- a/lib/identity/stacks-api.ts
+++ b/lib/identity/stacks-api.ts
@@ -36,7 +36,8 @@ export async function callReadOnly(
   functionName: string,
   args: ClarityValue[],
   hiroApiKey?: string,
-  logger?: Logger
+  logger?: Logger,
+  perAttemptTimeoutMs?: number
 ): Promise<any> {
   const [contractAddress, contractName] = contract.split(".");
   const url = `${STACKS_API_BASE}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
@@ -47,8 +48,9 @@ export async function callReadOnly(
   const headers = buildHiroHeaders(hiroApiKey);
   headers["Content-Type"] = "application/json";
 
-  // Reduced retry budget for synchronous profile lookups: worst-case ~20s
-  // instead of default ~71s. retries=2 (5xx), baseDelayMs=500, retries429=2.
+  // Reduced retry budget for synchronous profile lookups. Pass
+  // perAttemptTimeoutMs (SYNC_PER_ATTEMPT_TIMEOUT_MS) from request-path callers
+  // so a hung upstream fails fast instead of burning the caller's budget (#939).
   const response = await stacksApiFetch(
     url,
     {
@@ -59,7 +61,7 @@ export async function callReadOnly(
         arguments: hexArgs,
       }),
     },
-    { retries: 2, retries429: 2, logger }
+    { retries: 2, retries429: 2, perAttemptTimeoutMs, logger }
   );
 
   // Log cf-ray for observability if the final response is still a 429 after retries

--- a/lib/stacks-api-fetch.ts
+++ b/lib/stacks-api-fetch.ts
@@ -134,8 +134,18 @@ export function extractRateLimitInfo(
   return { remainingMonth, limitMonth, costStacks };
 }
 
-/** Per-attempt fetch timeout in milliseconds. */
+/** Per-attempt fetch timeout in milliseconds (default for background/non-sync calls). */
 const PER_ATTEMPT_TIMEOUT_MS = 8_000;
+
+/**
+ * Tighter per-attempt timeout for *synchronous, user/consumer-facing* lookups
+ * (profile enrichment, identity/BNS refresh). The 8s default is fine for
+ * background work but far too long on a request path whose consumers budget
+ * ~3s (e.g. aibtc.news identity-gate): a single hung CF→Hiro call would burn
+ * 8s × retries ≈ 16s and blow the caller's budget. Pair this with a reduced
+ * retry budget so the worst case stays well under a few seconds. See #939.
+ */
+export const SYNC_PER_ATTEMPT_TIMEOUT_MS = 3_500;
 
 /** Maximum delay from Retry-After header (milliseconds). */
 const MAX_RETRY_AFTER_MS = 30_000;
@@ -180,6 +190,12 @@ export interface StacksApiFetchConfig {
   /** Max attempts for 429 rate-limit errors (default: {@link RATE_LIMIT_RETRIES} = 5). */
   retries429?: number;
   /**
+   * Per-attempt fetch timeout in ms (default: {@link PER_ATTEMPT_TIMEOUT_MS} = 8000).
+   * Synchronous request-path callers should pass {@link SYNC_PER_ATTEMPT_TIMEOUT_MS}
+   * so a hung upstream fails fast instead of exhausting the caller's budget.
+   */
+  perAttemptTimeoutMs?: number;
+  /**
    * Optional Logger; when provided, emits `stacksApi.*` telemetry events
    * (approaching_monthly_quota, retry_budget_exhausted, retrying). Silent
    * when omitted — we do not fall back to `console.*`,
@@ -220,6 +236,7 @@ export async function stacksApiFetch(
     retries = 3,
     baseDelayMs = 500,
     retries429 = RATE_LIMIT_RETRIES,
+    perAttemptTimeoutMs = PER_ATTEMPT_TIMEOUT_MS,
     logger,
   } = config;
   const path = extractPath(url);
@@ -236,7 +253,7 @@ export async function stacksApiFetch(
     totalAttempts++;
     const attemptOptions: RequestInit = {
       ...options,
-      signal: AbortSignal.timeout(PER_ATTEMPT_TIMEOUT_MS),
+      signal: AbortSignal.timeout(perAttemptTimeoutMs),
     };
 
     try {


### PR DESCRIPTION
## Problem (#939)

When Hiro **rate-limits Cloudflare's shared egress IPs (429)**, the synchronous identity/BNS lookups on `POST /api/identity/{addr}/refresh` and the enrichment branch of `GET /api/agents/{addr}` turned a transient upstream blip into a **~25s hang returning `lookup-failed`** — even though direct Hiro calls answer in <500ms. Downstream (`aibtc.news` identity-gate, 3s budget) then 503s and loops.

Verified live while writing this: when Hiro is healthy, the path is fast and correct (`/refresh` 2.4s, `idOutcome`/`bnsOutcome` positive; direct Hiro holdings 0.66s). So this is **defensive hardening for throttle windows, not a correctness bug** — Hiro throttling our egress is the trigger; our code amplifying it into a 25s outage is what this fixes.

## Two compounding causes

1. **Amplification** — `detectAgentIdentity` treated *any* non-ok holdings response (incl. 429/5xx) as "holdings unavailable" and fell back to the **O(N) legacy scan**, firing 5+ more `call-read` requests at the *same throttled* upstream. One rate-limited call became a multi-second storm still ending in failure.
2. **8s × retries timeout** — a single hung call alone burned ~16s, past the consumer budget.

## Fix

- Legacy scan now triggers **only on a genuine 404**. 429/5xx **fail fast** as `lookup-failed` with the existing short-TTL negative cache, so the next request retries cleanly instead of storming.
- Add configurable `perAttemptTimeoutMs` to `stacksApiFetch` (default 8s preserved) and thread `SYNC_PER_ATTEMPT_TIMEOUT_MS` (3.5s) + reduced retries through the synchronous holdings / `get-token-uri` / BNS `get-primary` calls. Worst case on a throttled window drops from ~25s to a sub-second fast-fail.

## Tests

New `lib/identity/__tests__/detection.test.ts`: 429 and 5xx fail fast **without** the legacy scan; 404 still falls back to it; a holdings hit resolves positive. Full affected suite green.

## Not in scope

The heavier architectural option (B in the issue — move enrichment fully async/background) is deferred; this is the surgical fast-fail that resolves the measured 25s symptom.