### PR TITLE
feat(earnings): rank by total-since-join + methodology modal + profile transparency (#978)

### DIFF
--- a/app/api/agents/[address]/earnings/route.ts
+++ b/app/api/agents/[address]/earnings/route.ts
@@ -7,7 +7,11 @@ import {
   lookupProfileByBtcAddress,
   lookupProfileByAgentId,
 } from "@/lib/cache/agent-profile";
-import { getAgentRollup, getAgentLineItems } from "@/lib/earnings/reads";
+import {
+  getAgentRollup,
+  getAgentLineItems,
+  getAgentEarningsBreakdown,
+} from "@/lib/earnings/reads";
 
 const DEFAULT_LIMIT = 25;
 const MAX_LIMIT = 100;
@@ -38,6 +42,10 @@ function selfDoc() {
           earnings_lifetime_usd: "number",
           unique_payers_30d: "number",
           top_source_class_30d: "string | null",
+        },
+        breakdown: {
+          by_source: "Array<{ source_class, total_usd }> — verified earnings by source",
+          excluded_usd: "number — inbound NOT counted (self-dealing / unclassified)",
         },
         lineItems:
           "Array<{ txId, eventIndex, blockTime, sender, asset, amountRaw, amountUsd, sourceClass, sourceSubclass, explorerUrl }>",
@@ -104,8 +112,9 @@ export async function GET(
     const stxAddress = row.stx_address;
     const now = Date.now();
 
-    const [rollup, items] = await Promise.all([
+    const [rollup, breakdown, items] = await Promise.all([
       getAgentRollup(db, stxAddress, now),
+      getAgentEarningsBreakdown(db, stxAddress),
       getAgentLineItems(db, stxAddress, limit + 1, offset),
     ]);
 
@@ -124,7 +133,7 @@ export async function GET(
     }));
 
     return NextResponse.json(
-      { address, stxAddress, rollup, lineItems, pagination: { limit, offset, hasMore } },
+      { address, stxAddress, rollup, breakdown, lineItems, pagination: { limit, offset, hasMore } },
       {
         headers: {
           "Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}`,

--- a/app/api/stats/earnings/route.ts
+++ b/app/api/stats/earnings/route.ts
@@ -15,8 +15,10 @@ const LEADERBOARD_SIZE = 100;
 const CACHE_TTL_SECONDS = 3600; // 1h — platform aggregate + ranking change slowly.
 const WINDOWS: ReadonlySet<EarningsWindow> = new Set(["7d", "30d", "lifetime"]);
 
+// Default to lifetime so the public ranking matches the /leaderboard UI, which
+// ranks by total verified earnings since each agent joined.
 function parseWindow(raw: string | null): EarningsWindow {
-  return raw && WINDOWS.has(raw as EarningsWindow) ? (raw as EarningsWindow) : "30d";
+  return raw && WINDOWS.has(raw as EarningsWindow) ? (raw as EarningsWindow) : "lifetime";
 }
 
 function selfDoc() {
@@ -26,10 +28,11 @@ function selfDoc() {
       method: "GET",
       description:
         "Platform-wide verified earnings: total USD earned by all agents over 7d/30d/lifetime, " +
-        "a 30d breakdown by source class, and the top agents ranked by earnings in the chosen window.",
+        "a 30d breakdown by source class, and the top agents ranked by total earnings since they joined " +
+        "(matching the /leaderboard UI). Self-dealing (self-funded / ring) and unclassified inflows are excluded.",
       queryParameters: {
         window:
-          "Leaderboard ranking window: 7d | 30d | lifetime (default 30d). Platform totals always include all three.",
+          "Leaderboard ranking window: 7d | 30d | lifetime (default lifetime — total since join). Platform totals always include all three.",
       },
       responseFormat: {
         platform: {

--- a/app/components/EarningsActivity.tsx
+++ b/app/components/EarningsActivity.tsx
@@ -14,6 +14,10 @@ export interface EarningsResponse {
     unique_payers_30d: number;
     top_source_class_30d: string | null;
   };
+  breakdown: {
+    by_source: Array<{ source_class: string; total_usd: number }>;
+    excluded_usd: number;
+  };
   lineItems: Array<{
     txId: string;
     eventIndex: number;
@@ -78,17 +82,42 @@ export default function EarningsActivity({ btcAddress }: { btcAddress: string })
       ) : (
         <>
           <div className="mb-4 flex items-baseline gap-2">
-            <span className="text-2xl font-semibold text-white">{usd(data.rollup.earnings_30d_usd)}</span>
-            <span className="text-xs text-white/40">earned (30d)</span>
+            <span className="text-2xl font-semibold text-white">{usd(data.rollup.earnings_lifetime_usd)}</span>
+            <span className="text-xs text-white/40">earned since joining</span>
           </div>
           <div className="mb-5 grid grid-cols-3 gap-3">
-            <Stat label="7d" value={usd(data.rollup.earnings_7d_usd)} />
-            <Stat label="Lifetime" value={usd(data.rollup.earnings_lifetime_usd)} />
-            <Stat
-              label="Payers (30d)"
-              value={String(data.rollup.unique_payers_30d)}
-            />
+            <Stat label="Last 30d" value={usd(data.rollup.earnings_30d_usd)} />
+            <Stat label="Last 7d" value={usd(data.rollup.earnings_7d_usd)} />
+            <Stat label="Payers (30d)" value={String(data.rollup.unique_payers_30d)} />
           </div>
+
+          {/* Transparency: where the verified earnings came from, and what we
+              excluded (self-dealing / unclassified inflows). Guard `breakdown`
+              — a pre-deploy edge-cached API payload may not carry it. */}
+          {data.breakdown && (data.breakdown.by_source.length > 0 || data.breakdown.excluded_usd > 0) && (
+            <div className="mb-5 rounded-lg border border-white/[0.06] bg-white/[0.02] p-3">
+              <div className="mb-2 text-[11px] uppercase tracking-wide text-white/40">
+                By source
+              </div>
+              <ul className="space-y-1.5 text-sm">
+                {data.breakdown.by_source.map((s) => (
+                  <li key={s.source_class} className="flex items-center justify-between">
+                    <span className="text-white/70">{SOURCE_LABEL[s.source_class] ?? s.source_class}</span>
+                    <span className="font-medium text-white">{usd(s.total_usd)}</span>
+                  </li>
+                ))}
+                {data.breakdown.excluded_usd > 0 && (
+                  <li
+                    className="flex items-center justify-between border-t border-white/[0.06] pt-1.5"
+                    title="Self-funding, round-trips, and exchange/unclassified inflows — not counted toward earnings."
+                  >
+                    <span className="text-white/40">Excluded (self-dealing / unclassified)</span>
+                    <span className="text-white/40">{usd(data.breakdown.excluded_usd)}</span>
+                  </li>
+                )}
+              </ul>
+            </div>
+          )}
 
           {data.lineItems.length > 0 && (
             <ul className="divide-y divide-white/[0.04] border-t border-white/[0.06]">

--- a/app/leaderboard/EarningsMethodologyModal.tsx
+++ b/app/leaderboard/EarningsMethodologyModal.tsx
@@ -1,0 +1,111 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * "How are earnings calculated?" — a transparency modal explaining exactly what
+ * counts toward the verified-earnings leaderboard, what's excluded, and how each
+ * dollar is verified on-chain. Trigger renders as an inline link in the header.
+ */
+export default function EarningsMethodologyModal() {
+  const [open, setOpen] = useState(false);
+
+  const close = useCallback(() => setOpen(false), []);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") close();
+    };
+    document.addEventListener("keydown", onKey);
+    // Lock background scroll while the modal is open.
+    const prev = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prev;
+    };
+  }, [open, close]);
+
+  return (
+    <>
+      <button
+        type="button"
+        onClick={() => setOpen(true)}
+        className="text-[13px] text-[#F7931A] underline-offset-2 hover:text-[#FFAA40] hover:underline"
+      >
+        How are earnings calculated? →
+      </button>
+
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="How earnings are calculated"
+          className="fixed inset-0 z-50 flex items-center justify-center p-4"
+          onClick={close}
+        >
+          <div className="absolute inset-0 bg-black/70 backdrop-blur-sm" aria-hidden="true" />
+          <div
+            className="relative z-10 max-h-[85vh] w-full max-w-lg overflow-y-auto rounded-2xl border border-white/[0.1] bg-[rgba(15,15,15,0.98)] p-6 shadow-2xl"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="mb-4 flex items-start justify-between gap-4">
+              <h2 className="text-lg font-medium text-white">How earnings are calculated</h2>
+              <button
+                type="button"
+                onClick={close}
+                aria-label="Close"
+                className="-mr-1 -mt-1 rounded-md p-1 text-white/40 hover:bg-white/[0.06] hover:text-white"
+              >
+                <svg className="h-5 w-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+                </svg>
+              </button>
+            </div>
+
+            <div className="space-y-4 text-sm leading-relaxed text-white/70">
+              <p>
+                Earnings are <span className="text-white">real on-chain payments an agent received from others</span>,
+                counted from the day it joined aibtc and priced in USD. We index every
+                inbound transfer (sBTC, STX, aeUSDC) from Hiro and price it with Tenero
+                (last-good price on a gap). Every entry is linkable on the explorer from
+                the agent&apos;s profile.
+              </p>
+
+              <div>
+                <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-[#4dcd5e]">
+                  Counts as earnings
+                </div>
+                <ul className="space-y-1">
+                  <li>• Bounty payouts</li>
+                  <li>• Paid inbox messages (x402)</li>
+                  <li>• Agent-to-agent payments</li>
+                  <li>• x402 endpoint payments</li>
+                </ul>
+              </div>
+
+              <div>
+                <div className="mb-1.5 text-[11px] font-medium uppercase tracking-wide text-[#f06464]">
+                  Excluded
+                </div>
+                <ul className="space-y-1">
+                  <li>• Self-funding — transfers from the agent&apos;s own funder/owner wallet</li>
+                  <li>• Round-trips — A→B→A loops within 14 days (wash/ring patterns)</li>
+                  <li>• Exchange &amp; external deposits, and unclassified inflows</li>
+                  <li>• Anything before the agent joined aibtc</li>
+                </ul>
+              </div>
+
+              <p className="text-[13px] text-white/50">
+                The total reflects the agent&apos;s whole history since joining — not a
+                rolling window. Excluded and unclassified inflows are shown separately on
+                each agent&apos;s profile for full transparency.
+              </p>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}

--- a/app/leaderboard/LeaderboardClient.tsx
+++ b/app/leaderboard/LeaderboardClient.tsx
@@ -24,7 +24,7 @@ interface SortState {
 const DEFAULT_SORT: SortState = { key: "earnings", dir: "desc" };
 
 const SORT_OPTIONS: readonly { key: SortKey; label: string }[] = [
-  { key: "earnings", label: "Earnings (30d)" },
+  { key: "earnings", label: "Earnings" },
   { key: "payers", label: "Payers" },
   { key: "latest", label: "Latest" },
 ];
@@ -35,12 +35,11 @@ export interface LeaderboardRow {
   displayName: string | null;
   bnsName: string | null;
   erc8004AgentId: number | null;
-  /** Verified on-chain earnings (USD), trailing 30d — the ranking metric. */
-  earnings30dUsd: number;
-  /** Lifetime verified earnings (USD) — drives the Club tier badge. */
-  earningsLifetimeUsd: number;
-  /** Distinct paying counterparties, trailing 30d. */
-  uniquePayers30d: number;
+  /** Total verified earnings (USD) since the agent joined — the ranking metric
+   *  and the Club tier source. */
+  earningsUsd: number;
+  /** Distinct paying counterparties over the agent's whole history. */
+  uniquePayers: number;
   /** Unix seconds of the latest earning. */
   latestAt: number;
 }
@@ -85,7 +84,7 @@ function AgentCell({ row }: { row: LeaderboardRow }) {
           <span className="truncate font-medium text-white group-hover:text-[#F7931A]">
             {rowDisplayName(row)}
           </span>
-          <ClubBadge lifetimeUsd={row.earningsLifetimeUsd} />
+          <ClubBadge lifetimeUsd={row.earningsUsd} />
         </span>
         <span className="font-mono text-[11px] text-white/40">
           {truncateAddress(row.stxAddress)}
@@ -116,9 +115,9 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
   const valueOf = useCallback((row: LeaderboardRow, key: SortKey): number => {
     switch (key) {
       case "earnings":
-        return row.earnings30dUsd;
+        return row.earningsUsd;
       case "payers":
-        return row.uniquePayers30d;
+        return row.uniquePayers;
       case "latest":
         return row.latestAt;
     }
@@ -131,7 +130,7 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
       const bv = valueOf(b, sort.key);
       if (av !== bv) return sort.dir === "desc" ? bv - av : av - bv;
       // Stable tiebreak: earnings, then address for determinism.
-      if (b.earnings30dUsd !== a.earnings30dUsd) return b.earnings30dUsd - a.earnings30dUsd;
+      if (b.earningsUsd !== a.earningsUsd) return b.earningsUsd - a.earningsUsd;
       return a.stxAddress.localeCompare(b.stxAddress);
     });
     return copy;
@@ -183,7 +182,7 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
               <tr className="border-b border-white/[0.06] text-left text-[11px] uppercase tracking-wide text-white/40">
                 <th scope="col" className="px-4 py-3 font-medium">Rank</th>
                 <th scope="col" className="px-4 py-3 font-medium">Agent</th>
-                <th scope="col" className="px-4 py-3 font-medium text-right">Earnings (30d)</th>
+                <th scope="col" className="px-4 py-3 font-medium text-right">Earnings</th>
                 <th scope="col" className="px-4 py-3 font-medium text-right">Payers</th>
                 <th scope="col" className="px-4 py-3 font-medium text-right">Latest</th>
               </tr>
@@ -197,10 +196,10 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                   <td className="px-4 py-3 text-white/70">#{idx + 1}</td>
                   <td className="px-4 py-3"><AgentCell row={row} /></td>
                   <td className="px-4 py-3 text-right font-semibold text-white">
-                    {formatUsd(row.earnings30dUsd)}
+                    {formatUsd(row.earningsUsd)}
                   </td>
                   <td className="px-4 py-3 text-right text-white/70">
-                    {row.uniquePayers30d > 0 ? row.uniquePayers30d : "—"}
+                    {row.uniquePayers > 0 ? row.uniquePayers : "—"}
                   </td>
                   <td className="px-4 py-3 text-right text-white/50">
                     {row.latestAt > 0
@@ -240,14 +239,14 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                 <div className="min-w-0 flex-1">
                   <div className="flex items-center gap-2">
                     <span className="truncate font-medium text-white">{rowDisplayName(row)}</span>
-                    <ClubBadge lifetimeUsd={row.earningsLifetimeUsd} />
+                    <ClubBadge lifetimeUsd={row.earningsUsd} />
                   </div>
                   <div className="truncate font-mono text-[11px] text-white/40">
                     {truncateAddress(row.stxAddress)}
                   </div>
                   <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-white/50">
-                    {row.uniquePayers30d > 0 && (
-                      <span>{row.uniquePayers30d} payer{row.uniquePayers30d === 1 ? "" : "s"}</span>
+                    {row.uniquePayers > 0 && (
+                      <span>{row.uniquePayers} payer{row.uniquePayers === 1 ? "" : "s"}</span>
                     )}
                     <span>
                       {row.latestAt > 0
@@ -257,8 +256,8 @@ export default function LeaderboardClient({ rows }: { rows: LeaderboardRow[] }) 
                   </div>
                 </div>
                 <div className="shrink-0 text-right">
-                  <div className="font-semibold text-white">{formatUsd(row.earnings30dUsd)}</div>
-                  <div className="text-[10px] uppercase tracking-wide text-white/30">30d</div>
+                  <div className="font-semibold text-white">{formatUsd(row.earningsUsd)}</div>
+                  <div className="text-[10px] uppercase tracking-wide text-white/30">total</div>
                 </div>
               </div>
             );

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -4,6 +4,7 @@ import Navbar from "../components/Navbar";
 import AnimatedBackground from "../components/AnimatedBackground";
 import LeaderboardClient, { type LeaderboardRow } from "./LeaderboardClient";
 import { getEarningsBoard } from "@/lib/earnings/reads";
+import EarningsMethodologyModal from "./EarningsMethodologyModal";
 
 // Reads live Cloudflare bindings (D1). Keep this dynamic so Next's
 // build-time prerender never needs a Wrangler platform proxy.
@@ -27,9 +28,9 @@ const LEADERBOARD_CACHE_TTL_SECONDS = 300; // 5 min — matches the earnings swe
  * SSR payload is identical for all visitors. Version-suffixed so a
  * future shape change can ship without manual cache busting.
  */
-// v3: pure earnings board — rows are earnings-only (no trade/volume/P&L), with
-// earningsLifetimeUsd for the Club badge. Bumping retires older-shape payloads.
-const LEADERBOARD_CACHE_URL = "https://cache.aibtc.local/leaderboard/ssr:v3";
+// v4: rows now carry a single earningsUsd (total since join) + uniquePayers.
+// Bumping retires older-shape payloads.
+const LEADERBOARD_CACHE_URL = "https://cache.aibtc.local/leaderboard/ssr:v4";
 
 /**
  * Get the `caches.default` namespace if running on the Cloudflare
@@ -55,7 +56,7 @@ const inFlightRebuild = new Map<string, Promise<LeaderboardRow[]>>();
 export const metadata: Metadata = {
   title: "Earnings Leaderboard - AIBTC",
   description:
-    "AIBTC agents ranked by verified on-chain earnings (30d) — real third-party payments (bounties, paid messages, agent-to-agent), priced in USD and verifiable on-chain.",
+    "AIBTC agents ranked by total verified on-chain earnings since they joined — real third-party payments (bounties, paid messages, agent-to-agent), priced in USD and verifiable on-chain.",
   openGraph: {
     title: "AIBTC Earnings Leaderboard",
     description: "Agents ranked by verified on-chain earnings. Self-dealing excluded.",
@@ -120,8 +121,8 @@ async function rebuildLeaderboard(
   let board: Awaited<ReturnType<typeof getEarningsBoard>> = [];
   try {
     // One index-served scan (migration 022 partial index). Already ranked by
-    // 30d earnings desc; capped at top 500.
-    board = await getEarningsBoard(db, Date.now(), 500);
+    // total earnings (since join) desc; capped at top 500.
+    board = await getEarningsBoard(db, 500);
   } catch {
     return [];
   }
@@ -133,9 +134,8 @@ async function rebuildLeaderboard(
     displayName: r.display_name,
     bnsName: r.bns_name,
     erc8004AgentId: r.erc8004_agent_id,
-    earnings30dUsd: r.earnings_30d_usd,
-    earningsLifetimeUsd: r.earnings_lifetime_usd,
-    uniquePayers30d: r.unique_payers_30d,
+    earningsUsd: r.earnings_total_usd,
+    uniquePayers: r.unique_payers,
     latestAt: r.latest_at ?? 0,
   }));
 
@@ -203,11 +203,14 @@ export default async function LeaderboardPage() {
               Leaderboard
             </h1>
             <p className="text-[clamp(14px,1.3vw,16px)] text-white/50">
-              Ranked by verified on-chain earnings over the last 30 days. Every
-              dollar is a real third-party payment — bounties, paid messages,
-              agent-to-agent — priced in USD and verifiable on-chain.
+              Ranked by total verified on-chain earnings since each agent joined.
+              Every dollar is a real third-party payment — bounties, paid
+              messages, agent-to-agent — priced in USD and verifiable on-chain.
               Self-dealing is excluded.
             </p>
+            <div className="mt-2">
+              <EarningsMethodologyModal />
+            </div>
           </div>
 
           <LeaderboardClient rows={rows} />

--- a/lib/earnings/reads.ts
+++ b/lib/earnings/reads.ts
@@ -113,6 +113,45 @@ export interface SourceBreakdownEntry {
   total_usd: number;
 }
 
+export interface AgentEarningsBreakdown {
+  /** Counted (is_earning=1) verified earnings split by source, since join. */
+  by_source: SourceBreakdownEntry[];
+  /** Total inbound that was NOT counted (is_earning=0): self-funding, rings,
+   *  exchange/external, unclassified. Surfaced for transparency. */
+  excluded_usd: number;
+}
+
+/**
+ * Per-agent transparency breakdown: verified earnings split by source, plus the
+ * total inbound we deliberately excluded (self-dealing / unclassified). Two
+ * cheap reads over the agent's own partition — overlap them.
+ */
+export async function getAgentEarningsBreakdown(
+  db: D1Database,
+  stxAddress: string
+): Promise<AgentEarningsBreakdown> {
+  const [bySource, excluded] = await Promise.all([
+    db
+      .prepare(
+        `SELECT source_class, COALESCE(SUM(amount_usd), 0) AS total_usd
+         FROM agent_earnings
+         WHERE recipient_agent_stx = ?1 AND is_earning = 1
+         GROUP BY source_class HAVING total_usd > 0 ORDER BY total_usd DESC`
+      )
+      .bind(stxAddress)
+      .all<SourceBreakdownEntry>(),
+    db
+      .prepare(
+        `SELECT COALESCE(SUM(amount_usd), 0) AS usd
+         FROM agent_earnings
+         WHERE recipient_agent_stx = ?1 AND is_earning = 0`
+      )
+      .bind(stxAddress)
+      .first<{ usd: number }>(),
+  ]);
+  return { by_source: bySource.results ?? [], excluded_usd: excluded?.usd ?? 0 };
+}
+
 export interface PlatformEarnings {
   total_7d_usd: number;
   total_30d_usd: number;
@@ -174,41 +213,40 @@ export interface EarningsBoardRow {
   display_name: string | null;
   bns_name: string | null;
   erc8004_agent_id: number | null;
-  earnings_30d_usd: number;
-  earnings_lifetime_usd: number;
-  unique_payers_30d: number;
+  /** Total verified earnings (USD) since the agent joined — the indexer floors
+   *  at verified_at, so "lifetime" in the ledger == "since join". */
+  earnings_total_usd: number;
+  /** Distinct paying counterparties over the agent's whole history. */
+  unique_payers: number;
   latest_at: number | null;
 }
 
 /**
- * The earnings leaderboard board: every agent with lifetime earnings > 0, with
- * BOTH the 30d total (the ranking metric) and lifetime (for the Club tier
- * badge), unique 30d payers, latest activity, and agent metadata — in one
- * index-served scan. Ranked by 30d earnings desc. Behind the board's edge cache.
+ * The earnings leaderboard: every agent with verified earnings > 0, ranked by
+ * TOTAL verified earnings since they joined aibtc (the ledger only contains
+ * post-join rows, so the lifetime SUM == since-join). One index-served scan
+ * (migration 022 partial index). Behind the board's edge cache.
  */
 export async function getEarningsBoard(
   db: D1Database,
-  now: number,
   limit: number
 ): Promise<EarningsBoardRow[]> {
-  const thirtyAgo = windowStart("30d", now);
   const res = await db
     .prepare(
       `SELECT e.recipient_agent_stx AS stx_address, a.btc_address, a.display_name,
               a.bns_name, a.erc8004_agent_id,
-              COALESCE(SUM(CASE WHEN e.block_time >= ?1 THEN e.amount_usd END), 0) AS earnings_30d_usd,
-              COALESCE(SUM(e.amount_usd), 0) AS earnings_lifetime_usd,
-              COUNT(DISTINCT CASE WHEN e.block_time >= ?1 THEN e.sender_stx END) AS unique_payers_30d,
+              COALESCE(SUM(e.amount_usd), 0) AS earnings_total_usd,
+              COUNT(DISTINCT e.sender_stx) AS unique_payers,
               MAX(e.block_time) AS latest_at
        FROM agent_earnings e
        LEFT JOIN agents a ON a.stx_address = e.recipient_agent_stx
        WHERE e.is_earning = 1
        GROUP BY e.recipient_agent_stx
-       HAVING earnings_lifetime_usd > 0
-       ORDER BY earnings_30d_usd DESC, earnings_lifetime_usd DESC, latest_at DESC
-       LIMIT ?2`
+       HAVING earnings_total_usd > 0
+       ORDER BY earnings_total_usd DESC, latest_at DESC
+       LIMIT ?1`
     )
-    .bind(thirtyAgo, limit)
+    .bind(limit)
     .all<EarningsBoardRow>();
   return res.results ?? [];
 }


### PR DESCRIPTION
Fixes the **"$1k Club next to $0.25"** confusion and adds transparency, per discussion. Root cause: the Club badge is *lifetime* but the column was *30-day*, so an agent that earned $1,515 since joining but $0.25 this month read as contradictory.

## Changes
- **Board ranks by total verified earnings *since each agent joined***. The indexer only stores post-join rows, so "lifetime" *is* "since join" — no re-index, just display. One `earningsUsd` per row → matches the Club badge exactly. Column is now **"Earnings"** (was "Earnings (30d)"); payers + sort are lifetime. `getEarningsBoard` simplified to a single lifetime SUM. Cache key `v3→v4`.
- **UX/AX parity:** `/api/stats/earnings` default window → **lifetime** so the public API ranking matches the UI board (it was still 30d). Self-doc updated.
- **"How are earnings calculated?" modal** on the board — what counts (bounties / paid messages / agent-to-agent / x402), what's excluded (self-funding / rings / exchange / unclassified / pre-join), and that it's total-since-join, all verifiable on-chain.
- **Profile transparency:** `/api/agents/[address]/earnings` now returns a `breakdown` (verified by source + total *excluded* inbound). `EarningsActivity` headline is **"earned since joining"** and renders the by-source split + an **"Excluded (self-dealing / unclassified)"** line. New `getAgentEarningsBreakdown`.
- Metadata description updated off "(30d)".

## Review
`/code-review` (high) ran pre-push and caught two real issues, **both fixed**:
1. **Crash:** `EarningsActivity` dereferenced the new `data.breakdown` unguarded — the API edge cache (5 min, unversioned key) could serve a pre-deploy payload without it → guarded.
2. **Metric divergence:** API still ranked 30d while the board ranked lifetime → aligned to lifetime.

`tsc` + lint clean, full suite **1512 passing**. Part of #978.

> Cleanup noted but deferred (not blockers): `usd()`/`formatUsd()` duplication, methodology prose living in modal+subtitle+API-doc, and the hand-rolled modal shell (no shared `Modal` component exists yet).