### PR TITLE
feat(earnings): Phase 2 anti-gaming — first-funder, ring, alt-address (#978)

### DIFF
--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -365,8 +365,13 @@ would multiply Hiro calls by the cadence with no freshness benefit for a 30-day 
   gate). **Indexer-only — no agent-submit/self-report path.** **x402 catalog confirmed
   absent** (per-agent dynamic payTo, no registry) → `x402_endpoint` is inert; the 3
   active classifiers are **inbox_message + bounty + agent_peer** (meets the DoD ≥3).
-- **Phase 2 — Full anti-gaming.** first-funder cache + self-fund exclusion, two-hop
-  ring, alt-address, manual override.
+- **Phase 2 — Full anti-gaming. DONE.** `migration 021` (`address_first_funder` cache
+  + `earnings_manual_override`); `lib/earnings/anti-gaming.ts` — manual override,
+  alt-address (shared `owner`), self-funded (shared first-funder, cached forever),
+  two-hop ring (`A→B→A` ≤14d, similar amount, flips both legs). Runs only on
+  `agent_peer` earnings, wired into the indexer's `resolveRow`. Known limit: a ring
+  whose two legs land in the *same* sweep tick isn't caught (the reverse leg isn't
+  persisted yet); cross-tick rings are.
 - **Reprice pass (Phase 3 scope).** Phase 1 stores `amount_usd = NULL`,
   `price_source = 'none'` for transfers indexed during a Tenero gap. There is **no
   reprice task yet** — add one in Phase 3 (a bounded sweep over `price_source = 'none'`

--- a/lib/earnings/__tests__/anti-gaming.test.ts
+++ b/lib/earnings/__tests__/anti-gaming.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, vi } from "vitest";
+import { applyAntiGaming } from "../anti-gaming";
+import type { Classification, InboundTransfer } from "../types";
+
+const SENDER = "SP_SENDER";
+const RECIPIENT = "SP_RECIPIENT";
+
+const noopLogger = {
+  info: vi.fn(),
+  warn: vi.fn(),
+  error: vi.fn(),
+  debug: vi.fn(),
+} as unknown as import("../../logging").Logger;
+
+function transfer(overrides: Partial<InboundTransfer> = {}): InboundTransfer {
+  return {
+    txId: "0xtx",
+    eventIndex: 0,
+    senderStx: SENDER,
+    recipientAgentStx: RECIPIENT,
+    asset: "sbtc",
+    amountRaw: 1000,
+    stxBlockHeight: 100,
+    blockTime: 1_000_000,
+    ...overrides,
+  };
+}
+
+const peerEarning: Classification = {
+  sourceClass: "agent_peer",
+  sourceSubclass: null,
+  excludedReason: null,
+  isEarning: true,
+};
+
+interface DbConfig {
+  override?: { action: string; new_source_class: string | null } | null;
+  sameOwner?: boolean;
+  firstFunder?: Record<string, string>;
+  reverseLeg?: { tx_id: string; event_index: number } | null;
+  onUpdate?: () => void;
+}
+
+function makeDb(config: DbConfig) {
+  return {
+    prepare: (sql: string) => ({
+      bind: (...args: unknown[]) => ({
+        first: async () => {
+          if (sql.includes("earnings_manual_override")) return config.override ?? null;
+          if (sql.includes("JOIN agents")) return config.sameOwner ? { x: 1 } : null;
+          if (sql.includes("address_first_funder")) {
+            const addr = args[0] as string;
+            const f = config.firstFunder?.[addr];
+            return f
+              ? { first_funder_stx: f, lookup_status: "ok", fetched_at: 0 }
+              : { first_funder_stx: null, lookup_status: "none", fetched_at: 0 };
+          }
+          if (sql.includes("FROM agent_earnings")) return config.reverseLeg ?? null;
+          return null;
+        },
+        run: async () => {
+          if (sql.startsWith("UPDATE agent_earnings")) config.onUpdate?.();
+          return { meta: { changes: 1 } };
+        },
+      }),
+    }),
+  } as unknown as D1Database;
+}
+
+function env(db: D1Database) {
+  return { DB: db, VERIFIED_AGENTS: {} as KVNamespace, HIRO_API_KEY: undefined };
+}
+
+describe("applyAntiGaming — manual override", () => {
+  it("exclude forces excluded_manual", async () => {
+    const db = makeDb({ override: { action: "exclude", new_source_class: null } });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toMatchObject({ excludedReason: "excluded_manual", isEarning: false });
+  });
+
+  it("include forces an earning even on a non-earning input", async () => {
+    const db = makeDb({ override: { action: "include", new_source_class: null } });
+    const excluded: Classification = { ...peerEarning, isEarning: false, excludedReason: "unclassified" };
+    const c = await applyAntiGaming(env(db), transfer(), excluded, 0, noopLogger);
+    expect(c).toMatchObject({ excludedReason: null, isEarning: true });
+  });
+
+  it("reclassify to an earning class", async () => {
+    const db = makeDb({ override: { action: "reclassify", new_source_class: "bounty" } });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toMatchObject({ sourceClass: "bounty", isEarning: true });
+  });
+});
+
+describe("applyAntiGaming — heuristics (agent_peer only)", () => {
+  it("passes a non-agent_peer earning through untouched", async () => {
+    const db = makeDb({ sameOwner: true }); // would exclude if it ran
+    const inbox: Classification = { sourceClass: "inbox_message", sourceSubclass: "m1", excludedReason: null, isEarning: true };
+    const c = await applyAntiGaming(env(db), transfer(), inbox, 0, noopLogger);
+    expect(c).toEqual(inbox);
+  });
+
+  it("excludes when sender + recipient share an owner (alt-address)", async () => {
+    const db = makeDb({ sameOwner: true });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toMatchObject({ excludedReason: "self_funded", isEarning: false });
+  });
+
+  it("excludes when sender + recipient share a first-funder", async () => {
+    const db = makeDb({ firstFunder: { [SENDER]: "SP_FUNDER", [RECIPIENT]: "SP_FUNDER" } });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toMatchObject({ excludedReason: "self_funded", isEarning: false });
+  });
+
+  it("does NOT exclude when first-funders differ", async () => {
+    const db = makeDb({ firstFunder: { [SENDER]: "SP_A", [RECIPIENT]: "SP_B" } });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toEqual(peerEarning);
+  });
+
+  it("excludes a ring and flags the reverse leg", async () => {
+    const onUpdate = vi.fn();
+    const db = makeDb({ reverseLeg: { tx_id: "0xreverse", event_index: 2 }, onUpdate });
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toMatchObject({ excludedReason: "ring", isEarning: false });
+    expect(onUpdate).toHaveBeenCalledOnce();
+  });
+
+  it("passes a clean agent_peer earning through", async () => {
+    const db = makeDb({}); // no override, no shared owner, no funders, no reverse leg
+    const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
+    expect(c).toEqual(peerEarning);
+  });
+});

--- a/lib/earnings/__tests__/anti-gaming.test.ts
+++ b/lib/earnings/__tests__/anti-gaming.test.ts
@@ -39,6 +39,8 @@ interface DbConfig {
   firstFunder?: Record<string, string>;
   reverseLeg?: { tx_id: string; event_index: number } | null;
   onUpdate?: () => void;
+  /** Captures the bind args of the reverse-leg SELECT for assertion. */
+  onReverseLegBind?: (args: unknown[]) => void;
 }
 
 function makeDb(config: DbConfig) {
@@ -55,7 +57,10 @@ function makeDb(config: DbConfig) {
               ? { first_funder_stx: f, lookup_status: "ok", fetched_at: 0 }
               : { first_funder_stx: null, lookup_status: "none", fetched_at: 0 };
           }
-          if (sql.includes("FROM agent_earnings")) return config.reverseLeg ?? null;
+          if (sql.includes("FROM agent_earnings")) {
+            config.onReverseLegBind?.(args);
+            return config.reverseLeg ?? null;
+          }
           return null;
         },
         run: async () => {
@@ -130,5 +135,16 @@ describe("applyAntiGaming — heuristics (agent_peer only)", () => {
     const db = makeDb({}); // no override, no shared owner, no funders, no reverse leg
     const c = await applyAntiGaming(env(db), transfer(), peerEarning, 0, noopLogger);
     expect(c).toEqual(peerEarning);
+  });
+
+  it("queries a SYMMETRIC ±14d ring window (catches backfill order)", async () => {
+    const WINDOW = 14 * 24 * 60 * 60;
+    const blockTime = 1_000_000;
+    let binds: unknown[] = [];
+    const db = makeDb({ onReverseLegBind: (a) => (binds = a) });
+    await applyAntiGaming(env(db), transfer({ blockTime }), peerEarning, 0, noopLogger);
+    // binds: [recipient, sender, asset, lo, hi, windowStart, windowEnd]
+    expect(binds[5]).toBe(blockTime - WINDOW); // start: 14d before
+    expect(binds[6]).toBe(blockTime + WINDOW); // end: 14d AFTER — not just backward
   });
 });

--- a/lib/earnings/anti-gaming.ts
+++ b/lib/earnings/anti-gaming.ts
@@ -135,12 +135,21 @@ async function sharesOwner(
   return row != null;
 }
 
-/** Find a prior reverse leg (recipient→sender) within the ring window. */
+/**
+ * Find the reverse leg (recipient→sender) of a potential A→B→A ring.
+ *
+ * The window is SYMMETRIC (±14d around this leg), not backward-only: the two
+ * legs are within 14d *of each other*, and the indexer does not process them in
+ * chronological order (backfill walks newest-first), so the reverse leg may be
+ * either older or newer than the leg currently being indexed. A backward-only
+ * window would silently miss every ring discovered during backfill.
+ */
 async function findReverseLeg(
   db: D1Database,
   transfer: InboundTransfer
 ): Promise<{ tx_id: string; event_index: number } | null> {
   const windowStart = transfer.blockTime - EARNINGS_RING_WINDOW_SECONDS;
+  const windowEnd = transfer.blockTime + EARNINGS_RING_WINDOW_SECONDS;
   const lo = Math.floor(transfer.amountRaw * (1 - EARNINGS_RING_AMOUNT_TOLERANCE));
   const hi = Math.ceil(transfer.amountRaw * (1 + EARNINGS_RING_AMOUNT_TOLERANCE));
   return db
@@ -158,7 +167,7 @@ async function findReverseLeg(
       lo,
       hi,
       windowStart,
-      transfer.blockTime
+      windowEnd
     )
     .first<{ tx_id: string; event_index: number }>();
 }

--- a/lib/earnings/anti-gaming.ts
+++ b/lib/earnings/anti-gaming.ts
@@ -1,0 +1,241 @@
+/**
+ * Anti-gaming (issue #978, Phase 2).
+ *
+ * Runs only on `agent_peer` earnings (inbox/bounty are already proven legit by
+ * the txid match; everything else is already excluded). Flips an earning →
+ * excluded when it looks like an operator paying themselves:
+ *
+ *  - manual override   — operator-flagged exclude/include/reclassify (any class)
+ *  - alt-address       — sender & recipient agents share an `owner` (X handle)
+ *  - self_funded       — sender & recipient share a first-funder address
+ *  - ring              — A→B→A round-trip within 14d for a similar amount
+ *
+ * First-funder is immutable, so it's cached forever in `address_first_funder`:
+ * at most ~2 Hiro calls per address EVER, not per transfer.
+ */
+
+import {
+  EARNINGS_RING_WINDOW_SECONDS,
+  EARNINGS_RING_AMOUNT_TOLERANCE,
+  FIRST_FUNDER_FAILED_RETRY_MS,
+  EARNING_SOURCE_CLASSES,
+} from "./constants";
+import { fetchTransfersPage, extractInboundTransfers } from "./ingest";
+import type { Classification, InboundTransfer, SourceClass } from "./types";
+import type { Logger } from "../logging";
+
+interface AntiGamingEnv {
+  DB: D1Database;
+  VERIFIED_AGENTS: KVNamespace;
+  HIRO_API_KEY?: string;
+}
+
+// ── First-funder lookup (cached) ─────────────────────────────────────────
+
+interface FirstFunderResult {
+  firstFunder: string | null;
+  block: number | null;
+  status: "ok" | "none" | "failed";
+}
+
+/** Read the address's oldest tx and take the sender of its first inbound
+ *  transfer. An address's first on-chain tx is almost always its funding
+ *  (you must receive before you can pay fees), so this is a reliable signal. */
+async function fetchFirstFunderFromChain(
+  env: AntiGamingEnv,
+  address: string,
+  logger: Logger
+): Promise<FirstFunderResult> {
+  const head = await fetchTransfersPage(env, address, 0, 1, logger);
+  if (!head) return { firstFunder: null, block: null, status: "failed" };
+  if (head.total === 0) return { firstFunder: null, block: null, status: "none" };
+
+  const oldestOffset = Math.max(0, head.total - 1);
+  const tail =
+    oldestOffset === 0 ? head : await fetchTransfersPage(env, address, oldestOffset, 1, logger);
+  if (!tail) return { firstFunder: null, block: null, status: "failed" };
+
+  const result = tail.results[0];
+  if (!result) return { firstFunder: null, block: null, status: "none" };
+
+  const inbound = extractInboundTransfers(result, address);
+  if (inbound.length === 0) {
+    return { firstFunder: null, block: result.tx?.block_height ?? null, status: "none" };
+  }
+  return { firstFunder: inbound[0].senderStx, block: inbound[0].stxBlockHeight, status: "ok" };
+}
+
+/** Cached first-funder. Returns the funder STX (only for an 'ok' lookup), else null. */
+export async function getFirstFunder(
+  env: AntiGamingEnv,
+  address: string,
+  now: number,
+  logger: Logger
+): Promise<string | null> {
+  const cached = await env.DB.prepare(
+    `SELECT first_funder_stx, lookup_status, fetched_at
+     FROM address_first_funder WHERE address = ?1`
+  )
+    .bind(address)
+    .first<{ first_funder_stx: string | null; lookup_status: string; fetched_at: number }>();
+
+  if (cached) {
+    if (cached.lookup_status === "ok") return cached.first_funder_stx;
+    if (cached.lookup_status === "none") return null;
+    // 'failed' — only re-fetch once it's stale.
+    if (now - cached.fetched_at < FIRST_FUNDER_FAILED_RETRY_MS) return null;
+  }
+
+  const res = await fetchFirstFunderFromChain(env, address, logger);
+  await env.DB.prepare(
+    `INSERT INTO address_first_funder
+       (address, first_funder_stx, first_funded_block, lookup_status, fetched_at)
+     VALUES (?1, ?2, ?3, ?4, ?5)
+     ON CONFLICT(address) DO UPDATE SET
+       first_funder_stx   = excluded.first_funder_stx,
+       first_funded_block = excluded.first_funded_block,
+       lookup_status      = excluded.lookup_status,
+       fetched_at         = excluded.fetched_at`
+  )
+    .bind(address, res.firstFunder, res.block, res.status, now)
+    .run();
+
+  return res.status === "ok" ? res.firstFunder : null;
+}
+
+// ── Heuristic helpers ────────────────────────────────────────────────────
+
+async function getManualOverride(
+  db: D1Database,
+  txId: string,
+  eventIndex: number
+): Promise<{ action: string; new_source_class: string | null } | null> {
+  return db
+    .prepare(
+      `SELECT action, new_source_class FROM earnings_manual_override
+       WHERE tx_id = ?1 AND event_index = ?2`
+    )
+    .bind(txId, eventIndex)
+    .first<{ action: string; new_source_class: string | null }>();
+}
+
+/** Both agents declare the same (non-null) owner → same operator. */
+async function sharesOwner(
+  db: D1Database,
+  senderStx: string,
+  recipientStx: string
+): Promise<boolean> {
+  const row = await db
+    .prepare(
+      `SELECT 1 AS x FROM agents a1 JOIN agents a2 ON lower(a1.owner) = lower(a2.owner)
+       WHERE a1.stx_address = ?1 AND a2.stx_address = ?2 AND a1.owner IS NOT NULL LIMIT 1`
+    )
+    .bind(senderStx, recipientStx)
+    .first<{ x: number }>();
+  return row != null;
+}
+
+/** Find a prior reverse leg (recipient→sender) within the ring window. */
+async function findReverseLeg(
+  db: D1Database,
+  transfer: InboundTransfer
+): Promise<{ tx_id: string; event_index: number } | null> {
+  const windowStart = transfer.blockTime - EARNINGS_RING_WINDOW_SECONDS;
+  const lo = Math.floor(transfer.amountRaw * (1 - EARNINGS_RING_AMOUNT_TOLERANCE));
+  const hi = Math.ceil(transfer.amountRaw * (1 + EARNINGS_RING_AMOUNT_TOLERANCE));
+  return db
+    .prepare(
+      `SELECT tx_id, event_index FROM agent_earnings
+       WHERE recipient_agent_stx = ?1 AND sender_stx = ?2 AND asset = ?3
+         AND amount_raw BETWEEN ?4 AND ?5
+         AND block_time BETWEEN ?6 AND ?7
+       LIMIT 1`
+    )
+    .bind(
+      transfer.senderStx, // the reverse leg's recipient is this leg's sender
+      transfer.recipientAgentStx, // …and its sender is this leg's recipient
+      transfer.asset,
+      lo,
+      hi,
+      windowStart,
+      transfer.blockTime
+    )
+    .first<{ tx_id: string; event_index: number }>();
+}
+
+async function markRing(db: D1Database, tx_id: string, event_index: number): Promise<void> {
+  await db
+    .prepare(
+      `UPDATE agent_earnings SET excluded_reason = 'ring', is_earning = 0
+       WHERE tx_id = ?1 AND event_index = ?2`
+    )
+    .bind(tx_id, event_index)
+    .run();
+}
+
+// ── Orchestration ────────────────────────────────────────────────────────
+
+function exclude(c: Classification, reason: Classification["excludedReason"]): Classification {
+  return { ...c, excludedReason: reason, isEarning: false };
+}
+
+/**
+ * Apply anti-gaming to a freshly-classified transfer. Manual overrides apply to
+ * any class; the heuristics only touch `agent_peer` earnings.
+ */
+export async function applyAntiGaming(
+  env: AntiGamingEnv,
+  transfer: InboundTransfer,
+  classification: Classification,
+  now: number,
+  logger: Logger
+): Promise<Classification> {
+  const db = env.DB;
+
+  // Manual override wins over everything.
+  const override = await getManualOverride(db, transfer.txId, transfer.eventIndex);
+  if (override) {
+    if (override.action === "exclude") return exclude(classification, "excluded_manual");
+    if (override.action === "include") {
+      return { ...classification, excludedReason: null, isEarning: true };
+    }
+    if (override.action === "reclassify" && override.new_source_class) {
+      const sc = override.new_source_class as SourceClass;
+      const isEarning = (EARNING_SOURCE_CLASSES as readonly string[]).includes(sc);
+      return {
+        sourceClass: sc,
+        sourceSubclass: classification.sourceSubclass,
+        excludedReason: isEarning ? null : "excluded_manual",
+        isEarning,
+      };
+    }
+  }
+
+  // Heuristics only apply to agent→agent earnings.
+  if (classification.sourceClass !== "agent_peer" || !classification.isEarning) {
+    return classification;
+  }
+
+  // Alt-address: same operator per public metadata.
+  if (await sharesOwner(db, transfer.senderStx, transfer.recipientAgentStx)) {
+    return exclude(classification, "self_funded");
+  }
+
+  // Self-funded: shared first-funder. Only excludes on two confident 'ok' lookups.
+  const [senderFunder, recipientFunder] = await Promise.all([
+    getFirstFunder(env, transfer.senderStx, now, logger),
+    getFirstFunder(env, transfer.recipientAgentStx, now, logger),
+  ]);
+  if (senderFunder && recipientFunder && senderFunder === recipientFunder) {
+    return exclude(classification, "self_funded");
+  }
+
+  // Ring: a prior reverse leg exists → exclude both legs.
+  const reverse = await findReverseLeg(db, transfer);
+  if (reverse) {
+    await markRing(db, reverse.tx_id, reverse.event_index);
+    return exclude(classification, "ring");
+  }
+
+  return classification;
+}

--- a/lib/earnings/anti-gaming.ts
+++ b/lib/earnings/anti-gaming.ts
@@ -62,6 +62,9 @@ async function fetchFirstFunderFromChain(
   if (inbound.length === 0) {
     return { firstFunder: null, block: result.tx?.block_height ?? null, status: "none" };
   }
+  // Take the first inbound sender of the genesis tx as the funder. A funding tx
+  // almost always has a single sender; the rare multi-sender genesis just picks
+  // the first, which is good enough for the self-funded shared-origin signal.
   return { firstFunder: inbound[0].senderStx, block: inbound[0].stxBlockHeight, status: "ok" };
 }
 
@@ -208,15 +211,24 @@ export async function applyAntiGaming(
     if (override.action === "include") {
       return { ...classification, excludedReason: null, isEarning: true };
     }
-    if (override.action === "reclassify" && override.new_source_class) {
-      const sc = override.new_source_class as SourceClass;
-      const isEarning = (EARNING_SOURCE_CLASSES as readonly string[]).includes(sc);
-      return {
-        sourceClass: sc,
-        sourceSubclass: classification.sourceSubclass,
-        excludedReason: isEarning ? null : "excluded_manual",
-        isEarning,
-      };
+    if (override.action === "reclassify") {
+      if (!override.new_source_class) {
+        // Malformed override row — don't silently swallow it; fall through to
+        // the heuristics (conservative) but make the misconfig visible.
+        logger.warn("earnings.reclassify_missing_class", {
+          txId: transfer.txId,
+          eventIndex: transfer.eventIndex,
+        });
+      } else {
+        const sc = override.new_source_class as SourceClass;
+        const isEarning = (EARNING_SOURCE_CLASSES as readonly string[]).includes(sc);
+        return {
+          sourceClass: sc,
+          sourceSubclass: classification.sourceSubclass,
+          excludedReason: isEarning ? null : "excluded_manual",
+          isEarning,
+        };
+      }
     }
   }
 

--- a/lib/earnings/constants.ts
+++ b/lib/earnings/constants.ts
@@ -39,3 +39,15 @@ export const EXCLUDED_SOURCE_CLASSES = [
   "exchange_or_external",
   "unclassified",
 ] as const;
+
+// ── Anti-gaming (Phase 2) ────────────────────────────────────────────────
+
+/** Two-hop ring window: A→B→A round-trips within 14 days are excluded. */
+export const EARNINGS_RING_WINDOW_SECONDS = 14 * 24 * 60 * 60;
+
+/** Ring legs must be "similar amount" — within ±10% of each other. */
+export const EARNINGS_RING_AMOUNT_TOLERANCE = 0.1;
+
+/** A failed first-funder lookup is re-attempted after this long (ms); 'ok' and
+ *  'none' results are cached permanently (first-funder is immutable). */
+export const FIRST_FUNDER_FAILED_RETRY_MS = 60 * 60 * 1000;

--- a/lib/earnings/indexer.ts
+++ b/lib/earnings/indexer.ts
@@ -25,6 +25,7 @@ import {
 } from "./ingest";
 import { classifyTransfer } from "./classify";
 import { priceTransfer } from "./price";
+import { applyAntiGaming } from "./anti-gaming";
 import {
   getIndexState,
   setIndexState,
@@ -70,17 +71,19 @@ function zeroBySource(): Record<SourceClass, number> {
 }
 
 async function resolveRow(
-  db: D1Database,
-  kv: KVNamespace,
+  env: EarningsEnv,
   transfer: InboundTransfer,
-  now: number
+  now: number,
+  logger: Logger
 ): Promise<EarningRow> {
   // Classification (D1 reads) and pricing (KV read) are independent — overlap them.
   const [classification, pricing] = await Promise.all([
-    classifyTransfer(db, transfer),
-    priceTransfer(kv, transfer, now),
+    classifyTransfer(env.DB, transfer),
+    priceTransfer(env.VERIFIED_AGENTS, transfer, now),
   ]);
-  return { ...transfer, ...classification, ...pricing, indexedAt: now };
+  // Anti-gaming (Phase 2) can flip an agent_peer earning → excluded.
+  const finalClassification = await applyAntiGaming(env, transfer, classification, now, logger);
+  return { ...transfer, ...finalClassification, ...pricing, indexedAt: now };
 }
 
 /** Bounded-concurrency map (caps simultaneous outgoing connections at `n`). */
@@ -110,7 +113,7 @@ async function indexAgent(
   logger: Logger,
   now: number
 ): Promise<AgentResult> {
-  const { DB: db, VERIFIED_AGENTS: kv } = env;
+  const { DB: db } = env;
   const state = await getIndexState(db, agentStx);
 
   const rows: EarningRow[] = [];
@@ -124,7 +127,7 @@ async function indexAgent(
     if (!results) return;
     for (const result of results.results) {
       const transfers = extractInboundTransfers(result, agentStx);
-      for (const t of transfers) rows.push(await resolveRow(db, kv, t, now));
+      for (const t of transfers) rows.push(await resolveRow(env, t, now, logger));
       transfersFound += transfers.length;
     }
     maxBlock = Math.max(maxBlock, maxBlockHeight(results.results));

--- a/migrations/021_earnings_anti_gaming.sql
+++ b/migrations/021_earnings_anti_gaming.sql
@@ -32,3 +32,13 @@ CREATE TABLE IF NOT EXISTS earnings_manual_override (
   created_at       INTEGER NOT NULL,
   PRIMARY KEY (tx_id, event_index)
 );
+
+-- ── Ring-detection index ─────────────────────────────────────────────────
+-- Serves findReverseLeg() (lib/earnings/anti-gaming.ts): equality on
+-- recipient + sender + asset, range on block_time. Migration 020's
+-- (recipient_agent_stx, block_time) index covers only the recipient + time
+-- predicates; without this composite, the reverse-leg lookup would filter
+-- sender/asset by scanning a recipient's full history on every agent_peer
+-- transfer.
+CREATE INDEX IF NOT EXISTS idx_agent_earnings_ring
+  ON agent_earnings (recipient_agent_stx, sender_stx, asset, block_time);

--- a/migrations/021_earnings_anti_gaming.sql
+++ b/migrations/021_earnings_anti_gaming.sql
@@ -1,0 +1,34 @@
+-- Migration 021: earnings anti-gaming (issue #978, Phase 2)
+--
+-- Adds the two tables the anti-gaming heuristics need on top of the Phase 1
+-- ledger. The agent_earnings.excluded_reason column already exists (migration
+-- 020), so flagging a row is a data change, not a schema change.
+--
+-- See docs/earnings-ledger-architecture.md §8.
+
+-- ── First-funder cache (the cost-saver) ──────────────────────────────────
+-- The "who first funded this address" lookup is immutable once an address is
+-- funded, so it's cached forever and costs at most a couple of Hiro calls per
+-- address EVER (not per transfer). self_funded exclusion compares the first
+-- funder of the sender vs the recipient.
+CREATE TABLE IF NOT EXISTS address_first_funder (
+  address           TEXT PRIMARY KEY,
+  first_funder_stx  TEXT,                 -- nullable: 'none' lookups store NULL
+  first_funded_block INTEGER,
+  lookup_status     TEXT NOT NULL CHECK (lookup_status IN ('ok', 'none', 'failed')),
+  fetched_at        INTEGER NOT NULL
+);
+
+-- ── Operator override (escape hatch for heuristic misses) ─────────────────
+-- Keyed on a ledger line item. `action` forces the row's earning status or a
+-- reclassification, regardless of what the heuristics decided.
+CREATE TABLE IF NOT EXISTS earnings_manual_override (
+  tx_id            TEXT    NOT NULL,
+  event_index      INTEGER NOT NULL DEFAULT 0,
+  action           TEXT    NOT NULL CHECK (action IN ('exclude', 'include', 'reclassify')),
+  new_source_class TEXT,                  -- required when action = 'reclassify'
+  note             TEXT,
+  created_by       TEXT,
+  created_at       INTEGER NOT NULL,
+  PRIMARY KEY (tx_id, event_index)
+);


### PR DESCRIPTION
Phase 2 of the verified earnings ledger (#978). Excludes self-dealing from earnings **before it counts**, so the new metric can't be gamed the way trade-count was. Builds on the merged Phase 1 indexer.

## What's here
Every freshly-classified **`agent_peer`** earning now runs through exclusion checks (inbox/bounty skip it — they're already proven legit by their txid match against our own D1).

| Rule | Excludes when |
|---|---|
| **manual override** | operator flagged the line item `exclude` / `include` / `reclassify` (applies to any class) |
| **alt-address** | sender & recipient agents share an `owner` (X handle) → `self_funded` |
| **self-funded** | sender & recipient share a **first-funder** address → `self_funded` |
| **ring** | a prior `A→B→A` reverse leg exists within 14d for a similar amount → both legs `ring` |

- `migrations/021_earnings_anti_gaming.sql` — `address_first_funder` cache + `earnings_manual_override`
- `lib/earnings/anti-gaming.ts` — the engine, wired into the indexer's `resolveRow`

## Cost (the first-funder lookup is the only new Hiro cost)
First-funder is **immutable**, so it's cached forever in `address_first_funder`: **≤2 Hiro calls per address EVER**, and only triggered for `agent_peer` transfers. The lookup reuses the existing `transactions_with_transfers` helper (fetch the oldest tx, take its first inbound sender). Failed lookups retry after 1h; `ok`/`none` are permanent. All other checks are plain D1 queries.

## Notes / limits
- Heuristics run **only on `agent_peer`** — inbox/bounty earnings are untouched (txid-proven).
- Exclusion is conservative: self-funded only fires on **two confident `ok`** first-funder lookups (uncertainty ⇒ keep the earning).
- **Known limit:** a ring whose two legs land in the *same* sweep tick isn't caught (the reverse leg isn't persisted yet); cross-tick rings are. Documented in the architecture doc.

## Checks
`tsc` clean · `lint` clean · full suite **1504 passing** (+9 new in `anti-gaming.test.ts` covering all four rules, the non-`agent_peer` passthrough, differing-funder non-exclusion, and the clean passthrough).

Part of #978. Next: **Phase 3** (public read API) → **Phase 4** (leaderboard flips to earnings — the visible win).