### PR TITLE
feat(earnings): Phase 1 indexer core — schema + classify + price (#978)

### DIFF
--- a/app/api/admin/scheduler/route.ts
+++ b/app/api/admin/scheduler/route.ts
@@ -10,7 +10,12 @@ import {
 } from "@/lib/scheduler/cron-runner";
 import type { SchedulerTask } from "@/lib/scheduler/rpc-types";
 
-const ALLOWED_TASKS = new Set<SchedulerTask>(["tenero", "competition", "all"]);
+const ALLOWED_TASKS = new Set<SchedulerTask>([
+  "tenero",
+  "competition",
+  "earnings",
+  "all",
+]);
 
 function json(body: unknown, init: ResponseInit = {}) {
   const headers = new Headers(init.headers);
@@ -31,7 +36,7 @@ function schedulerTask(url: URL): SchedulerTask | NextResponse {
   const task = url.searchParams.get("task") || "tenero";
   if (!ALLOWED_TASKS.has(task as SchedulerTask)) {
     return json(
-      { error: "Unsupported task. Use tenero, competition, or all." },
+      { error: "Unsupported task. Use tenero, competition, earnings, or all." },
       { status: 400 }
     );
   }

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -27,4 +27,5 @@ interface CloudflareEnv {
   // is no SCHEDULER binding.
   TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for the cron Tenero refresh
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
+  EARNINGS_INDEX_ENABLED?: "true"; // Gate for the cron earnings indexer (issue #978); ships dormant, set "true" to enable
 }

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -356,14 +356,15 @@ would multiply Hiro calls by the cadence with no freshness benefit for a 30-day 
   competition from a Cloudflare Cron Trigger via `worker.ts` `scheduled()` +
   `lib/scheduler/cron-runner.ts` (KV-backed state). Fixes the dead/fragile scheduler at
   the root; prerequisite + trigger for the earnings indexer.
-- **Phase 1 — Schema + indexer core (backend only).** Migration `020`; `lib/earnings/`
-  ingest + classify + index-time pricing + idempotent writes; `runEarnings()` task in
-  `lib/scheduler/cron-runner.ts` (`runScheduledTasks`). Verify via admin/dry-run.
-  **Indexer-only — no agent-submit/self-report
-  path** (unlike competition's `source='agent'` fast-path; earnings tolerate indexing
-  lag and a submit endpoint is needless attack surface). **Also: investigate the x402
-  payTo catalog here** — if none exists, `x402_endpoint` launches inert (bounty + inbox
-  + peer only).
+- **Phase 1 — Schema + indexer core (backend only). DONE.** Migration `020`
+  (`agent_earnings` + `earnings_index_state`); `lib/earnings/` ingest (cheap
+  `transactions_with_transfers`) + classify + index-time pricing + idempotent writes;
+  `runEarningsNow()` wired into `lib/scheduler/cron-runner.ts` on a 30-min cadence,
+  gated by `EARNINGS_INDEX_ENABLED` (**ships dormant**). Verify via
+  `POST /api/admin/scheduler?action=refresh&task=earnings` (force-runs a sweep past the
+  gate). **Indexer-only — no agent-submit/self-report path.** **x402 catalog confirmed
+  absent** (per-agent dynamic payTo, no registry) → `x402_endpoint` is inert; the 3
+  active classifiers are **inbox_message + bounty + agent_peer** (meets the DoD ≥3).
 - **Phase 2 — Full anti-gaming.** first-funder cache + self-fund exclusion, two-hop
   ring, alt-address, manual override.
 - **Phase 3 — Public API.** `/api/agents/{addr}/earnings`, `/api/stats/earnings`,

--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -367,6 +367,10 @@ would multiply Hiro calls by the cadence with no freshness benefit for a 30-day 
   active classifiers are **inbox_message + bounty + agent_peer** (meets the DoD ≥3).
 - **Phase 2 — Full anti-gaming.** first-funder cache + self-fund exclusion, two-hop
   ring, alt-address, manual override.
+- **Reprice pass (Phase 3 scope).** Phase 1 stores `amount_usd = NULL`,
+  `price_source = 'none'` for transfers indexed during a Tenero gap. There is **no
+  reprice task yet** — add one in Phase 3 (a bounded sweep over `price_source = 'none'`
+  rows that re-reads the Tenero cache), so the gap doesn't get lost between phases.
 - **Phase 3 — Public API.** `/api/agents/{addr}/earnings`, `/api/stats/earnings`,
   trading-board earnings ranking (all read-time + edge-cached).
 - **Phase 4 — UI.** leaderboard chip + new default, profile Earnings section, homepage

--- a/lib/earnings/__tests__/earnings.test.ts
+++ b/lib/earnings/__tests__/earnings.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi } from "vitest";
+import { assetInfoForFt, assetInfoForAsset } from "../assets";
+import { extractInboundTransfers } from "../ingest";
+import { classifyTransfer } from "../classify";
+import { priceTransfer } from "../price";
+import type { InboundTransfer } from "../types";
+
+const AGENT = "SP_AGENT_RECIPIENT";
+const PEER = "SP_OTHER_AGENT";
+const SBTC_ASSET_ID =
+  "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token";
+const AEUSDC_ASSET_ID =
+  "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-aeusdc::aeusdc";
+
+// ─────────────────────────── assets ───────────────────────────
+
+describe("assetInfoForFt", () => {
+  it("maps sBTC (8 decimals, not stablecoin)", () => {
+    const info = assetInfoForFt(SBTC_ASSET_ID);
+    expect(info).toEqual({
+      asset: "sbtc",
+      decimals: 8,
+      teneroTokenId: SBTC_ASSET_ID,
+      stablecoin: false,
+    });
+  });
+
+  it("maps aeUSDC (6 decimals, stablecoin) regardless of asset suffix", () => {
+    const info = assetInfoForFt(AEUSDC_ASSET_ID);
+    expect(info?.asset).toBe("aeusdc");
+    expect(info?.decimals).toBe(6);
+    expect(info?.stablecoin).toBe(true);
+  });
+
+  it("returns null for an untracked token", () => {
+    expect(assetInfoForFt("SP000.random-token::x")).toBeNull();
+  });
+});
+
+describe("assetInfoForAsset", () => {
+  it("resolves stx / sbtc / aeusdc", () => {
+    expect(assetInfoForAsset("stx").decimals).toBe(6);
+    expect(assetInfoForAsset("sbtc").decimals).toBe(8);
+    expect(assetInfoForAsset("aeusdc").stablecoin).toBe(true);
+  });
+});
+
+// ─────────────────────────── ingest ───────────────────────────
+
+describe("extractInboundTransfers", () => {
+  it("extracts inbound STX + sBTC with stable event_index, skips outbound", () => {
+    const tx = {
+      tx: { tx_id: "0xabc", tx_status: "success", block_height: 100, burn_block_time: 1700 },
+      stx_transfers: [
+        { amount: "1000000", sender: PEER, recipient: AGENT }, // inbound, idx 0
+        { amount: "500", sender: AGENT, recipient: PEER }, // outbound, idx 1 (skip)
+      ],
+      ft_transfers: [
+        { amount: "42000", sender: PEER, recipient: AGENT, asset_identifier: SBTC_ASSET_ID }, // inbound, idx 2
+      ],
+    };
+    const out = extractInboundTransfers(tx, AGENT);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toMatchObject({ asset: "stx", eventIndex: 0, amountRaw: 1000000, senderStx: PEER });
+    expect(out[1]).toMatchObject({ asset: "sbtc", eventIndex: 2, amountRaw: 42000 });
+    expect(out.every((t) => t.recipientAgentStx === AGENT && t.blockTime === 1700)).toBe(true);
+  });
+
+  it("skips non-success, unanchored, self-transfers, and untracked assets", () => {
+    expect(
+      extractInboundTransfers(
+        { tx: { tx_id: "0x1", tx_status: "abort_by_response", block_height: 1, burn_block_time: 1 },
+          stx_transfers: [{ amount: "1", sender: PEER, recipient: AGENT }] },
+        AGENT
+      )
+    ).toHaveLength(0);
+
+    expect(
+      extractInboundTransfers(
+        { tx: { tx_id: "0x2", tx_status: "success", is_unanchored: true, block_height: 1, burn_block_time: 1 },
+          stx_transfers: [{ amount: "1", sender: PEER, recipient: AGENT }] },
+        AGENT
+      )
+    ).toHaveLength(0);
+
+    expect(
+      extractInboundTransfers(
+        { tx: { tx_id: "0x3", tx_status: "success", block_height: 1, burn_block_time: 1 },
+          stx_transfers: [{ amount: "1", sender: AGENT, recipient: AGENT }],
+          ft_transfers: [{ amount: "1", sender: PEER, recipient: AGENT, asset_identifier: "SP.unknown::x" }] },
+        AGENT
+      )
+    ).toHaveLength(0);
+  });
+});
+
+// ─────────────────────────── classify ───────────────────────────
+
+function transfer(overrides: Partial<InboundTransfer> = {}): InboundTransfer {
+  return {
+    txId: "0xtx",
+    eventIndex: 0,
+    senderStx: PEER,
+    recipientAgentStx: AGENT,
+    asset: "sbtc",
+    amountRaw: 1000,
+    stxBlockHeight: 100,
+    blockTime: 1700,
+    ...overrides,
+  };
+}
+
+/** D1 mock whose three classification queries return preset rows (or null). */
+function classifyDb(rows: { inbox?: unknown; bounty?: unknown; agent?: unknown }) {
+  return {
+    prepare: vi.fn((sql: string) => ({
+      bind: vi.fn(() => ({
+        first: vi.fn().mockResolvedValue(
+          sql.includes("inbox_messages")
+            ? rows.inbox ?? null
+            : sql.includes("bounties")
+              ? rows.bounty ?? null
+              : sql.includes("agents")
+                ? rows.agent ?? null
+                : null
+        ),
+      })),
+    })),
+  } as unknown as D1Database;
+}
+
+describe("classifyTransfer", () => {
+  it("classifies a confirmed inbox payment", async () => {
+    const c = await classifyTransfer(classifyDb({ inbox: { message_id: "m1" } }), transfer());
+    expect(c).toEqual({ sourceClass: "inbox_message", sourceSubclass: "m1", excludedReason: null, isEarning: true });
+  });
+
+  it("classifies a paid bounty to the winner", async () => {
+    const c = await classifyTransfer(classifyDb({ bounty: { id: "b1" } }), transfer());
+    expect(c).toMatchObject({ sourceClass: "bounty", sourceSubclass: "b1", isEarning: true });
+  });
+
+  it("classifies a registered peer agent", async () => {
+    const c = await classifyTransfer(classifyDb({ agent: { x: 1 } }), transfer());
+    expect(c).toMatchObject({ sourceClass: "agent_peer", isEarning: true });
+  });
+
+  it("falls back to unclassified (excluded) when nothing matches", async () => {
+    const c = await classifyTransfer(classifyDb({}), transfer());
+    expect(c).toEqual({
+      sourceClass: "unclassified",
+      sourceSubclass: null,
+      excludedReason: "unclassified",
+      isEarning: false,
+    });
+  });
+});
+
+// ─────────────────────────── price ───────────────────────────
+
+function kvWith(prices: Record<string, { priceUsd: number | null; fetchedAt: number }>) {
+  return {
+    get: vi.fn(async (key: string) => {
+      const id = key.replace("tenero:price:", "");
+      return prices[id] ?? null;
+    }),
+  } as unknown as KVNamespace;
+}
+
+describe("priceTransfer", () => {
+  it("prices aeUSDC at the $1 peg without a Tenero lookup", async () => {
+    const kv = kvWith({});
+    const p = await priceTransfer(kv, transfer({ asset: "aeusdc", amountRaw: 2_500_000 }), 999);
+    expect(p).toEqual({ amountUsd: 2.5, priceUsd: 1, priceSource: "stablecoin", pricedAt: 999 });
+    expect(kv.get).not.toHaveBeenCalled();
+  });
+
+  it("prices sBTC from the Tenero cache", async () => {
+    const kv = kvWith({ [assetInfoForAsset("sbtc").teneroTokenId]: { priceUsd: 100_000, fetchedAt: 1 } });
+    // 50_000 sats = 0.0005 sBTC * $100,000 = $50
+    const p = await priceTransfer(kv, transfer({ asset: "sbtc", amountRaw: 50_000 }), 999);
+    expect(p.priceSource).toBe("tenero");
+    expect(p.amountUsd).toBeCloseTo(50, 6);
+  });
+
+  it("leaves unpriced when the cache has no price", async () => {
+    const p = await priceTransfer(kvWith({}), transfer({ asset: "stx", amountRaw: 1_000_000 }), 999);
+    expect(p).toEqual({ amountUsd: null, priceUsd: null, priceSource: "none", pricedAt: 999 });
+  });
+});

--- a/lib/earnings/assets.ts
+++ b/lib/earnings/assets.ts
@@ -1,0 +1,74 @@
+/**
+ * Asset detection + decimals + Tenero price-cache key, for the three in-scope
+ * assets (sBTC, STX, aeUSDC). Anything else is ignored by the indexer.
+ */
+
+import { SBTC_CONTRACT_MAINNET } from "../bounty/constants";
+import type { EarningAsset } from "./types";
+
+export interface AssetInfo {
+  asset: EarningAsset;
+  decimals: number;
+  /** Key for getCachedTokenPrice (matches the Tenero static-token-id form). */
+  teneroTokenId: string;
+  /** True → price is the $1 stablecoin peg, no Tenero lookup needed. */
+  stablecoin: boolean;
+}
+
+// sBTC FT asset_identifier is `<contract>::sbtc-token`; the Tenero cache keys
+// sBTC under that same `::`-suffixed form (STATIC_TOKEN_IDS).
+export const SBTC_ASSET_ID = `${SBTC_CONTRACT_MAINNET}::sbtc-token`;
+
+// Only aeUSDC is in scope among stablecoins (not USDA/USDCx/sUSDT). Match by the
+// contract id (the part before `::`), since the asset name after `::` can vary.
+const AEUSDC_CONTRACTS: ReadonlySet<string> = new Set([
+  "SP3K8BC0PPEVCV7NZ6QSRWPQ2JE9E5B6N3PA0KBR9.token-aeusdc",
+  "SP3Y2ZSH8P7D50B0VBTSX11S7XSG24M1VB9YFQA4K.token-aeusdc",
+]);
+
+/** STX native transfers (from Hiro `stx_transfers`). */
+export const STX_ASSET_INFO: AssetInfo = {
+  asset: "stx",
+  decimals: 6,
+  teneroTokenId: "stx",
+  stablecoin: false,
+};
+
+/** Resolve an AssetInfo from our asset enum (for pricing a stored transfer). */
+export function assetInfoForAsset(asset: EarningAsset): AssetInfo {
+  switch (asset) {
+    case "stx":
+      return STX_ASSET_INFO;
+    case "sbtc":
+      return { asset: "sbtc", decimals: 8, teneroTokenId: SBTC_ASSET_ID, stablecoin: false };
+    case "aeusdc":
+      return { asset: "aeusdc", decimals: 6, teneroTokenId: "", stablecoin: true };
+  }
+}
+
+/**
+ * Resolve a Hiro FT `asset_identifier` to one of the three tracked assets, or
+ * null if it isn't one we index.
+ */
+export function assetInfoForFt(assetIdentifier: string): AssetInfo | null {
+  const contractId = assetIdentifier.split("::")[0];
+  if (contractId === SBTC_CONTRACT_MAINNET) {
+    return {
+      asset: "sbtc",
+      decimals: 8,
+      teneroTokenId: SBTC_ASSET_ID,
+      stablecoin: false,
+    };
+  }
+  if (AEUSDC_CONTRACTS.has(contractId)) {
+    return {
+      asset: "aeusdc",
+      decimals: 6,
+      // aeUSDC is priced by the $1 peg, so teneroTokenId is unused; keep the
+      // real id for completeness/debuggability.
+      teneroTokenId: assetIdentifier,
+      stablecoin: true,
+    };
+  }
+  return null;
+}

--- a/lib/earnings/classify.ts
+++ b/lib/earnings/classify.ts
@@ -1,0 +1,70 @@
+/**
+ * Counterparty classification (issue #978, Phase 1).
+ *
+ * Classification is txid-based against our OWN D1 records (not on-chain memos):
+ * a confirmed inbox payment, or a paid bounty whose winner is the recipient.
+ * Falls back to sender-is-a-registered-agent (agent_peer), else unclassified.
+ *
+ * x402_endpoint is intentionally inert: no enumerable x402 payTo catalog exists
+ * (per-agent dynamic payTo), so it cannot be distinguished here. inbox_message +
+ * bounty + agent_peer give the 3 active classifiers the #978 DoD requires.
+ *
+ * NOTE: agent_peer counts every agent→agent inflow as an earning in Phase 1.
+ * The self_funded / ring exclusions land in Phase 2 (anti-gaming) before any of
+ * this is exposed via the public API (Phase 3).
+ */
+
+import type { Classification, InboundTransfer, SourceClass } from "./types";
+
+function earning(
+  sourceClass: SourceClass,
+  sourceSubclass: string | null
+): Classification {
+  return { sourceClass, sourceSubclass, excludedReason: null, isEarning: true };
+}
+
+export async function classifyTransfer(
+  db: D1Database,
+  transfer: InboundTransfer
+): Promise<Classification> {
+  // 1. inbox_message — txid matches a confirmed inbound inbox payment to this agent.
+  const inbox = await db
+    .prepare(
+      `SELECT message_id FROM inbox_messages
+       WHERE payment_txid = ?1 AND payment_status = 'confirmed' AND to_stx_address = ?2
+       LIMIT 1`
+    )
+    .bind(transfer.txId, transfer.recipientAgentStx)
+    .first<{ message_id: string }>();
+  if (inbox) return earning("inbox_message", inbox.message_id);
+
+  // 2. bounty — txid matches a paid bounty whose accepted winner is this agent.
+  const bounty = await db
+    .prepare(
+      `SELECT b.id FROM bounties b
+       JOIN bounty_submissions s ON s.id = b.accepted_submission_id
+       WHERE b.paid_txid = ?1 AND s.submitter_stx_address = ?2
+       LIMIT 1`
+    )
+    .bind(transfer.txId, transfer.recipientAgentStx)
+    .first<{ id: string }>();
+  if (bounty) return earning("bounty", bounty.id);
+
+  // 3. agent_peer — sender is another registered agent.
+  const peer = await db
+    .prepare(`SELECT 1 AS x FROM agents WHERE stx_address = ?1 LIMIT 1`)
+    .bind(transfer.senderStx)
+    .first<{ x: number }>();
+  if (peer) return earning("agent_peer", null);
+
+  // 4. x402_endpoint — inert (no payTo catalog). Skipped.
+
+  // 5. Unmatched → unclassified, excluded from earnings (surfaced for review).
+  //    exchange_or_external requires a seeded known-funder list (Phase 2+).
+  return {
+    sourceClass: "unclassified",
+    sourceSubclass: null,
+    excludedReason: "unclassified",
+    isEarning: false,
+  };
+}

--- a/lib/earnings/constants.ts
+++ b/lib/earnings/constants.ts
@@ -1,0 +1,41 @@
+/**
+ * Earnings indexer constants (issue #978, Phase 1).
+ *
+ * Cost-first defaults: small per-tick slice, bounded backfill, concurrency
+ * under Cloudflare's 6 simultaneous-connection cap. The whole task is gated by
+ * EARNINGS_INDEX_ENABLED so it ships dormant and can be killed instantly.
+ */
+
+/** D1 `competition_state` key holding the round-robin sweep cursor. */
+export const EARNINGS_CURSOR_KEY = "earnings_scheduler_cursor";
+
+/** Agents processed per sweep tick. Small so a tick stays cheap and bounded. */
+export const EARNINGS_MAX_AGENTS_PER_RUN = 25;
+
+/** Concurrent agent fetches. Must stay <= 5 — Cloudflare caps a Worker at 6
+ *  simultaneous outgoing connections waiting for response headers. */
+export const EARNINGS_FETCH_CONCURRENCY = 5;
+
+/** Hiro `transactions_with_transfers` page size. */
+export const EARNINGS_HIRO_PAGE_LIMIT = 50;
+
+/** Max pages walked per agent per tick. Bounds the first-run backfill burst so
+ *  day-one indexing can't spike Hiro usage; deep history fills over many ticks. */
+export const EARNINGS_MAX_PAGES_PER_AGENT = 4;
+
+/** How often the earnings sweep is due (ms). Slower than competition — a 30-day
+ *  board does not need minute freshness, and slower = cheaper. */
+export const EARNINGS_INTERVAL_MS = 30 * 60 * 1000;
+
+/** Source classifications. `is_earning` is derived from these + excluded_reason. */
+export const EARNING_SOURCE_CLASSES = [
+  "inbox_message",
+  "bounty",
+  "x402_endpoint",
+  "agent_peer",
+] as const;
+
+export const EXCLUDED_SOURCE_CLASSES = [
+  "exchange_or_external",
+  "unclassified",
+] as const;

--- a/lib/earnings/d1.ts
+++ b/lib/earnings/d1.ts
@@ -1,0 +1,156 @@
+/**
+ * D1 persistence for the earnings indexer (issue #978, Phase 1).
+ *
+ * - agent_earnings: idempotent INSERT OR IGNORE on (tx_id, event_index).
+ * - earnings_index_state: per-agent high-water mark + backfill progress.
+ * - competition_state: reused for the round-robin sweep cursor.
+ * - registered_wallets: the agent address input set (cursor-paginated).
+ */
+
+import { EARNINGS_CURSOR_KEY } from "./constants";
+import type { EarningRow } from "./types";
+
+export interface IndexState {
+  lastIndexedBlock: number;
+  backfillOffset: number;
+  backfillComplete: boolean;
+}
+
+export async function getIndexState(
+  db: D1Database,
+  agentStx: string
+): Promise<IndexState> {
+  const row = await db
+    .prepare(
+      `SELECT last_indexed_block, backfill_offset, backfill_complete
+       FROM earnings_index_state WHERE agent_stx = ?1`
+    )
+    .bind(agentStx)
+    .first<{
+      last_indexed_block: number;
+      backfill_offset: number;
+      backfill_complete: number;
+    }>();
+  return {
+    lastIndexedBlock: row?.last_indexed_block ?? 0,
+    backfillOffset: row?.backfill_offset ?? 0,
+    backfillComplete: (row?.backfill_complete ?? 0) === 1,
+  };
+}
+
+export async function setIndexState(
+  db: D1Database,
+  agentStx: string,
+  state: IndexState,
+  now: number
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO earnings_index_state
+         (agent_stx, last_indexed_block, backfill_offset, backfill_complete, last_indexed_at)
+       VALUES (?1, ?2, ?3, ?4, ?5)
+       ON CONFLICT(agent_stx) DO UPDATE SET
+         last_indexed_block = excluded.last_indexed_block,
+         backfill_offset    = excluded.backfill_offset,
+         backfill_complete  = excluded.backfill_complete,
+         last_indexed_at    = excluded.last_indexed_at`
+    )
+    .bind(
+      agentStx,
+      state.lastIndexedBlock,
+      state.backfillOffset,
+      state.backfillComplete ? 1 : 0,
+      now
+    )
+    .run();
+}
+
+/** Persist ledger rows; returns inserted vs already-known (idempotent). */
+export async function persistEarningRows(
+  db: D1Database,
+  rows: EarningRow[]
+): Promise<{ inserted: number; alreadyKnown: number }> {
+  if (rows.length === 0) return { inserted: 0, alreadyKnown: 0 };
+
+  const stmt = db.prepare(
+    `INSERT OR IGNORE INTO agent_earnings
+       (tx_id, event_index, stx_block_height, block_time, recipient_agent_stx, sender_stx,
+        asset, amount_raw, amount_usd, price_usd, price_source, priced_at,
+        source_class, source_subclass, excluded_reason, is_earning, indexed_at)
+     VALUES (?1,?2,?3,?4,?5,?6,?7,?8,?9,?10,?11,?12,?13,?14,?15,?16,?17)`
+  );
+
+  const batch = rows.map((r) =>
+    stmt.bind(
+      r.txId,
+      r.eventIndex,
+      r.stxBlockHeight,
+      r.blockTime,
+      r.recipientAgentStx,
+      r.senderStx,
+      r.asset,
+      r.amountRaw,
+      r.amountUsd,
+      r.priceUsd,
+      r.priceSource,
+      r.pricedAt,
+      r.sourceClass,
+      r.sourceSubclass,
+      r.excludedReason,
+      r.isEarning ? 1 : 0,
+      r.indexedAt
+    )
+  );
+
+  const res = await db.batch(batch);
+  // INSERT OR IGNORE: meta.changes is 1 when inserted, 0 when the row already
+  // existed — so the sum is the true insert count.
+  let inserted = 0;
+  for (const r of res) inserted += r.meta?.changes ?? 0;
+  return { inserted, alreadyKnown: rows.length - inserted };
+}
+
+export async function getEarningsCursor(db: D1Database): Promise<string | null> {
+  const row = await db
+    .prepare(`SELECT value FROM competition_state WHERE key = ?1`)
+    .bind(EARNINGS_CURSOR_KEY)
+    .first<{ value: string }>();
+  return row?.value ?? null;
+}
+
+export async function setEarningsCursor(
+  db: D1Database,
+  cursor: string | null
+): Promise<void> {
+  if (cursor === null) {
+    await db
+      .prepare(`DELETE FROM competition_state WHERE key = ?1`)
+      .bind(EARNINGS_CURSOR_KEY)
+      .run();
+    return;
+  }
+  await db
+    .prepare(
+      `INSERT INTO competition_state (key, value, updated_at)
+       VALUES (?1, ?2, unixepoch())
+       ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`
+    )
+    .bind(EARNINGS_CURSOR_KEY, cursor)
+    .run();
+}
+
+/** Next page of agent STX addresses, ordered by stx_address for stable cursoring. */
+export async function fetchAgentPage(
+  db: D1Database,
+  cursor: string | null,
+  limit: number
+): Promise<string[]> {
+  const sql = cursor
+    ? `SELECT stx_address FROM registered_wallets WHERE stx_address > ?1 ORDER BY stx_address ASC LIMIT ?2`
+    : `SELECT stx_address FROM registered_wallets ORDER BY stx_address ASC LIMIT ?1`;
+  const stmt = cursor
+    ? db.prepare(sql).bind(cursor, limit)
+    : db.prepare(sql).bind(limit);
+  const res = await stmt.all<{ stx_address: string }>();
+  return (res.results ?? []).map((r) => r.stx_address);
+}

--- a/lib/earnings/indexer.ts
+++ b/lib/earnings/indexer.ts
@@ -1,0 +1,258 @@
+/**
+ * Earnings sweep orchestrator (issue #978, Phase 1).
+ *
+ * One cron tick: take the next slice of agents (round-robin cursor over
+ * registered_wallets), and for each, either backfill history (bounded
+ * pages/tick) or process only NEW txs since its high-water mark. Classify +
+ * price + idempotently persist. Indexer-only — no agent self-report.
+ *
+ * Gated by EARNINGS_INDEX_ENABLED so it ships dormant and can be killed
+ * instantly. Concurrency is bounded under Cloudflare's 6-connection cap.
+ */
+
+import {
+  EARNINGS_MAX_AGENTS_PER_RUN,
+  EARNINGS_FETCH_CONCURRENCY,
+  EARNINGS_HIRO_PAGE_LIMIT,
+  EARNINGS_MAX_PAGES_PER_AGENT,
+} from "./constants";
+import {
+  fetchTransfersPage,
+  extractInboundTransfers,
+  maxBlockHeight,
+} from "./ingest";
+import { classifyTransfer } from "./classify";
+import { priceTransfer } from "./price";
+import {
+  getIndexState,
+  setIndexState,
+  persistEarningRows,
+  getEarningsCursor,
+  setEarningsCursor,
+  fetchAgentPage,
+} from "./d1";
+import type { EarningRow, EarningsSweepSummary, SourceClass } from "./types";
+import type { Logger } from "../logging";
+
+interface EarningsEnv {
+  DB: D1Database;
+  VERIFIED_AGENTS: KVNamespace;
+  HIRO_API_KEY?: string;
+  EARNINGS_INDEX_ENABLED?: string;
+  DEPLOY_ENV?: string;
+}
+
+interface AgentResult {
+  transfersFound: number;
+  inserted: number;
+  alreadyKnown: number;
+  earningRows: number;
+  excludedRows: number;
+  hiroCalls: number;
+  bySourceClass: Record<SourceClass, number>;
+}
+
+function zeroBySource(): Record<SourceClass, number> {
+  return {
+    inbox_message: 0,
+    bounty: 0,
+    x402_endpoint: 0,
+    agent_peer: 0,
+    exchange_or_external: 0,
+    unclassified: 0,
+  };
+}
+
+async function resolveRow(
+  db: D1Database,
+  kv: KVNamespace,
+  transfer: import("./types").InboundTransfer,
+  now: number
+): Promise<EarningRow> {
+  const classification = await classifyTransfer(db, transfer);
+  const pricing = await priceTransfer(kv, transfer, now);
+  return { ...transfer, ...classification, ...pricing, indexedAt: now };
+}
+
+/** Bounded-concurrency map (caps simultaneous outgoing connections at `n`). */
+async function mapPool<T, R>(
+  items: T[],
+  n: number,
+  fn: (item: T) => Promise<R>
+): Promise<R[]> {
+  const results: R[] = new Array(items.length);
+  let next = 0;
+  async function worker(): Promise<void> {
+    for (;;) {
+      const i = next++;
+      if (i >= items.length) return;
+      results[i] = await fn(items[i]);
+    }
+  }
+  await Promise.all(
+    Array.from({ length: Math.min(n, items.length) }, () => worker())
+  );
+  return results;
+}
+
+async function indexAgent(
+  env: EarningsEnv,
+  agentStx: string,
+  logger: Logger,
+  now: number
+): Promise<AgentResult> {
+  const { DB: db, VERIFIED_AGENTS: kv } = env;
+  const state = await getIndexState(db, agentStx);
+
+  const rows: EarningRow[] = [];
+  let transfersFound = 0;
+  let hiroCalls = 0;
+  let maxBlock = state.lastIndexedBlock;
+  let backfillOffset = state.backfillOffset;
+  let backfillComplete = state.backfillComplete;
+
+  const collect = async (results: Awaited<ReturnType<typeof fetchTransfersPage>>) => {
+    if (!results) return;
+    for (const result of results.results) {
+      const transfers = extractInboundTransfers(result, agentStx);
+      for (const t of transfers) rows.push(await resolveRow(db, kv, t, now));
+      transfersFound += transfers.length;
+    }
+    maxBlock = Math.max(maxBlock, maxBlockHeight(results.results));
+  };
+
+  if (!backfillComplete) {
+    // Backfill: walk older pages from the saved offset, bounded per tick.
+    let offset = backfillOffset;
+    for (let p = 0; p < EARNINGS_MAX_PAGES_PER_AGENT; p++) {
+      const page = await fetchTransfersPage(env, agentStx, offset, EARNINGS_HIRO_PAGE_LIMIT, logger);
+      hiroCalls++;
+      if (!page) break;
+      await collect(page);
+      offset += page.results.length;
+      backfillOffset = offset;
+      if (page.exhausted) {
+        backfillComplete = true;
+        backfillOffset = 0;
+        break;
+      }
+    }
+  } else {
+    // Incremental: page newest-first, stop once we reach already-indexed blocks.
+    let offset = 0;
+    for (let p = 0; p < EARNINGS_MAX_PAGES_PER_AGENT; p++) {
+      const page = await fetchTransfersPage(env, agentStx, offset, EARNINGS_HIRO_PAGE_LIMIT, logger);
+      hiroCalls++;
+      if (!page) break;
+      const reachedKnown = page.results.some(
+        (r) => (r.tx?.block_height ?? 0) <= state.lastIndexedBlock
+      );
+      // Only collect txs strictly newer than the high-water mark.
+      const fresh = {
+        ...page,
+        results: page.results.filter((r) => (r.tx?.block_height ?? 0) > state.lastIndexedBlock),
+      };
+      await collect(fresh);
+      offset += page.results.length;
+      if (reachedKnown || page.exhausted) break;
+    }
+  }
+
+  const { inserted, alreadyKnown } = await persistEarningRows(db, rows);
+  await setIndexState(
+    db,
+    agentStx,
+    { lastIndexedBlock: maxBlock, backfillOffset, backfillComplete },
+    now
+  );
+
+  const bySourceClass = zeroBySource();
+  let earningRows = 0;
+  let excludedRows = 0;
+  for (const r of rows) {
+    bySourceClass[r.sourceClass]++;
+    if (r.isEarning) earningRows++;
+    else excludedRows++;
+  }
+
+  return { transfersFound, inserted, alreadyKnown, earningRows, excludedRows, hiroCalls, bySourceClass };
+}
+
+function emptySummary(enabled: boolean, cursor: string | null): EarningsSweepSummary {
+  return {
+    enabled,
+    agentsScanned: 0,
+    transfersFound: 0,
+    inserted: 0,
+    alreadyKnown: 0,
+    earningRows: 0,
+    excludedRows: 0,
+    hiroCalls: 0,
+    bySourceClass: zeroBySource(),
+    cursor,
+  };
+}
+
+export async function runEarningsSweep(
+  env: EarningsEnv,
+  logger: Logger,
+  now: number = Date.now(),
+  // `force` bypasses the EARNINGS_INDEX_ENABLED gate — used by the admin
+  // refresh endpoint so an operator can verify a sweep without enabling the
+  // always-on cron. The cron path never forces.
+  force: boolean = false
+): Promise<EarningsSweepSummary> {
+  if (!force && env.EARNINGS_INDEX_ENABLED !== "true") {
+    logger.info("earnings.skipped_disabled", {
+      deployEnv: env.DEPLOY_ENV ?? "unset",
+      earningsIndexEnabled: env.EARNINGS_INDEX_ENABLED ?? "unset",
+    });
+    return emptySummary(false, null);
+  }
+
+  const db = env.DB;
+  const cursor = await getEarningsCursor(db);
+  const agents = await fetchAgentPage(db, cursor, EARNINGS_MAX_AGENTS_PER_RUN);
+
+  if (agents.length === 0) {
+    // End of the roster — wrap the cursor back to the start for the next cycle.
+    await setEarningsCursor(db, null);
+    logger.info("earnings.cycle_complete", { fromCursor: cursor });
+    return emptySummary(true, null);
+  }
+
+  const perAgent = await mapPool(agents, EARNINGS_FETCH_CONCURRENCY, (stx) =>
+    indexAgent(env, stx, logger, now)
+  );
+
+  const summary = emptySummary(true, null);
+  summary.agentsScanned = agents.length;
+  for (const r of perAgent) {
+    summary.transfersFound += r.transfersFound;
+    summary.inserted += r.inserted;
+    summary.alreadyKnown += r.alreadyKnown;
+    summary.earningRows += r.earningRows;
+    summary.excludedRows += r.excludedRows;
+    summary.hiroCalls += r.hiroCalls;
+    for (const k of Object.keys(summary.bySourceClass) as SourceClass[]) {
+      summary.bySourceClass[k] += r.bySourceClass[k];
+    }
+  }
+
+  // Advance the cursor; a short page means we hit the end → wrap next tick.
+  const nextCursor =
+    agents.length === EARNINGS_MAX_AGENTS_PER_RUN ? agents[agents.length - 1] : null;
+  await setEarningsCursor(db, nextCursor);
+  summary.cursor = nextCursor;
+
+  logger.info("earnings.sweep_complete", {
+    agentsScanned: summary.agentsScanned,
+    transfersFound: summary.transfersFound,
+    inserted: summary.inserted,
+    earningRows: summary.earningRows,
+    hiroCalls: summary.hiroCalls,
+    cursor: summary.cursor,
+  });
+
+  return summary;
+}

--- a/lib/earnings/indexer.ts
+++ b/lib/earnings/indexer.ts
@@ -15,6 +15,8 @@ import {
   EARNINGS_FETCH_CONCURRENCY,
   EARNINGS_HIRO_PAGE_LIMIT,
   EARNINGS_MAX_PAGES_PER_AGENT,
+  EARNING_SOURCE_CLASSES,
+  EXCLUDED_SOURCE_CLASSES,
 } from "./constants";
 import {
   fetchTransfersPage,
@@ -31,7 +33,12 @@ import {
   setEarningsCursor,
   fetchAgentPage,
 } from "./d1";
-import type { EarningRow, EarningsSweepSummary, SourceClass } from "./types";
+import type {
+  EarningRow,
+  EarningsSweepSummary,
+  InboundTransfer,
+  SourceClass,
+} from "./types";
 import type { Logger } from "../logging";
 
 interface EarningsEnv {
@@ -52,25 +59,27 @@ interface AgentResult {
   bySourceClass: Record<SourceClass, number>;
 }
 
+// Derived from the source-class constants so a new class added in a later
+// phase is counted automatically instead of being silently dropped.
 function zeroBySource(): Record<SourceClass, number> {
-  return {
-    inbox_message: 0,
-    bounty: 0,
-    x402_endpoint: 0,
-    agent_peer: 0,
-    exchange_or_external: 0,
-    unclassified: 0,
-  };
+  const out = {} as Record<SourceClass, number>;
+  for (const c of [...EARNING_SOURCE_CLASSES, ...EXCLUDED_SOURCE_CLASSES]) {
+    out[c] = 0;
+  }
+  return out;
 }
 
 async function resolveRow(
   db: D1Database,
   kv: KVNamespace,
-  transfer: import("./types").InboundTransfer,
+  transfer: InboundTransfer,
   now: number
 ): Promise<EarningRow> {
-  const classification = await classifyTransfer(db, transfer);
-  const pricing = await priceTransfer(kv, transfer, now);
+  // Classification (D1 reads) and pricing (KV read) are independent — overlap them.
+  const [classification, pricing] = await Promise.all([
+    classifyTransfer(db, transfer),
+    priceTransfer(kv, transfer, now),
+  ]);
   return { ...transfer, ...classification, ...pricing, indexedAt: now };
 }
 

--- a/lib/earnings/ingest.ts
+++ b/lib/earnings/ingest.ts
@@ -1,0 +1,161 @@
+/**
+ * Hiro ingestion (issue #978, Phase 1).
+ *
+ * Uses `/extended/v1/address/{principal}/transactions_with_transfers`, which
+ * returns each tx WITH its stx + ft transfers inline — so one call per page
+ * yields every inbound transfer with sender/amount/asset, no per-tx detail
+ * fetch and no memo parsing. That roughly halves Hiro calls vs the
+ * list-then-fetch-each-tx pattern.
+ */
+
+import { stacksApiFetch, buildHiroHeaders } from "../stacks-api-fetch";
+import { STACKS_API_BASE } from "../identity/constants";
+import { assetInfoForFt, STX_ASSET_INFO, type AssetInfo } from "./assets";
+import type { InboundTransfer } from "./types";
+import type { Logger } from "../logging";
+
+interface HiroTransfer {
+  amount?: string;
+  sender?: string;
+  recipient?: string;
+  asset_identifier?: string; // ft transfers only
+}
+
+interface HiroTxWithTransfers {
+  tx?: {
+    tx_id?: string;
+    tx_status?: string;
+    block_height?: number;
+    burn_block_time?: number;
+    is_unanchored?: boolean;
+  };
+  stx_transfers?: HiroTransfer[];
+  ft_transfers?: HiroTransfer[];
+}
+
+export interface TransfersPage {
+  results: HiroTxWithTransfers[];
+  total: number;
+  /** True when this is the last page (results < limit or end reached). */
+  exhausted: boolean;
+}
+
+/** Fetch one page of an address's transactions-with-transfers. Returns null on
+ *  a failed request (caller treats as "no progress this tick"). */
+export async function fetchTransfersPage(
+  env: { HIRO_API_KEY?: string },
+  stxAddress: string,
+  offset: number,
+  limit: number,
+  logger?: Logger
+): Promise<TransfersPage | null> {
+  const url =
+    `${STACKS_API_BASE}/extended/v1/address/${encodeURIComponent(stxAddress)}` +
+    `/transactions_with_transfers?limit=${limit}&offset=${offset}`;
+  let res: Response;
+  try {
+    res = await stacksApiFetch(
+      url,
+      { method: "GET", headers: buildHiroHeaders(env.HIRO_API_KEY) },
+      { logger }
+    );
+  } catch (err) {
+    logger?.warn("earnings.hiro_fetch_threw", { stxAddress, offset, error: String(err) });
+    return null;
+  }
+  if (!res.ok) {
+    logger?.warn("earnings.hiro_page_failed", { stxAddress, offset, status: res.status });
+    return null;
+  }
+  const body = (await res.json()) as {
+    total?: number;
+    results?: HiroTxWithTransfers[];
+  };
+  const results = body.results ?? [];
+  const total = typeof body.total === "number" ? body.total : 0;
+  return {
+    results,
+    total,
+    exhausted: results.length < limit || offset + results.length >= total,
+  };
+}
+
+function parseAmount(raw: string | undefined): number | null {
+  if (!raw) return null;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0 || !Number.isInteger(n)) return null;
+  return n;
+}
+
+function makeTransfer(
+  txId: string,
+  eventIndex: number,
+  sender: string,
+  recipient: string,
+  info: AssetInfo,
+  amountRaw: number,
+  blockHeight: number | null,
+  blockTime: number
+): InboundTransfer {
+  return {
+    txId,
+    eventIndex,
+    senderStx: sender,
+    recipientAgentStx: recipient,
+    asset: info.asset,
+    amountRaw,
+    stxBlockHeight: blockHeight,
+    blockTime,
+  };
+}
+
+/**
+ * Extract the inbound (recipient = agent, sender ≠ agent) sBTC / STX / aeUSDC
+ * transfers from one confirmed tx. `event_index` is the position within the
+ * combined [stx_transfers…, ft_transfers…] list, so it's stable across re-runs
+ * (the idempotency key is (tx_id, event_index)).
+ */
+export function extractInboundTransfers(
+  result: HiroTxWithTransfers,
+  agentStx: string
+): InboundTransfer[] {
+  const tx = result.tx;
+  if (!tx || tx.tx_id == null) return [];
+  if (tx.tx_status !== "success") return [];
+  if (tx.is_unanchored === true) return []; // microblock — wait for anchor
+  const blockTime = typeof tx.burn_block_time === "number" ? tx.burn_block_time : 0;
+  if (blockTime <= 0) return [];
+  const blockHeight = typeof tx.block_height === "number" ? tx.block_height : null;
+
+  const out: InboundTransfer[] = [];
+  let idx = 0;
+
+  for (const t of result.stx_transfers ?? []) {
+    const amt = parseAmount(t.amount);
+    if (t.recipient === agentStx && t.sender && t.sender !== agentStx && amt && amt > 0) {
+      out.push(makeTransfer(tx.tx_id, idx, t.sender, agentStx, STX_ASSET_INFO, amt, blockHeight, blockTime));
+    }
+    idx++;
+  }
+
+  for (const t of result.ft_transfers ?? []) {
+    const info = t.asset_identifier ? assetInfoForFt(t.asset_identifier) : null;
+    const amt = parseAmount(t.amount);
+    if (info && t.recipient === agentStx && t.sender && t.sender !== agentStx && amt && amt > 0) {
+      out.push(makeTransfer(tx.tx_id, idx, t.sender, agentStx, info, amt, blockHeight, blockTime));
+    }
+    idx++;
+  }
+
+  return out;
+}
+
+/** Highest stx block height among a page's successful txs (for the HWM). */
+export function maxBlockHeight(results: HiroTxWithTransfers[]): number {
+  let max = 0;
+  for (const r of results) {
+    const h = r.tx?.block_height;
+    if (typeof h === "number" && h > max) max = h;
+  }
+  return max;
+}

--- a/lib/earnings/price.ts
+++ b/lib/earnings/price.ts
@@ -1,0 +1,47 @@
+/**
+ * Index-time USD pricing (issue #978, Phase 1).
+ *
+ * Tenero serves spot prices only (no historical endpoint), so we price at index
+ * time and persist price_usd + price_source alongside the raw amount. Because
+ * the indexer runs continuously over recent txs, index-time ≈ tx-time. aeUSDC
+ * uses the $1 peg; sBTC/STX read the Tenero KV cache (which itself holds the
+ * last-good value for 24h). Unpriceable transfers are stored with amount_usd
+ * NULL and repriced on a later pass.
+ */
+
+import { getCachedTokenPrice } from "../external/tenero/kv-cache";
+import { assetInfoForAsset, type AssetInfo } from "./assets";
+import type { InboundTransfer, Pricing } from "./types";
+
+function finalize(
+  transfer: InboundTransfer,
+  assetInfo: AssetInfo,
+  priceUsd: number,
+  priceSource: Pricing["priceSource"],
+  now: number
+): Pricing {
+  const amountUsd =
+    (transfer.amountRaw / Math.pow(10, assetInfo.decimals)) * priceUsd;
+  return { amountUsd, priceUsd, priceSource, pricedAt: now };
+}
+
+export async function priceTransfer(
+  kv: KVNamespace,
+  transfer: InboundTransfer,
+  now: number
+): Promise<Pricing> {
+  const assetInfo = assetInfoForAsset(transfer.asset);
+
+  // aeUSDC → $1 peg, no Tenero lookup.
+  if (assetInfo.stablecoin) {
+    return finalize(transfer, assetInfo, 1, "stablecoin", now);
+  }
+
+  const cached = await getCachedTokenPrice(kv, assetInfo.teneroTokenId);
+  if (cached && typeof cached.priceUsd === "number" && Number.isFinite(cached.priceUsd)) {
+    return finalize(transfer, assetInfo, cached.priceUsd, "tenero", now);
+  }
+
+  // No price available (cache miss, or Tenero confirmed-null). Leave unpriced.
+  return { amountUsd: null, priceUsd: null, priceSource: "none", pricedAt: now };
+}

--- a/lib/earnings/types.ts
+++ b/lib/earnings/types.ts
@@ -1,0 +1,74 @@
+/**
+ * Earnings indexer types (issue #978, Phase 1).
+ */
+
+export type EarningAsset = "sbtc" | "stx" | "aeusdc";
+
+export type SourceClass =
+  | "inbox_message"
+  | "bounty"
+  | "x402_endpoint"
+  | "agent_peer"
+  | "exchange_or_external"
+  | "unclassified";
+
+export type ExcludedReason =
+  | "self_funded"
+  | "ring"
+  | "external"
+  | "unclassified"
+  | "excluded_manual";
+
+export type PriceSource = "tenero" | "stablecoin" | "last_good" | "none";
+
+/** One confirmed inbound transfer to an agent, as read from Hiro. */
+export interface InboundTransfer {
+  txId: string;
+  /** Index of this transfer within the tx (stx + ft transfers, stable order). */
+  eventIndex: number;
+  senderStx: string;
+  recipientAgentStx: string;
+  asset: EarningAsset;
+  amountRaw: number;
+  stxBlockHeight: number | null;
+  /** Unix seconds. */
+  blockTime: number;
+}
+
+/** Classification result layered onto an InboundTransfer. */
+export interface Classification {
+  sourceClass: SourceClass;
+  sourceSubclass: string | null;
+  excludedReason: ExcludedReason | null;
+  isEarning: boolean;
+}
+
+/** Pricing result layered onto an InboundTransfer. */
+export interface Pricing {
+  amountUsd: number | null;
+  priceUsd: number | null;
+  priceSource: PriceSource;
+  pricedAt: number;
+}
+
+/** A fully-resolved ledger row ready to persist to `agent_earnings`. */
+export interface EarningRow
+  extends InboundTransfer,
+    Classification,
+    Pricing {
+  indexedAt: number;
+}
+
+/** Per-tick summary, surfaced in the scheduler status like the competition sweep. */
+export interface EarningsSweepSummary {
+  enabled: boolean;
+  agentsScanned: number;
+  transfersFound: number;
+  inserted: number;
+  alreadyKnown: number;
+  earningRows: number;
+  excludedRows: number;
+  hiroCalls: number;
+  bySourceClass: Record<SourceClass, number>;
+  cursor: string | null;
+}

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -29,6 +29,9 @@ import {
   runCompetitionScheduler,
   type CompetitionSchedulerSummary,
 } from "../competition/scheduler";
+import { runEarningsSweep } from "../earnings/indexer";
+import { EARNINGS_INTERVAL_MS } from "../earnings/constants";
+import type { EarningsSweepSummary } from "../earnings/types";
 import type { Logger } from "../logging";
 import type {
   SchedulerStatus,
@@ -36,14 +39,15 @@ import type {
   SchedulerTask,
 } from "./rpc-types";
 
-// Cadences. The cron fires every TENERO_INTERVAL_MS; competition is gated
-// to its longer interval via a last-run check (mirrors the old DO alarm).
+// Cadences. The cron fires every TENERO_INTERVAL_MS; competition + earnings are
+// gated to their longer intervals via a last-run check (mirrors the old DO alarm).
 export const TENERO_INTERVAL_MS = 5 * 60 * 1000;
 export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
 
 // KV keys (VERIFIED_AGENTS namespace).
 const K_TENERO = "scheduler:tenero";
 const K_COMPETITION = "scheduler:competition";
+const K_EARNINGS = "scheduler:earnings";
 const K_PAUSED = "scheduler:paused-until";
 
 interface TeneroState {
@@ -58,6 +62,11 @@ interface CompetitionState {
   lastRunAt: number;
   result: CompetitionSchedulerSummary;
   consecutiveFailures: number;
+}
+
+interface EarningsState {
+  lastRunAt: number;
+  result: EarningsSweepSummary;
 }
 
 async function readJson<T>(kv: KVNamespace, key: string): Promise<T | null> {
@@ -198,6 +207,33 @@ export async function runCompetitionNow(
   return result;
 }
 
+/**
+ * Run one earnings indexer sweep and persist its result to KV. Gated internally
+ * by EARNINGS_INDEX_ENABLED (returns a disabled summary when off); the cursor
+ * lives in D1 so it resumes across ticks. `lastRunAt` is persisted whether or
+ * not the indexer is enabled, so the slow cadence is respected even while dormant.
+ */
+export async function runEarningsNow(
+  env: CloudflareEnv,
+  parentLogger: Logger,
+  // `force` bypasses the EARNINGS_INDEX_ENABLED gate (operator-triggered admin
+  // refresh). The cron tick calls without force, respecting the gate.
+  force: boolean = false
+): Promise<EarningsSweepSummary> {
+  const logger = parentLogger.child
+    ? parentLogger.child({ task: "earnings" })
+    : parentLogger;
+
+  const result = await runEarningsSweep(env, logger, Date.now(), force);
+
+  await env.VERIFIED_AGENTS.put(
+    K_EARNINGS,
+    JSON.stringify({ lastRunAt: Date.now(), result } satisfies EarningsState)
+  );
+
+  return result;
+}
+
 // ─────────────────────────── cron entry point ───────────────────────────
 
 /**
@@ -223,9 +259,10 @@ export async function runScheduledTasks(
     return;
   }
 
-  const [tenero, competition] = await Promise.all([
+  const [tenero, competition, earnings] = await Promise.all([
     readJson<TeneroState>(kv, K_TENERO),
     readJson<CompetitionState>(kv, K_COMPETITION),
+    readJson<EarningsState>(kv, K_EARNINGS),
   ]);
 
   // Tenero — every tick, unless inside a rate-limit backoff window.
@@ -268,6 +305,26 @@ export async function runScheduledTasks(
       lastRunAt: competition?.lastRunAt ?? null,
     });
   }
+
+  // Earnings indexer — on its slow cadence. Internally gated by
+  // EARNINGS_INDEX_ENABLED, so this is a single no-op log while dormant.
+  const earningsDue =
+    (earnings?.lastRunAt ?? 0) + EARNINGS_INTERVAL_MS <= now + 1_000;
+  if (earningsDue) {
+    try {
+      await runEarningsNow(env, logger);
+    } catch (error) {
+      logger.error("scheduler.earnings_unexpected_error", {
+        error: String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+      await bumpFailure(kv, K_EARNINGS);
+    }
+  } else {
+    logger.debug("scheduler.earnings_not_due", {
+      lastRunAt: earnings?.lastRunAt ?? null,
+    });
+  }
 }
 
 async function bumpFailure(kv: KVNamespace, key: string): Promise<void> {
@@ -282,9 +339,10 @@ async function bumpFailure(kv: KVNamespace, key: string): Promise<void> {
 export async function readSchedulerStatus(
   kv: KVNamespace
 ): Promise<SchedulerStatus> {
-  const [tenero, competition, pausedUntil] = await Promise.all([
+  const [tenero, competition, earnings, pausedUntil] = await Promise.all([
     readJson<TeneroState>(kv, K_TENERO),
     readJson<CompetitionState>(kv, K_COMPETITION),
+    readJson<EarningsState>(kv, K_EARNINGS),
     getPausedUntil(kv),
   ]);
 
@@ -295,6 +353,8 @@ export async function readSchedulerStatus(
     lastTeneroResult: tenero?.result ?? null,
     lastCompetitionRunAt: competition?.lastRunAt ?? null,
     lastCompetitionResult: competition?.result ?? null,
+    lastEarningsRunAt: earnings?.lastRunAt ?? null,
+    lastEarningsResult: earnings?.result ?? null,
     consecutiveFailures: {
       tenero: tenero?.consecutiveFailures ?? 0,
       competition: competition?.consecutiveFailures ?? 0,
@@ -320,6 +380,10 @@ export async function refreshScheduler(
   }
   if (task === "competition" || task === "all") {
     out.competition = await runCompetitionNow(env, logger);
+  }
+  if (task === "earnings" || task === "all") {
+    // Operator-triggered: force past the dormant gate so a sweep can be verified.
+    out.earnings = await runEarningsNow(env, logger, true);
   }
   return out;
 }

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -67,6 +67,9 @@ interface CompetitionState {
 interface EarningsState {
   lastRunAt: number;
   result: EarningsSweepSummary;
+  // Set by bumpFailure() on a thrown sweep; cleared when runEarningsNow()
+  // overwrites the blob on the next successful run.
+  consecutiveFailures?: number;
 }
 
 async function readJson<T>(kv: KVNamespace, key: string): Promise<T | null> {
@@ -224,11 +227,12 @@ export async function runEarningsNow(
     ? parentLogger.child({ task: "earnings" })
     : parentLogger;
 
-  const result = await runEarningsSweep(env, logger, Date.now(), force);
+  const startedAt = Date.now();
+  const result = await runEarningsSweep(env, logger, startedAt, force);
 
   await env.VERIFIED_AGENTS.put(
     K_EARNINGS,
-    JSON.stringify({ lastRunAt: Date.now(), result } satisfies EarningsState)
+    JSON.stringify({ lastRunAt: startedAt, result } satisfies EarningsState)
   );
 
   return result;
@@ -358,6 +362,7 @@ export async function readSchedulerStatus(
     consecutiveFailures: {
       tenero: tenero?.consecutiveFailures ?? 0,
       competition: competition?.consecutiveFailures ?? 0,
+      earnings: earnings?.consecutiveFailures ?? 0,
     },
     nextRunAfter: {
       tenero: tenero?.nextRunAfter ?? null,

--- a/lib/scheduler/rpc-types.ts
+++ b/lib/scheduler/rpc-types.ts
@@ -17,7 +17,7 @@ export interface SchedulerStatus {
   lastCompetitionResult: CompetitionSchedulerSummary | null;
   lastEarningsRunAt: number | null;
   lastEarningsResult: EarningsSweepSummary | null;
-  consecutiveFailures: { tenero: number; competition: number };
+  consecutiveFailures: { tenero: number; competition: number; earnings: number };
   nextRunAfter: { tenero: number | null; competition: number | null };
   // Always null under cron scheduling (no self-scheduled DO alarm); kept
   // for status-shape stability.

--- a/lib/scheduler/rpc-types.ts
+++ b/lib/scheduler/rpc-types.ts
@@ -4,8 +4,9 @@
 // for the admin status/refresh endpoint.
 import type { TeneroRunResult } from "./tenero-task";
 import type { CompetitionSchedulerSummary } from "../competition/scheduler";
+import type { EarningsSweepSummary } from "../earnings/types";
 
-export type SchedulerTask = "tenero" | "competition" | "all";
+export type SchedulerTask = "tenero" | "competition" | "earnings" | "all";
 
 export interface SchedulerStatus {
   now: number;
@@ -14,6 +15,8 @@ export interface SchedulerStatus {
   lastTeneroResult: TeneroRunResult | null;
   lastCompetitionRunAt: number | null;
   lastCompetitionResult: CompetitionSchedulerSummary | null;
+  lastEarningsRunAt: number | null;
+  lastEarningsResult: EarningsSweepSummary | null;
   consecutiveFailures: { tenero: number; competition: number };
   nextRunAfter: { tenero: number | null; competition: number | null };
   // Always null under cron scheduling (no self-scheduled DO alarm); kept
@@ -24,4 +27,5 @@ export interface SchedulerStatus {
 export interface SchedulerRefreshResult {
   tenero?: TeneroRunResult;
   competition?: CompetitionSchedulerSummary;
+  earnings?: EarningsSweepSummary;
 }

--- a/migrations/020_agent_earnings.sql
+++ b/migrations/020_agent_earnings.sql
@@ -1,0 +1,64 @@
+-- Migration 020: agent earnings ledger (Phase 1 — schema + indexer core)
+--
+-- Verified on-chain earnings ledger (issue #978). A cron-driven indexer scans
+-- confirmed inbound transfers (sBTC / STX / aeUSDC) to every registered agent
+-- STX address, classifies each by counterparty, prices it in USD at index time,
+-- and writes an idempotent line-item ledger here.
+--
+-- Phase 1 scope: agent_earnings (the ledger) + earnings_index_state (per-agent
+-- high-water mark). Anti-gaming tables (address_first_funder,
+-- earnings_manual_override) land in Phase 2; the agent_earnings.excluded_reason
+-- column already exists so Phase 2 can flag rows without a schema change.
+--
+-- See docs/earnings-ledger-architecture.md.
+
+-- ── The ledger ───────────────────────────────────────────────────────────
+-- One row per inbound transfer event. Idempotent on (tx_id, event_index): a
+-- single tx can carry multiple FT/STX transfers, each indexed separately.
+CREATE TABLE IF NOT EXISTS agent_earnings (
+  tx_id               TEXT    NOT NULL,
+  event_index         INTEGER NOT NULL DEFAULT 0,
+  stx_block_height    INTEGER,
+  block_time          INTEGER NOT NULL,            -- unix seconds (burn block time)
+  recipient_agent_stx TEXT    NOT NULL,            -- the earner (FK agents.stx_address)
+  sender_stx          TEXT    NOT NULL,            -- counterparty
+  asset               TEXT    NOT NULL CHECK (asset IN ('sbtc', 'stx', 'aeusdc')),
+  amount_raw          INTEGER NOT NULL,            -- base units (sats / microSTX / 1e-6 aeUSDC)
+  amount_usd          REAL,                        -- nullable until priced
+  price_usd           REAL,
+  price_source        TEXT    CHECK (price_source IN ('tenero', 'stablecoin', 'last_good', 'none') OR price_source IS NULL),
+  priced_at           INTEGER,
+  source_class        TEXT    NOT NULL CHECK (source_class IN (
+                        'inbox_message', 'bounty', 'x402_endpoint', 'agent_peer',
+                        'exchange_or_external', 'unclassified')),
+  source_subclass     TEXT,                        -- e.g. bounty id, inbox message id
+  excluded_reason     TEXT    CHECK (excluded_reason IN (
+                        'self_funded', 'ring', 'external', 'unclassified', 'excluded_manual')
+                        OR excluded_reason IS NULL),
+  is_earning          INTEGER NOT NULL DEFAULT 0,  -- derived & stored for fast agg/index
+  indexed_at          INTEGER NOT NULL,
+  PRIMARY KEY (tx_id, event_index)
+);
+
+-- Per-agent rollup window scans (7d/30d/lifetime) and per-agent line-item reads.
+CREATE INDEX IF NOT EXISTS idx_agent_earnings_recipient_time
+  ON agent_earnings (recipient_agent_stx, block_time);
+
+-- Leaderboard / platform aggregate scans only ever touch earning rows.
+CREATE INDEX IF NOT EXISTS idx_agent_earnings_earning_time
+  ON agent_earnings (block_time) WHERE is_earning = 1;
+
+-- Review queue for excluded / unclassified rows (Phase 2 tagging).
+CREATE INDEX IF NOT EXISTS idx_agent_earnings_excluded
+  ON agent_earnings (source_class) WHERE excluded_reason IS NOT NULL;
+
+-- ── Per-agent high-water mark ────────────────────────────────────────────
+-- Lets the sweep process only NEW transfers since each agent's last indexed
+-- block, so steady-state cost decays to the rate of new on-chain activity.
+CREATE TABLE IF NOT EXISTS earnings_index_state (
+  agent_stx          TEXT    PRIMARY KEY,
+  last_indexed_block INTEGER NOT NULL DEFAULT 0,   -- highest stx block height indexed (incremental frontier)
+  backfill_offset    INTEGER NOT NULL DEFAULT 0,   -- pagination offset for the initial history walk
+  backfill_complete  INTEGER NOT NULL DEFAULT 0,   -- 1 once the initial history walk finishes
+  last_indexed_at    INTEGER
+);


### PR DESCRIPTION
Phase 1 of the verified earnings ledger (#978): the backend indexer core. Builds on the Phase 0 cron scheduler. **Ships dormant** — zero behaviour change until explicitly enabled.

## What's here
A cron-driven, **indexer-only** sweep (no agent self-report) that scans confirmed inbound **sBTC / STX / aeUSDC** transfers to every registered agent, classifies by counterparty, prices in USD at index time, and writes an idempotent line-item ledger.

| Area | File(s) |
|---|---|
| Schema | `migrations/020_agent_earnings.sql` — `agent_earnings` (PK `tx_id,event_index`) + `earnings_index_state` (HWM + backfill offset) |
| Ingest | `lib/earnings/ingest.ts` — Hiro `transactions_with_transfers` (inline transfers → **no per-tx detail fetch, no memo parsing**) |
| Classify | `lib/earnings/classify.ts` — **txid-matched against our own D1**: `inbox_messages.payment_txid` (confirmed) / `bounties.paid_txid` (winner) / `agents` (peer) |
| Price | `lib/earnings/price.ts` — Tenero cache for sBTC/STX, `$1` peg for aeUSDC, index-time |
| Persist | `lib/earnings/d1.ts` — `INSERT OR IGNORE`, per-agent state, cursor |
| Orchestrate | `lib/earnings/indexer.ts` — cursor sweep, per-agent backfill→incremental, concurrency 5 |
| Wire-in | `lib/scheduler/cron-runner.ts` — `runEarningsNow()` on a 30-min cadence + admin status/refresh |

## Cost controls (the whole point)
- **Per-agent high-water mark** → zero Hiro calls for an agent with nothing new.
- **`transactions_with_transfers`** → ~half the Hiro calls of list-then-fetch-each-tx.
- **Bounded backfill** (4 pages/agent/tick), **slice 25 agents/tick**, **concurrency ≤5** (under CF's 6-connection cap).
- **Idempotent writes**; read-time aggregation + edge cache come in Phase 3.
- **Ships dormant behind `EARNINGS_INDEX_ENABLED`** — merge + deploy do nothing; flip on when you're watching the bill, flip off instantly to kill.

## Classifiers
`x402_endpoint` is **inert** — confirmed there's no enumerable x402 payTo catalog (per-agent dynamic payTo). The 3 active classifiers **inbox_message + bounty + agent_peer** meet the #978 DoD (≥3). Anti-gaming (`self_funded`/`ring`) is Phase 2; the `excluded_reason` column already exists so it's a data change, not a schema change.

## Deploy / verify steps
1. Merge → deploys dormant (no behaviour change).
2. Apply the D1 migration: `wrangler d1 migrations apply landing-page --remote` (tables are `IF NOT EXISTS`, idempotent).
3. **Verify without enabling the cron:** `POST /api/admin/scheduler?action=refresh&task=earnings` — force-runs one sweep past the gate and returns the summary (agentsScanned / transfersFound / inserted / earningRows / bySourceClass).
4. When happy, enable the cron: set `EARNINGS_INDEX_ENABLED=true` and deploy.

## Tests / checks
`tsc` clean, `next lint` clean, full vitest **1495 passing** (+13 new in `lib/earnings/__tests__/earnings.test.ts` covering asset mapping, inbound extraction/event-index stability, all 4 classifier branches, and pricing incl. the $1 peg + unpriced fallback).

Part of #978. Next: Phase 2 (anti-gaming) → Phase 3 (public API) → Phase 4 (UI).