### PR TITLE
fix(leaderboard): dedupe /api/leaderboard rows by erc8004AgentId (#820)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -607,6 +607,51 @@ Both `stx:` and `btc:` keys point to identical records and must be updated toget
 - `middleware.ts` — CLI tool detection, deprecated path redirects, serves `/llms.txt` at `/` for curl/wget
 - `wrangler.jsonc` — Cloudflare Workers configuration (routes to aibtc.com)
 
+## Client Data Fetching (SWR)
+
+Client components fetch `/api/*` data with [SWR](https://swr.vercel.app/). A global
+`SWRConfig` provider in `app/providers.tsx` sets the shared defaults so individual
+`useSWR` calls stay bare:
+
+```ts
+// app/providers.tsx
+<SWRConfig value={{
+  fetcher,                            // lib/fetcher.ts — throws on non-2xx
+  dedupingInterval: DEFAULT_CACHE_MS, // lib/swr-keys.ts — 15 min
+  revalidateOnFocus: true,
+  revalidateOnReconnect: true,
+  keepPreviousData: true,
+}}>
+```
+
+Because of the provider, a plain `useSWR(swrKeys.leaderboard(12))` already gets the
+shared `fetcher`, a 15-minute dedupe/cache window, and coordinated revalidation —
+no per-call options needed for the common read-once case.
+
+### Default to SSR-hydrated SWR, not bare client fetches
+
+When SSR is cheap, render the initial data on the server (`page.tsx`) and hand it to
+SWR as `fallbackData` so first paint has data and the background revalidate keeps it
+fresh:
+
+```ts
+useSWR<ActivityResponse>(swrKeys.activity(), {
+  refreshInterval: 30_000,
+  dedupingInterval: 30_000,  // see polling footgun below
+  fallbackData: initialData, // SSR-provided — no loading flash
+})
+```
+
+Reference implementations: `app/components/ActivityFeed.tsx`,
+`app/components/ActivityFeedHero.tsx`, `app/status/RelayStatus.tsx`.
+
+- **Keys:** use the builders in `lib/swr-keys.ts` (`swrKeys.*`) so keys stay
+  consistent across SSR hydration, client reads, and `mutate()` invalidation.
+- **Polling footgun:** the global `dedupingInterval` is 15 min. A polling component
+  (`refreshInterval` set) **MUST** override `dedupingInterval` locally to a value at
+  or below its `refreshInterval`, or the dedupe window silently swallows the polling
+  tick. See the note in `app/providers.tsx`.
+
 ## Styling Patterns
 
 - Uses CSS custom properties via `@theme` (e.g., `--color-orange: #F7931A`)

--- a/app/api/leaderboard/__tests__/dedup-erc8004.test.ts
+++ b/app/api/leaderboard/__tests__/dedup-erc8004.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// Mock the Cloudflare context + cached agent list the route reads from.
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+vi.mock("@/lib/cache", () => ({
+  getCachedAgentList: vi.fn(),
+}));
+
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { getCachedAgentList } from "@/lib/cache";
+import { GET as leaderboardGET } from "../route";
+
+/** Minimal cached-agent fixture; only the fields the route reads matter. */
+function agent(overrides: Record<string, unknown>) {
+  return {
+    stxAddress: "SP_PLACEHOLDER",
+    btcAddress: "bc1placeholder",
+    stxPublicKey: null,
+    btcPublicKey: null,
+    taprootAddress: null,
+    displayName: "Agent",
+    description: null,
+    bnsName: null,
+    owner: null,
+    verifiedAt: "2026-01-01T00:00:00.000Z",
+    lastActiveAt: null,
+    erc8004AgentId: null,
+    nostrPublicKey: null,
+    referredBy: null,
+    level: 1,
+    levelName: "Registered",
+    ...overrides,
+  };
+}
+
+function req(query = "") {
+  return new NextRequest(`https://aibtc.com/api/leaderboard${query}`);
+}
+
+interface LeaderboardBody {
+  leaderboard: Array<{
+    erc8004AgentId: number | null;
+    btcAddress: string;
+    displayName: string;
+    level: number;
+    levelName: string;
+  }>;
+  pagination: { total: number };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  (getCloudflareContext as Mock).mockResolvedValue({
+    env: { VERIFIED_AGENTS: {} },
+  });
+});
+
+describe("/api/leaderboard — dedupe by erc8004AgentId (#820)", () => {
+  it("collapses two rotated wallets sharing an agent-id into one row (current display, max level)", async () => {
+    (getCachedAgentList as Mock).mockResolvedValue({
+      agents: [
+        // Old / Genesis wallet — earlier verifiedAt, level 2.
+        agent({
+          stxAddress: "SP4DXVEC16FS6QR7RBKGWZYJKTXPC81W49W0ATJE",
+          btcAddress: "bc1qqaxq5vxszt0lzmr9gskv4lcx7jzrg772s4vxpp",
+          displayName: "Secret Mars",
+          verifiedAt: "2026-02-05T00:00:00.000Z",
+          erc8004AgentId: 5,
+          level: 2,
+          levelName: "Genesis",
+        }),
+        // Current wallet — later verifiedAt, only level 1.
+        agent({
+          stxAddress: "SP20GPDS5RYB2DV03KG4W08EG6HD11KYPK6FQJE1",
+          btcAddress: "bc1qxhjvcm",
+          displayName: "Quasar Garuda",
+          verifiedAt: "2026-04-18T00:00:00.000Z",
+          erc8004AgentId: 5,
+          level: 1,
+          levelName: "Verified Agent",
+        }),
+      ],
+    });
+
+    const resp = await leaderboardGET(req());
+    expect(resp.status).toBe(200);
+    const body = (await resp.json()) as LeaderboardBody;
+
+    const five = body.leaderboard.filter((r) => r.erc8004AgentId === 5);
+    // Exactly one row for the shared identity, not two.
+    expect(five).toHaveLength(1);
+    // Display comes from the most recently verified (current) wallet...
+    expect(five[0].btcAddress).toBe("bc1qxhjvcm");
+    expect(five[0].displayName).toBe("Quasar Garuda");
+    // ...but the level/levelName is the max across the rotation chain.
+    expect(five[0].level).toBe(2);
+    expect(five[0].levelName).toBe("Genesis");
+  });
+
+  it("leaves agents without an erc8004AgentId untouched (no false collapsing)", async () => {
+    (getCachedAgentList as Mock).mockResolvedValue({
+      agents: [
+        agent({ stxAddress: "SP_A", btcAddress: "bc1a", erc8004AgentId: null }),
+        agent({ stxAddress: "SP_B", btcAddress: "bc1b", erc8004AgentId: null }),
+        agent({ stxAddress: "SP_C", btcAddress: "bc1c", erc8004AgentId: 7 }),
+      ],
+    });
+
+    const resp = await leaderboardGET(req());
+    const body = (await resp.json()) as LeaderboardBody;
+    // All three distinct rows survive — null identity is never a duplicate.
+    expect(body.leaderboard).toHaveLength(3);
+    expect(body.pagination.total).toBe(3);
+  });
+});

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -186,6 +186,48 @@ export async function GET(request: NextRequest) {
       };
     });
 
+    // Collapse wallet-rotated agents. Rows sharing an `erc8004AgentId` are the
+    // same on-chain identity (the agent rotated wallets but kept the NFT), so the
+    // leaderboard shows one row per identity: the most recently verified wallet's
+    // display, carrying the highest level/score across the rotation chain (status
+    // follows the identity, not the abandoned wallet). Rows with no on-chain
+    // identity can't be rotation duplicates and pass through unchanged.
+    const identityGroups = new Map<number, typeof ranked>();
+    const deduped: typeof ranked = [];
+    for (const row of ranked) {
+      if (row.erc8004AgentId == null) {
+        deduped.push(row);
+        continue;
+      }
+      const group = identityGroups.get(row.erc8004AgentId);
+      if (group) group.push(row);
+      else identityGroups.set(row.erc8004AgentId, [row]);
+    }
+    for (const group of identityGroups.values()) {
+      if (group.length === 1) {
+        deduped.push(group[0]);
+        continue;
+      }
+      // Most recently verified wallet supplies the display fields (current wallet).
+      const canonical = group.reduce((a, b) =>
+        new Date(b.verifiedAt).getTime() > new Date(a.verifiedAt).getTime() ? b : a
+      );
+      // Highest level across the rotation chain is authoritative for the identity.
+      const top = group.reduce((a, b) => (b.level > a.level ? b : a));
+      deduped.push({
+        ...canonical,
+        level: top.level,
+        levelName: top.levelName,
+        // Swap the level bonus to the chain's top level, keeping the canonical
+        // wallet's BNS + recency contributions.
+        score:
+          canonical.score -
+          computeLevelBonus(canonical.level) +
+          computeLevelBonus(top.level),
+      });
+    }
+    ranked = deduped;
+
     // Filter by level if requested
     if (levelFilter !== null) {
       const filterLevel = parseInt(levelFilter, 10);


### PR DESCRIPTION
Addresses the **duplicate-rows half** of #820.

## Problem

A wallet-rotated agent (rotated to a fresh wallet but kept the same on-chain identity NFT) ends up with **two registered `agents` rows sharing one `erc8004_agent_id`**. `/api/leaderboard` listed both — the same agent at two ranks with different levels (per #820: old wallet "Secret Mars" level 2, current wallet "Quasar Garuda" level 1, both `erc8004AgentId: 5`).

## Fix

Collapse rows that share an `erc8004AgentId` into one, right after the ranked list is built (before filter/sort/distribution/paginate):

- **Display fields** come from the **most recently verified** wallet (the current one).
- **`level` / `levelName`** is the **MAX across the rotation chain** — status follows the on-chain identity, not the abandoned wallet. `score` swaps the level bonus to that top level while keeping the canonical wallet's BNS + recency contributions.
- Rows with a **null `erc8004AgentId`** can't be rotation duplicates and pass through unchanged.

So the rotated agent now appears **once** — current wallet's name/address, Genesis level.

## Tests

New `app/api/leaderboard/__tests__/dedup-erc8004.test.ts`:
- two rotated wallets sharing agent-id 5 → one row, current wallet's display, `level: 2`
- agents with null `erc8004AgentId` are never collapsed (3 in → 3 out)

`tsc` clean; 2/2 pass.

## Scope

This is **only** the leaderboard-dedup half of #820. The other half — Genesis/level being keyed to `claims.btc_address` instead of `erc8004_agent_id` (so wallet rotation drops Genesis, still affecting e.g. the #896 mint gate) — is a separate change and **#820 stays open** for it.