### PR TITLE
chore(earnings): relax sweep cadence 5min → 30min (#978)

### DIFF
--- a/lib/earnings/constants.ts
+++ b/lib/earnings/constants.ts
@@ -23,10 +23,10 @@ export const EARNINGS_HIRO_PAGE_LIMIT = 50;
  *  day-one indexing can't spike Hiro usage; deep history fills over many ticks. */
 export const EARNINGS_MAX_PAGES_PER_AGENT = 4;
 
-// How often the earnings sweep is due (ms). 5 min during the initial backfill
-// rollout = every cron tick (the fastest the every-5-min cron trigger allows)
-// so the roster backfills quickly. Relax once fully backfilled.
-export const EARNINGS_INTERVAL_MS = 5 * 60 * 1000;
+// How often the earnings sweep is due (ms). 30 min in steady state — the full
+// roster is backfilled, so this only needs to catch new inflows incrementally.
+// (Was 5 min during the initial backfill rollout to fill the board fast.)
+export const EARNINGS_INTERVAL_MS = 30 * 60 * 1000;
 
 /** Source classifications. `is_earning` is derived from these + excluded_reason. */
 export const EARNING_SOURCE_CLASSES = [


### PR DESCRIPTION
Backfill is complete (**1005/1005 indexed**, 573 earners, $23.3k verified), so the indexer only needs to catch new inflows incrementally now.

- **`EARNINGS_INTERVAL_MS` 5 min → 30 min.** The 5-min cadence was a temporary rollout setting to fill the board fast; 30 min is the steady-state value (~6× less D1/Hiro work).

The cron trigger still fires every 5 min; this just gates the earnings sweep to every 30 min (Tenero/competition tasks unaffected). One-line change, 36 scheduler/earnings tests pass. Part of #978.