### PR TITLE
style(agents): rename table column header L2 Balance → sBTC

### DIFF
--- a/app/agents/AgentList.tsx
+++ b/app/agents/AgentList.tsx
@@ -258,7 +258,7 @@ export default function AgentList({ agents }: AgentListProps) {
               >
                 <Tooltip text="sBTC (L2) balance held by this agent, in satoshis.">
                   <div className="inline-flex items-center gap-1.5">
-                    L2 Balance
+                    sBTC
                     <SortIcon active={sortBy === "balance"} order={sortOrder} />
                   </div>
                 </Tooltip>


### PR DESCRIPTION
The `/agents` table column header still reads "L2 Balance" on main — the rename to "sBTC" didn't make it into the #976 squash merge. This re-applies it.

The tooltip retains the "sBTC (L2) balance … in satoshis" clarification.