### PR TITLE
feat: Phase 4 UI — pure earnings leaderboard + profile earnings + Club badges (#978)

### DIFF
--- a/app/agents/[address]/AgentProfile.tsx
+++ b/app/agents/[address]/AgentProfile.tsx
@@ -7,6 +7,8 @@ import { X_HANDLE } from "@/lib/constants";
 import Navbar from "../../components/Navbar";
 import AnimatedBackground from "../../components/AnimatedBackground";
 import LevelBadge from "../../components/LevelBadge";
+import ClubBadge from "../../components/ClubBadge";
+import EarningsActivity, { type EarningsResponse } from "../../components/EarningsActivity";
 import LevelProgress from "../../components/LevelProgress";
 import LevelTooltip from "../../components/LevelTooltip";
 import LevelCelebration from "../../components/LevelCelebration";
@@ -91,6 +93,13 @@ export default function AgentProfile({
   const { data: vouchData } = useSWR<VouchResponse>(
     agentLevel >= 1 ? swrKeys.vouch(agent.btcAddress) : null
   );
+
+  // Shared with <EarningsActivity> (same SWR key → one request). Drives the
+  // Club badge in the sidebar.
+  const { data: earningsData } = useSWR<EarningsResponse>(
+    agentLevel >= 1 ? swrKeys.earnings(agent.btcAddress) : null
+  );
+  const lifetimeEarningsUsd = earningsData?.rollup?.earnings_lifetime_usd ?? 0;
 
   const handleValidateCode = async () => {
     if (!codeInput.trim()) return;
@@ -223,6 +232,7 @@ export default function AgentProfile({
                       </svg>
                       Verified
                     </span>
+                    <ClubBadge lifetimeUsd={lifetimeEarningsUsd} />
                     {agent.owner && (
                       <a
                         href={`https://x.com/${agent.owner}`}
@@ -396,6 +406,9 @@ export default function AgentProfile({
                   <ReputationSummary address={agent.btcAddress} />
                 </div>
               )}
+
+              {/* Earnings — verified on-chain earnings (issue #978) */}
+              {agentLevel >= 1 && <EarningsActivity btcAddress={agent.btcAddress} />}
 
               {/* Claim section — tri-state: Claimed / Code input / Tweet flow */}
               <div className="rounded-xl border border-white/[0.08] bg-[rgba(12,12,12,0.6)] backdrop-blur-sm p-5 sm:p-6">

--- a/app/components/ClubBadge.tsx
+++ b/app/components/ClubBadge.tsx
@@ -1,0 +1,35 @@
+/**
+ * Earned-tier badge (issue #978). Shows the highest "Club" an agent has reached
+ * on LIFETIME verified earnings. Rendered as a chip next to the level/status
+ * chips on the agent profile. Returns null below the $10 floor.
+ */
+
+interface Tier {
+  threshold: number;
+  label: string;
+  /** Tailwind classes for the chip (border/bg/text), escalating by tier. */
+  className: string;
+}
+
+// Highest first — first match wins.
+const TIERS: readonly Tier[] = [
+  { threshold: 100_000, label: "$100k Club", className: "border-[#F7931A]/50 bg-[#F7931A]/15 text-[#F7931A]" },
+  { threshold: 10_000, label: "$10k Club", className: "border-[#F7931A]/40 bg-[#F7931A]/10 text-[#F7931A]" },
+  { threshold: 1_000, label: "$1k Club", className: "border-[#FFD37A]/40 bg-[#FFD37A]/10 text-[#FFD37A]" },
+  { threshold: 100, label: "$100 Club", className: "border-white/15 bg-white/[0.06] text-white/80" },
+  { threshold: 10, label: "$10 Club", className: "border-white/10 bg-white/[0.04] text-white/60" },
+];
+
+export default function ClubBadge({ lifetimeUsd }: { lifetimeUsd: number }) {
+  const tier = TIERS.find((t) => lifetimeUsd >= t.threshold);
+  if (!tier) return null;
+  return (
+    <span
+      title={`Lifetime verified earnings ≥ $${tier.threshold.toLocaleString("en-US")}`}
+      className={`inline-flex items-center gap-1 rounded-md border px-2 py-0.5 text-xs font-medium ${tier.className}`}
+    >
+      <span aria-hidden="true">◆</span>
+      {tier.label}
+    </span>
+  );
+}

--- a/app/components/EarningsActivity.tsx
+++ b/app/components/EarningsActivity.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import useSWR from "swr";
+import { swrKeys } from "@/lib/swr-keys";
+import { truncateAddress, formatRelativeTime } from "@/lib/utils";
+
+export interface EarningsResponse {
+  address: string;
+  stxAddress: string;
+  rollup: {
+    earnings_7d_usd: number;
+    earnings_30d_usd: number;
+    earnings_lifetime_usd: number;
+    unique_payers_30d: number;
+    top_source_class_30d: string | null;
+  };
+  lineItems: Array<{
+    txId: string;
+    eventIndex: number;
+    blockTime: number;
+    sender: string;
+    asset: string;
+    amountRaw: number;
+    amountUsd: number | null;
+    sourceClass: string;
+    sourceSubclass: string | null;
+    explorerUrl: string;
+  }>;
+  pagination: { limit: number; offset: number; hasMore: boolean };
+}
+
+const SOURCE_LABEL: Record<string, string> = {
+  inbox_message: "Paid message",
+  bounty: "Bounty",
+  agent_peer: "Agent payment",
+  x402_endpoint: "x402 endpoint",
+};
+
+function usd(value: number | null): string {
+  if (value == null || !Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  return `$${value.toLocaleString("en-US", {
+    minimumFractionDigits: abs < 10_000 ? 2 : 0,
+    maximumFractionDigits: abs < 10_000 ? 2 : 0,
+  })}`;
+}
+
+function Stat({ label, value }: { label: string; value: string }) {
+  return (
+    <div>
+      <div className="text-[11px] uppercase tracking-wide text-white/40">{label}</div>
+      <div className="text-sm font-medium text-white">{value}</div>
+    </div>
+  );
+}
+
+export default function EarningsActivity({ btcAddress }: { btcAddress: string }) {
+  const { data, isLoading } = useSWR<EarningsResponse>(swrKeys.earnings(btcAddress));
+
+  return (
+    <div className="rounded-xl border border-white/[0.08] bg-[rgba(12,12,12,0.6)] backdrop-blur-sm p-5 sm:p-6">
+      <div className="mb-3 flex items-center gap-2">
+        <svg className="h-4 w-4 text-white/70" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2}
+            d="M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z" />
+        </svg>
+        <span className="text-sm font-medium text-white">Earnings</span>
+        <span className="text-[11px] text-white/30">verified on-chain</span>
+      </div>
+
+      {isLoading && !data ? (
+        <div className="text-sm text-white/40">Loading earnings…</div>
+      ) : !data || data.rollup.earnings_lifetime_usd <= 0 ? (
+        <div className="text-sm text-white/50">
+          No verified earnings yet. Earnings appear here once this agent receives
+          sBTC, STX, or aeUSDC from bounties, paid messages, or other agents.
+        </div>
+      ) : (
+        <>
+          <div className="mb-4 flex items-baseline gap-2">
+            <span className="text-2xl font-semibold text-white">{usd(data.rollup.earnings_30d_usd)}</span>
+            <span className="text-xs text-white/40">earned (30d)</span>
+          </div>
+          <div className="mb-5 grid grid-cols-3 gap-3">
+            <Stat label="7d" value={usd(data.rollup.earnings_7d_usd)} />
+            <Stat label="Lifetime" value={usd(data.rollup.earnings_lifetime_usd)} />
+            <Stat
+              label="Payers (30d)"
+              value={String(data.rollup.unique_payers_30d)}
+            />
+          </div>
+
+          {data.lineItems.length > 0 && (
+            <ul className="divide-y divide-white/[0.04] border-t border-white/[0.06]">
+              {data.lineItems.map((i) => (
+                <li
+                  key={`${i.txId}:${i.eventIndex}`}
+                  className="flex items-center justify-between gap-3 py-2.5 text-sm"
+                >
+                  <div className="min-w-0">
+                    <div className="text-white/80">
+                      {SOURCE_LABEL[i.sourceClass] ?? i.sourceClass}
+                      <span className="ml-2 text-[11px] uppercase text-white/30">{i.asset}</span>
+                    </div>
+                    <div className="text-[11px] text-white/40">
+                      from {truncateAddress(i.sender)} ·{" "}
+                      {formatRelativeTime(new Date(i.blockTime * 1000).toISOString())}
+                    </div>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-3">
+                    <span className="font-medium text-white">{usd(i.amountUsd)}</span>
+                    <a
+                      href={i.explorerUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-[11px] text-[#F7931A] hover:underline"
+                      title="Verify on chain"
+                    >
+                      verify ↗
+                    </a>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Phase 4 UI for the verified earnings ledger (#978) — the visible payoff.

## 1. Pure earnings leaderboard (`/leaderboard`)
Per product call, this page **stops being the trading competition's scoreboard** and becomes a pure verified-earnings board.
- **Columns:** Rank · Agent (+ **Club chip**) · Earnings (30d) · Payers · Latest. Sort chips: Earnings (default) · Payers · Latest.
- **Removed:** Trades / Volume / Unrealized P&L columns + chips, the `LEADERBOARD_AGGREGATE_SQL` swap scan (the code's *"largest D1 read surface"*), the whole client-side Tenero price-fetch, and the competition countdown. Header/metadata rewritten for earnings.
- **Data:** new `getEarningsBoard` — one index-served scan (migration 022 partial index) returning per-agent 30d + lifetime + payers + latest + metadata. Behind the 5-min SSR cache. **Net: far less D1 + zero client price calls.**

## 2. Profile Earnings section + Club badges
- `EarningsActivity` card on `/agents/{addr}`: 30d headline, 7d/lifetime/payers, line items linking to Hiro ("verify ↗").
- `ClubBadge` (`$10/$100/$1k/$10k/$100k`, lifetime) — beside the profile chips **and now on each leaderboard row**.
- One shared SWR fetch (badge + card dedupe).

## 3. Faster backfill
`EARNINGS_INTERVAL_MS` → **5 min** (every cron tick) so the roster backfills in ~3h during rollout. Relax once full.

## Review
Ran `/code-review` (high) pre-push. It caught a **blocker I'd introduced** — a `*/5` inside a JSDoc comment closed the block and broke compilation — now fixed (line comments). Also: deleted the orphaned `CompetitionCountdown.tsx` and refreshed stale comments. Correctness pass otherwise clean (SQL binds/units, cache-key bump v2→v3, exhaustive sort, null guards, SWR dedup all verified). `tsc` + lint clean, full suite **1512 passing**.

Hero stat still deferred to a follow-up. Part of #978.