### PR TITLE
fix(inbox): correct mislabeled circuit-breaker.opened log fields (#895)

### DIFF
--- a/lib/inbox/circuit-breaker.ts
+++ b/lib/inbox/circuit-breaker.ts
@@ -23,7 +23,11 @@
  */
 
 import type { Logger } from "@/lib/logging";
-import { RELAY_CIRCUIT_BREAKER_TTL_SECONDS } from "./constants";
+import {
+  RELAY_CIRCUIT_BREAKER_TTL_SECONDS,
+  RELAY_CIRCUIT_BREAKER_BINDING_LIMIT,
+  RELAY_CIRCUIT_BREAKER_BINDING_PERIOD_SECONDS,
+} from "./constants";
 
 /** Result of a circuit breaker check. */
 export interface CircuitBreakerState {
@@ -113,8 +117,15 @@ export async function recordRelayFailure(
     } else {
       await put;
     }
+    // Log the actual trip threshold (binding: 10 failures / 60s) AND the
+    // marker TTL separately. The old single `thresholdSeconds` field carried
+    // the marker TTL but read as the failure-rate threshold — a conflation that
+    // would silently misfire any alert rule if the TTL were ever retuned
+    // independently of the binding window (#895).
     logger?.warn?.("circuit-breaker.opened", {
-      thresholdSeconds: RELAY_CIRCUIT_BREAKER_TTL_SECONDS,
+      bindingLimit: RELAY_CIRCUIT_BREAKER_BINDING_LIMIT,
+      bindingPeriodSeconds: RELAY_CIRCUIT_BREAKER_BINDING_PERIOD_SECONDS,
+      markerTtlSeconds: RELAY_CIRCUIT_BREAKER_TTL_SECONDS,
     });
   } catch (e) {
     logger?.warn?.("circuit-breaker.record_failed", { error: String(e) });

--- a/lib/inbox/constants.ts
+++ b/lib/inbox/constants.ts
@@ -88,6 +88,18 @@ export const RELAY_CIRCUIT_BREAKER_TTL_SECONDS = 60;
  */
 export const RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS = 60;
 
+/**
+ * Failure threshold that trips the breaker, mirrored for log/telemetry context.
+ *
+ * The authoritative config is the `RATE_LIMIT_RELAY_FAILURES` ratelimits binding
+ * in `wrangler.jsonc` (`{ limit: 10, period: 60 }` — 10 failures / 60s rolling
+ * window). These constants exist only so `circuit-breaker.opened` logs can
+ * report the actual trip threshold alongside the marker TTL — keep them in sync
+ * with the binding if it's ever retuned (#895).
+ */
+export const RELAY_CIRCUIT_BREAKER_BINDING_LIMIT = 10;
+export const RELAY_CIRCUIT_BREAKER_BINDING_PERIOD_SECONDS = 60;
+
 // --- Payment failure cache constants ---
 
 /**


### PR DESCRIPTION
Lands item **#2** from #895.

`circuit-breaker.opened` logged `thresholdSeconds: <marker TTL>`, which reads as the failure-rate threshold but actually carries the cache-marker TTL. The real trip threshold is the `RATE_LIMIT_RELAY_FAILURES` binding (`10 failures / 60s`, in `wrangler.jsonc`) — separate config. They're both 60s today, so the conflation is invisible until the TTL is retuned independently, at which point any alert rule anchored on `thresholdSeconds` silently misfires.

Now emits self-describing fields — `bindingLimit` + `bindingPeriodSeconds` (the actual threshold) and `markerTtlSeconds` (the open-marker TTL) — backed by new constants mirroring the binding. No behavior change; circuit-breaker tests green (13/13).

Items **#1** (post-merge monitoring should watch all 5 `circuit-breaker.*` events) and **#3** (rolling-window behavior-contract sentence) target `phases/P4/*` planning docs and the PR body, neither of which lives in this repo — they're ops-runbook notes, nothing to land here. Closes #895.