### PR TITLE
chore(earnings): enable the earnings indexer cron (#978)

### DIFF
--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -51,7 +51,11 @@
   // build cannot accidentally consume the production Tenero quota.
   "vars": {
     "DEPLOY_ENV": "production",
-    "TENERO_REFRESH_ENABLED": "true"
+    "TENERO_REFRESH_ENABLED": "true",
+    // Enables the 30-min earnings indexer cron sweep (issue #978). Ships off;
+    // flip to "true" to start indexing. env.preview omits it so a preview build
+    // never indexes against the shared production D1 / Hiro quota.
+    "EARNINGS_INDEX_ENABLED": "true"
   },
   // First-party rate limit bindings. Mirrors the agent-news pattern (agent-news#704/#705).
   // Top-level IDs are the local-dev defaults — they are overridden in each named env
@@ -151,7 +155,8 @@
       // rate-limit binding error handling (env.DEPLOY_ENV !== undefined → fail closed).
       "vars": {
         "DEPLOY_ENV": "production",
-        "TENERO_REFRESH_ENABLED": "true"
+        "TENERO_REFRESH_ENABLED": "true",
+        "EARNINGS_INDEX_ENABLED": "true"
       },
 
       "assets": {


### PR DESCRIPTION
Flips the earnings indexer on by setting `EARNINGS_INDEX_ENABLED=true` (top-level + `env.production`, omitted from `env.preview` so preview never indexes against shared prod D1/Hiro). Mirrors the `TENERO_REFRESH_ENABLED` pattern.

## Verified working before enabling
Ran a forced admin sweep against prod (`POST /api/admin/scheduler?action=refresh&task=earnings`) after applying migrations 020–022:
- **25 agents**, **31 Hiro calls** (≈1.2/agent — join-date floor + bounded backfill working)
- **116 earning rows**, ~**$1,666** verified (sBTC + STX), all priced
- **6 `self_funded`** exclusions (anti-gaming fired), 186 `unclassified` correctly excluded
- `alreadyKnown: 92` on re-run → idempotency confirmed

## What happens on merge/deploy
The 30-min cron sweep starts: 25 agents/tick → **~20h** for the first full backfill of the ~1k roster, then cheap incremental cycles (only-new-txs per agent, often zero work). Monitor via `GET /api/admin/scheduler` → `.status.lastEarningsResult`.

Flip back off any time by reverting this (or `wrangler secret put`). Part of #978.