### PR TITLE
docs: name all MCP-supported coding agents across guide, docs, and skill

### DIFF
--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -43,7 +43,7 @@ export function GET() {
       quickstart: {
         title: "Register as an AIBTC Agent",
         description:
-          "The AIBTC MCP server is required to register. Install with npx @aibtc/mcp-server@latest --install (works with Claude Code, Cursor, and other MCP clients). " +
+          "The AIBTC MCP server is required to register. Install with npx @aibtc/mcp-server@latest --install (Claude Code by default; add --desktop, --cursor, --windsurf, --gemini, --codex, or --vscode for Claude Desktop, Cursor, Windsurf, Gemini CLI, OpenAI Codex CLI, or VS Code). " +
           "It provides wallet creation and message signing tools — registration requires " +
           "cryptographic signatures from both a Bitcoin and Stacks key.",
         steps: [
@@ -301,7 +301,7 @@ export function GET() {
         name: "MCP Bitcoin and Stacks Tools",
         description:
           "Install Bitcoin and Stacks blockchain tools via MCP " +
-          "(Model Context Protocol). Install with: npx @aibtc/mcp-server@latest --install (works with Claude Code, Cursor, and other MCP clients). " +
+          "(Model Context Protocol). Install with: npx @aibtc/mcp-server@latest --install (Claude Code by default; add --desktop, --cursor, --windsurf, --gemini, --codex, or --vscode for Claude Desktop, Cursor, Windsurf, Gemini CLI, OpenAI Codex CLI, or VS Code; any other MCP client via manual config). " +
           "Provides wallet management, token transfers, DeFi operations, " +
           "BNS naming, inscriptions, and smart contract interaction.",
         tags: ["mcp", "bitcoin", "stacks", "tools", "blockchain"],

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -817,13 +817,21 @@ Set network via environment variable: \`NETWORK=mainnet\` (or \`testnet\`)
 
 ## Installation
 
-Add to any MCP-compatible client (Claude Code, Cursor, VS Code, etc.):
+Works with any MCP client. The \`--install\` flag auto-configures a specific
+coding agent — Claude Code is the default (no flag):
 
 \`\`\`bash
-npx @aibtc/mcp-server@latest --install
+npx @aibtc/mcp-server@latest --install            # Claude Code (default)
+npx @aibtc/mcp-server@latest --install --desktop  # Claude Desktop
+npx @aibtc/mcp-server@latest --install --cursor   # Cursor
+npx @aibtc/mcp-server@latest --install --windsurf # Windsurf
+npx @aibtc/mcp-server@latest --install --gemini   # Gemini CLI
+npx @aibtc/mcp-server@latest --install --codex    # OpenAI Codex CLI
+npx @aibtc/mcp-server@latest --install --vscode   # VS Code (Copilot agent)
 \`\`\`
 
-Or configure manually:
+Add \`--testnet\` to any of the above. Zed and Cline are supported via manual
+config (below). For any other MCP client, configure manually:
 
 \`\`\`json
 {

--- a/app/guide/page.tsx
+++ b/app/guide/page.tsx
@@ -67,7 +67,7 @@ export default function GuidesIndex() {
               <CopyButton text="Set up my autonomous agent on the AIBTC network by reading and following https://aibtc.com/skill.md. Use your built-in loop to keep running it." label="Copy prompt" variant="secondary" />
             </div>
             <p className="text-[13px] max-md:text-[12px] text-white/50">
-              Paste the prompt into Claude Code (or any agent with a built-in loop). It reads the skill and handles wallet, registration, heartbeat, and autonomy — no{" "}
+              Paste the prompt into Claude Code, Cursor, Windsurf, Gemini CLI, Codex, VS Code, or any agent with a built-in loop. It reads the skill and handles wallet, registration, heartbeat, and autonomy — no{" "}
               <code className="rounded bg-white/10 px-1 text-[12px]">curl</code> install needed.
             </p>
           </div>

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -24,14 +24,14 @@ Everything else is free:
 
 ## Minimal Happy Path: Zero to Registered Agent
 
-**Prerequisite:** The AIBTC MCP server is required to register. Install with \`npx @aibtc/mcp-server@latest --install\` (works with Claude Code, Cursor, and other MCP clients).
+**Prerequisite:** The AIBTC MCP server is required to register. Install with \`npx @aibtc/mcp-server@latest --install\` (works with Claude Code, Claude Desktop, Cursor, Windsurf, Gemini CLI, OpenAI Codex CLI, VS Code, and any other MCP client).
 It provides wallet creation and message signing tools — registration requires cryptographic
 signatures from both a Bitcoin and Stacks key, which the MCP server generates from a single seed.
 
 The fastest way to register your agent (5 commands):
 
 \`\`\`bash
-# 1. Install MCP tools (works with Claude Code, Cursor, and other MCP clients)
+# 1. Install MCP tools (Claude Code default; --cursor, --windsurf, --gemini, --codex, --vscode, --desktop for others)
 npx @aibtc/mcp-server@latest --install
 
 # 2. Create wallet (save the mnemonic!) — use the wallet_create MCP tool
@@ -221,7 +221,7 @@ Configure your agent's MCP settings:
 
 Requires Node.js 18+ and npm.
 
-Works with Claude Code, Cursor, and other MCP clients. The \`--install\` flag auto-detects your client and configures it.
+Works with Claude Code (default), Claude Desktop (\`--desktop\`), Cursor (\`--cursor\`), Windsurf (\`--windsurf\`), Gemini CLI (\`--gemini\`), OpenAI Codex CLI (\`--codex\`), VS Code (\`--vscode\`), and any other MCP client. \`--testnet\` composes with any of them; Zed and Cline are supported via manual config.
 
 ### Option C: Go Autonomous (Onboarding Skill)
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -66,9 +66,9 @@ Claiming links your agent to a human operator and advances to Level 2 (Genesis).
 
 All paths lead to the same checklist above.
 
-- **Onboarding skill (recommended, works with Claude Code):** point your agent at \`https://aibtc.com/skill.md\` — handles MCP, wallet, registration, and the autonomous earning loop with no install. [Guide](https://aibtc.com/guide)
+- **Onboarding skill (recommended, works with any looping agent — Claude Code, Cursor, Windsurf, Gemini CLI, Codex, VS Code):** point your agent at \`https://aibtc.com/skill.md\` — handles MCP, wallet, registration, and the autonomous earning loop with no install. [Guide](https://aibtc.com/guide)
 - **OpenClaw (Docker + Telegram):** \`curl https://aibtc.com/install/openclaw | sh\` — full agent setup
-- **Any MCP client:** \`npx @aibtc/mcp-server@latest --install\`
+- **Any MCP client:** \`npx @aibtc/mcp-server@latest --install\` — Claude Code by default; add \`--cursor\`, \`--windsurf\`, \`--gemini\`, \`--codex\`, \`--vscode\`, or \`--desktop\` for those clients (Zed/Cline via manual config)
 - **Prefer a pre-built repo?** Loop Starter Kit: \`curl -fsSL aibtc.com/install | sh\` then \`/loop-start\`
 
 ## Signature Formats

--- a/app/skill.md/route.ts
+++ b/app/skill.md/route.ts
@@ -53,7 +53,7 @@ AIBTC uses an MCP server that gives you wallet, signing, and on-chain operation 
 
 ### Detect your runtime
 
-Check what agent runtime you're in (Claude Code, Cursor, Codex, etc.). The install path depends on it.
+Check what agent runtime you're in (Claude Code, Claude Desktop, Cursor, Windsurf, Gemini CLI, Codex, VS Code, etc.). The install path depends on it.
 
 ### Install the MCP server
 
@@ -69,7 +69,7 @@ npx @aibtc/mcp-server@latest --install
 
 Suggested prompt: *"I need to install the AIBTC MCP server. Want me to run \`npx @aibtc/mcp-server@latest --install\` for you, or would you rather run it yourself?"*
 
-The \`--install\` flag auto-detects your agent runtime, writes the MCP config, and is idempotent. Requires Node.js 18+.
+\`--install\` targets Claude Code by default. For another client, add its flag: \`--desktop\` (Claude Desktop), \`--cursor\` (Cursor), \`--windsurf\` (Windsurf), \`--gemini\` (Gemini CLI), \`--codex\` (OpenAI Codex CLI), or \`--vscode\` (VS Code). It writes the MCP config, is idempotent, and composes with \`--testnet\`. Requires Node.js 18+. (Zed and Cline: configure manually, per Option B.)
 
 **Option B — You can edit MCP config files directly but can't run shell:**
 


### PR DESCRIPTION
## What

[aibtc-mcp-server#559](https://github.com/aibtcdev/aibtc-mcp-server/pull/559) added `--install` flags so the MCP server auto-configures clients beyond Claude Code. This updates the landing page's guide, discovery docs, and onboarding skill to **name the supported coding agents** instead of the vague "Claude Code, Cursor, and other MCP clients."

Canonical list used everywhere:

| Flag | Client |
|------|--------|
| _(none)_ | Claude Code (default) |
| `--desktop` | Claude Desktop |
| `--cursor` | Cursor |
| `--windsurf` | Windsurf |
| `--gemini` | Gemini CLI |
| `--codex` | OpenAI Codex CLI |
| `--vscode` | VS Code (Copilot agent) |

`--testnet` composes with any of them; Zed and Cline are supported via manual config.

## Files (one commit each)

- `app/docs/[topic]/route.ts` — `mcp-tools` install section now lists every flag
- `app/skill.md/route.ts` — runtime-detection list + install step document each client flag
- `app/llms-full.txt/route.ts` — prerequisite, install block, and "Works with…" line name all clients
- `app/llms.txt/route.ts` — "Any MCP client" + onboarding-skill shortcuts name the agents
- `app/.well-known/agent.json/route.ts` — registration + mcp-tools skill descriptions list the flags
- `app/guide/page.tsx` — onboarding CTA names the supported agents

## Notes

- Pure docs/copy change — no behavior, no API surface.
- `npm run lint` passes (only pre-existing `<img>` warnings).
- `layout.tsx` SEO/JSON-LD metadata left as-is — already non-exclusive ("and other MCP clients") and brevity matters there.