### PR TITLE
fix(inbox): standardize 409 already_redeemed shape across both emit points (#757)

### DIFF
--- a/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
+++ b/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
@@ -260,6 +260,27 @@ describe("POST /api/inbox/[address] — txid-recovery UNIQUE violation → 409 (
     });
   });
 
+  it("pre-insert guard: returns 409 already_redeemed with canonical shape (no txid field) when txid already redeemed before INSERT (#757)", async () => {
+    // Default checkRedeemedTxidInD1 mock returns EXISTING_MESSAGE_ID, so the
+    // pre-insert SELECT guard fires and 409s before any INSERT is attempted.
+    mockCloudflareContext({
+      VERIFIED_AGENTS: createMockKV(),
+      DB: createMockDB(),
+      RATE_LIMIT_MUTATING: createRateLimitMock(true),
+    });
+
+    const resp = await inboxPOST(buildTxidRecoveryRequest(), routeParams());
+
+    expect(resp.status).toBe(409);
+    const body = await resp.json();
+    // Standardized to match the post-INSERT UNIQUE-violation 409 shape.
+    expect(body.error).toBe("already_redeemed");
+    expect(body.existingMessageId).toBe(EXISTING_MESSAGE_ID);
+    // No human string and no txid echo — canonical id only.
+    expect(body).not.toHaveProperty("txid");
+    expect(insertInboundMessageToD1 as Mock).not.toHaveBeenCalled();
+  });
+
   it("returns 409 with already_redeemed and existingMessageId when INSERT hits UNIQUE(payment_txid)", async () => {
     // Simulate: first SELECT guard passes (no existing record), then INSERT hits UNIQUE violation.
     // This is the txid-recovery race between SELECT and INSERT.

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -995,10 +995,11 @@ export async function POST(
     }
     if (existingRedemptionMessageId) {
       logger.warn("Txid already redeemed", { txid: paymentTxid });
+      // Same shape as the post-INSERT UNIQUE-violation 409 (resolvePaymentTxidConflict):
+      // machine-parseable code + canonical existingMessageId, no human string or txid echo (#757).
       return NextResponse.json(
         {
-          error: "This transaction has already been used for a message",
-          txid: paymentTxid,
+          error: "already_redeemed",
           existingMessageId: existingRedemptionMessageId,
         },
         { status: 409 }


### PR DESCRIPTION
Closes #757.

The inbox `POST` handler returned **two different 409 bodies** for the same logical condition (txid already redeemed), depending on race timing:

| Path | Old shape |
|---|---|
| Pre-insert SELECT guard (`route.ts`) | `{ error: "This transaction has already been used for a message", txid, existingMessageId }` |
| Post-INSERT UNIQUE-violation (`resolvePaymentTxidConflict`) | `{ error: "already_redeemed", existingMessageId }` |

A client saw one or the other depending on whether it lost the SELECT→INSERT race — a latent footgun for anyone parsing the body.

## Change

Standardize the pre-insert guard on the machine-parseable shape already used by the UNIQUE-violation handler:

```json
{ "error": "already_redeemed", "existingMessageId": "<id>" }
```

- Drops the human string and the `txid` echo (callers already supplied the txid; the canonical `existingMessageId` is sufficient).
- The `already_redeemed` code mirrors the `inbox.payment_txid_unique_violation` log event and the 409 shape used elsewhere.

## Tests

- Added a **pre-insert-guard test** asserting the canonical shape (`error: "already_redeemed"`, `existingMessageId` present, **no `txid` field**, and INSERT never attempted).
- Existing UNIQUE-violation tests already assert this shape. `uniq-violation-409.test.ts` → **11/11 pass**.

## Notes

- LOW priority / cosmetic correctness per the issue — agents key off the `409` status, not the error string — but removes the inconsistency.
- Not sponsor-related: the txid-redemption guard sits on the on-chain-txid recovery path, which serves **both** sponsored and non-sponsored payments (`lib/inbox/x402-verify.ts:5`), so it stays relevant after the sponsored-relay wind-down.