### PR TITLE
docs(claude): document the SSR-hydrated SWR + global SWRConfig pattern (#882)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,6 +607,51 @@ Both `stx:` and `btc:` keys point to identical records and must be updated toget
 - `middleware.ts` — CLI tool detection, deprecated path redirects, serves `/llms.txt` at `/` for curl/wget
 - `wrangler.jsonc` — Cloudflare Workers configuration (routes to aibtc.com)
 
+## Client Data Fetching (SWR)
+
+Client components fetch `/api/*` data with [SWR](https://swr.vercel.app/). A global
+`SWRConfig` provider in `app/providers.tsx` sets the shared defaults so individual
+`useSWR` calls stay bare:
+
+```ts
+// app/providers.tsx
+<SWRConfig value={{
+  fetcher,                            // lib/fetcher.ts — throws on non-2xx
+  dedupingInterval: DEFAULT_CACHE_MS, // lib/swr-keys.ts — 15 min
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  keepPreviousData: true,
+}}>
+```
+
+Because of the provider, a plain `useSWR(swrKeys.leaderboard(12))` already gets the
+shared `fetcher`, a 15-minute dedupe/cache window, and coordinated revalidation —
+no per-call options needed for the common read-once case.
+
+### Default to SSR-hydrated SWR, not bare client fetches
+
+When SSR is cheap, render the initial data on the server (`page.tsx`) and hand it to
+SWR as `fallbackData` so first paint has data and the background revalidate keeps it
+fresh:
+
+```ts
+useSWR<ActivityResponse>(swrKeys.activity(), {
+  refreshInterval: 30_000,
+  dedupingInterval: 30_000,  // see polling footgun below
+  fallbackData: initialData, // SSR-provided — no loading flash
+})
+```
+
+Reference implementations: `app/components/ActivityFeed.tsx`,
+`app/components/ActivityFeedHero.tsx`, `app/status/RelayStatus.tsx`.
+
+- **Keys:** use the builders in `lib/swr-keys.ts` (`swrKeys.*`) so keys stay
+  consistent across SSR hydration, client reads, and `mutate()` invalidation.
+- **Polling footgun:** the global `dedupingInterval` is 15 min. A polling component
+  (`refreshInterval` set) **MUST** override `dedupingInterval` locally to a value at
+  or below its `refreshInterval`, or the dedupe window silently swallows the polling
+  tick. See the note in `app/providers.tsx`.
+
 ## Styling Patterns
 
 - Uses CSS custom properties via `@theme` (e.g., `--color-orange: #F7931A`)


### PR DESCRIPTION
Closes #882.

Adds a **Client Data Fetching (SWR)** section to CLAUDE.md — the last open acceptance item on #882. The other two criteria already shipped:

| #882 acceptance criterion | Status |
|---|---|
| `SWRConfig` provider at root layout | ✅ shipped in #877 (`app/providers.tsx`) |
| ≥2 more components on `fallbackData + refreshInterval` | ✅ `ActivityFeedHero` + `RelayStatus` (beyond the original `ActivityFeed`) |
| **CLAUDE.md section** | ✅ **this PR** |

## What the section covers

- The global `SWRConfig` shape in `app/providers.tsx` (shared `fetcher`, 15-min `dedupingInterval`, revalidation policy) — so bare `useSWR(swrKeys.x())` calls inherit it.
- **Default to SSR-hydrated SWR**: render initial data on `page.tsx`, pass it as `fallbackData`, set `refreshInterval`. Points at the three reference components.
- Use the `swrKeys.*` builders (`lib/swr-keys.ts`) for consistent keys across SSR / client / `mutate()`.
- The **polling footgun** already noted in `providers.tsx`: a component with `refreshInterval` must override `dedupingInterval` locally to ≤ its interval, or the 15-min dedupe window swallows the tick.

Documents **what actually shipped** (the 15-min-cache-DRY config from #877), not the issue's original 5s proposal.

Docs-only — no code changes.