### PR TITLE
feat(scheduler): cron trigger replaces SchedulerDO (Phase 0 of #978)

### DIFF
--- a/app/api/admin/scheduler/__tests__/route.test.ts
+++ b/app/api/admin/scheduler/__tests__/route.test.ts
@@ -9,32 +9,46 @@ vi.mock("@/lib/admin/auth", () => ({
   requireAdmin: vi.fn().mockResolvedValue(null),
 }));
 
-import { getCloudflareContext } from "@opennextjs/cloudflare";
-import { requireAdmin } from "@/lib/admin/auth";
-import { GET, POST } from "../route";
+vi.mock("@/lib/logging", () => ({
+  isLogsRPC: vi.fn(() => false),
+  createLogger: vi.fn(),
+  createConsoleLogger: vi.fn(() => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  })),
+}));
 
-const schedulerStub = {
-  status: vi.fn().mockResolvedValue({ now: 123 }),
-  refreshNow: vi.fn().mockResolvedValue({
+vi.mock("@/lib/scheduler/cron-runner", () => ({
+  readSchedulerStatus: vi.fn().mockResolvedValue({ now: 123 }),
+  refreshScheduler: vi.fn().mockResolvedValue({
     tenero: { succeeded: 1 },
     competition: { scanned: 1 },
   }),
-  pauseUntil: vi.fn().mockResolvedValue(undefined),
-  resume: vi.fn().mockResolvedValue(undefined),
-};
+  pauseScheduler: vi.fn().mockResolvedValue(undefined),
+  resumeScheduler: vi.fn().mockResolvedValue(undefined),
+}));
 
-const schedulerNamespace = {
-  idFromName: vi.fn((name: string) => `id:${name}`),
-  get: vi.fn(() => schedulerStub),
-};
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { requireAdmin } from "@/lib/admin/auth";
+import {
+  readSchedulerStatus,
+  refreshScheduler,
+  pauseScheduler,
+  resumeScheduler,
+} from "@/lib/scheduler/cron-runner";
+import { GET, POST } from "../route";
+
+const kv = { get: vi.fn(), put: vi.fn(), delete: vi.fn() };
 
 function request(path: string, method = "GET") {
   return new NextRequest(`https://aibtc.com${path}`, { method });
 }
 
-function mockCloudflareContext() {
+function mockCloudflareContext(env: Record<string, unknown> = { VERIFIED_AGENTS: kv }) {
   (getCloudflareContext as Mock).mockResolvedValue({
-    env: { SCHEDULER: schedulerNamespace },
+    env,
     ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
   });
 }
@@ -64,31 +78,19 @@ describe("GET /api/admin/scheduler", () => {
     expect(response.status).toBe(200);
     expect(response.headers.get("cache-control")).toBe("no-store");
     expect(response.headers.get("x-robots-tag")).toBe("noindex");
-    expect(schedulerNamespace.idFromName).toHaveBeenCalledWith("v2");
-    expect(body).toEqual({ name: "v2", status: { now: 123 } });
+    expect(readSchedulerStatus).toHaveBeenCalledWith(kv);
+    expect(body).toEqual({ status: { now: 123 } });
   });
 
-  it("rejects unknown scheduler names before touching a stub", async () => {
-    const response = await GET(request("/api/admin/scheduler?name=typo"));
-    const body = (await response.json()) as any;
-
-    expect(response.status).toBe(400);
-    expect(body.error).toContain("Unsupported scheduler name");
-    expect(schedulerNamespace.idFromName).not.toHaveBeenCalled();
-  });
-
-  it("returns 503 when the SchedulerDO binding is unavailable", async () => {
-    (getCloudflareContext as Mock).mockResolvedValueOnce({
-      env: {},
-      ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
-    });
+  it("returns 503 when the KV state store is unavailable", async () => {
+    mockCloudflareContext({});
 
     const response = await GET(request("/api/admin/scheduler"));
     const body = (await response.json()) as any;
 
     expect(response.status).toBe(503);
-    expect(body.error).toContain("Scheduler binding unavailable");
-    expect(schedulerNamespace.idFromName).not.toHaveBeenCalled();
+    expect(body.error).toContain("KV) unavailable");
+    expect(readSchedulerStatus).not.toHaveBeenCalled();
   });
 });
 
@@ -101,14 +103,34 @@ describe("POST /api/admin/scheduler", () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toContain("Missing `until`");
-    expect(schedulerStub.pauseUntil).not.toHaveBeenCalled();
+    expect(pauseScheduler).not.toHaveBeenCalled();
   });
 
-  it("returns 503 on writes when the SchedulerDO binding is unavailable", async () => {
-    (getCloudflareContext as Mock).mockResolvedValueOnce({
-      env: {},
-      ctx: { waitUntil: vi.fn(), passThroughOnException: vi.fn() },
-    });
+  it("pauses until a future timestamp", async () => {
+    const until = Date.now() + 60_000;
+    const response = await POST(
+      request(`/api/admin/scheduler?action=pause&until=${until}`, "POST")
+    );
+    const body = (await response.json()) as any;
+
+    expect(response.status).toBe(200);
+    expect(pauseScheduler).toHaveBeenCalledWith(kv, until);
+    expect(body).toEqual({ pausedUntil: until });
+  });
+
+  it("resumes the scheduler", async () => {
+    const response = await POST(
+      request("/api/admin/scheduler?action=resume", "POST")
+    );
+    const body = (await response.json()) as any;
+
+    expect(response.status).toBe(200);
+    expect(resumeScheduler).toHaveBeenCalledWith(kv);
+    expect(body).toEqual({ resumed: true });
+  });
+
+  it("returns 503 on writes when the KV state store is unavailable", async () => {
+    mockCloudflareContext({});
 
     const response = await POST(
       request("/api/admin/scheduler?action=refresh&task=all", "POST")
@@ -116,8 +138,8 @@ describe("POST /api/admin/scheduler", () => {
     const body = (await response.json()) as any;
 
     expect(response.status).toBe(503);
-    expect(body.error).toContain("Scheduler binding unavailable");
-    expect(schedulerStub.refreshNow).not.toHaveBeenCalled();
+    expect(body.error).toContain("KV) unavailable");
+    expect(refreshScheduler).not.toHaveBeenCalled();
   });
 
   it("rejects invalid refresh tasks", async () => {
@@ -128,20 +150,22 @@ describe("POST /api/admin/scheduler", () => {
 
     expect(response.status).toBe(400);
     expect(body.error).toContain("Unsupported task");
-    expect(schedulerStub.refreshNow).not.toHaveBeenCalled();
+    expect(refreshScheduler).not.toHaveBeenCalled();
   });
 
   it("refreshes an allowlisted scheduler task", async () => {
     const response = await POST(
-      request("/api/admin/scheduler?name=v3&action=refresh&task=all", "POST")
+      request("/api/admin/scheduler?action=refresh&task=all", "POST")
     );
     const body = (await response.json()) as any;
 
     expect(response.status).toBe(200);
-    expect(schedulerNamespace.idFromName).toHaveBeenCalledWith("v3");
-    expect(schedulerStub.refreshNow).toHaveBeenCalledWith("all");
+    expect(refreshScheduler).toHaveBeenCalledWith(
+      expect.objectContaining({ VERIFIED_AGENTS: kv }),
+      expect.anything(),
+      "all"
+    );
     expect(body).toEqual({
-      name: "v3",
       task: "all",
       result: { tenero: { succeeded: 1 }, competition: { scanned: 1 } },
     });
@@ -154,7 +178,11 @@ describe("POST /api/admin/scheduler", () => {
     const body = (await response.json()) as any;
 
     expect(response.status).toBe(200);
-    expect(schedulerStub.refreshNow).toHaveBeenCalledWith("competition");
+    expect(refreshScheduler).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      "competition"
+    );
     expect(body.task).toBe("competition");
   });
 });

--- a/app/api/admin/scheduler/route.ts
+++ b/app/api/admin/scheduler/route.ts
@@ -1,10 +1,15 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
-import type { SchedulerRpc, SchedulerTask } from "@/lib/scheduler/rpc-types";
+import { createConsoleLogger, createLogger, isLogsRPC } from "@/lib/logging";
+import {
+  readSchedulerStatus,
+  refreshScheduler,
+  pauseScheduler,
+  resumeScheduler,
+} from "@/lib/scheduler/cron-runner";
+import type { SchedulerTask } from "@/lib/scheduler/rpc-types";
 
-const DEFAULT_SCHEDULER_INSTANCE = "v2";
-const ALLOWED_SCHEDULER_INSTANCES = new Set(["v1", "v2", "v3"]);
 const ALLOWED_TASKS = new Set<SchedulerTask>(["tenero", "competition", "all"]);
 
 function json(body: unknown, init: ResponseInit = {}) {
@@ -14,25 +19,10 @@ function json(body: unknown, init: ResponseInit = {}) {
   return NextResponse.json(body, { ...init, headers });
 }
 
-function schedulerName(url: URL): string | NextResponse {
-  const name = url.searchParams.get("name") || DEFAULT_SCHEDULER_INSTANCE;
-  if (!ALLOWED_SCHEDULER_INSTANCES.has(name)) {
-    return json(
-      { error: "Unsupported scheduler name. Use v1, v2, or v3." },
-      { status: 400 }
-    );
-  }
-  return name;
-}
-
-function schedulerStub(env: CloudflareEnv, name: string): SchedulerRpc {
-  return env.SCHEDULER!.get(env.SCHEDULER!.idFromName(name));
-}
-
-function requireSchedulerBinding(env: CloudflareEnv): NextResponse | null {
-  if (env.SCHEDULER) return null;
+function requireKv(env: CloudflareEnv): NextResponse | null {
+  if (env.VERIFIED_AGENTS) return null;
   return json(
-    { error: "Scheduler binding unavailable in this environment." },
+    { error: "Scheduler state store (KV) unavailable in this environment." },
     { status: 503 }
   );
 }
@@ -53,31 +43,23 @@ export async function GET(request: NextRequest) {
   if (denied) return denied;
 
   const { env } = await getCloudflareContext();
-  const missingScheduler = requireSchedulerBinding(env);
-  if (missingScheduler) return missingScheduler;
+  const missingKv = requireKv(env);
+  if (missingKv) return missingKv;
 
-  const url = new URL(request.url);
-  const name = schedulerName(url);
-  if (typeof name !== "string") return name;
-
-  const status = await schedulerStub(env, name).status();
-  return json({ name, status });
+  const status = await readSchedulerStatus(env.VERIFIED_AGENTS);
+  return json({ status });
 }
 
 export async function POST(request: NextRequest) {
   const denied = await requireAdmin(request);
   if (denied) return denied;
 
-  const { env } = await getCloudflareContext();
-  const missingScheduler = requireSchedulerBinding(env);
-  if (missingScheduler) return missingScheduler;
+  const { env, ctx } = await getCloudflareContext();
+  const missingKv = requireKv(env);
+  if (missingKv) return missingKv;
 
   const url = new URL(request.url);
-  const name = schedulerName(url);
-  if (typeof name !== "string") return name;
-
   const action = url.searchParams.get("action");
-  const stub = schedulerStub(env, name);
 
   if (action === "pause") {
     const rawUntil = url.searchParams.get("until");
@@ -95,21 +77,25 @@ export async function POST(request: NextRequest) {
         { status: 400 }
       );
     }
-    await stub.pauseUntil(until);
-    return json({ name, pausedUntil: until });
+    await pauseScheduler(env.VERIFIED_AGENTS, until);
+    return json({ pausedUntil: until });
   }
 
   if (action === "resume") {
-    await stub.resume();
-    return json({ name, resumed: true });
+    await resumeScheduler(env.VERIFIED_AGENTS);
+    return json({ resumed: true });
   }
 
   if (action === "refresh") {
     const task = schedulerTask(url);
     if (typeof task !== "string") return task;
 
-    const result = await stub.refreshNow(task);
-    return json({ name, task, result });
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { path: "/api/admin/scheduler", action: "refresh", task })
+      : createConsoleLogger({ path: "/api/admin/scheduler", action: "refresh", task });
+
+    const result = await refreshScheduler(env, logger, task);
+    return json({ task, result });
   }
 
   return json(

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -7,17 +7,15 @@ import CompetitionCountdown from "./CompetitionCountdown";
 import { COMP_START_TIMESTAMP } from "@/lib/competition/constants";
 import { LEADERBOARD_AGGREGATE_SQL } from "@/lib/competition/leaderboard-query";
 
-// Reads live Cloudflare bindings (D1, SchedulerDO). Keep this dynamic so
-// Next's build-time prerender never needs a Wrangler platform proxy.
+// Reads live Cloudflare bindings (D1). Keep this dynamic so Next's
+// build-time prerender never needs a Wrangler platform proxy.
 // USD prices + token decimals are fetched client-side from Tenero — this
 // path no longer hardcodes a decimals map or reads the KV price cache.
 export const dynamic = "force-dynamic";
 
-const SCHEDULER_INSTANCE_NAME = "v2";
-
 /**
- * Leaderboard SSR cache TTL — 5 minutes. Matches the scheduler's
- * ALARM_TICK_MS / TENERO_INTERVAL_MS = 5*60*1000 (`worker.ts:55,57`).
+ * Leaderboard SSR cache TTL — 5 minutes. Matches the cron scheduler's
+ * Tenero refresh cadence (TENERO_INTERVAL_MS = 5*60*1000).
  * Competition sweep cadence is 15min (`COMPETITION_INTERVAL_MS`) so
  * 5-min TTL is more responsive than the slowest data path; chainhook
  * can deliver between sweeps and that surfaces on the next rebuild.
@@ -123,29 +121,9 @@ async function fetchLeaderboard(): Promise<LeaderboardRow[]> {
   const { env, ctx } = await getCloudflareContext();
   const db = env.DB as D1Database | undefined;
 
-  // Opportunistic SchedulerDO kick — runs on EVERY visit, including
-  // cache hits, because a DO instance doesn't exist until something
-  // calls a method on it. Skipping the kick on cache hits would let
-  // alarm re-arming/recovery stall for up to the cache TTL after a DO
-  // reset or deploy (Codex PR #891 feedback). Idempotent on warm DOs.
-  // ctx may be undefined in non-Workers test runtimes — the catch
-  // below handles that path.
-  try {
-    if (env.SCHEDULER) {
-      const kick = env.SCHEDULER.get(env.SCHEDULER.idFromName(SCHEDULER_INSTANCE_NAME))
-        .status()
-        .then(() => undefined)
-        .catch(() => undefined);
-      if (ctx?.waitUntil) {
-        ctx.waitUntil(kick);
-      } else {
-        // No ctx (test runtime) — drop the kick rather than block the response.
-        void kick;
-      }
-    }
-  } catch {
-    // Binding access threw — render proceeds without the kick.
-  }
+  // Scheduler liveness no longer depends on this page: periodic work runs
+  // from a Cloudflare Cron Trigger (worker.ts `scheduled()`), so there is
+  // no DO to opportunistically kick on render.
 
   // P3B cache layer — short-circuit the LEADERBOARD_AGGREGATE_SQL scan +
   // per-sender rollup on cache hit. The cache is *data-level*, not

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -21,22 +21,9 @@ interface CloudflareEnv {
   X402_RELAY_URL?: string; // x402 relay URL for all payment settlement (default: https://x402-relay.aibtc.com)
   X402_RELAY?: import("./lib/inbox/relay-rpc").RelayRPC; // x402 sponsor relay RPC service binding (undefined in local dev)
   INBOX_RECONCILIATION_QUEUE?: Queue<import("./lib/inbox/reconciliation-queue").InboxReconciliationQueueMessage>;
-  // Inline stub interface (not `import("./worker").SchedulerDO`) so this
-  // d.ts doesn't pull worker.ts into Next.js's type-check pass, where
-  // `./.open-next/worker.js` doesn't resolve until after OpenNext runs.
-  //
-  // The `Rpc.DurableObjectBranded` intersection is load-bearing:
-  // `DurableObjectNamespace<T>` requires T to extend that brand for the
-  // stub returned from `.get(id)` to surface T's RPC methods (per
-  // @cloudflare/workers-types — DurableObjectStub<T> = Fetcher<T> which
-  // only expands T's methods when T is branded). Without it, callers
-  // see `.fetch()` / `.connect()` only, never `.status()` / etc.
-  //
-  // Keep these method signatures in sync with SchedulerRpc in
-  // lib/scheduler/rpc-types.ts and SchedulerDO in worker.ts.
-  SCHEDULER?: DurableObjectNamespace<
-    Rpc.DurableObjectBranded & import("./lib/scheduler/rpc-types").SchedulerRpc
-  >;
-  TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for SchedulerDO Tenero refreshes
+  // Scheduled background work runs from a Cloudflare Cron Trigger (see
+  // worker.ts `scheduled()` + lib/scheduler/cron-runner.ts), not a Durable
+  // Object — so there is no SCHEDULER binding to declare here.
+  TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for the cron Tenero refresh
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
 }

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -22,8 +22,11 @@ interface CloudflareEnv {
   X402_RELAY?: import("./lib/inbox/relay-rpc").RelayRPC; // x402 sponsor relay RPC service binding (undefined in local dev)
   INBOX_RECONCILIATION_QUEUE?: Queue<import("./lib/inbox/reconciliation-queue").InboxReconciliationQueueMessage>;
   // Scheduled background work runs from a Cloudflare Cron Trigger (see
-  // worker.ts `scheduled()` + lib/scheduler/cron-runner.ts), not a Durable
-  // Object — so there is no SCHEDULER binding to declare here.
+  // worker.ts `scheduled()` + lib/scheduler/cron-runner.ts). The SchedulerDO
+  // binding is retained but neutered — the class can't be deleted on the
+  // versioned-upload deploy path (CF error 10211) — and nothing in the app
+  // calls it, so it has no RPC surface. Declared as a plain namespace.
+  SCHEDULER?: DurableObjectNamespace;
   TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for the cron Tenero refresh
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
 }

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -67,19 +67,30 @@ DO-independent and the competition cursor already lives in D1, so the DO only he
 
 - `wrangler.jsonc`: `"triggers": { "crons": ["*/5 * * * *"] }` in top-level **and**
   `env.production` (crons are not inherited by named envs); **omitted** in
-  `env.preview` so preview never runs schedulers against shared prod quota. DO
-  binding emptied + `v4 deleted_classes` migration tears the class down.
-- `worker.ts`: `scheduled(event, env, ctx)` → `runScheduledTasks(env, logger)`.
+  `env.preview` so preview never runs schedulers against shared prod quota.
+- `worker.ts`: `scheduled(event, env, ctx)` → `runScheduledTasks(env, logger)`. The
+  `SchedulerDO` class is **retained but neutered** (no-op `alarm()` that does not
+  re-arm) rather than deleted — see the deploy-path note below.
 - `lib/scheduler/cron-runner.ts`: Tenero every tick (respecting rate-limit backoff),
   competition on its 15-min cadence; KV-backed status/pause/resume.
 - `app/leaderboard/page.tsx`: the per-render DO poke is **removed**.
 - `app/api/admin/scheduler/route.ts`: rewired from DO RPC to the KV state helpers.
 
-Why cron-only beats a DO heartbeat: a heartbeat still keeps the fragile DO in the
-loop. Cron-only removes the DO (and its delete/recreate migration footguns + its
-duration GB-s billing) and makes the trigger Cloudflare-guaranteed, independent of
+**Deploy-path constraint (why the DO is neutered, not deleted):** a `deleted_classes`
+Durable Object migration is rejected on the **versioned-upload** deploy path the CI
+uses (`wrangler versions upload` → Cloudflare error 10211; DO migrations require a
+non-versioned `wrangler deploy`). So this PR keeps the class + its existing
+binding/migration history (v1/v2/v3) — no migration is applied, CI deploys cleanly —
+and neuters the class so any alarm still armed from the DO era drains on its next fire
+instead of double-running with the cron. Nothing in the app pokes the DO anymore, so
+it is never re-instantiated after that drain. Full teardown (a `v4 deleted_classes`
+tag) is a deferred one-off non-versioned `wrangler deploy`.
+
+Why cron beats a DO heartbeat: a heartbeat still keeps the fragile DO in the driving
+loop. Driving from cron makes the trigger Cloudflare-guaranteed, independent of
 `/leaderboard` traffic — fixing the exact "I thought the scheduler is not running"
-failure at the root.
+failure at the root — while the neutered DO sits idle (never re-instantiated) until a
+later non-versioned deploy removes it.
 
 **Concurrency note (verified limit):** Cloudflare caps **6 simultaneous outgoing
 connections** waiting for response headers (both plans). Any sliced fan-out (the
@@ -323,8 +334,11 @@ Cost-relevant facts confirmed from the docs:
 - **Subrequest cap: 10,000/invocation on Paid** (50 on Free) — huge headroom.
 - **6 simultaneous outgoing connections** waiting for headers — the real concurrency
   limit; keep Hiro fan-out ≤5.
-- **Retiring the DO is net cost-negative:** ends its duration billing (400k GB-s incl,
-  then $12.50/M) and the per-`/leaderboard`-view DO request charges.
+- **Neutering the DO is net cost-negative:** the per-`/leaderboard`-view DO request
+  charge is removed outright, and the neutered DO is never re-instantiated after its
+  legacy alarm drains, so its duration billing (400k GB-s incl, then $12.50/M) drops
+  to ~0. The remaining small storage line is reclaimed when the deferred non-versioned
+  deploy formally deletes the class.
 - The only surface that scales with growth is **D1 rows-read on aggregation**; gated by
   the 1h `caches.default` layer + `(is_earning, block_time)` index, with a precomputed
   `agent_earnings_agg` table as the escape hatch (25B/mo included → vast headroom).

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -1,0 +1,363 @@
+# Verified Earnings Ledger — Architecture Design
+
+Status: **design / pre-implementation**
+Tracking issue: [#978](https://github.com/aibtcdev/landing-page/issues/978)
+Author: design pass, June 2026
+
+> This repo is part of the bill-reduction sprint (see `cloudflare-cost-runbook.md`).
+> Every section that touches a scheduled job, Hiro call, or D1/KV access records
+> the cost shape. The naive reading of #978 — "scan every agent address
+> frequently" — is explicitly rejected here on cost grounds.
+
+---
+
+## 1. One-paragraph definition
+
+A background indexer reads **confirmed inbound transfers** (sBTC, STX, aeUSDC) to
+every registered agent's STX address, **classifies each by who sent it** (bounty /
+x402 / inbox / peer / external), **prices it in USD** at index time, runs it through
+**anti-gaming filters**, and writes an **idempotent line-item ledger** to D1. Public
+read APIs aggregate that ledger into per-agent and platform-wide earnings, which the
+trading leaderboard, profiles, homepage, and badges render. Earnings cannot be faked
+because they require real third-party on-chain value transfer.
+
+---
+
+## 2. Decisions locked (from review)
+
+| Decision | Choice | Rationale |
+|---|---|---|
+| Anti-gaming scope (v1) | **Full set** | self-funded (shared first-funder) + two-hop ring + alt-address + manual override |
+| USD pricing source | **Tenero + last-good fallback** | only ~3 tokens; already cached in KV |
+| Ingestion shape | **Separate earnings task, own slow cursor** | clean separation from competition sweep |
+| Scheduling host | **Cloudflare Cron Trigger; SchedulerDO retired (Phase 0, done)** | see §3 — the DO alarm was request-bootstrapped and silently died |
+| Earnings leaderboard surface | **Trading board (`app/leaderboard`)** | this is the board whose trade-count default got gamed |
+| x402_endpoint classifier | **Investigate catalog in Phase 1** | may launch inert if no payTo catalog exists |
+| Rollup storage | **Read-time `GROUP BY` + `caches.default` (1h)** | matches existing leaderboard; no extra write job |
+
+---
+
+## 3. Phase 0 — Fix scheduler liveness FIRST (prerequisite)
+
+**Finding:** `SchedulerDO` has **no cron trigger**. It only stays alive because the
+`/leaderboard` page pokes it on every SSR render (`app/leaderboard/page.tsx:135`
+calls `SCHEDULER.get(idFromName("v2")).status()`, which runs the constructor at
+`worker.ts:76-81` and arms the alarm). Once armed, `alarm()` re-arms itself every
+5 min (`worker.ts:196`) — self-perpetuating, but **only after that first poke**.
+
+Failure modes that leave it silently dormant:
+- DO storage wiped (the `v2 → v3` class migration, or a manual reset) **and** no
+  `/leaderboard` visit afterward.
+- An error breaks the re-arm chain; only a fresh page visit revives it.
+- No alert exists, so "the scheduler died N hours ago" is invisible.
+
+**Verify current prod state** (requires admin key):
+```bash
+curl -s -H "X-Admin-Key: $ADMIN_KEY" "https://aibtc.com/api/admin/scheduler?name=v2" | jq
+# lastTeneroRunAt / lastCompetitionRunAt within ~15 min => alive; stale/null => dormant
+```
+
+**Phase 0 change (implemented):** retire the DO entirely; drive scheduling from a
+real Cloudflare **Cron Trigger**, the same pattern `aibtc-dashboard` uses in
+production (`worker.ts` `scheduled()` → `runHoldingsScan`). The DO was *already*
+pointless — both task functions (`runTeneroTask`, `runCompetitionScheduler`) are
+DO-independent and the competition cursor already lives in D1, so the DO only held
+`lastRunAt`/backoff bookkeeping, which moved to KV (`scheduler:*` keys).
+
+- `wrangler.jsonc`: `"triggers": { "crons": ["*/5 * * * *"] }` in top-level **and**
+  `env.production` (crons are not inherited by named envs); **omitted** in
+  `env.preview` so preview never runs schedulers against shared prod quota. DO
+  binding emptied + `v4 deleted_classes` migration tears the class down.
+- `worker.ts`: `scheduled(event, env, ctx)` → `runScheduledTasks(env, logger)`.
+- `lib/scheduler/cron-runner.ts`: Tenero every tick (respecting rate-limit backoff),
+  competition on its 15-min cadence; KV-backed status/pause/resume.
+- `app/leaderboard/page.tsx`: the per-render DO poke is **removed**.
+- `app/api/admin/scheduler/route.ts`: rewired from DO RPC to the KV state helpers.
+
+Why cron-only beats a DO heartbeat: a heartbeat still keeps the fragile DO in the
+loop. Cron-only removes the DO (and its delete/recreate migration footguns + its
+duration GB-s billing) and makes the trigger Cloudflare-guaranteed, independent of
+`/leaderboard` traffic — fixing the exact "I thought the scheduler is not running"
+failure at the root.
+
+**Concurrency note (verified limit):** Cloudflare caps **6 simultaneous outgoing
+connections** waiting for response headers (both plans). Any sliced fan-out (the
+earnings indexer, Phase 1+) must keep concurrent Hiro fetches **≤ 5**, matching the
+dashboard's `CONCURRENCY = 5`.
+
+Without Phase 0, the earnings indexer would inherit the exact fragility that prompted
+"I thought the scheduler is not running."
+
+---
+
+## 4. Data flow
+
+```
+                         ┌────────────────────────────────────────────┐
+   NEW cron heartbeat ──▶│  SchedulerDO  (5-min alarm)                  │
+   (Phase 0, */5)        │  ── runTenero (5m)  ── runCompetition (15m)  │
+                         │  ── runEarnings (NEW, slow cursor)           │
+                         └───────────────────┬──────────────────────────┘
+                                             │ batch of N agents per tick
+                    ┌────────────────────────▼─────────────────────────┐
+   D1 registered    │  1. INGEST   Hiro inbound transfers for agent A   │
+   _wallets  ──────▶│              only txs newer than A's high-water mark│
+                    │              (sBTC / STX / aeUSDC transfers in)     │
+                    ├──────────────────────────────────────────────────────┤
+   D1 inbox_msgs    │  2. CLASSIFY counterparty → source_class            │
+   D1 bounties  ───▶│     inbox_message / bounty / x402_endpoint /         │
+   x402 catalog     │     agent_peer / exchange_or_external / unclassified │
+   agents table     ├──────────────────────────────────────────────────────┤
+   Tenero KV    ───▶│  3. PRICE    index-time spot → amount_usd            │
+                    ├──────────────────────────────────────────────────────┤
+   first-funder     │  4. ANTI-GAME  self_funded / ring / alt / manual     │
+   cache (D1)   ───▶│     → set excluded_reason, is_earning=0              │
+                    ├──────────────────────────────────────────────────────┤
+                    │  5. PERSIST  INSERT OR IGNORE (tx_id, event_index)   │
+                    │              advance A's high-water mark              │
+                    └────────────────────────┬─────────────────────────────┘
+                                             ▼
+                               D1  agent_earnings  (the ledger)
+                                             │
+               read-time GROUP BY + caches.default (1h)  ◀── the "agg"
+                                             │
+         ┌───────────────────┬───────────────┼───────────────────┐
+         ▼                   ▼               ▼                   ▼
+   /api/.../earnings   trading board    /api/stats     UI: board / profile
+    (per agent)         earnings sort    /earnings      / hero / club badges
+```
+
+---
+
+## 5. Components & where they live
+
+| Component | New file(s) | Reuses |
+|---|---|---|
+| Cron heartbeat (Phase 0) | edit `wrangler.jsonc`, `worker.ts` `scheduled()` | existing `SchedulerDO` |
+| Earnings sweep task | `lib/earnings/indexer.ts` | `runCompetitionScheduler` cursor pattern |
+| Wire into scheduler | edit `worker.ts` `SchedulerDO` | existing 5-min alarm |
+| Hiro ingestion | `lib/earnings/ingest.ts` | `lib/stacks-api-fetch.ts`, `findSbtcTransferEvent` |
+| Classifier | `lib/earnings/classify.ts` | `inbox_messages`, `bounties` D1 tables |
+| Pricing | `lib/earnings/price.ts` | Tenero KV `tenero:price:{id}` |
+| Anti-gaming | `lib/earnings/anti-gaming.ts` | new `address_first_funder` cache |
+| D1 schema | `migrations/020_agent_earnings.sql` | migration conventions |
+| Aggregation reads | `lib/earnings/reads.ts` | leaderboard `caches.default` singleflight |
+| APIs | `app/api/agents/[address]/earnings/`, `app/api/stats/earnings/`, trading-board read | route self-doc conventions |
+| UI | leaderboard chip, profile section, hero stat, `ClubBadge.tsx` | `LeaderboardClient`, `LevelBadge` |
+
+---
+
+## 6. D1 schema (`migrations/020_agent_earnings.sql`)
+
+### `agent_earnings` — immutable line-item ledger
+```
+tx_id TEXT, event_index INTEGER       -- PK (tx_id, event_index)  ← idempotency
+stx_block_height INTEGER, block_time INTEGER
+recipient_agent_stx TEXT              -- FK agents.stx_address
+sender_stx TEXT
+asset TEXT                            -- 'sbtc' | 'stx' | 'aeusdc'
+amount_raw INTEGER
+amount_usd REAL                       -- nullable until priced
+price_usd REAL, price_source TEXT, priced_at INTEGER  -- 'tenero'|'stablecoin'|'last_good'|'none'
+source_class TEXT
+source_subclass TEXT                  -- bounty id / x402 endpoint id
+excluded_reason TEXT                  -- nullable: self_funded|ring|external|unclassified|excluded_manual
+is_earning INTEGER                    -- 1 = counts; derived & stored for fast agg/index
+indexed_at INTEGER
+-- INDEX (recipient_agent_stx, block_time), (is_earning, block_time), (source_class) WHERE excluded
+```
+
+### `address_first_funder` — permanent anti-gaming cache (the cost-saver)
+```
+address TEXT PRIMARY KEY
+first_funder_stx TEXT                 -- immutable once funded
+first_funded_block INTEGER
+lookup_status TEXT                    -- 'ok' | 'none' | 'failed'
+fetched_at INTEGER
+```
+
+### `earnings_index_state` — per-agent high-water mark (incremental scanning)
+```
+agent_stx TEXT PRIMARY KEY
+last_indexed_block INTEGER
+backfill_complete INTEGER
+last_indexed_at INTEGER
+```
+
+### `earnings_manual_override` — operator escape hatch
+```
+tx_id TEXT, event_index INTEGER       -- PK
+action TEXT                           -- 'exclude' | 'include' | 'reclassify'
+new_source_class TEXT, note TEXT, created_by TEXT, created_at INTEGER
+```
+
+Global sweep cursor (`earnings_scheduler_cursor`) lives in the **existing**
+`competition_state` table — no new table for it.
+
+**No `agent_earnings_agg` table.** We aggregate at read time (`GROUP BY` over the
+indexed ledger) and cache 1h in `caches.default`, exactly how `app/leaderboard`
+already serves. Add a precomputed agg table only if profiling later shows the
+lifetime cross-agent query is heavy — not before.
+
+---
+
+## 7. Classification decision tree
+
+Evaluated per inbound transfer, **first match wins**:
+
+```
+1. tx_id ∈ inbox_messages (confirmed, recipient=A)   → inbox_message       [EARNING]
+2. tx memo == "BNTY:{id}" AND bounty.winner == A      → bounty              [EARNING]
+3. sender ∈ x402 payTo catalog                        → x402_endpoint       [EARNING]
+4. sender ∈ known-funder list (exchange/faucet)       → exchange_or_external[EXCLUDED:external]
+5. sender ∈ agents table (another registered agent)   → agent_peer          [EARNING]
+6. otherwise                                          → unclassified        [EXCLUDED:unclassified]
+```
+
+> **Divergence from #978 — bounty classification.** The issue assumed "counterparty
+> is the AIBTC bounty board *contract*." In this codebase bounty payouts are
+> **direct poster→winner sBTC transfers with memo `BNTY:{bountyId}`** (see Bounty
+> System in CLAUDE.md), not contract calls. We classify bounties by **memo + a
+> lookup in the `bounties` table**, which is both accurate and stronger anti-fraud
+> (the memo already binds the transfer to a specific bounty the agent won).
+
+---
+
+## 8. Anti-gaming (full set)
+
+Runs after classification; can flip an earning → excluded:
+
+1. **`self_funded` (shared first-funder)** — look up `first_funder(sender)` and
+   `first_funder(recipient)` via `extended/v2/addresses/{stx}/transactions`. Equal →
+   same operator → exclude. First-funder is immutable, so it's cached permanently in
+   `address_first_funder` → **one lookup per address ever**, not per transfer. This is
+   what keeps anti-gaming cheap.
+2. **`ring` (A→B→A within 14d, similar amount)** — pure query over our **own**
+   `agent_earnings` table (both legs are agent→agent inflows we already index). No
+   extra Hiro calls. Exclude both legs.
+3. **`self_funded` (alt-address)** — sender is a registered agent whose `owner`
+   (X handle in agent metadata) matches recipient's owner → same operator → exclude.
+4. **`excluded_manual`** — an `earnings_manual_override` row forces
+   exclude/include/reclassify.
+
+> **Divergence from #978 — ring detection scope.** Rings are only detectable when
+> **both** addresses are registered agents (we index agent inflows, not arbitrary
+> addresses'). An A→B→A ring where B is unregistered is invisible to ring detection —
+> but it's still caught by the shared-first-funder rule. Documented, not pretended.
+
+---
+
+## 9. Pricing (index-time spot + last-good)
+
+> **Divergence from #978 — "transaction-time price" is not achievable.** Tenero
+> serves **spot only**, no historical endpoint. We capture the **index-time** Tenero
+> spot price (≈ tx-time because the indexer runs continuously over recent txs) and
+> persist `price_usd` + `price_source` + `priced_at` next to `amount_raw`.
+> aeUSDC/USDA → $1. sBTC → sBTC token price. STX → STX price. Null from Tenero →
+> `last_good` from the 24h KV cache; still null → `amount_usd = NULL`,
+> `price_source = 'none'`, repriced on a later pass. ~3 tokens, all already in the
+> Tenero KV cache → **no new external API spend.**
+
+---
+
+## 10. Scheduling
+
+- **Host inside `SchedulerDO`** — `runEarnings()` rides the existing 5-min alarm on a
+  slow internal cadence (process a small batch of agents per tick).
+- **Own cursor** (`earnings_scheduler_cursor`) + **per-agent high-water mark**
+  (`earnings_index_state`): the first sweep backfills history (bounded pages/tick to
+  avoid a day-one Hiro burst), and steady state processes only **new** txs since each
+  agent's last indexed block. Cost decays to ~the rate of new on-chain activity.
+- Surfaces in the existing `/api/admin/scheduler` status/pause/resume.
+- Guaranteed to actually run by the Phase 0 cron heartbeat.
+
+---
+
+## 11. Public API
+
+| Endpoint | Returns | Cache |
+|---|---|---|
+| `GET /api/agents/{stxOrBtc}/earnings` | rollup (7d/30d/lifetime, unique_payers_30d, top_source_class_30d) + recent line items w/ Hiro links | short |
+| `GET /api/stats/earnings` | platform totals 7d/30d/lifetime + source_class breakdown | 1h |
+| trading-board earnings ranking | agents ranked by `earnings_30d` (+`7d`/`lifetime`) | 1h |
+
+> **Naming note.** Two leaderboards exist: `/api/leaderboard` (agent *levels/score*)
+> and the trading board at `app/leaderboard` (the gamed one). Earnings becomes the
+> default sort on the **trading board**, served from a clean earnings ranking read —
+> not by overloading `/api/leaderboard`.
+
+---
+
+## 12. UI
+
+- **Trading leaderboard** (`app/leaderboard`): new **"Earnings (30d)"** chip, becomes
+  **default sort**; trade-count demoted to non-default. Each row: USD figure,
+  unique-payer count, compact source mini-breakdown.
+- **Agent profile**: **Earnings** section (existing card-stack pattern, not a new tab
+  framework) — headline 30d USD, source breakdown, weekly sparkline, line-item table
+  with per-tx Hiro "verify on chain" links.
+- **Homepage hero**: aggregate "AIBTC agents earned $X this week" (cached 1h).
+- **Club badges**: `$10 / $100 / $1k / $10k / $100k` on **lifetime** earnings, new
+  `ClubBadge.tsx` rendered beside `LevelBadge`.
+
+---
+
+## 13. Cloudflare cost shape (verified against live docs, June 2026)
+
+Account is on the **$5/mo Workers Paid base** (required by — and now freed from — the
+DO). Every earnings surface lands inside the included allowances, so net new spend is
+**$0** and the bill stays flat at $5. Included tiers (verified):
+
+| Surface | Our monthly load | Included (Paid) | % of allowance |
+|---|---|---|---|
+| Cron `*/5` invocations (billed as requests) | 8,640 | 10,000,000 req | 0.09% |
+| Worker CPU (I/O-bound ticks) | ~0.4–1.7M CPU-ms | 30,000,000 CPU-ms | 1–6% |
+| D1 rows written (= new inflows) | ~10⁴ | 50,000,000 | 0.02% |
+| D1 rows read (agg behind 1h edge cache) | ~10⁸ at 50k-row ledger | 25,000,000,000 | <1% |
+| KV (3 price reads/tick) | trivial | 10,000,000 read | noise |
+
+Cost-relevant facts confirmed from the docs:
+- **Subrequest cap: 10,000/invocation on Paid** (50 on Free) — huge headroom.
+- **6 simultaneous outgoing connections** waiting for headers — the real concurrency
+  limit; keep Hiro fan-out ≤5.
+- **Retiring the DO is net cost-negative:** ends its duration billing (400k GB-s incl,
+  then $12.50/M) and the per-`/leaderboard`-view DO request charges.
+- The only surface that scales with growth is **D1 rows-read on aggregation**; gated by
+  the 1h `caches.default` layer + `(is_earning, block_time)` index, with a precomputed
+  `agent_earnings_agg` table as the escape hatch (25B/mo included → vast headroom).
+
+Sources: Workers / Durable Objects / D1 / KV pricing + Workers limits docs.
+
+Rejected: polling every agent address on a fast cadence (the #978 naive reading) —
+would multiply Hiro calls by the cadence with no freshness benefit for a 30-day board.
+
+---
+
+## 14. Phasing (each = one PR)
+
+- **Phase 0 — Scheduler cron migration (DONE).** Retire `SchedulerDO`; drive Tenero +
+  competition from a Cloudflare Cron Trigger via `worker.ts` `scheduled()` +
+  `lib/scheduler/cron-runner.ts` (KV-backed state). Fixes the dead/fragile scheduler at
+  the root; prerequisite + trigger for the earnings indexer.
+- **Phase 1 — Schema + indexer core (backend only).** Migration `020`; `lib/earnings/`
+  ingest + classify + index-time pricing + idempotent writes; `runEarnings()` task in
+  `SchedulerDO`. Verify via admin/dry-run. **Also: investigate the x402 payTo catalog
+  here** — if none exists, `x402_endpoint` launches inert (bounty + inbox + peer only).
+- **Phase 2 — Full anti-gaming.** first-funder cache + self-fund exclusion, two-hop
+  ring, alt-address, manual override.
+- **Phase 3 — Public API.** `/api/agents/{addr}/earnings`, `/api/stats/earnings`,
+  trading-board earnings ranking (all read-time + edge-cached).
+- **Phase 4 — UI.** leaderboard chip + new default, profile Earnings section, homepage
+  hero stat, `$10–$100k` Club badges.
+
+---
+
+## 15. Risks / prerequisites for the #978 DoD
+
+- **x402 payTo catalog** must be enumerable for the `x402_endpoint` classifier to be
+  live (DoD requires ≥3 active classifiers). If absent, launch inert and hit 2.
+- **Known-funder list** (exchange/onramp/faucet) is seeded manually; starts small.
+- **Backfill burst**: the first full history scan of ~1000 agents must be page-bounded
+  so it doesn't hammer Hiro on day one.
+- **Scheduler liveness** (Phase 0) must land first, or the whole pipeline can sit
+  silently idle.

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -95,8 +95,8 @@ Without Phase 0, the earnings indexer would inherit the exact fragility that pro
 
 ```
                          ┌────────────────────────────────────────────┐
-   NEW cron heartbeat ──▶│  SchedulerDO  (5-min alarm)                  │
-   (Phase 0, */5)        │  ── runTenero (5m)  ── runCompetition (15m)  │
+   Cron Trigger (*/5) ──▶│  worker.ts scheduled() → runScheduledTasks   │
+   (Phase 0, DONE)       │  ── runTenero (5m)  ── runCompetition (15m)  │
                          │  ── runEarnings (NEW, slow cursor)           │
                          └───────────────────┬──────────────────────────┘
                                              │ batch of N agents per tick
@@ -134,9 +134,9 @@ Without Phase 0, the earnings indexer would inherit the exact fragility that pro
 
 | Component | New file(s) | Reuses |
 |---|---|---|
-| Cron heartbeat (Phase 0) | edit `wrangler.jsonc`, `worker.ts` `scheduled()` | existing `SchedulerDO` |
+| Cron scheduling (Phase 0, DONE) | `wrangler.jsonc` `triggers.crons`, `worker.ts` `scheduled()`, `lib/scheduler/cron-runner.ts` | `aibtc-dashboard` cron pattern |
 | Earnings sweep task | `lib/earnings/indexer.ts` | `runCompetitionScheduler` cursor pattern |
-| Wire into scheduler | edit `worker.ts` `SchedulerDO` | existing 5-min alarm |
+| Wire into scheduler | add `runEarnings()` call in `lib/scheduler/cron-runner.ts` `runScheduledTasks` | the cron tick |
 | Hiro ingestion | `lib/earnings/ingest.ts` | `lib/stacks-api-fetch.ts`, `findSbtcTransferEvent` |
 | Classifier | `lib/earnings/classify.ts` | `inbox_messages`, `bounties` D1 tables |
 | Pricing | `lib/earnings/price.ts` | Tenero KV `tenero:price:{id}` |
@@ -263,14 +263,16 @@ Runs after classification; can flip an earning → excluded:
 
 ## 10. Scheduling
 
-- **Host inside `SchedulerDO`** — `runEarnings()` rides the existing 5-min alarm on a
-  slow internal cadence (process a small batch of agents per tick).
+- **Host in the cron runner** — add a `runEarnings()` call to `runScheduledTasks` in
+  `lib/scheduler/cron-runner.ts`, on a slow internal cadence (process a small batch of
+  agents per tick, gated by a last-run check like competition).
 - **Own cursor** (`earnings_scheduler_cursor`) + **per-agent high-water mark**
   (`earnings_index_state`): the first sweep backfills history (bounded pages/tick to
   avoid a day-one Hiro burst), and steady state processes only **new** txs since each
   agent's last indexed block. Cost decays to ~the rate of new on-chain activity.
+- **Concurrency ≤5** per tick (the verified 6-connection cap, §13).
 - Surfaces in the existing `/api/admin/scheduler` status/pause/resume.
-- Guaranteed to actually run by the Phase 0 cron heartbeat.
+- Guaranteed to actually run by the Phase 0 Cron Trigger.
 
 ---
 
@@ -342,7 +344,8 @@ would multiply Hiro calls by the cadence with no freshness benefit for a 30-day 
   the root; prerequisite + trigger for the earnings indexer.
 - **Phase 1 — Schema + indexer core (backend only).** Migration `020`; `lib/earnings/`
   ingest + classify + index-time pricing + idempotent writes; `runEarnings()` task in
-  `SchedulerDO`. Verify via admin/dry-run. **Indexer-only — no agent-submit/self-report
+  `lib/scheduler/cron-runner.ts` (`runScheduledTasks`). Verify via admin/dry-run.
+  **Indexer-only — no agent-submit/self-report
   path** (unlike competition's `source='agent'` fast-path; earnings tolerate indexing
   lag and a submit endpoint is needless attack surface). **Also: investigate the x402
   payTo catalog here** — if none exists, `x402_endpoint` launches inert (bounty + inbox

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -30,6 +30,7 @@ because they require real third-party on-chain value transfer.
 | Anti-gaming scope (v1) | **Full set** | self-funded (shared first-funder) + two-hop ring + alt-address + manual override |
 | USD pricing source | **Tenero + last-good fallback** | only ~3 tokens; already cached in KV |
 | Ingestion shape | **Separate earnings task, own slow cursor** | clean separation from competition sweep |
+| Ingestion model | **Indexer-only (pull), all agents — no agent self-report** | earnings must be derived from chain truth, never asserted by the agent (anti-gaming); covers the dormant cohort that would never submit |
 | Scheduling host | **Cloudflare Cron Trigger; SchedulerDO retired (Phase 0, done)** | see §3 — the DO alarm was request-bootstrapped and silently died |
 | Earnings leaderboard surface | **Trading board (`app/leaderboard`)** | this is the board whose trade-count default got gamed |
 | x402_endpoint classifier | **Investigate catalog in Phase 1** | may launch inert if no payTo catalog exists |
@@ -341,8 +342,11 @@ would multiply Hiro calls by the cadence with no freshness benefit for a 30-day 
   the root; prerequisite + trigger for the earnings indexer.
 - **Phase 1 — Schema + indexer core (backend only).** Migration `020`; `lib/earnings/`
   ingest + classify + index-time pricing + idempotent writes; `runEarnings()` task in
-  `SchedulerDO`. Verify via admin/dry-run. **Also: investigate the x402 payTo catalog
-  here** — if none exists, `x402_endpoint` launches inert (bounty + inbox + peer only).
+  `SchedulerDO`. Verify via admin/dry-run. **Indexer-only — no agent-submit/self-report
+  path** (unlike competition's `source='agent'` fast-path; earnings tolerate indexing
+  lag and a submit endpoint is needless attack surface). **Also: investigate the x402
+  payTo catalog here** — if none exists, `x402_endpoint` launches inert (bounty + inbox
+  + peer only).
 - **Phase 2 — Full anti-gaming.** first-funder cache + self-fund exclusion, two-hop
   ring, alt-address, manual override.
 - **Phase 3 — Public API.** `/api/agents/{addr}/earnings`, `/api/stats/earnings`,

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -71,7 +71,7 @@ async function readJson<T>(kv: KVNamespace, key: string): Promise<T | null> {
 }
 
 function lookupTeneroApiKey(env: CloudflareEnv): string | undefined {
-  const key = (env as unknown as { TENERO_API_KEY?: string }).TENERO_API_KEY;
+  const key = env.TENERO_API_KEY;
   return typeof key === "string" && key.length > 0 ? key : undefined;
 }
 
@@ -104,7 +104,11 @@ export async function resumeScheduler(kv: KVNamespace): Promise<void> {
  */
 export async function runTeneroNow(
   env: CloudflareEnv,
-  parentLogger: Logger
+  parentLogger: Logger,
+  // Optional pre-read state to avoid a duplicate K_TENERO read when the cron
+  // tick already fetched it for its due-check. `undefined` = read it here;
+  // `null` = caller read it and there was none.
+  prevState?: TeneroState | null
 ): Promise<TeneroRunResult> {
   const logger = parentLogger.child
     ? parentLogger.child({ task: "tenero" })
@@ -138,7 +142,8 @@ export async function runTeneroNow(
     apiKey: lookupTeneroApiKey(env),
   });
 
-  const prev = await readJson<TeneroState>(kv, K_TENERO);
+  const prev =
+    prevState !== undefined ? prevState : await readJson<TeneroState>(kv, K_TENERO);
   const succeededCleanly =
     result.succeeded > 0 && result.failed === 0 && !rateLimited;
   const consecutiveFailures = succeededCleanly
@@ -230,7 +235,7 @@ export async function runScheduledTasks(
     (tenero?.lastRunAt ?? 0) + TENERO_INTERVAL_MS <= now + 1_000;
   if (teneroDue) {
     try {
-      await runTeneroNow(env, logger);
+      await runTeneroNow(env, logger, tenero);
     } catch (error) {
       logger.error("scheduler.tenero_unexpected_error", {
         error: String(error),

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -1,0 +1,320 @@
+/**
+ * Cron-driven scheduler — orchestrates the periodic background tasks
+ * (Tenero price refresh + competition Hiro catch-up sweep) from a
+ * Cloudflare Cron Trigger instead of a Durable Object alarm.
+ *
+ * Why this replaced SchedulerDO (PR: scheduler cron migration):
+ * the DO had no independent trigger — its alarm only stayed armed because
+ * the /leaderboard SSR poked it on every render. After a DO storage wipe
+ * (the v2→v3 class migration) with no leaderboard visit, the alarm was
+ * never re-armed and ALL scheduled work silently stopped. A Cloudflare
+ * Cron Trigger fires on a guaranteed schedule regardless of traffic.
+ *
+ * State that the DO held in `ctx.storage` now lives in KV (VERIFIED_AGENTS)
+ * under `scheduler:*` keys. The competition cursor already lived in D1
+ * (`competition_state`), so it is unaffected.
+ *
+ * Both task functions (`runTeneroTask`, `runCompetitionScheduler`) were
+ * already DO-independent — this module just wires their dependencies,
+ * gates cadence, and persists results, exactly as the DO wrapper did.
+ */
+
+import { getActiveTokenIds } from "../external/tenero";
+import {
+  runTeneroTask,
+  TENERO_MINUTE_QUOTA_BACKOFF_MS,
+  type TeneroRunResult,
+} from "./tenero-task";
+import {
+  runCompetitionScheduler,
+  type CompetitionSchedulerSummary,
+} from "../competition/scheduler";
+import type { Logger } from "../logging";
+import type {
+  SchedulerStatus,
+  SchedulerRefreshResult,
+  SchedulerTask,
+} from "./rpc-types";
+
+// Cadences. The cron fires every TENERO_INTERVAL_MS; competition is gated
+// to its longer interval via a last-run check (mirrors the old DO alarm).
+export const TENERO_INTERVAL_MS = 5 * 60 * 1000;
+export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
+
+// KV keys (VERIFIED_AGENTS namespace).
+const K_TENERO = "scheduler:tenero";
+const K_COMPETITION = "scheduler:competition";
+const K_PAUSED = "scheduler:paused-until";
+
+interface TeneroState {
+  lastRunAt: number;
+  result: TeneroRunResult;
+  consecutiveFailures: number;
+  /** Unix ms before which Tenero should not run again (rate-limit backoff). */
+  nextRunAfter: number | null;
+}
+
+interface CompetitionState {
+  lastRunAt: number;
+  result: CompetitionSchedulerSummary;
+  consecutiveFailures: number;
+}
+
+async function readJson<T>(kv: KVNamespace, key: string): Promise<T | null> {
+  const raw = await kv.get(key);
+  if (!raw) return null;
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function lookupTeneroApiKey(env: CloudflareEnv): string | undefined {
+  const key = (env as unknown as { TENERO_API_KEY?: string }).TENERO_API_KEY;
+  return typeof key === "string" && key.length > 0 ? key : undefined;
+}
+
+// ─────────────────────────── pause / resume ───────────────────────────
+
+export async function getPausedUntil(kv: KVNamespace): Promise<number | null> {
+  const raw = await kv.get(K_PAUSED);
+  if (!raw) return null;
+  const n = Number(raw);
+  return Number.isFinite(n) ? n : null;
+}
+
+export async function pauseScheduler(
+  kv: KVNamespace,
+  until: number
+): Promise<void> {
+  await kv.put(K_PAUSED, String(until));
+}
+
+export async function resumeScheduler(kv: KVNamespace): Promise<void> {
+  await kv.delete(K_PAUSED);
+}
+
+// ─────────────────────────── individual tasks ───────────────────────────
+
+/**
+ * Run the Tenero price refresh and persist its result + backoff to KV.
+ * Honours `TENERO_REFRESH_ENABLED` (skips when not "true"), mirroring the
+ * old DO wrapper so preview/local cannot consume production Tenero quota.
+ */
+export async function runTeneroNow(
+  env: CloudflareEnv,
+  parentLogger: Logger
+): Promise<TeneroRunResult> {
+  const logger = parentLogger.child
+    ? parentLogger.child({ task: "tenero" })
+    : parentLogger;
+  const kv = env.VERIFIED_AGENTS;
+  const startedAt = Date.now();
+
+  if (env.TENERO_REFRESH_ENABLED !== "true") {
+    logger.warn("tenero.refresh_skipped_disabled", {
+      deployEnv: env.DEPLOY_ENV ?? "unset",
+      teneroRefreshEnabled: env.TENERO_REFRESH_ENABLED ?? "unset",
+    });
+    return {
+      startedAt,
+      durationMs: Date.now() - startedAt,
+      tokensAttempted: 0,
+      succeeded: 0,
+      failed: 0,
+      minuteRemaining: null,
+      monthRemaining: null,
+    };
+  }
+
+  const tokenIds = await getActiveTokenIds(env.DB);
+  logger.info("tenero.token_set_resolved", { count: tokenIds.length });
+
+  const { result, rateLimited, rateLimitBackoffMs } = await runTeneroTask({
+    logger,
+    kv,
+    tokenIds,
+    apiKey: lookupTeneroApiKey(env),
+  });
+
+  const prev = await readJson<TeneroState>(kv, K_TENERO);
+  const succeededCleanly =
+    result.succeeded > 0 && result.failed === 0 && !rateLimited;
+  const consecutiveFailures = succeededCleanly
+    ? 0
+    : result.failed > 0 || rateLimited
+      ? (prev?.consecutiveFailures ?? 0) + 1
+      : (prev?.consecutiveFailures ?? 0);
+  const nextRunAfter = rateLimited
+    ? Date.now() + (rateLimitBackoffMs ?? TENERO_MINUTE_QUOTA_BACKOFF_MS)
+    : null;
+
+  await kv.put(
+    K_TENERO,
+    JSON.stringify({
+      lastRunAt: Date.now(),
+      result,
+      consecutiveFailures,
+      nextRunAfter,
+    } satisfies TeneroState)
+  );
+
+  return result;
+}
+
+/**
+ * Run the competition Hiro catch-up sweep and persist its result to KV.
+ * The sweep cursor itself lives in D1 (`competition_state`), so this is
+ * resumable across cron ticks unchanged from the DO era.
+ */
+export async function runCompetitionNow(
+  env: CloudflareEnv,
+  parentLogger: Logger
+): Promise<CompetitionSchedulerSummary> {
+  const logger = parentLogger.child
+    ? parentLogger.child({ task: "competition" })
+    : parentLogger;
+
+  const result = await runCompetitionScheduler(
+    { DB: env.DB, HIRO_API_KEY: env.HIRO_API_KEY },
+    logger
+  );
+
+  await env.VERIFIED_AGENTS.put(
+    K_COMPETITION,
+    JSON.stringify({
+      lastRunAt: Date.now(),
+      result,
+      consecutiveFailures: 0,
+    } satisfies CompetitionState)
+  );
+
+  return result;
+}
+
+// ─────────────────────────── cron entry point ───────────────────────────
+
+/**
+ * One cron tick. Runs Tenero every tick (respecting rate-limit backoff)
+ * and the competition sweep on its longer cadence. A failure in one task
+ * is logged and its failure counter bumped, but never blocks the other.
+ *
+ * Idempotency note: if a slow tick overruns the cron interval and a second
+ * tick starts concurrently, no harm results — Tenero overwrites KV and the
+ * competition sweep uses `INSERT OR IGNORE` on (txid). The DO previously
+ * serialized this; cron does not, which is acceptable given idempotency.
+ */
+export async function runScheduledTasks(
+  env: CloudflareEnv,
+  logger: Logger,
+  now: number = Date.now()
+): Promise<void> {
+  const kv = env.VERIFIED_AGENTS;
+
+  const pausedUntil = await getPausedUntil(kv);
+  if (pausedUntil && pausedUntil > now) {
+    logger.info("scheduler.skipped_paused", { pausedUntil });
+    return;
+  }
+
+  const [tenero, competition] = await Promise.all([
+    readJson<TeneroState>(kv, K_TENERO),
+    readJson<CompetitionState>(kv, K_COMPETITION),
+  ]);
+
+  // Tenero — every tick, unless inside a rate-limit backoff window.
+  const teneroBackoff = tenero?.nextRunAfter ?? 0;
+  const teneroDue =
+    teneroBackoff <= now &&
+    (tenero?.lastRunAt ?? 0) + TENERO_INTERVAL_MS <= now + 1_000;
+  if (teneroDue) {
+    try {
+      await runTeneroNow(env, logger);
+    } catch (error) {
+      logger.error("scheduler.tenero_unexpected_error", {
+        error: String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      await bumpFailure(kv, K_TENERO);
+    }
+  } else {
+    logger.debug("scheduler.tenero_not_due", {
+      lastRunAt: tenero?.lastRunAt ?? null,
+      nextRunAfter: teneroBackoff || null,
+    });
+  }
+
+  // Competition — on its longer cadence.
+  const competitionDue =
+    (competition?.lastRunAt ?? 0) + COMPETITION_INTERVAL_MS <= now + 1_000;
+  if (competitionDue) {
+    try {
+      await runCompetitionNow(env, logger);
+    } catch (error) {
+      logger.error("scheduler.competition_unexpected_error", {
+        error: String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      await bumpFailure(kv, K_COMPETITION);
+    }
+  } else {
+    logger.debug("scheduler.competition_not_due", {
+      lastRunAt: competition?.lastRunAt ?? null,
+    });
+  }
+}
+
+async function bumpFailure(kv: KVNamespace, key: string): Promise<void> {
+  const prev = await readJson<{ consecutiveFailures?: number }>(kv, key);
+  const next = { ...(prev ?? {}), consecutiveFailures: (prev?.consecutiveFailures ?? 0) + 1 };
+  await kv.put(key, JSON.stringify(next));
+}
+
+// ─────────────────────────── admin surface ───────────────────────────
+
+/** Compose the status payload the admin endpoint serves. */
+export async function readSchedulerStatus(
+  kv: KVNamespace
+): Promise<SchedulerStatus> {
+  const [tenero, competition, pausedUntil] = await Promise.all([
+    readJson<TeneroState>(kv, K_TENERO),
+    readJson<CompetitionState>(kv, K_COMPETITION),
+    getPausedUntil(kv),
+  ]);
+
+  return {
+    now: Date.now(),
+    pausedUntil: pausedUntil ?? null,
+    lastTeneroRunAt: tenero?.lastRunAt ?? null,
+    lastTeneroResult: tenero?.result ?? null,
+    lastCompetitionRunAt: competition?.lastRunAt ?? null,
+    lastCompetitionResult: competition?.result ?? null,
+    consecutiveFailures: {
+      tenero: tenero?.consecutiveFailures ?? 0,
+      competition: competition?.consecutiveFailures ?? 0,
+    },
+    nextRunAfter: {
+      tenero: tenero?.nextRunAfter ?? null,
+      competition: null,
+    },
+    // Cron-driven: there is no single self-scheduled alarm to report.
+    nextAlarmAt: null,
+  };
+}
+
+/** Manual operator-triggered run, used by POST /api/admin/scheduler. */
+export async function refreshScheduler(
+  env: CloudflareEnv,
+  logger: Logger,
+  task: SchedulerTask
+): Promise<SchedulerRefreshResult> {
+  const out: SchedulerRefreshResult = {};
+  if (task === "tenero" || task === "all") {
+    out.tenero = await runTeneroNow(env, logger);
+  }
+  if (task === "competition" || task === "all") {
+    out.competition = await runCompetitionNow(env, logger);
+  }
+  return out;
+}

--- a/lib/scheduler/rpc-types.ts
+++ b/lib/scheduler/rpc-types.ts
@@ -1,3 +1,7 @@
+// Shared scheduler types. Formerly also declared the SchedulerDO RPC
+// interface; the DO was retired in favour of a Cloudflare Cron Trigger
+// (see lib/scheduler/cron-runner.ts). These shapes are still the contract
+// for the admin status/refresh endpoint.
 import type { TeneroRunResult } from "./tenero-task";
 import type { CompetitionSchedulerSummary } from "../competition/scheduler";
 
@@ -12,17 +16,12 @@ export interface SchedulerStatus {
   lastCompetitionResult: CompetitionSchedulerSummary | null;
   consecutiveFailures: { tenero: number; competition: number };
   nextRunAfter: { tenero: number | null; competition: number | null };
+  // Always null under cron scheduling (no self-scheduled DO alarm); kept
+  // for status-shape stability.
   nextAlarmAt: number | null;
 }
 
 export interface SchedulerRefreshResult {
   tenero?: TeneroRunResult;
   competition?: CompetitionSchedulerSummary;
-}
-
-export interface SchedulerRpc {
-  status(): Promise<SchedulerStatus>;
-  refreshNow(task: SchedulerTask): Promise<SchedulerRefreshResult>;
-  pauseUntil(timestamp: number): Promise<void>;
-  resume(): Promise<void>;
 }

--- a/worker.ts
+++ b/worker.ts
@@ -3,397 +3,29 @@ import openNextWorker, {
   DOQueueHandler,
   DOShardedTagCache,
 } from "./.open-next/worker.js";
-import { DurableObject } from "cloudflare:workers";
 import {
   createConsoleLogger,
   createLogger,
   isLogsRPC,
-  type Logger,
 } from "./lib/logging";
 import { getPaymentRepoVersion } from "./lib/inbox/payment-logging";
 import { processInboxReconciliationQueue } from "./lib/inbox/reconciliation-queue";
-import { getActiveTokenIds } from "./lib/external/tenero";
-import {
-  runTeneroTask,
-  type TeneroRunResult,
-  TENERO_MINUTE_QUOTA_BACKOFF_MS,
-} from "./lib/scheduler/tenero-task";
-import {
-  runCompetitionScheduler,
-  type CompetitionSchedulerSummary,
-} from "./lib/competition/scheduler";
-import type {
-  SchedulerRefreshResult,
-  SchedulerStatus,
-  SchedulerTask,
-} from "./lib/scheduler/rpc-types";
+import { runScheduledTasks } from "./lib/scheduler/cron-runner";
 
-// ─────────────────────────── SchedulerDO ───────────────────────────
+// ─────────────────────────── Scheduler ───────────────────────────
 //
-// Defined inline at the worker entry (not imported from a separate file)
-// so OpenNext + wrangler's esbuild bundle includes the class body. When
-// SchedulerDO was imported from `./lib/scheduler/scheduler-do`, the class
-// was dropped from the deployed bundle even though it appeared in `export
-// { SchedulerDO }` — workerd then refused to start with "no such actor
-// class; c = SchedulerDO" and every route returned 404 with
-// x-preview-user-error: true. See PR #743 build logs at 07:28Z and 07:34Z,
-// and OpenNext issue #502 for the broader context on custom-DO bundling
-// failures with this adapter.
+// Periodic background work (Tenero price refresh + competition Hiro
+// catch-up sweep) runs from a Cloudflare Cron Trigger via the `scheduled()`
+// handler below — see `triggers.crons` in wrangler.jsonc and the
+// orchestration in `lib/scheduler/cron-runner.ts`.
 //
-// Storage layout (this.ctx.storage):
-// - lastTeneroRunAt        — unix millis when the Tenero task last completed
-// - lastTeneroResult       — { succeeded, failed, minuteRemaining, monthRemaining }
-// - lastCompetitionRunAt   — unix millis when the competition sweep last completed
-// - lastCompetitionResult  — { scanned, found, inserted, alreadyKnown, pending, rejected, rejectionReasons, cursor }
-// - consecutiveFailures    — { tenero: number, competition: number }
-// - pausedUntil            — unix millis; alarm() is a no-op until this passes
-// - nextRunAfter           — adaptive backoff per task
-//
-// Long-lived cursors stay in D1 per issue #768 — the DO holds only its
-// own bookkeeping.
-
-const TENERO_INTERVAL_MS = 5 * 60 * 1000;
-const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
-const ALARM_TICK_MS = TENERO_INTERVAL_MS;
-
-type SchedulerFailureTask = "tenero" | "competition";
-
-type StoredScheduler = {
-  lastTeneroRunAt?: number;
-  lastTeneroResult?: TeneroRunResult;
-  lastCompetitionRunAt?: number;
-  lastCompetitionResult?: CompetitionSchedulerSummary;
-  consecutiveFailures?: Partial<Record<SchedulerFailureTask, number>>;
-  pausedUntil?: number;
-  nextRunAfter?: Partial<Record<SchedulerFailureTask, number>>;
-};
-
-export class SchedulerDO extends DurableObject<CloudflareEnv> {
-  constructor(state: DurableObjectState, env: CloudflareEnv) {
-    super(state, env);
-    // Ensure an alarm is always armed. Idempotent — getAlarm() returns
-    // null if none is set.
-    this.ctx.blockConcurrencyWhile(async () => {
-      const current = await this.ctx.storage.getAlarm();
-      if (current === null) {
-        await this.ctx.storage.setAlarm(Date.now() + ALARM_TICK_MS);
-      }
-    });
-  }
-
-  async status(): Promise<SchedulerStatus> {
-    const s = await this.readStored();
-    const nextAlarmAt = await this.ctx.storage.getAlarm();
-    return {
-      now: Date.now(),
-      pausedUntil: s.pausedUntil ?? null,
-      lastTeneroRunAt: s.lastTeneroRunAt ?? null,
-      lastTeneroResult: s.lastTeneroResult ?? null,
-      lastCompetitionRunAt: s.lastCompetitionRunAt ?? null,
-      lastCompetitionResult: s.lastCompetitionResult ?? null,
-      consecutiveFailures: {
-        tenero: s.consecutiveFailures?.tenero ?? 0,
-        competition: s.consecutiveFailures?.competition ?? 0,
-      },
-      nextRunAfter: {
-        tenero: s.nextRunAfter?.tenero ?? null,
-        competition: s.nextRunAfter?.competition ?? null,
-      },
-      nextAlarmAt,
-    };
-  }
-
-  async refreshNow(task: SchedulerTask): Promise<SchedulerRefreshResult> {
-    const logger = this.makeLogger({ trigger: "refreshNow", task });
-    const out: SchedulerRefreshResult = {};
-    if (task === "tenero" || task === "all") {
-      out.tenero = await this.runTenero(logger);
-    }
-    if (task === "competition" || task === "all") {
-      out.competition = await this.runCompetition(logger);
-    }
-    return out;
-  }
-
-  async pauseUntil(timestamp: number): Promise<void> {
-    await this.ctx.storage.put("pausedUntil", timestamp);
-    this.makeLogger({ trigger: "pauseUntil" }).warn("scheduler.paused", {
-      pausedUntil: timestamp,
-    });
-  }
-
-  async resume(): Promise<void> {
-    await this.ctx.storage.delete("pausedUntil");
-    this.makeLogger({ trigger: "resume" }).info("scheduler.resumed", {});
-  }
-
-  async alarm(): Promise<void> {
-    const tickStartedAt = Date.now();
-    const logger = this.makeLogger({ trigger: "alarm", tickStartedAt });
-
-    try {
-      const stored = await this.readStored();
-
-      if (stored.pausedUntil && stored.pausedUntil > tickStartedAt) {
-        logger.info("scheduler.alarm_skipped_paused", {
-          pausedUntil: stored.pausedUntil,
-        });
-        return;
-      }
-
-      // TODO(#768 follow-up): once balance snapshots land, this branching
-      // shape becomes a copy-paste smell. Refactor to a task registry:
-      //   for (const task of TASKS) if (task.isDue(stored, tickStartedAt))
-      //     await task.run(logger, this.ctx);
-      // Each task owns its own cadence, persist helper, and failure key.
-      const teneroNextRunAfter = stored.nextRunAfter?.tenero ?? 0;
-      const teneroDue =
-        teneroNextRunAfter <= tickStartedAt &&
-        (stored.lastTeneroRunAt ?? 0) + TENERO_INTERVAL_MS <=
-          tickStartedAt + 1_000;
-
-      if (teneroDue) {
-        try {
-          await this.runTenero(logger);
-        } catch (error) {
-          logger.error("scheduler.tenero_unexpected_error", {
-            error: String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-          await this.bumpFailures("tenero");
-        }
-      } else {
-        logger.debug("scheduler.tenero_not_due", {
-          lastRunAt: stored.lastTeneroRunAt ?? null,
-          nextRunAfter: teneroNextRunAfter || null,
-        });
-      }
-
-      const competitionNextRunAfter = stored.nextRunAfter?.competition ?? 0;
-      const competitionDue =
-        competitionNextRunAfter <= tickStartedAt &&
-        (stored.lastCompetitionRunAt ?? 0) + COMPETITION_INTERVAL_MS <=
-          tickStartedAt + 1_000;
-
-      if (competitionDue) {
-        try {
-          await this.runCompetition(logger);
-        } catch (error) {
-          logger.error("scheduler.competition_unexpected_error", {
-            error: String(error),
-            stack: error instanceof Error ? error.stack : undefined,
-          });
-          await this.bumpFailures("competition");
-          await this.deferTask("competition", COMPETITION_INTERVAL_MS);
-        }
-      } else {
-        logger.debug("scheduler.competition_not_due", {
-          lastRunAt: stored.lastCompetitionRunAt ?? null,
-          nextRunAfter: competitionNextRunAfter || null,
-        });
-      }
-    } finally {
-      await this.ctx.storage.setAlarm(Date.now() + ALARM_TICK_MS);
-    }
-  }
-
-  // TODO(#768 follow-up): when the balance task ships, give each task a
-  // bounded slice of the tick (e.g. AbortSignal.timeout(30_000) per task)
-  // so a slow Hiro response can't starve other scheduler work.
-  //
-  // The orchestration body is `runTeneroTask` in
-  // `lib/scheduler/tenero-task.ts` — kept testable without a DO harness.
-  // This wrapper only wires DO-scoped dependencies and persists the run
-  // result + failure counters / backoff to DO storage.
-  private async runTenero(parentLogger: Logger): Promise<TeneroRunResult> {
-    const logger = parentLogger.child
-      ? parentLogger.child({ task: "tenero" })
-      : parentLogger;
-    const startedAt = Date.now();
-
-    if (this.env.TENERO_REFRESH_ENABLED !== "true") {
-      logger.warn("tenero.refresh_skipped_disabled", {
-        deployEnv: this.env.DEPLOY_ENV ?? "unset",
-        teneroRefreshEnabled: this.env.TENERO_REFRESH_ENABLED ?? "unset",
-      });
-      return {
-        startedAt,
-        durationMs: Date.now() - startedAt,
-        tokensAttempted: 0,
-        succeeded: 0,
-        failed: 0,
-        minuteRemaining: null,
-        monthRemaining: null,
-      };
-    }
-
-    // Pull the active token set from the swaps table (union'd with the
-    // static core; falls back to static-only on missing binding or query
-    // failure). See `getActiveTokenIds` doc for the SQL + filter.
-    const tokenIds = await getActiveTokenIds(this.env.DB);
-    logger.info("tenero.token_set_resolved", { count: tokenIds.length });
-
-    const { result, rateLimited, rateLimitBackoffMs } = await runTeneroTask({
-      logger,
-      kv: this.env.VERIFIED_AGENTS,
-      tokenIds,
-      apiKey: this.lookupTeneroApiKey(),
-    });
-
-    await this.persistTeneroResult(result, { rateLimited, rateLimitBackoffMs });
-    return result;
-  }
-
-  private async runCompetition(parentLogger: Logger): Promise<CompetitionSchedulerSummary> {
-    const logger = parentLogger.child
-      ? parentLogger.child({ task: "competition" })
-      : parentLogger;
-
-    const result = await runCompetitionScheduler(
-      { DB: this.env.DB, HIRO_API_KEY: this.env.HIRO_API_KEY },
-      logger
-    );
-
-    await this.persistCompetitionResult(result);
-    return result;
-  }
-
-  /**
-   * Read the DO's bookkeeping in a single parallel batch of targeted gets.
-   * `storage.list({ prefix: "" })` scans every stored key — fine at today's
-   * 5 keys, but the *point* of this DO is to grow more tasks (each with
-   * its own cursors and `lastResult`), so targeted `get<T>` calls keep
-   * read cost bounded by the schema, not the storage size.
-   *
-   * Pattern mirrors `x402-sponsor-relay/src/durable-objects/nonce-do.ts`.
-   */
-  private async readStored(): Promise<StoredScheduler> {
-    const [
-      lastTeneroRunAt,
-      lastTeneroResult,
-      lastCompetitionRunAt,
-      lastCompetitionResult,
-      consecutiveFailures,
-      pausedUntil,
-      nextRunAfter,
-    ] = await Promise.all([
-      this.ctx.storage.get<number>("lastTeneroRunAt"),
-      this.ctx.storage.get<TeneroRunResult>("lastTeneroResult"),
-      this.ctx.storage.get<number>("lastCompetitionRunAt"),
-      this.ctx.storage.get<CompetitionSchedulerSummary>("lastCompetitionResult"),
-      this.ctx.storage.get<Partial<Record<SchedulerFailureTask, number>>>(
-        "consecutiveFailures"
-      ),
-      this.ctx.storage.get<number>("pausedUntil"),
-      this.ctx.storage.get<Partial<Record<SchedulerFailureTask, number>>>(
-        "nextRunAfter"
-      ),
-    ]);
-    return {
-      ...(typeof lastTeneroRunAt === "number" ? { lastTeneroRunAt } : {}),
-      ...(lastTeneroResult ? { lastTeneroResult } : {}),
-      ...(typeof lastCompetitionRunAt === "number" ? { lastCompetitionRunAt } : {}),
-      ...(lastCompetitionResult ? { lastCompetitionResult } : {}),
-      ...(consecutiveFailures ? { consecutiveFailures } : {}),
-      ...(typeof pausedUntil === "number" ? { pausedUntil } : {}),
-      ...(nextRunAfter ? { nextRunAfter } : {}),
-    };
-  }
-
-  private async persistTeneroResult(
-    result: TeneroRunResult,
-    opts: { rateLimited: boolean; rateLimitBackoffMs?: number }
-  ): Promise<void> {
-    await this.ctx.storage.put("lastTeneroRunAt", Date.now());
-    await this.ctx.storage.put("lastTeneroResult", result);
-
-    if (result.succeeded > 0 && result.failed === 0 && !opts.rateLimited) {
-      await this.clearFailures("tenero");
-      const nextRunAfter = await this.readNextRunAfter();
-      if (nextRunAfter.tenero) {
-        delete nextRunAfter.tenero;
-        await this.ctx.storage.put("nextRunAfter", nextRunAfter);
-      }
-    } else if (result.failed > 0 || opts.rateLimited) {
-      await this.bumpFailures("tenero");
-    }
-
-    if (opts.rateLimited) {
-      const nextRunAfter = await this.readNextRunAfter();
-      nextRunAfter.tenero =
-        Date.now() + (opts.rateLimitBackoffMs ?? TENERO_MINUTE_QUOTA_BACKOFF_MS);
-      await this.ctx.storage.put("nextRunAfter", nextRunAfter);
-    }
-  }
-
-  private async persistCompetitionResult(
-    result: CompetitionSchedulerSummary
-  ): Promise<void> {
-    await this.ctx.storage.put("lastCompetitionRunAt", Date.now());
-    await this.ctx.storage.put("lastCompetitionResult", result);
-    await this.clearFailures("competition");
-    const nextRunAfter = await this.readNextRunAfter();
-    if (nextRunAfter.competition) {
-      delete nextRunAfter.competition;
-      await this.ctx.storage.put("nextRunAfter", nextRunAfter);
-    }
-  }
-
-  private async bumpFailures(task: SchedulerFailureTask): Promise<void> {
-    const cur =
-      ((await this.ctx.storage.get<Partial<Record<SchedulerFailureTask, number>>>(
-        "consecutiveFailures"
-      )) ?? {}) as Partial<Record<SchedulerFailureTask, number>>;
-    cur[task] = (cur[task] ?? 0) + 1;
-    await this.ctx.storage.put("consecutiveFailures", cur);
-  }
-
-  private async clearFailures(task: SchedulerFailureTask): Promise<void> {
-    const cur =
-      ((await this.ctx.storage.get<Partial<Record<SchedulerFailureTask, number>>>(
-        "consecutiveFailures"
-      )) ?? {}) as Partial<Record<SchedulerFailureTask, number>>;
-    if ((cur[task] ?? 0) === 0) return;
-    cur[task] = 0;
-    await this.ctx.storage.put("consecutiveFailures", cur);
-  }
-
-  private async deferTask(
-    task: SchedulerFailureTask,
-    delayMs: number
-  ): Promise<void> {
-    const nextRunAfter = await this.readNextRunAfter();
-    nextRunAfter[task] = Date.now() + delayMs;
-    await this.ctx.storage.put("nextRunAfter", nextRunAfter);
-  }
-
-  private async readNextRunAfter(): Promise<
-    Partial<Record<SchedulerFailureTask, number>>
-  > {
-    return (
-      (await this.ctx.storage.get<Partial<Record<SchedulerFailureTask, number>>>(
-        "nextRunAfter"
-      )) ?? {}
-    );
-  }
-
-  private makeLogger(extra: Record<string, unknown>): Logger {
-    const ctxBase = {
-      path: "/__do/scheduler",
-      doName: "scheduler",
-      ...extra,
-    };
-    return isLogsRPC(this.env.LOGS)
-      ? createLogger(this.env.LOGS, this.ctx, ctxBase)
-      : createConsoleLogger(ctxBase);
-  }
-
-  private lookupTeneroApiKey(): string | undefined {
-    const key = (this.env as unknown as { TENERO_API_KEY?: string })
-      .TENERO_API_KEY;
-    return typeof key === "string" && key.length > 0 ? key : undefined;
-  }
-}
+// This replaced the former `SchedulerDO` Durable Object. The DO's alarm
+// had no independent trigger: it only stayed armed because the /leaderboard
+// SSR poked it on every render, so a DO storage wipe (the v2→v3 class
+// migration) with no leaderboard traffic left ALL scheduled work silently
+// stopped. A Cron Trigger fires on a guaranteed schedule regardless of
+// traffic. State the DO held in `ctx.storage` now lives in KV under
+// `scheduler:*` keys; the competition cursor already lived in D1.
 
 // ─────────────────────────── Exports ───────────────────────────
 
@@ -402,6 +34,28 @@ export { BucketCachePurge, DOQueueHandler, DOShardedTagCache };
 export default {
   async fetch(request: Request, env: CloudflareEnv, ctx: ExecutionContext) {
     return openNextWorker.fetch(request, env, ctx);
+  },
+
+  async scheduled(
+    event: ScheduledController,
+    env: CloudflareEnv,
+    ctx: ExecutionContext
+  ) {
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, {
+          path: "/__cron/scheduler",
+          cron: event.cron,
+        })
+      : createConsoleLogger({ path: "/__cron/scheduler", cron: event.cron });
+
+    ctx.waitUntil(
+      runScheduledTasks(env, logger).catch((error) =>
+        logger.error("scheduler.cron_failed", {
+          error: String(error),
+          stack: error instanceof Error ? error.stack : undefined,
+        })
+      )
+    );
   },
 
   async queue(

--- a/worker.ts
+++ b/worker.ts
@@ -3,6 +3,7 @@ import openNextWorker, {
   DOQueueHandler,
   DOShardedTagCache,
 } from "./.open-next/worker.js";
+import { DurableObject } from "cloudflare:workers";
 import {
   createConsoleLogger,
   createLogger,
@@ -15,17 +16,37 @@ import { runScheduledTasks } from "./lib/scheduler/cron-runner";
 // ─────────────────────────── Scheduler ───────────────────────────
 //
 // Periodic background work (Tenero price refresh + competition Hiro
-// catch-up sweep) runs from a Cloudflare Cron Trigger via the `scheduled()`
-// handler below — see `triggers.crons` in wrangler.jsonc and the
-// orchestration in `lib/scheduler/cron-runner.ts`.
+// catch-up sweep) now runs from a Cloudflare Cron Trigger via the
+// `scheduled()` handler below — see `triggers.crons` in wrangler.jsonc and
+// the orchestration in `lib/scheduler/cron-runner.ts`.
 //
-// This replaced the former `SchedulerDO` Durable Object. The DO's alarm
-// had no independent trigger: it only stayed armed because the /leaderboard
-// SSR poked it on every render, so a DO storage wipe (the v2→v3 class
-// migration) with no leaderboard traffic left ALL scheduled work silently
-// stopped. A Cron Trigger fires on a guaranteed schedule regardless of
-// traffic. State the DO held in `ctx.storage` now lives in KV under
-// `scheduler:*` keys; the competition cursor already lived in D1.
+// This replaces the former `SchedulerDO` driver. The DO's alarm had no
+// independent trigger: it only stayed armed because the /leaderboard SSR
+// poked it on every render, so a DO storage wipe (the v2→v3 class migration)
+// with no leaderboard traffic left ALL scheduled work silently stopped. A
+// Cron Trigger fires on a guaranteed schedule regardless of traffic. State
+// the DO held in `ctx.storage` now lives in KV under `scheduler:*` keys; the
+// competition cursor already lived in D1.
+
+// SchedulerDO is RETAINED but NEUTERED. We cannot delete the class in this
+// PR: a `deleted_classes` Durable Object migration is rejected on the
+// versioned-upload deploy path the CI uses (Cloudflare error 10211 — DO
+// migrations require a non-versioned `wrangler deploy`). Keeping the class +
+// its existing binding/migration history (v1/v2/v3) means no migration is
+// applied, so CI deploys cleanly. The `alarm()` below is a no-op that does
+// NOT re-arm, so any alarm still armed from the DO era drains itself on its
+// next fire instead of double-running alongside the cron. Nothing in the app
+// pokes this DO anymore (the /leaderboard kick and admin RPC were removed),
+// so it is never re-instantiated after that drain. Full teardown (a v4
+// `deleted_classes` migration) can land later via a one-off non-versioned
+// `wrangler deploy`.
+export class SchedulerDO extends DurableObject<CloudflareEnv> {
+  async alarm(): Promise<void> {
+    // Intentionally empty and intentionally does NOT re-arm. Drains any
+    // legacy alarm left over from the DO-driven era; scheduling is now the
+    // cron trigger's job.
+  }
+}
 
 // ─────────────────────────── Exports ───────────────────────────
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -110,18 +110,21 @@
   "triggers": {
     "crons": ["*/5 * * * *"]
   },
-  // SchedulerDO retired. The v4 deleted_classes migration tears down the
-  // Durable Object and its storage; the binding is removed (empty array).
-  // Earlier tags are kept because wrangler needs the full applied history
-  // to deploy without errors.
+  // SchedulerDO is RETAINED but neutered (see worker.ts). It no longer drives
+  // any work — the cron trigger above does — but the class + binding stay so
+  // that NO Durable Object migration is applied on deploy. A `deleted_classes`
+  // migration is rejected on the versioned-upload deploy path the CI uses
+  // (Cloudflare error 10211). Full teardown can land later via a one-off
+  // non-versioned `wrangler deploy` that adds a v4 deleted_classes tag.
   "durable_objects": {
-    "bindings": []
+    "bindings": [
+      { "name": "SCHEDULER", "class_name": "SchedulerDO" }
+    ]
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
     { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
-    { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
+    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
   ],
 
   /**
@@ -227,16 +230,17 @@
       "triggers": {
         "crons": ["*/5 * * * *"]
       },
-      // SchedulerDO retired — see top-level note. Empty bindings + v4
-      // deleted_classes migration.
+      // SchedulerDO retained but neutered — see top-level note. No DO
+      // migration is applied so the versioned-upload deploy path succeeds.
       "durable_objects": {
-        "bindings": []
+        "bindings": [
+          { "name": "SCHEDULER", "class_name": "SchedulerDO" }
+        ]
       },
       "migrations": [
         { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
         { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
-        { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
+        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
       ]
     },
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -98,28 +98,30 @@
     ]
   },
 
-  // SchedulerDO: single instance coordinating periodic background work.
-  // Current scope: Tenero price refresh (every ~5 min) writing to
-  // VERIFIED_AGENTS KV under `tenero:price:{tokenId}`, plus the trading
-  // competition Hiro catch-up sweep (every ~15 min). Balance snapshots
-  // land in a follow-up PR. See issue #768.
-  // Singleton resolved via env.SCHEDULER.idFromName("v1") — the instance
-  // name is independent of the migration tag, so it stays "v1" even
-  // though the migration history is up to v3.
-  "durable_objects": {
-    "bindings": [
-      { "name": "SCHEDULER", "class_name": "SchedulerDO" }
-    ]
+  // Cron Trigger drives periodic background work (Tenero price refresh
+  // every tick + competition Hiro catch-up sweep on its longer cadence)
+  // via the worker's scheduled() handler — see lib/scheduler/cron-runner.ts.
+  // This replaced the former SchedulerDO, whose alarm had no independent
+  // trigger: it only stayed armed because /leaderboard SSR poked it on every
+  // render, so a DO storage wipe with no leaderboard visit left all
+  // scheduled work silently stopped. Crons are NOT inherited by named envs,
+  // so env.production below repeats this; env.preview omits it so preview
+  // deploys never run schedulers against the shared production D1/KV quota.
+  "triggers": {
+    "crons": ["*/5 * * * *"]
   },
-  // Migration history reflects what's been applied to CF, not just what
-  // this PR introduces. v1 + v2 happened during the original #743
-  // experimentation (registered, then deleted via hotfix #772). v3
-  // reintroduces the class cleanly. Keep all three declared — wrangler
-  // needs the full history to deploy without errors.
+  // SchedulerDO retired. The v4 deleted_classes migration tears down the
+  // Durable Object and its storage; the binding is removed (empty array).
+  // Earlier tags are kept because wrangler needs the full applied history
+  // to deploy without errors.
+  "durable_objects": {
+    "bindings": []
+  },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
     { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
+    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
+    { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
   ],
 
   /**
@@ -220,15 +222,21 @@
         ]
       },
 
+      // Cron Trigger for the named-production deploy path (`--env production`).
+      // Repeated here because wrangler does not inherit top-level triggers.
+      "triggers": {
+        "crons": ["*/5 * * * *"]
+      },
+      // SchedulerDO retired — see top-level note. Empty bindings + v4
+      // deleted_classes migration.
       "durable_objects": {
-        "bindings": [
-          { "name": "SCHEDULER", "class_name": "SchedulerDO" }
-        ]
+        "bindings": []
       },
       "migrations": [
         { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
         { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
+        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
+        { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
       ]
     },
 
@@ -323,9 +331,10 @@
         ]
       },
 
-      // Preview intentionally has no SchedulerDO binding. It shares
-      // production D1/KV/logging, so a preview scheduler can consume real
-      // upstream quota and write real competition/cache state.
+      // Preview intentionally runs no scheduler: no cron trigger (omitted
+      // above) and no Durable Object. It shares production D1/KV/logging, so
+      // a preview scheduler could consume real upstream quota and write real
+      // competition/cache state.
       "durable_objects": {
         "bindings": []
       },


### PR DESCRIPTION
## Problem

The scheduler **had no independent trigger**. The `SchedulerDO` alarm only stayed armed because `/leaderboard` SSR poked it on every render (`page.tsx`, with errors swallowed via `.catch(() => undefined)`). After the `v2→v3` DO class-delete migration wiped its storage, any stretch with no leaderboard visit left the alarm unarmed — and **all** scheduled work (Tenero price refresh + competition Hiro catch-up sweep) silently stopped, with nothing surfacing it. This is the "I thought the scheduler is not working" report.

## Change — cron, the way `aibtc-dashboard` does it

Retire the DO; drive periodic work from a Cloudflare **Cron Trigger**.

- **`worker.ts`** — `scheduled()` handler → `runScheduledTasks()`; `SchedulerDO` class removed.
- **`lib/scheduler/cron-runner.ts`** (new) — KV-backed orchestration. Tenero every tick (respecting rate-limit backoff), competition on its 15-min cadence. DO bookkeeping (`lastRunAt`/backoff/pause) moved to KV `scheduler:*` keys; the competition cursor already lived in D1, untouched.
- **`wrangler.jsonc`** — `triggers.crons: ["*/5 * * * *"]` in **top-level + `env.production`** (crons are not inherited by named envs); **omitted in `env.preview`** so preview never runs schedulers against shared prod quota. DO binding emptied + **`v4 deleted_classes`** migration tears the class down.
- **`app/leaderboard/page.tsx`** — removes the per-render DO poke (also drops a per-pageview DO request charge).
- **`app/api/admin/scheduler/route.ts`** — rewired status/refresh/pause/resume from DO RPC to the KV state helpers.

Both task functions (`runTeneroTask`, `runCompetitionScheduler`) were already DO-independent, so this only changes the *trigger* and *where bookkeeping lives*.

## Cost (verified against live Cloudflare docs)

Account is on the flat **$5/mo Workers Paid base**. This is **net cost-negative**: it ends the DO's duration GB-s billing (400k GB-s incl, then \$12.50/M) and the per-`/leaderboard`-view DO request charges. The cron itself is 8,640 invocations/mo against 10M included — noise.

## Deploy notes for reviewer

- The **`v4 deleted_classes: ["SchedulerDO"]`** migration deletes the DO + its storage on deploy. Intended.
- First cron fires within 5 min of deploy. **Verify with the admin status:**
  ```bash
  curl -s -H "X-Admin-Key: $ADMIN_KEY" "https://aibtc.com/api/admin/scheduler" | jq
  ```
  After ~5 min, `lastTeneroRunAt` should be recent; after ~15 min, `lastCompetitionRunAt` too. (Note: the route no longer takes a `?name=` instance param.)
- Validated locally: `tsc --noEmit` clean on changed files, `next lint` clean, full vitest suite **1482 passing**, and `wrangler.jsonc` parses with the cron config in place.

## Out of scope / follow-ups

- Prose mentions of "SchedulerDO" remain in AX docs (`llms.txt`, `llms-full.txt`, `agent.json`, `openapi.json`, a few route comments). Functionally harmless; will sweep in a small docs follow-up.
- This is **Phase 0** of the verified earnings ledger (#978). The design for the indexer + API + UI is included in `docs/earnings-ledger-architecture.md`; Phases 1–4 (the earnings indexer itself) follow once this lands.

Part of #978.