### PR TITLE
feat(admin): add /api/admin/schema-health endpoint for EXPLAIN-based index regression detection

### DIFF
--- a/app/api/admin/schema-health/__tests__/schema-health.test.ts
+++ b/app/api/admin/schema-health/__tests__/schema-health.test.ts
@@ -9,7 +9,7 @@
  */
 
 import { describe, it, expect, vi } from "vitest";
-import { isScanWithoutIndex } from "../route";
+import { isScanWithoutIndex } from "../scan-detection";
 
 // ── (a-c) isScanWithoutIndex unit tests ─────────────────────────────────────
 

--- a/app/api/admin/schema-health/__tests__/schema-health.test.ts
+++ b/app/api/admin/schema-health/__tests__/schema-health.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for /api/admin/schema-health
+ *
+ * Covers:
+ *   (a) isScanWithoutIndex — SCAN detection helper: flagged cases
+ *   (b) isScanWithoutIndex — SCAN detection helper: acceptable cases (index used)
+ *   (c) isScanWithoutIndex — non-SCAN lines are never flagged
+ *   (d) Admin auth rejection — 401 without X-Admin-Key
+ */
+
+import { describe, it, expect, vi } from "vitest";
+import { isScanWithoutIndex } from "../route";
+
+// ── (a-c) isScanWithoutIndex unit tests ─────────────────────────────────────
+
+describe("isScanWithoutIndex: flagged cases", () => {
+  it("(a1) bare SCAN with no USING clause is flagged", () => {
+    expect(isScanWithoutIndex("SCAN inbox_messages")).toBe(true);
+  });
+
+  it("(a2) SCAN agents with no USING clause is flagged", () => {
+    expect(isScanWithoutIndex("SCAN agents")).toBe(true);
+  });
+
+  it("(a3) SCAN with temp B-TREE note but no index is flagged", () => {
+    // The temp-B-tree note appears on its OWN line; a SCAN line is separate.
+    // This test verifies a SCAN line is flagged even when the detail has trailing text.
+    expect(isScanWithoutIndex("SCAN bounties ")).toBe(true);
+  });
+});
+
+describe("isScanWithoutIndex: acceptable cases (index used)", () => {
+  it("(b1) SCAN with USING COVERING INDEX is NOT flagged", () => {
+    expect(
+      isScanWithoutIndex(
+        "SCAN inbox_messages USING COVERING INDEX idx_inbox_to_btc_sent_at"
+      )
+    ).toBe(false);
+  });
+
+  it("(b2) SCAN with USING INDEX is NOT flagged", () => {
+    expect(
+      isScanWithoutIndex(
+        "SCAN inbox_messages USING INDEX idx_inbox_unread"
+      )
+    ).toBe(false);
+  });
+
+  it("(b3) SEARCH with USING INDEX is NOT flagged", () => {
+    expect(
+      isScanWithoutIndex(
+        "SEARCH inbox_messages USING INDEX idx_inbox_to_btc_sent_at (to_btc_address=?)"
+      )
+    ).toBe(false);
+  });
+
+  it("(b4) SEARCH with USING COVERING INDEX is NOT flagged", () => {
+    expect(
+      isScanWithoutIndex(
+        "SEARCH agents USING COVERING INDEX idx_agents_verified_at"
+      )
+    ).toBe(false);
+  });
+});
+
+describe("isScanWithoutIndex: non-SCAN informational lines", () => {
+  it("(c1) USE TEMP B-TREE FOR ORDER BY is NOT flagged", () => {
+    expect(isScanWithoutIndex("USE TEMP B-TREE FOR ORDER BY")).toBe(false);
+  });
+
+  it("(c2) empty string is NOT flagged", () => {
+    expect(isScanWithoutIndex("")).toBe(false);
+  });
+
+  it("(c3) COMPOUND QUERY plan line is NOT flagged", () => {
+    expect(isScanWithoutIndex("COMPOUND QUERY")).toBe(false);
+  });
+});
+
+// ── (d) Admin auth rejection ─────────────────────────────────────────────────
+//
+// We mock requireAdmin to return a 401 NextResponse and verify the GET handler
+// short-circuits without trying to access the D1 binding.
+
+vi.mock("@/lib/admin/auth", () => ({
+  requireAdmin: vi.fn().mockResolvedValue(
+    new Response(JSON.stringify({ error: "Missing X-Admin-Key header" }), {
+      status: 401,
+      headers: { "Content-Type": "application/json" },
+    })
+  ),
+}));
+
+// We also need to mock getCloudflareContext so the import resolves.
+// If requireAdmin rejects before we reach getCloudflareContext, this mock
+// should never be called — and that's what the test verifies.
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn().mockRejectedValue(
+    new Error("getCloudflareContext should not be called when auth fails")
+  ),
+}));
+
+import { GET } from "../route";
+import { requireAdmin } from "@/lib/admin/auth";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+describe("GET /api/admin/schema-health: admin auth rejection", () => {
+  it("(d) returns 401 and does not call getCloudflareContext when X-Admin-Key is missing", async () => {
+    const request = new Request("https://example.com/api/admin/schema-health");
+    const response = await GET(request as unknown as import("next/server").NextRequest);
+
+    // requireAdmin must be called
+    expect(requireAdmin).toHaveBeenCalledTimes(1);
+
+    // Should be a 401 response
+    expect(response.status).toBe(401);
+
+    // getCloudflareContext must NOT be called — handler short-circuited
+    expect(getCloudflareContext).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/admin/schema-health/__tests__/schema-health.test.ts
+++ b/app/api/admin/schema-health/__tests__/schema-health.test.ts
@@ -5,13 +5,38 @@
  *   (a) isScanWithoutIndex — SCAN detection helper: flagged cases
  *   (b) isScanWithoutIndex — SCAN detection helper: acceptable cases (index used)
  *   (c) isScanWithoutIndex — non-SCAN lines are never flagged
- *   (d) Admin auth rejection — 401 without X-Admin-Key
+ *   (d) isScanWithoutIndex — SCAN SUBQUERY is NOT misclassified as a table-scan
+ *   (e) Admin auth rejection — 401 without X-Admin-Key
+ *   (f) GET handler — 200 and healthy:true when all expected indexes present
+ *   (g) GET handler — 503 and healthy:false when expected index dropped (fallback index used)
+ *   (h) GET handler — 503 and healthy:false when expected index missing from sqlite_master
+ *
+ * Mock ordering follows the pattern from app/api/admin/backfill/__tests__/route.test.ts:
+ *   vi.mock(...) declarations FIRST, then import of the route module AFTER.
+ *   This ensures the mock is installed before the module factory resolves,
+ *   preventing the real requireAdmin/getCloudflareContext from being bound.
  */
 
-import { describe, it, expect, vi } from "vitest";
-import { isScanWithoutIndex } from "../scan-detection";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 
-// ── (a-c) isScanWithoutIndex unit tests ─────────────────────────────────────
+// ── Module mocks — MUST come before route import ─────────────────────────────
+
+vi.mock("@/lib/admin/auth", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+// ── Imports after mocks ───────────────────────────────────────────────────────
+
+import { isScanWithoutIndex } from "../scan-detection";
+import { GET } from "../route";
+import { requireAdmin } from "@/lib/admin/auth";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+
+// ── (a-d) isScanWithoutIndex unit tests ──────────────────────────────────────
 
 describe("isScanWithoutIndex: flagged cases", () => {
   it("(a1) bare SCAN with no USING clause is flagged", () => {
@@ -22,10 +47,14 @@ describe("isScanWithoutIndex: flagged cases", () => {
     expect(isScanWithoutIndex("SCAN agents")).toBe(true);
   });
 
-  it("(a3) SCAN with temp B-TREE note but no index is flagged", () => {
+  it("(a3) SCAN with trailing whitespace but no index is flagged", () => {
     // The temp-B-tree note appears on its OWN line; a SCAN line is separate.
     // This test verifies a SCAN line is flagged even when the detail has trailing text.
     expect(isScanWithoutIndex("SCAN bounties ")).toBe(true);
+  });
+
+  it("(a4) SCAN with leading whitespace (indented plan line) and no index is flagged", () => {
+    expect(isScanWithoutIndex("  SCAN inbox_messages")).toBe(true);
   });
 });
 
@@ -40,9 +69,7 @@ describe("isScanWithoutIndex: acceptable cases (index used)", () => {
 
   it("(b2) SCAN with USING INDEX is NOT flagged", () => {
     expect(
-      isScanWithoutIndex(
-        "SCAN inbox_messages USING INDEX idx_inbox_unread"
-      )
+      isScanWithoutIndex("SCAN inbox_messages USING INDEX idx_inbox_unread")
     ).toBe(false);
   });
 
@@ -77,45 +104,301 @@ describe("isScanWithoutIndex: non-SCAN informational lines", () => {
   });
 });
 
-// ── (d) Admin auth rejection ─────────────────────────────────────────────────
-//
-// We mock requireAdmin to return a 401 NextResponse and verify the GET handler
-// short-circuits without trying to access the D1 binding.
+describe("isScanWithoutIndex: SCAN SUBQUERY not misclassified", () => {
+  it("(d1) SCAN SUBQUERY ... is NOT flagged as a table-scan regression", () => {
+    expect(isScanWithoutIndex("SCAN SUBQUERY 1")).toBe(false);
+  });
 
-vi.mock("@/lib/admin/auth", () => ({
-  requireAdmin: vi.fn().mockResolvedValue(
-    new Response(JSON.stringify({ error: "Missing X-Admin-Key header" }), {
-      status: 401,
-      headers: { "Content-Type": "application/json" },
-    })
-  ),
-}));
+  it("(d2) SCAN SUBQUERY with additional text is NOT flagged", () => {
+    expect(isScanWithoutIndex("SCAN SUBQUERY 2 AS t")).toBe(false);
+  });
 
-// We also need to mock getCloudflareContext so the import resolves.
-// If requireAdmin rejects before we reach getCloudflareContext, this mock
-// should never be called — and that's what the test verifies.
-vi.mock("@opennextjs/cloudflare", () => ({
-  getCloudflareContext: vi.fn().mockRejectedValue(
-    new Error("getCloudflareContext should not be called when auth fails")
-  ),
-}));
+  it("(d3) indented SCAN SUBQUERY is NOT flagged", () => {
+    expect(isScanWithoutIndex("  SCAN SUBQUERY 1")).toBe(false);
+  });
+});
 
-import { GET } from "../route";
-import { requireAdmin } from "@/lib/admin/auth";
-import { getCloudflareContext } from "@opennextjs/cloudflare";
+// ── (e) Admin auth rejection ──────────────────────────────────────────────────
 
 describe("GET /api/admin/schema-health: admin auth rejection", () => {
-  it("(d) returns 401 and does not call getCloudflareContext when X-Admin-Key is missing", async () => {
-    const request = new Request("https://example.com/api/admin/schema-health");
-    const response = await GET(request as unknown as import("next/server").NextRequest);
+  beforeEach(() => {
+    (requireAdmin as Mock).mockResolvedValue(
+      new Response(JSON.stringify({ error: "Missing X-Admin-Key header" }), {
+        status: 401,
+        headers: { "Content-Type": "application/json" },
+      })
+    );
+  });
 
-    // requireAdmin must be called
+  it("(e) returns 401 and does not call getCloudflareContext when X-Admin-Key is missing", async () => {
+    const request = new Request(
+      "https://example.com/api/admin/schema-health"
+    );
+    const response = await GET(
+      request as unknown as import("next/server").NextRequest
+    );
+
     expect(requireAdmin).toHaveBeenCalledTimes(1);
-
-    // Should be a 401 response
     expect(response.status).toBe(401);
-
-    // getCloudflareContext must NOT be called — handler short-circuited
     expect(getCloudflareContext).not.toHaveBeenCalled();
+  });
+});
+
+// ── Helpers for (f-h) handler tests ──────────────────────────────────────────
+
+/**
+ * Build a minimal D1Database mock.
+ * - `explainResults`: plan detail lines returned for EXPLAIN QUERY PLAN calls
+ * - `masterIndexes`: rows returned from the sqlite_master query
+ */
+function buildDbMock(
+  explainResults: string[],
+  masterIndexes: Array<{ name: string; tbl_name: string; sql: string | null }>
+): D1Database {
+  const db = {
+    prepare: vi.fn((sql: string) => {
+      const stmt = {
+        bind: vi.fn((..._args: unknown[]) => stmt),
+        all: vi.fn(async () => {
+          if (sql.startsWith("EXPLAIN QUERY PLAN")) {
+            return {
+              results: explainResults.map((detail, i) => ({
+                id: i,
+                parent: 0,
+                notused: 0,
+                detail,
+              })),
+            };
+          }
+          // sqlite_master query
+          return { results: masterIndexes };
+        }),
+      };
+      return stmt;
+    }),
+  } as unknown as D1Database;
+  return db;
+}
+
+function makeAdminRequest(): Request {
+  return new Request("https://example.com/api/admin/schema-health", {
+    headers: { "X-Admin-Key": "test-key" },
+  });
+}
+
+// ── (f) Healthy: expected indexes present ────────────────────────────────────
+
+describe("GET /api/admin/schema-health: healthy when all expected indexes present", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAdmin as Mock).mockResolvedValue(null);
+  });
+
+  it("(f) returns 200 and healthy:true when plan references expected index and index is in sqlite_master", async () => {
+    // All explicit (non-autoindex) expected index names across all HOT_QUERIES.
+    // The plan mock returns lines referencing all of these so every query's
+    // planUsesExpectedIndex check passes. The sqlite_master mock includes all
+    // explicit indexes so the missingFromMaster check passes too.
+    // sqlite_autoindex_agent_inbox_stats_1 is skipped from master check by design.
+    const allExplicitIndexNames = [
+      "idx_inbox_to_btc_sent_at",
+      "idx_swaps_token_in_active",
+      "idx_swaps_sender_burn_time",
+      "idx_agents_verified_at",
+      "idx_bounties_active_created",
+    ];
+    // Also include the autoindex in the plan so inbox_unread_stats is covered
+    const allPlanIndexNames = [
+      ...allExplicitIndexNames,
+      "sqlite_autoindex_agent_inbox_stats_1",
+    ];
+
+    // Plan mentions all expected indexes (one line per index, same plan returned
+    // for every query in this mock — each query's planText will include all names)
+    const planLines = allPlanIndexNames.map(
+      (name) => `SEARCH table USING COVERING INDEX ${name} (?)`
+    );
+
+    const masterIndexes = allExplicitIndexNames.map((name) => ({
+      name,
+      tbl_name: "some_table",
+      sql: `CREATE INDEX ${name} ON some_table(col)`,
+    }));
+
+    const db = buildDbMock(planLines, masterIndexes);
+    (getCloudflareContext as Mock).mockResolvedValue({ env: { DB: db } });
+
+    const response = await GET(
+      makeAdminRequest() as unknown as import("next/server").NextRequest
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.healthy).toBe(true);
+    expect(body.flaggedCount).toBe(0);
+  });
+});
+
+// ── (g) Unhealthy: expected index dropped but fallback index used ─────────────
+
+describe("GET /api/admin/schema-health: unhealthy when expected index dropped", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAdmin as Mock).mockResolvedValue(null);
+  });
+
+  it("(g) returns 503 and healthy:false when EXPLAIN uses a fallback index after drop of intended index", async () => {
+    // Simulate: idx_bounties_active_created was dropped; planner falls back to
+    // idx_bounties_created (a different, non-partial index). The EXPLAIN plan
+    // would NOT contain "idx_bounties_active_created" — only "idx_bounties_created".
+    // isScanWithoutIndex would NOT flag this (it's still using AN index), but the
+    // expected-index check MUST flag it.
+
+    // Provide plan lines that reference a fallback index but NOT the expected one.
+    // For the inbox_list / bounty_list / agents_list queries, use the expected ones
+    // except for bounty_list which uses the fallback.
+    const db = {
+      prepare: vi.fn((sql: string) => {
+        const stmt = {
+          bind: vi.fn((..._args: unknown[]) => stmt),
+          all: vi.fn(async () => {
+            if (sql.startsWith("EXPLAIN QUERY PLAN")) {
+              // Return a plan that uses a fallback index for bounties,
+              // but the correct ones for all other queries
+              if (sql.includes("FROM bounties")) {
+                return {
+                  results: [
+                    {
+                      id: 0,
+                      parent: 0,
+                      notused: 0,
+                      // Fallback: idx_bounties_created instead of idx_bounties_active_created
+                      detail:
+                        "SCAN bounties USING INDEX idx_bounties_created ORDER BY created_at DESC",
+                    },
+                  ],
+                };
+              }
+              // All other queries: plan uses expected indexes
+              return {
+                results: [
+                  {
+                    id: 0,
+                    parent: 0,
+                    notused: 0,
+                    detail:
+                      "SEARCH table USING COVERING INDEX idx_inbox_to_btc_sent_at (?)",
+                  },
+                ],
+              };
+            }
+            // sqlite_master: idx_bounties_active_created IS MISSING (dropped),
+            // but idx_bounties_created is still present
+            return {
+              results: [
+                {
+                  name: "idx_inbox_to_btc_sent_at",
+                  tbl_name: "inbox_messages",
+                  sql: null,
+                },
+                {
+                  name: "sqlite_autoindex_agent_inbox_stats_1",
+                  tbl_name: "agent_inbox_stats",
+                  sql: null,
+                },
+                {
+                  name: "idx_swaps_token_in_active",
+                  tbl_name: "swaps",
+                  sql: null,
+                },
+                {
+                  // idx_bounties_active_created is ABSENT — this is the regression
+                  name: "idx_bounties_created",
+                  tbl_name: "bounties",
+                  sql: null,
+                },
+                {
+                  name: "idx_agents_verified_at",
+                  tbl_name: "agents",
+                  sql: null,
+                },
+              ],
+            };
+          }),
+        };
+        return stmt;
+      }),
+    } as unknown as D1Database;
+
+    (getCloudflareContext as Mock).mockResolvedValue({ env: { DB: db } });
+
+    const response = await GET(
+      makeAdminRequest() as unknown as import("next/server").NextRequest
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.healthy).toBe(false);
+    expect(body.flaggedCount).toBeGreaterThan(0);
+
+    const bountyResult = body.queries.find(
+      (q: { name: string }) => q.name === "bounty_list"
+    );
+    expect(bountyResult).toBeDefined();
+    expect(bountyResult.flagged).toBe(true);
+    expect(bountyResult.missingIndex).toBeDefined();
+  });
+});
+
+// ── (h) Unhealthy: expected index missing from sqlite_master ─────────────────
+
+describe("GET /api/admin/schema-health: unhealthy when expected index absent from sqlite_master", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (requireAdmin as Mock).mockResolvedValue(null);
+  });
+
+  it("(h) returns 503 and healthy:false when expected index is absent from sqlite_master even if plan looks clean", async () => {
+    // Simulate a state where EXPLAIN returns a clean plan (no bare SCAN),
+    // but the expected index is completely missing from sqlite_master.
+    // This covers the belt-and-suspenders check: the index was dropped
+    // (migration regressed) even before EXPLAIN reflects the full impact.
+
+    const allExpectedIndexes = [
+      "idx_inbox_to_btc_sent_at",
+      "sqlite_autoindex_agent_inbox_stats_1",
+      "idx_swaps_token_in_active",
+      "idx_bounties_active_created",
+      "idx_agents_verified_at",
+    ];
+
+    // EXPLAIN plan looks fine — references expected indexes
+    const cleanPlanLines = allExpectedIndexes.map(
+      (name) => `SEARCH table USING COVERING INDEX ${name} (?)`
+    );
+
+    // sqlite_master is EMPTY — all indexes are missing
+    const db = buildDbMock(cleanPlanLines, []);
+    (getCloudflareContext as Mock).mockResolvedValue({ env: { DB: db } });
+
+    const response = await GET(
+      makeAdminRequest() as unknown as import("next/server").NextRequest
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(503);
+    expect(body.healthy).toBe(false);
+    expect(body.flaggedCount).toBeGreaterThan(0);
+
+    // Queries with explicit CREATE INDEX entries must be flagged (not in sqlite_master).
+    // inbox_unread_stats uses a sqlite_autoindex which is exempt from the master check,
+    // so it will be healthy (its plan still references the autoindex).
+    const explicitIndexQueries = ["inbox_list", "bounty_list", "agents_list"];
+    for (const name of explicitIndexQueries) {
+      const q = body.queries.find((r: { name: string }) => r.name === name);
+      expect(q).toBeDefined();
+      expect(q.flagged).toBe(true);
+      expect(q.missingIndex).toBeDefined();
+    }
   });
 });

--- a/app/api/admin/schema-health/route.ts
+++ b/app/api/admin/schema-health/route.ts
@@ -2,7 +2,7 @@
  * GET /api/admin/schema-health
  *
  * Runs EXPLAIN QUERY PLAN on critical hot queries and flags any result whose
- * plan contains a full table SCAN without using an index. Cross-references
+ * plan does not reference its expected index(es). Cross-references
  * sqlite_master for a live index inventory so silently dropped indexes are
  * visible immediately.
  *
@@ -18,8 +18,8 @@
  * Cost: EXPLAIN QUERY PLAN is plan-only and free — it never scans rows.
  *
  * See: migrations/019_restore_dropped_indexes.sql (the fix for migration 008)
- * See: ~/dev/aibtcdev/cloudflare-bill-audit-2026-04.md (incident details)
- * See: ~/dev/whoabuddy/claude-knowledge/patterns/d1-schema-health.md (recipe)
+ * See: migrations/014_bounties.sql (idx_bounties_active_created)
+ * See: migrations/001_agents.sql (idx_agents_verified_at)
  */
 
 import { NextRequest, NextResponse } from "next/server";
@@ -36,6 +36,19 @@ interface QueryDef {
   name: string;
   sql: string;
   params: (string | number)[];
+  /**
+   * The specific SQLite index name(s) this query MUST use in production.
+   * A query is flagged unhealthy if EITHER:
+   *   (a) none of these names appears in the EXPLAIN plan, OR
+   *   (b) any of these names (excluding sqlite_autoindex_* entries) is absent
+   *       from the sqlite_master index inventory.
+   *
+   * For PRIMARY KEY lookups, SQLite generates an autoindex whose name follows
+   * the pattern `sqlite_autoindex_<table>_1`. List it to assert plan usage, but
+   * note: autoindexes do NOT appear in sqlite_master (they are schema-level
+   * constraints, not CREATE INDEX rows), so the master check is skipped for them.
+   */
+  expectedIndexes: string[];
 }
 
 /**
@@ -44,6 +57,13 @@ interface QueryDef {
  *
  * Use representative bound parameters (not real addresses) so the query
  * planner exercises the same code path as production.
+ *
+ * Index name sources:
+ *   inbox_list            → migrations/019_restore_dropped_indexes.sql (line 33)
+ *   inbox_unread_stats    → migrations/012_agent_inbox_stats.sql (btc_address TEXT PRIMARY KEY)
+ *   leaderboard_aggregate → migrations/010_swaps_token_indexes.sql + 005_swaps.sql
+ *   bounty_list           → migrations/014_bounties.sql (line 51)
+ *   agents_list           → migrations/001_agents.sql (line 39)
  */
 const HOT_QUERIES: QueryDef[] = [
   {
@@ -60,6 +80,9 @@ const HOT_QUERIES: QueryDef[] = [
       ORDER BY sent_at DESC LIMIT ? OFFSET ?
     `.trim(),
     params: ["bc1placeholder", 20, 0],
+    // Partial covering index on (to_btc_address, sent_at DESC) WHERE is_reply = 0
+    // Defined in migrations/003_inbox_messages.sql, restored by migrations/019
+    expectedIndexes: ["idx_inbox_to_btc_sent_at"],
   },
   {
     name: "inbox_unread_stats",
@@ -69,11 +92,24 @@ const HOT_QUERIES: QueryDef[] = [
       WHERE btc_address = ?
     `.trim(),
     params: ["bc1placeholder"],
+    // agent_inbox_stats has btc_address TEXT PRIMARY KEY → SQLite autoindex
+    // Defined in migrations/012_agent_inbox_stats.sql
+    expectedIndexes: ["sqlite_autoindex_agent_inbox_stats_1"],
   },
   {
     name: "leaderboard_aggregate",
     sql: LEADERBOARD_AGGREGATE_SQL.trim(),
     params: [],
+    // Covers swaps access patterns: either composite token index (010)
+    // or the sender/time index (005) may be chosen by the planner.
+    // Also accepts the agents verified_at index for the JOIN side.
+    // Any of these in the plan confirms index use; their presence in
+    // sqlite_master is checked belt-and-suspenders.
+    expectedIndexes: [
+      "idx_swaps_token_in_active",
+      "idx_swaps_sender_burn_time",
+      "idx_agents_verified_at",
+    ],
   },
   {
     name: "bounty_list",
@@ -88,6 +124,9 @@ const HOT_QUERIES: QueryDef[] = [
       ORDER BY created_at DESC LIMIT ? OFFSET ?
     `.trim(),
     params: [20, 0],
+    // Partial index on (created_at DESC) WHERE cancelled_at IS NULL AND paid_at IS NULL
+    // Defined in migrations/014_bounties.sql (line 51)
+    expectedIndexes: ["idx_bounties_active_created"],
   },
   {
     name: "agents_list",
@@ -100,6 +139,8 @@ const HOT_QUERIES: QueryDef[] = [
       ORDER BY verified_at DESC LIMIT ? OFFSET ?
     `.trim(),
     params: [20, 0],
+    // Defined in migrations/001_agents.sql (line 39), re-created by migration 008
+    expectedIndexes: ["idx_agents_verified_at"],
   },
 ];
 
@@ -113,6 +154,8 @@ interface QueryResult {
   plan: string[];
   usesIndex: boolean;
   flagged: boolean;
+  /** Which expected index name was not found (in plan or sqlite_master). */
+  missingIndex?: string;
   error?: string;
 }
 
@@ -152,13 +195,18 @@ interface ExplainRow {
  * sqlite_master for the live index inventory. Returns a structured JSON
  * report with per-query plan details and an overall healthy boolean.
  *
- * A result is flagged when the EXPLAIN plan contains a "SCAN tablename"
- * line without any "USING INDEX" clause — meaning the query planner found
- * no usable index and will scan every row in the table.
+ * A result is flagged when EITHER:
+ *   (a) the EXPLAIN plan does not reference any of the query's expected
+ *       indexes — this catches both pure-SCAN regressions AND cases where
+ *       the planner falls back to a different index after the intended one
+ *       is dropped (e.g. DROP INDEX idx_bounties_active_created → planner
+ *       falls back to idx_bounties_created, which still passes isScanWithoutIndex
+ *       but misses the partial-index optimization), OR
+ *   (b) any of the expected indexes is absent from sqlite_master — this
+ *       catches a drop even before EXPLAIN reflects it.
  *
- * If healthy === false, at least one query is doing a full table scan.
- * This is exactly the condition migration 019 fixed; if it ever regresses,
- * this endpoint will flag it on the next run.
+ * Returns HTTP 200 when healthy, 503 when at least one query is flagged,
+ * so external uptime monitors can alert on schema regressions.
  */
 export async function GET(request: NextRequest) {
   const denied = await requireAdmin(request);
@@ -185,6 +233,28 @@ export async function GET(request: NextRequest) {
 
   const checkedAt = new Date().toISOString();
 
+  // Fetch live index inventory from sqlite_master first — used for belt-and-
+  // suspenders check against expectedIndexes for each query.
+  let indexes: IndexRecord[] = [];
+  const liveIndexNames = new Set<string>();
+  try {
+    const indexResult = await db
+      .prepare(
+        `SELECT name, tbl_name, sql
+         FROM sqlite_master
+         WHERE type = 'index'
+         ORDER BY tbl_name, name`
+      )
+      .all<IndexRecord>();
+    indexes = indexResult.results ?? [];
+    for (const idx of indexes) {
+      liveIndexNames.add(idx.name);
+    }
+  } catch (e) {
+    console.error("schema-health: sqlite_master query failed", e);
+    // Non-fatal: continue with empty index set (all expectedIndexes will flag)
+  }
+
   // Run EXPLAIN QUERY PLAN on each critical query
   const queryResults: QueryResult[] = await Promise.all(
     HOT_QUERIES.map(async (q): Promise<QueryResult> => {
@@ -197,16 +267,49 @@ export async function GET(request: NextRequest) {
 
         const planRows = result.results ?? [];
         const planDetails = planRows.map((row) => row.detail ?? "");
+        const planText = planDetails.join("\n");
 
-        // Flag if any plan line is a SCAN without an index
+        // Belt-and-suspenders check:
+        // (a) Does the EXPLAIN plan reference any expected index?
+        const planUsesExpectedIndex = q.expectedIndexes.some((idx) =>
+          planText.includes(idx)
+        );
+
+        // (b) Are all explicit (non-auto) expected indexes present in sqlite_master?
+        //     SQLite autoindexes (sqlite_autoindex_*) are implicitly created for
+        //     PRIMARY KEY / UNIQUE constraints and do NOT appear in sqlite_master —
+        //     they only show up in EXPLAIN plans. Skip the master check for those;
+        //     the plan check above already covers their presence. For explicit
+        //     CREATE INDEX entries, absence from sqlite_master means the index was
+        //     silently dropped (the migration-008 failure mode).
+        const missingFromMaster = q.expectedIndexes.find(
+          (idx) =>
+            !idx.startsWith("sqlite_autoindex_") && !liveIndexNames.has(idx)
+        );
+
+        // Also flag a bare SCAN for belt-and-suspenders visibility even if
+        // expectedIndexes were not listed — pure helper coverage
         const hasBadScan = planDetails.some(isScanWithoutIndex);
+
+        // Flagged if: plan doesn't use an expected index OR expected index is missing
+        const flagged =
+          !planUsesExpectedIndex ||
+          missingFromMaster !== undefined ||
+          hasBadScan;
+
+        const missingIndex = !planUsesExpectedIndex
+          ? q.expectedIndexes[0]
+          : missingFromMaster;
 
         return {
           name: q.name,
           sql: q.sql,
           plan: planDetails,
           usesIndex: !hasBadScan,
-          flagged: hasBadScan,
+          flagged,
+          ...(flagged && missingIndex !== undefined
+            ? { missingIndex }
+            : undefined),
         };
       } catch (e) {
         // EXPLAIN itself failed (e.g. table doesn't exist yet, syntax error).
@@ -219,28 +322,12 @@ export async function GET(request: NextRequest) {
           plan: [],
           usesIndex: false,
           flagged: true,
+          missingIndex: q.expectedIndexes[0],
           error: errMsg,
         };
       }
     })
   );
-
-  // Fetch live index inventory from sqlite_master
-  let indexes: IndexRecord[] = [];
-  try {
-    const indexResult = await db
-      .prepare(
-        `SELECT name, tbl_name, sql
-         FROM sqlite_master
-         WHERE type = 'index'
-         ORDER BY tbl_name, name`
-      )
-      .all<IndexRecord>();
-    indexes = indexResult.results ?? [];
-  } catch (e) {
-    console.error("schema-health: sqlite_master query failed", e);
-    // Non-fatal: continue with empty index list
-  }
 
   const flaggedCount = queryResults.filter((q) => q.flagged).length;
   const healthy = flaggedCount === 0;
@@ -253,5 +340,6 @@ export async function GET(request: NextRequest) {
     flaggedCount,
   };
 
-  return NextResponse.json(body, { status: healthy ? 200 : 200 });
+  // Return 503 when unhealthy so external uptime monitors can alert on regressions.
+  return NextResponse.json(body, { status: healthy ? 200 : 503 });
 }

--- a/app/api/admin/schema-health/route.ts
+++ b/app/api/admin/schema-health/route.ts
@@ -1,0 +1,284 @@
+/**
+ * GET /api/admin/schema-health
+ *
+ * Runs EXPLAIN QUERY PLAN on critical hot queries and flags any result whose
+ * plan contains a full table SCAN without using an index. Cross-references
+ * sqlite_master for a live index inventory so silently dropped indexes are
+ * visible immediately.
+ *
+ * Motivation: migration 008 (nullable_btc_public_key) silently dropped the
+ * inbox_messages, claims, vouches, swaps, and balances indexes via the SQLite
+ * table-rebuild dance. Every inbox listing became a full table scan and caused
+ * ~96% of all D1 rows-read (~4.5B/day, ~$100+/mo overage). The indexes existed
+ * in migration *files* but not in the live database — trusted the files, never
+ * ran EXPLAIN / checked sqlite_master until the cost exploded. This endpoint
+ * catches exactly that class of regression before it becomes a billing event.
+ *
+ * Auth: X-Admin-Key header (same as all admin routes).
+ * Cost: EXPLAIN QUERY PLAN is plan-only and free — it never scans rows.
+ *
+ * See: migrations/019_restore_dropped_indexes.sql (the fix for migration 008)
+ * See: ~/dev/aibtcdev/cloudflare-bill-audit-2026-04.md (incident details)
+ * See: ~/dev/whoabuddy/claude-knowledge/patterns/d1-schema-health.md (recipe)
+ */
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import { LEADERBOARD_AGGREGATE_SQL } from "@/lib/competition/leaderboard-query";
+
+// ---------------------------------------------------------------------------
+// SCAN detection
+// ---------------------------------------------------------------------------
+
+/**
+ * Determine whether an EXPLAIN QUERY PLAN detail line represents a full table
+ * scan without any index.
+ *
+ * SQLite EXPLAIN QUERY PLAN output shapes:
+ *   "SCAN tablename"                                    → BAD  (full scan, no index)
+ *   "SCAN tablename USING COVERING INDEX idx_name"      → OK   (index-only scan)
+ *   "SCAN tablename USING INDEX idx_name"               → OK   (index scan)
+ *   "SEARCH tablename USING INDEX idx_name (...)"       → OK   (index seek)
+ *   "SEARCH tablename USING COVERING INDEX idx_name"    → OK   (covering index seek)
+ *   "USE TEMP B-TREE FOR ORDER BY"                      → informational, not a scan
+ *
+ * We flag only the first case: SCAN without any USING INDEX clause.
+ */
+export function isScanWithoutIndex(detail: string): boolean {
+  // Must start with "SCAN " (SQLite uses uppercase)
+  if (!detail.includes("SCAN ")) return false;
+  // If it uses any index, it is acceptable
+  if (detail.includes("USING INDEX") || detail.includes("USING COVERING INDEX")) {
+    return false;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// Query definitions
+// ---------------------------------------------------------------------------
+
+interface QueryDef {
+  name: string;
+  sql: string;
+  params: (string | number)[];
+}
+
+/**
+ * Critical hot queries to EXPLAIN. These are the production queries most
+ * likely to cause runaway D1 row-read costs if an index is dropped.
+ *
+ * Use representative bound parameters (not real addresses) so the query
+ * planner exercises the same code path as production.
+ */
+const HOT_QUERIES: QueryDef[] = [
+  {
+    name: "inbox_list",
+    sql: `
+      SELECT
+        message_id, from_stx_address, to_btc_address, to_stx_address,
+        content, payment_txid, payment_satoshis, payment_status,
+        payment_id, receipt_id, recovered_via_txid, authenticated,
+        bitcoin_signature, sender_btc_address,
+        sent_at, read_at, replied_at, reply_to_message_id
+      FROM inbox_messages
+      WHERE to_btc_address = ? AND is_reply = 0
+      ORDER BY sent_at DESC LIMIT ? OFFSET ?
+    `.trim(),
+    params: ["bc1placeholder", 20, 0],
+  },
+  {
+    name: "inbox_unread_stats",
+    sql: `
+      SELECT received_count, unread_count, sent_count, last_message_at, last_sent_at
+      FROM agent_inbox_stats
+      WHERE btc_address = ?
+    `.trim(),
+    params: ["bc1placeholder"],
+  },
+  {
+    name: "leaderboard_aggregate",
+    sql: LEADERBOARD_AGGREGATE_SQL.trim(),
+    params: [],
+  },
+  {
+    name: "bounty_list",
+    sql: `
+      SELECT
+        id, poster_btc_address, poster_stx_address, title, description,
+        reward_sats, submission_count, created_at, expires_at,
+        accepted_submission_id, accepted_at, paid_txid, paid_at,
+        cancelled_at, updated_at, tags
+      FROM bounties
+      WHERE cancelled_at IS NULL AND paid_at IS NULL
+      ORDER BY created_at DESC LIMIT ? OFFSET ?
+    `.trim(),
+    params: [20, 0],
+  },
+  {
+    name: "agents_list",
+    sql: `
+      SELECT
+        stx_address, btc_address, display_name, bns_name, description,
+        owner, taproot_address, nostr_public_key, last_active_at,
+        last_check_in_at, verified_at, erc8004_agent_id, referred_by_btc
+      FROM agents
+      ORDER BY verified_at DESC LIMIT ? OFFSET ?
+    `.trim(),
+    params: [20, 0],
+  },
+];
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+interface QueryResult {
+  name: string;
+  sql: string;
+  plan: string[];
+  usesIndex: boolean;
+  flagged: boolean;
+  error?: string;
+}
+
+interface IndexRecord {
+  name: string;
+  tbl_name: string;
+  sql: string | null;
+}
+
+interface SchemaHealthResponse {
+  healthy: boolean;
+  checkedAt: string;
+  queries: QueryResult[];
+  indexes: IndexRecord[];
+  flaggedCount: number;
+}
+
+// ---------------------------------------------------------------------------
+// EXPLAIN QUERY PLAN row shape
+// ---------------------------------------------------------------------------
+
+interface ExplainRow {
+  id: number;
+  parent: number;
+  notused: number;
+  detail: string;
+}
+
+// ---------------------------------------------------------------------------
+// Route handler
+// ---------------------------------------------------------------------------
+
+/**
+ * GET /api/admin/schema-health
+ *
+ * Runs EXPLAIN QUERY PLAN on each critical hot query and cross-references
+ * sqlite_master for the live index inventory. Returns a structured JSON
+ * report with per-query plan details and an overall healthy boolean.
+ *
+ * A result is flagged when the EXPLAIN plan contains a "SCAN tablename"
+ * line without any "USING INDEX" clause — meaning the query planner found
+ * no usable index and will scan every row in the table.
+ *
+ * If healthy === false, at least one query is doing a full table scan.
+ * This is exactly the condition migration 019 fixed; if it ever regresses,
+ * this endpoint will flag it on the next run.
+ */
+export async function GET(request: NextRequest) {
+  const denied = await requireAdmin(request);
+  if (denied) return denied;
+
+  let db: D1Database | undefined;
+  try {
+    const { env } = await getCloudflareContext();
+    db = env.DB as D1Database | undefined;
+  } catch (e) {
+    console.error("schema-health: failed to get Cloudflare context", e);
+    return NextResponse.json(
+      { error: "Failed to get runtime context" },
+      { status: 500 }
+    );
+  }
+
+  if (!db) {
+    return NextResponse.json(
+      { error: "D1 binding (DB) not available" },
+      { status: 503 }
+    );
+  }
+
+  const checkedAt = new Date().toISOString();
+
+  // Run EXPLAIN QUERY PLAN on each critical query
+  const queryResults: QueryResult[] = await Promise.all(
+    HOT_QUERIES.map(async (q): Promise<QueryResult> => {
+      try {
+        const explainSql = `EXPLAIN QUERY PLAN ${q.sql}`;
+        const result = await db!
+          .prepare(explainSql)
+          .bind(...q.params)
+          .all<ExplainRow>();
+
+        const planRows = result.results ?? [];
+        const planDetails = planRows.map((row) => row.detail ?? "");
+
+        // Flag if any plan line is a SCAN without an index
+        const hasBadScan = planDetails.some(isScanWithoutIndex);
+
+        return {
+          name: q.name,
+          sql: q.sql,
+          plan: planDetails,
+          usesIndex: !hasBadScan,
+          flagged: hasBadScan,
+        };
+      } catch (e) {
+        // EXPLAIN itself failed (e.g. table doesn't exist yet, syntax error).
+        // Treat as flagged so missing tables are visible.
+        const errMsg = e instanceof Error ? e.message : String(e);
+        console.error(`schema-health: EXPLAIN failed for ${q.name}:`, errMsg);
+        return {
+          name: q.name,
+          sql: q.sql,
+          plan: [],
+          usesIndex: false,
+          flagged: true,
+          error: errMsg,
+        };
+      }
+    })
+  );
+
+  // Fetch live index inventory from sqlite_master
+  let indexes: IndexRecord[] = [];
+  try {
+    const indexResult = await db
+      .prepare(
+        `SELECT name, tbl_name, sql
+         FROM sqlite_master
+         WHERE type = 'index'
+         ORDER BY tbl_name, name`
+      )
+      .all<IndexRecord>();
+    indexes = indexResult.results ?? [];
+  } catch (e) {
+    console.error("schema-health: sqlite_master query failed", e);
+    // Non-fatal: continue with empty index list
+  }
+
+  const flaggedCount = queryResults.filter((q) => q.flagged).length;
+  const healthy = flaggedCount === 0;
+
+  const body: SchemaHealthResponse = {
+    healthy,
+    checkedAt,
+    queries: queryResults,
+    indexes,
+    flaggedCount,
+  };
+
+  return NextResponse.json(body, { status: healthy ? 200 : 200 });
+}

--- a/app/api/admin/schema-health/route.ts
+++ b/app/api/admin/schema-health/route.ts
@@ -26,34 +26,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
 import { LEADERBOARD_AGGREGATE_SQL } from "@/lib/competition/leaderboard-query";
-
-// ---------------------------------------------------------------------------
-// SCAN detection
-// ---------------------------------------------------------------------------
-
-/**
- * Determine whether an EXPLAIN QUERY PLAN detail line represents a full table
- * scan without any index.
- *
- * SQLite EXPLAIN QUERY PLAN output shapes:
- *   "SCAN tablename"                                    → BAD  (full scan, no index)
- *   "SCAN tablename USING COVERING INDEX idx_name"      → OK   (index-only scan)
- *   "SCAN tablename USING INDEX idx_name"               → OK   (index scan)
- *   "SEARCH tablename USING INDEX idx_name (...)"       → OK   (index seek)
- *   "SEARCH tablename USING COVERING INDEX idx_name"    → OK   (covering index seek)
- *   "USE TEMP B-TREE FOR ORDER BY"                      → informational, not a scan
- *
- * We flag only the first case: SCAN without any USING INDEX clause.
- */
-export function isScanWithoutIndex(detail: string): boolean {
-  // Must start with "SCAN " (SQLite uses uppercase)
-  if (!detail.includes("SCAN ")) return false;
-  // If it uses any index, it is acceptable
-  if (detail.includes("USING INDEX") || detail.includes("USING COVERING INDEX")) {
-    return false;
-  }
-  return true;
-}
+import { isScanWithoutIndex } from "./scan-detection";
 
 // ---------------------------------------------------------------------------
 // Query definitions

--- a/app/api/admin/schema-health/scan-detection.ts
+++ b/app/api/admin/schema-health/scan-detection.ts
@@ -1,0 +1,31 @@
+/**
+ * EXPLAIN QUERY PLAN SCAN-detection helper for the schema-health endpoint.
+ *
+ * Kept in a sibling module (not route.ts) because Next.js App Router route
+ * files may only export HTTP handlers + route config — exporting a helper from
+ * route.ts fails the `next build` route-export validation.
+ */
+
+/**
+ * Determine whether an EXPLAIN QUERY PLAN detail line represents a full table
+ * scan without any index.
+ *
+ * SQLite EXPLAIN QUERY PLAN output shapes:
+ *   "SCAN tablename"                                    → BAD  (full scan, no index)
+ *   "SCAN tablename USING COVERING INDEX idx_name"      → OK   (index-only scan)
+ *   "SCAN tablename USING INDEX idx_name"               → OK   (index scan)
+ *   "SEARCH tablename USING INDEX idx_name (...)"       → OK   (index seek)
+ *   "SEARCH tablename USING COVERING INDEX idx_name"    → OK   (covering index seek)
+ *   "USE TEMP B-TREE FOR ORDER BY"                      → informational, not a scan
+ *
+ * We flag only the first case: SCAN without any USING INDEX clause.
+ */
+export function isScanWithoutIndex(detail: string): boolean {
+  // Must start with "SCAN " (SQLite uses uppercase)
+  if (!detail.includes("SCAN ")) return false;
+  // If it uses any index, it is acceptable
+  if (detail.includes("USING INDEX") || detail.includes("USING COVERING INDEX")) {
+    return false;
+  }
+  return true;
+}

--- a/app/api/admin/schema-health/scan-detection.ts
+++ b/app/api/admin/schema-health/scan-detection.ts
@@ -16,15 +16,23 @@
  *   "SCAN tablename USING INDEX idx_name"               → OK   (index scan)
  *   "SEARCH tablename USING INDEX idx_name (...)"       → OK   (index seek)
  *   "SEARCH tablename USING COVERING INDEX idx_name"    → OK   (covering index seek)
+ *   "SCAN SUBQUERY ..."                                 → informational, not a table-scan
  *   "USE TEMP B-TREE FOR ORDER BY"                      → informational, not a scan
  *
- * We flag only the first case: SCAN without any USING INDEX clause.
+ * We flag only: a line that starts with "SCAN " (after trimming leading
+ * whitespace), is NOT "SCAN SUBQUERY", and has no "USING INDEX" clause.
  */
 export function isScanWithoutIndex(detail: string): boolean {
+  const trimmed = detail.trimStart();
   // Must start with "SCAN " (SQLite uses uppercase)
-  if (!detail.includes("SCAN ")) return false;
+  if (!trimmed.startsWith("SCAN ")) return false;
+  // SCAN SUBQUERY lines are plan-structure annotations, not table scans
+  if (trimmed.startsWith("SCAN SUBQUERY")) return false;
   // If it uses any index, it is acceptable
-  if (detail.includes("USING INDEX") || detail.includes("USING COVERING INDEX")) {
+  if (
+    trimmed.includes("USING INDEX") ||
+    trimmed.includes("USING COVERING INDEX")
+  ) {
     return false;
   }
   return true;


### PR DESCRIPTION
## Summary

- Adds `app/api/admin/schema-health/route.ts` — a new admin-only endpoint that runs `EXPLAIN QUERY PLAN` on the 5 critical hot D1 queries and flags any plan containing a `SCAN tablename` without a `USING INDEX` clause
- Cross-references `sqlite_master` for the live index inventory, so a silently dropped index is immediately visible
- 11 unit tests covering `isScanWithoutIndex` detection logic (flagged cases, index-present cases, informational lines) and admin auth rejection (401 without key)
- Pattern doc written at `~/dev/whoabuddy/claude-knowledge/patterns/d1-schema-health.md`

## Motivation: migration-008 silent index drop

Migration 008 (`nullable_btc_public_key`) used the SQLite table-rebuild dance to drop a `NOT NULL` constraint. `DROP TABLE` silently removed the `inbox_messages`, `claims`, `vouches`, `swaps`, and `balances` indexes — only the `agents` indexes were restored. Every inbox listing became a full table scan:

- `EXPLAIN QUERY PLAN` showed `SCAN inbox_messages` + temp B-tree sort on every request
- `wrangler d1 insights` showed ~96% of all D1 rows-read from `inbox_messages` SELECTs (~4.5B rows/day, ~$100+/mo overage at <1K agents)
- The indexes existed in migration files but not in the live DB; the prior campaign trusted the files and never ran EXPLAIN or checked `sqlite_master`

Migration 019 restored the indexes. This endpoint catches the same class of regression — a hot query degrading to a SCAN after an index is dropped — before it becomes a billing event.

See: `~/dev/aibtcdev/cloudflare-bill-audit-2026-04.md` for full incident context.

## What this checks

Five real production queries via `EXPLAIN QUERY PLAN` (plan-only, free, no row scanning):

| Query name | Table | Critical index |
|---|---|---|
| `inbox_list` | `inbox_messages` | `idx_inbox_to_btc_sent_at` |
| `inbox_unread_stats` | `agent_inbox_stats` | PK lookup on `btc_address` |
| `leaderboard_aggregate` | `swaps` + `agents` join | `idx_swaps_sender_burn_time`, `idx_agents_*` |
| `bounty_list` | `bounties` | `idx_bounties_active_created` |
| `agents_list` | `agents` | `idx_agents_verified_at` |

**Goal-backward test:** if migration-008's drop were re-introduced (drop `idx_inbox_to_btc_sent_at`), `EXPLAIN` on `inbox_list` returns `"SCAN inbox_messages"`, `isScanWithoutIndex` flags it, and the response returns `healthy: false` with `flaggedCount: 1`.

## Test plan

- [x] `npm run test -- --run app/api/admin/schema-health` — 11 tests pass
- [x] `npm run typecheck` — no new errors in schema-health files (pre-existing test debt unrelated)
- [ ] CI green on this PR (Lint + Workers Build + Tests)
- [ ] Endpoint live in production + first-run shows no index regressions (post-merge, deferred gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)