### PR TITLE
chore(scheduler): delete SchedulerDO (v4 migration, manual deploy)

### DIFF
--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -22,11 +22,9 @@ interface CloudflareEnv {
   X402_RELAY?: import("./lib/inbox/relay-rpc").RelayRPC; // x402 sponsor relay RPC service binding (undefined in local dev)
   INBOX_RECONCILIATION_QUEUE?: Queue<import("./lib/inbox/reconciliation-queue").InboxReconciliationQueueMessage>;
   // Scheduled background work runs from a Cloudflare Cron Trigger (see
-  // worker.ts `scheduled()` + lib/scheduler/cron-runner.ts). The SchedulerDO
-  // binding is retained but neutered — the class can't be deleted on the
-  // versioned-upload deploy path (CF error 10211) — and nothing in the app
-  // calls it, so it has no RPC surface. Declared as a plain namespace.
-  SCHEDULER?: DurableObjectNamespace;
+  // worker.ts `scheduled()` + lib/scheduler/cron-runner.ts), not a Durable
+  // Object — SchedulerDO is removed (v4 deleted_classes migration), so there
+  // is no SCHEDULER binding.
   TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for the cron Tenero refresh
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
 }

--- a/worker.ts
+++ b/worker.ts
@@ -3,7 +3,6 @@ import openNextWorker, {
   DOQueueHandler,
   DOShardedTagCache,
 } from "./.open-next/worker.js";
-import { DurableObject } from "cloudflare:workers";
 import {
   createConsoleLogger,
   createLogger,
@@ -16,37 +15,18 @@ import { runScheduledTasks } from "./lib/scheduler/cron-runner";
 // ─────────────────────────── Scheduler ───────────────────────────
 //
 // Periodic background work (Tenero price refresh + competition Hiro
-// catch-up sweep) now runs from a Cloudflare Cron Trigger via the
-// `scheduled()` handler below — see `triggers.crons` in wrangler.jsonc and
-// the orchestration in `lib/scheduler/cron-runner.ts`.
+// catch-up sweep) runs from a Cloudflare Cron Trigger via the `scheduled()`
+// handler below — see `triggers.crons` in wrangler.jsonc and the
+// orchestration in `lib/scheduler/cron-runner.ts`.
 //
-// This replaces the former `SchedulerDO` driver. The DO's alarm had no
-// independent trigger: it only stayed armed because the /leaderboard SSR
-// poked it on every render, so a DO storage wipe (the v2→v3 class migration)
-// with no leaderboard traffic left ALL scheduled work silently stopped. A
-// Cron Trigger fires on a guaranteed schedule regardless of traffic. State
-// the DO held in `ctx.storage` now lives in KV under `scheduler:*` keys; the
-// competition cursor already lived in D1.
-
-// SchedulerDO is RETAINED but NEUTERED. We cannot delete the class in this
-// PR: a `deleted_classes` Durable Object migration is rejected on the
-// versioned-upload deploy path the CI uses (Cloudflare error 10211 — DO
-// migrations require a non-versioned `wrangler deploy`). Keeping the class +
-// its existing binding/migration history (v1/v2/v3) means no migration is
-// applied, so CI deploys cleanly. The `alarm()` below is a no-op that does
-// NOT re-arm, so any alarm still armed from the DO era drains itself on its
-// next fire instead of double-running alongside the cron. Nothing in the app
-// pokes this DO anymore (the /leaderboard kick and admin RPC were removed),
-// so it is never re-instantiated after that drain. Full teardown (a v4
-// `deleted_classes` migration) can land later via a one-off non-versioned
-// `wrangler deploy`.
-export class SchedulerDO extends DurableObject<CloudflareEnv> {
-  async alarm(): Promise<void> {
-    // Intentionally empty and intentionally does NOT re-arm. Drains any
-    // legacy alarm left over from the DO-driven era; scheduling is now the
-    // cron trigger's job.
-  }
-}
+// The former `SchedulerDO` Durable Object (and the neutered bridge class
+// that followed it) is now fully removed via the `v4 deleted_classes`
+// migration in wrangler.jsonc. NOTE: a DO migration only applies on the
+// non-versioned deploy path (`wrangler deploy`), which is what the production
+// (main) Cloudflare Workers Build runs — so this lands automatically on merge
+// to main. The per-PR preview build (`wrangler versions upload`) rejects DO
+// migrations (error 10211), so this branch's preview check will show red;
+// that is expected and does not affect the production deploy.
 
 // ─────────────────────────── Exports ───────────────────────────
 

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -110,21 +110,25 @@
   "triggers": {
     "crons": ["*/5 * * * *"]
   },
-  // SchedulerDO is RETAINED but neutered (see worker.ts). It no longer drives
-  // any work — the cron trigger above does — but the class + binding stay so
-  // that NO Durable Object migration is applied on deploy. A `deleted_classes`
-  // migration is rejected on the versioned-upload deploy path the CI uses
-  // (Cloudflare error 10211). Full teardown can land later via a one-off
-  // non-versioned `wrangler deploy` that adds a v4 deleted_classes tag.
+  // SchedulerDO fully removed — the cron trigger above drives all scheduled
+  // work. The v4 deleted_classes migration tears down the Durable Object and
+  // its storage; the binding is removed (empty array). Earlier tags are kept
+  // because wrangler needs the full applied history.
+  //
+  // DEPLOY NOTE: DO migrations only apply on the NON-VERSIONED deploy path
+  // (`wrangler deploy`), which is what the production (main) Cloudflare Workers
+  // Build runs — so this lands automatically on merge to main. The per-PR
+  // preview build (`wrangler versions upload`) rejects DO migrations
+  // (Cloudflare error 10211), so this branch's preview check shows red by
+  // design; it does not affect the production deploy.
   "durable_objects": {
-    "bindings": [
-      { "name": "SCHEDULER", "class_name": "SchedulerDO" }
-    ]
+    "bindings": []
   },
   "migrations": [
     { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
     { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
+    { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
+    { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
   ],
 
   /**
@@ -230,17 +234,16 @@
       "triggers": {
         "crons": ["*/5 * * * *"]
       },
-      // SchedulerDO retained but neutered — see top-level note. No DO
-      // migration is applied so the versioned-upload deploy path succeeds.
+      // SchedulerDO fully removed — see top-level note. Applies on the
+      // production (main) non-versioned deploy.
       "durable_objects": {
-        "bindings": [
-          { "name": "SCHEDULER", "class_name": "SchedulerDO" }
-        ]
+        "bindings": []
       },
       "migrations": [
         { "tag": "v1", "new_sqlite_classes": ["SchedulerDO"] },
         { "tag": "v2", "deleted_classes": ["SchedulerDO"] },
-        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] }
+        { "tag": "v3", "new_sqlite_classes": ["SchedulerDO"] },
+        { "tag": "v4", "deleted_classes": ["SchedulerDO"] }
       ]
     },
 


### PR DESCRIPTION
Follow-up to #979. Fully removes the neutered `SchedulerDO` now that the cron trigger drives all scheduled work. Rebased onto `main` after #979 was squash-merged.

## Changes (3 files, +33/-52)
- `worker.ts` — remove the neutered class + `DurableObject` import
- `wrangler.jsonc` — empty `durable_objects.bindings` + add `v4 deleted_classes` (top-level + `env.production`); cron triggers untouched
- `cloudflare-env.d.ts` — drop the `SCHEDULER` binding type

## Deploys automatically on merge — no manual step
Earlier I thought this needed a manual deploy; that was wrong. The `10211` error only happens on the **per-PR preview build** (`wrangler versions upload`, which rejects DO migrations). The **production deploy on merge to `main` uses `wrangler deploy` (non-versioned)**, which applies DO migrations fine — proven by the existing `v1/v2/v3` SchedulerDO migrations having been applied through the same pipeline (PRs #743/#772).

So: **merging this to `main` applies the `v4` deletion automatically.** The only visible artifact is this PR's **Cloudflare preview check showing red** (expected, `10211`) — `main` isn't branch-protected, so it doesn't block the merge.

## Merge order
1. #979 merged — cron live, scheduler fixed.
2. Confirm cron is firing (`/api/admin/scheduler` -> fresh `lastTeneroRunAt`).
3. Merge this PR -> production `wrangler deploy` tears down the DO. Done, no terminal.

Until then the neutered DO from #979 is inert (never re-instantiated), so there's no rush.