### PR TITLE
feat(earnings): count earnings from join date (verified_at floor) (#978)

### DIFF
--- a/docs/earnings-ledger-architecture.md
+++ b/docs/earnings-ledger-architecture.md
@@ -31,6 +31,7 @@ because they require real third-party on-chain value transfer.
 | USD pricing source | **Tenero + last-good fallback** | only ~3 tokens; already cached in KV |
 | Ingestion shape | **Separate earnings task, own slow cursor** | clean separation from competition sweep |
 | Ingestion model | **Indexer-only (pull), all agents — no agent self-report** | earnings must be derived from chain truth, never asserted by the agent (anti-gaming); covers the dormant cohort that would never submit |
+| Earnings window | **From join date** — only inflows with `block_time >= agents.verified_at` count | "earnings" = earned *as an agent*, not lifetime personal history; closes the `agent_peer` gap where pre-platform transfers between later-registered addresses would count; also bounds backfill (stops at registration, not genesis). Flippable to all-time via a re-backfill (reset `earnings_index_state`); free to change while the indexer is dormant. |
 | Scheduling host | **Cloudflare Cron Trigger; SchedulerDO retired (Phase 0, done)** | see §3 — the DO alarm was request-bootstrapped and silently died |
 | Earnings leaderboard surface | **Trading board (`app/leaderboard`)** | this is the board whose trade-count default got gamed |
 | x402_endpoint classifier | **Investigate catalog in Phase 1** | may launch inert if no payTo catalog exists |

--- a/lib/earnings/__tests__/join-date.test.ts
+++ b/lib/earnings/__tests__/join-date.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from "vitest";
+import { fetchAgentPage } from "../d1";
+
+/** D1 mock returning preset registered_wallets rows. */
+function makeDb(rows: { stx_address: string; verified_at: string | null }[]) {
+  return {
+    prepare: () => ({
+      bind: () => ({ all: async () => ({ results: rows }) }),
+    }),
+  } as unknown as D1Database;
+}
+
+describe("fetchAgentPage — join-date floor parsing", () => {
+  it("parses verified_at (ISO) to unix seconds", async () => {
+    const iso = "2026-01-01T00:00:00Z";
+    const expectedSec = Math.floor(Date.parse(iso) / 1000);
+    const out = await fetchAgentPage(makeDb([{ stx_address: "SP_A", verified_at: iso }]), null, 25);
+    expect(out).toEqual([{ stxAddress: "SP_A", verifiedAtSec: expectedSec }]);
+    expect(out[0].verifiedAtSec).toBeGreaterThan(0);
+  });
+
+  it("falls back to floor 0 (all-time) when verified_at is null or unparseable", async () => {
+    const out = await fetchAgentPage(
+      makeDb([
+        { stx_address: "SP_NULL", verified_at: null },
+        { stx_address: "SP_BAD", verified_at: "not-a-date" },
+      ]),
+      null,
+      25
+    );
+    expect(out[0].verifiedAtSec).toBe(0);
+    expect(out[1].verifiedAtSec).toBe(0);
+  });
+});

--- a/lib/earnings/d1.ts
+++ b/lib/earnings/d1.ts
@@ -139,18 +139,30 @@ export async function setEarningsCursor(
     .run();
 }
 
-/** Next page of agent STX addresses, ordered by stx_address for stable cursoring. */
+export interface AgentPageRow {
+  stxAddress: string;
+  /** Registration time as unix seconds — the earnings floor (0 if unknown). */
+  verifiedAtSec: number;
+}
+
+/** Next page of agents (stx + registration time), ordered by stx_address. */
 export async function fetchAgentPage(
   db: D1Database,
   cursor: string | null,
   limit: number
-): Promise<string[]> {
+): Promise<AgentPageRow[]> {
   const sql = cursor
-    ? `SELECT stx_address FROM registered_wallets WHERE stx_address > ?1 ORDER BY stx_address ASC LIMIT ?2`
-    : `SELECT stx_address FROM registered_wallets ORDER BY stx_address ASC LIMIT ?1`;
+    ? `SELECT stx_address, verified_at FROM registered_wallets WHERE stx_address > ?1 ORDER BY stx_address ASC LIMIT ?2`
+    : `SELECT stx_address, verified_at FROM registered_wallets ORDER BY stx_address ASC LIMIT ?1`;
   const stmt = cursor
     ? db.prepare(sql).bind(cursor, limit)
     : db.prepare(sql).bind(limit);
-  const res = await stmt.all<{ stx_address: string }>();
-  return (res.results ?? []).map((r) => r.stx_address);
+  const res = await stmt.all<{ stx_address: string; verified_at: string | null }>();
+  return (res.results ?? []).map((r) => ({
+    stxAddress: r.stx_address,
+    // ISO-8601 → unix seconds; 0 (no floor → all-time) if missing/unparseable.
+    verifiedAtSec: r.verified_at
+      ? Math.floor(Date.parse(r.verified_at) / 1000) || 0
+      : 0,
+  }));
 }

--- a/lib/earnings/indexer.ts
+++ b/lib/earnings/indexer.ts
@@ -110,6 +110,12 @@ async function mapPool<T, R>(
 async function indexAgent(
   env: EarningsEnv,
   agentStx: string,
+  // Earnings floor: only inflows at/after the agent's registration count.
+  // Excludes pre-platform history (esp. agent_peer transfers between addresses
+  // that only later registered) and lets backfill stop at registration instead
+  // of walking to genesis. 0 = no floor (all-time fallback when verified_at is
+  // missing).
+  verifiedAtSec: number,
   logger: Logger,
   now: number
 ): Promise<AgentResult> {
@@ -127,11 +133,23 @@ async function indexAgent(
     if (!results) return;
     for (const result of results.results) {
       const transfers = extractInboundTransfers(result, agentStx);
-      for (const t of transfers) rows.push(await resolveRow(env, t, now, logger));
-      transfersFound += transfers.length;
+      for (const t of transfers) {
+        if (t.blockTime < verifiedAtSec) continue; // pre-registration → not earnings
+        rows.push(await resolveRow(env, t, now, logger));
+        transfersFound++;
+      }
     }
     maxBlock = Math.max(maxBlock, maxBlockHeight(results.results));
   };
+
+  // True once a page reaches transactions older than registration — since pages
+  // are newest-first, everything beyond is pre-join and can be skipped.
+  const reachedPreJoin = (results: Awaited<ReturnType<typeof fetchTransfersPage>>): boolean =>
+    !!results &&
+    results.results.some((r) => {
+      const t = r.tx?.burn_block_time ?? 0;
+      return t > 0 && t < verifiedAtSec;
+    });
 
   if (!backfillComplete) {
     // Backfill: walk older pages from the saved offset, bounded per tick.
@@ -143,7 +161,7 @@ async function indexAgent(
       await collect(page);
       offset += page.results.length;
       backfillOffset = offset;
-      if (page.exhausted) {
+      if (page.exhausted || reachedPreJoin(page)) {
         backfillComplete = true;
         backfillOffset = 0;
         break;
@@ -233,8 +251,8 @@ export async function runEarningsSweep(
     return emptySummary(true, null);
   }
 
-  const perAgent = await mapPool(agents, EARNINGS_FETCH_CONCURRENCY, (stx) =>
-    indexAgent(env, stx, logger, now)
+  const perAgent = await mapPool(agents, EARNINGS_FETCH_CONCURRENCY, (a) =>
+    indexAgent(env, a.stxAddress, a.verifiedAtSec, logger, now)
   );
 
   const summary = emptySummary(true, null);
@@ -253,7 +271,9 @@ export async function runEarningsSweep(
 
   // Advance the cursor; a short page means we hit the end → wrap next tick.
   const nextCursor =
-    agents.length === EARNINGS_MAX_AGENTS_PER_RUN ? agents[agents.length - 1] : null;
+    agents.length === EARNINGS_MAX_AGENTS_PER_RUN
+      ? agents[agents.length - 1].stxAddress
+      : null;
   await setEarningsCursor(db, nextCursor);
   summary.cursor = nextCursor;
 


### PR DESCRIPTION
Scopes earnings to **money earned as an agent**, not lifetime personal on-chain history. Only inflows with `block_time >= agents.verified_at` (registration) count.

## Why
Surfaced reviewing the metric semantics: of the three classifiers, `inbox_message` and `bounty` are already post-join (they match platform DB records that only exist after registration) — but **`agent_peer` had no time bound**. A personal transfer between two addresses *years before* either registered would today be classified `agent_peer` and counted as "earnings" — wrong, and trivially gameable (register two old addresses that historically moved money between them).

## What
- `fetchAgentPage` now returns `verified_at` parsed to unix seconds (`verifiedAtSec`); `0` = no floor (all-time fallback when `verified_at` is missing/unparseable).
- `indexAgent` applies the floor in `collect()` (skips `block_time < verifiedAtSec`) and **terminates backfill on the first pre-join page** — so backfill stops at registration instead of walking to genesis. More correct *and* cheaper Hiro usage.

## Reversibility
Flippable to all-time later via a re-backfill (reset `earnings_index_state.backfill_complete`/`backfill_offset`; the sweep re-walks history). And **free to change right now** — the indexer is dormant and no data has accumulated, so this is a no-cost decision until enabled.

## Notes
- Touches Phase 1 indexer code on `main`; independent of the open Phase 3 API PR (#983) — different files.
- `tsc` + lint clean; earnings tests green (+2 new in `join-date.test.ts` for the `verified_at` → floor parsing incl. null/unparseable fallback).

Part of #978.