### PR TITLE
docs(openapi): drop stale ratelimit: key from delete-agent challenges group

### DIFF
--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2145,7 +2145,7 @@ export function GET() {
                             type: "array",
                             items: { type: "string" },
                             description:
-                              "Challenge and rate limit records (challenge:..., checkin:..., ratelimit:...)",
+                              "Challenge and check-in records (challenge:..., checkin:...)",
                           },
                           inbox: {
                             type: "array",


### PR DESCRIPTION
Salvaged from the now-closed #850.

The OpenAPI schema for the `delete-agent` deletion summary described the `challenges` group as containing `challenge:...`, `checkin:...`, **and `ratelimit:...`** keys. That last one is stale: the route only ever builds/deletes `challenge:{btcAddress}` and `checkin:{btcAddress}` (`app/api/admin/delete-agent/route.ts:56-58` / `:200-202`, reported `challenges: 2`). The `ratelimit:` family was retired in the KV-RMW → `ratelimits`-binding migration (#769); the only surviving `ratelimit:payment-failure:` key is a typed inbox cache and isn't touched by this delete path.

One-line description fix, no behavior change. (The CLAUDE.md half of #850 was dropped — that content is already in main and re-adding it would regress the #923 40k-char trim.)