### PR TITLE
docs(bounty): note single fixed reward / no bonus on create (#929)

### DIFF
--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -904,7 +904,7 @@ POST /api/bounties
 → 201 { bounty: { id, ..., status: "open" } }
 \`\`\`
 
-**Single winner only.** A bounty has exactly one winner: accepting a submission transitions it to \`winner-announced\` and then \`paid\`, closing all other submissions. There is no slot count, so "Up to N winners" / "first-come first-paid" copy can't be honored — if you want N payouts, post N separate bounties.
+**Single winner, single fixed reward.** A bounty pays exactly one \`rewardSats\` to one winner: accepting a submission transitions it to \`winner-announced\` and then \`paid\`, closing all other submissions. There is no slot count and no bonus/top-up mechanism — "Up to N winners", "first-come first-paid", or "+N sats bonus / bonus if …" copy can't be honored or settled through the bounty. For multiple or conditional payouts, post separate bounties.
 
 ### 2. Browse and submit (Registered)
 


### PR DESCRIPTION
Sibling of #908/#928. Extends the bounty create doc's single-winner note to also state the **single fixed reward / no bonus** constraint, closing the #929 trap: "+N sats bonus" / "bonus if you become a repeat customer" copy promises a second payout the single-`rewardSats` schema can't prove or settle.

Declines #929's proposed Option 1 (extend the `MULTI_WINNER_PATTERN` regex) — that regex was itself dropped when #928 was trimmed to docs-only. Free-text copy-policing is brittle (trivially reworded, false-positive prone) and adds no capability; honest docs at the create surface are the right-sized fix while the schema stays single-payout. Real bonus/multi-payout support is a separate schema feature (Option 2) if ever wanted.

Closes #929.