### PR TITLE
perf(cf): cut KV list/write quota burn on health, tenero, and uncached GETs

### DIFF
--- a/app/api/capabilities/route.ts
+++ b/app/api/capabilities/route.ts
@@ -4,6 +4,13 @@ import type { AgentRecord } from "@/lib/types";
 import { normalizeAgentRecord } from "@/lib/agents";
 import { getAgentsIndex, type AgentIndexEntry } from "@/lib/agents-index";
 
+// Capability declarations change rarely (signed profile updates); an hour of
+// edge staleness is acceptable and collapses the per-request agents:index KV
+// read + per-agent record fan-out to once per TTL per colo. Mirrors the
+// /api/agents list cadence.
+const CACHE_CONTROL =
+  "public, max-age=300, s-maxage=3600, stale-while-revalidate=86400";
+
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
 
@@ -27,6 +34,8 @@ export async function GET(request: NextRequest) {
         filterByCapability: "/api/capabilities?capability=btc",
         paginateResults: "/api/capabilities?capability=defi&limit=10&offset=20",
       },
+    }, {
+      headers: { "Cache-Control": CACHE_CONTROL },
     });
   }
 
@@ -87,6 +96,8 @@ export async function GET(request: NextRequest) {
           offset,
           hasMore: offset + limit < matching.length,
         },
+      }, {
+        headers: { "Cache-Control": CACHE_CONTROL },
       });
     }
 
@@ -105,6 +116,8 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       capabilities: sorted,
       totalAgentsWithCapabilities: indexed.length,
+    }, {
+      headers: { "Cache-Control": CACHE_CONTROL },
     });
   } catch (err: unknown) {
     return NextResponse.json({ error: (err as Error).message }, { status: 500 });

--- a/app/api/get-name/route.ts
+++ b/app/api/get-name/route.ts
@@ -34,17 +34,31 @@ export async function GET(request: NextRequest) {
           address: "bc1qw508d6qejxtdg4y5r3zarvary0c5xw7kv8f3t4",
         },
       },
-      { status: 200 }
+      {
+        status: 200,
+        headers: {
+          "Cache-Control": "public, max-age=3600, s-maxage=86400",
+        },
+      }
     );
   }
 
   const hash = hashAddress(address);
   const generated = generateNameDetailed(address);
 
-  return NextResponse.json({
-    name: generated.full,
-    parts: generated.parts,
-    hash,
-    address,
-  });
+  // Deterministic: the same address always produces the same name, so the
+  // response is cacheable indefinitely — no KV/D1 reads to go stale.
+  return NextResponse.json(
+    {
+      name: generated.full,
+      parts: generated.parts,
+      hash,
+      address,
+    },
+    {
+      headers: {
+        "Cache-Control": "public, max-age=86400, s-maxage=604800, immutable",
+      },
+    }
+  );
 }

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { withEdgeCache } from "@/lib/edge-cache";
 
 /**
  * GET /api/health — System health check endpoint.
@@ -12,7 +13,37 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
  *
  * Used by agents and monitoring systems to verify the platform is operational
  * before attempting registration or verification calls.
+ *
+ * Cost note: agent counts come from full `kv.list()` prefix scans, and list
+ * operations are the smallest KV quota on the paid plan (1M/mo, $5/M after).
+ * This endpoint is polled by monitors and unauthenticated agents, so the
+ * counts are served from `caches.default` (5-min TTL) and only the scan
+ * refresh pays for list operations. Connectivity is probed with a single
+ * keys-read (10M/mo quota) instead.
  */
+
+const COUNTS_CACHE_KEY =
+  "https://cache.aibtc.local/internal/health-agent-counts";
+const COUNTS_CACHE_TTL_SECONDS = 300;
+
+interface AgentCounts {
+  registered: number;
+  claimed: number;
+}
+
+async function countPrefix(ns: KVNamespace, prefix: string): Promise<number> {
+  let count = 0;
+  let cursor: string | undefined;
+  let complete = false;
+  while (!complete) {
+    const page = await ns.list({ prefix, cursor });
+    count += page.keys.length;
+    complete = page.list_complete;
+    cursor = !page.list_complete ? page.cursor : undefined;
+  }
+  return count;
+}
+
 export async function GET() {
   const timestamp = new Date().toISOString();
   const version = "1.0.0";
@@ -26,26 +57,32 @@ export async function GET() {
     const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
+    // Connectivity probe: a single read (null result still proves KV
+    // answered) — never a list scan.
+    await kv.get("health:probe");
     kvStatus = "connected";
 
-    async function countPrefix(ns: KVNamespace, prefix: string): Promise<number> {
-      let count = 0;
-      let cursor: string | undefined;
-      let complete = false;
-      while (!complete) {
-        const page = await ns.list({ prefix, cursor });
-        count += page.keys.length;
-        complete = page.list_complete;
-        cursor = !page.list_complete ? page.cursor : undefined;
-      }
-      return count;
-    }
-
-    // Count registered and claimed agents in parallel
-    [registeredCount, claimedCount] = await Promise.all([
-      countPrefix(kv, "stx:"),
-      countPrefix(kv, "claim:"),
-    ]);
+    const countsResponse = await withEdgeCache(
+      COUNTS_CACHE_KEY,
+      COUNTS_CACHE_TTL_SECONDS,
+      async () => {
+        const [registered, claimed] = await Promise.all([
+          countPrefix(kv, "stx:"),
+          countPrefix(kv, "claim:"),
+        ]);
+        return NextResponse.json(
+          { registered, claimed } satisfies AgentCounts,
+          {
+            headers: {
+              "Cache-Control": `public, s-maxage=${COUNTS_CACHE_TTL_SECONDS}`,
+            },
+          },
+        );
+      },
+    );
+    const counts = (await countsResponse.json()) as AgentCounts;
+    registeredCount = counts.registered;
+    claimedCount = counts.claimed;
   } catch (e) {
     kvError = (e as Error).message;
   }

--- a/lib/scheduler/__tests__/tenero-task.test.ts
+++ b/lib/scheduler/__tests__/tenero-task.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   runTeneroTask,
   TENERO_MONTH_QUOTA_BACKOFF_MS,
+  TENERO_UNCHANGED_REWRITE_MS,
 } from "../tenero-task";
 
 /** Minimal logger double — captures events without console noise. */
@@ -166,6 +167,113 @@ describe("runTeneroTask", () => {
     expect(
       events.some((e) => e.msg === "tenero.price_stablecoin_fallback_used")
     ).toBe(true);
+  });
+
+  it("unchanged price with a fresh cache entry: skips the KV rewrite", async () => {
+    const { logger } = createCapturingLogger();
+    const { kv, puts, store } = createFakeKv();
+
+    const fixedNow = 1_715_000_000_000;
+    // Pre-seed a fresh cache entry with the same price the fetch returns.
+    store.set(
+      "tenero:price:stx",
+      JSON.stringify({
+        priceUsd: 1.85,
+        fetchedAt: fixedNow - 5 * 60 * 1000,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    );
+
+    globalThis.fetch = vi.fn(async () =>
+      teneroResponse(200, {
+        priceUsd: 1.85,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    ) as unknown as typeof fetch;
+
+    const { result } = await runTeneroTask({
+      logger,
+      kv,
+      tokenIds: ["stx"],
+      now: () => fixedNow,
+    });
+
+    expect(result.succeeded).toBe(1);
+    expect(result.failed).toBe(0);
+    expect(puts).toHaveLength(0);
+  });
+
+  it("unchanged price but stale cache entry: rewrites to renew TTL", async () => {
+    const { logger } = createCapturingLogger();
+    const { kv, puts, store } = createFakeKv();
+
+    const fixedNow = 1_715_000_000_000;
+    // Same price, but the entry is past the unchanged-rewrite window.
+    store.set(
+      "tenero:price:stx",
+      JSON.stringify({
+        priceUsd: 1.85,
+        fetchedAt: fixedNow - TENERO_UNCHANGED_REWRITE_MS - 1,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    );
+
+    globalThis.fetch = vi.fn(async () =>
+      teneroResponse(200, {
+        priceUsd: 1.85,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    ) as unknown as typeof fetch;
+
+    const { result } = await runTeneroTask({
+      logger,
+      kv,
+      tokenIds: ["stx"],
+      now: () => fixedNow,
+    });
+
+    expect(result.succeeded).toBe(1);
+    expect(puts).toHaveLength(1);
+    expect(JSON.parse(puts[0].value).fetchedAt).toBe(fixedNow);
+  });
+
+  it("changed price: rewrites even when the cache entry is fresh", async () => {
+    const { logger } = createCapturingLogger();
+    const { kv, puts, store } = createFakeKv();
+
+    const fixedNow = 1_715_000_000_000;
+    store.set(
+      "tenero:price:stx",
+      JSON.stringify({
+        priceUsd: 1.8,
+        fetchedAt: fixedNow - 5 * 60 * 1000,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    );
+
+    globalThis.fetch = vi.fn(async () =>
+      teneroResponse(200, {
+        priceUsd: 1.85,
+        minuteRemaining: 99,
+        monthRemaining: 49_000,
+      })
+    ) as unknown as typeof fetch;
+
+    const { result } = await runTeneroTask({
+      logger,
+      kv,
+      tokenIds: ["stx"],
+      now: () => fixedNow,
+    });
+
+    expect(result.succeeded).toBe(1);
+    expect(puts).toHaveLength(1);
+    expect(JSON.parse(puts[0].value).priceUsd).toBe(1.85);
   });
 
   it("5xx response: bumps `failed`, no KV write", async () => {

--- a/lib/scheduler/tenero-task.ts
+++ b/lib/scheduler/tenero-task.ts
@@ -12,7 +12,10 @@
  */
 
 import { fetchTokenPriceUsd } from "../external/tenero";
-import { setCachedTokenPrice } from "../external/tenero/kv-cache";
+import {
+  getCachedTokenPrice,
+  setCachedTokenPrice,
+} from "../external/tenero/kv-cache";
 import type { Logger } from "../logging";
 
 export interface TeneroRunResult {
@@ -52,6 +55,16 @@ export interface TeneroTaskOutcome {
 export const TENERO_MINUTE_QUOTA_BACKOFF_MS = 5 * 60 * 1000;
 export const TENERO_MONTH_QUOTA_BACKOFF_MS = 24 * 60 * 60 * 1000;
 
+/**
+ * Skip the KV rewrite when the fetched price equals the cached one and the
+ * cached entry is younger than this. KV writes are the tightest paid-plan
+ * quota (1M/mo; this task alone was ~458k/mo at 53 tokens × 5-min cadence)
+ * while the comparison read costs 10x less than the write it avoids. The
+ * periodic rewrite past this age keeps `fetchedAt` honest for readers and
+ * renews the 24h KV TTL safety net.
+ */
+export const TENERO_UNCHANGED_REWRITE_MS = 60 * 60 * 1000;
+
 export async function runTeneroTask(
   deps: TeneroTaskDeps
 ): Promise<TeneroTaskOutcome> {
@@ -80,12 +93,19 @@ export async function runTeneroTask(
       rateLimited = true;
     } else if (r.status === 200) {
       try {
-        await setCachedTokenPrice(kv, tokenId, {
-          priceUsd: r.priceUsd,
-          fetchedAt: now(),
-          minuteRemaining: r.rateLimit.minuteRemaining,
-          monthRemaining: r.rateLimit.monthRemaining,
-        });
+        const prev = await getCachedTokenPrice(kv, tokenId);
+        const unchanged =
+          prev !== null &&
+          prev.priceUsd === r.priceUsd &&
+          now() - prev.fetchedAt < TENERO_UNCHANGED_REWRITE_MS;
+        if (!unchanged) {
+          await setCachedTokenPrice(kv, tokenId, {
+            priceUsd: r.priceUsd,
+            fetchedAt: now(),
+            minuteRemaining: r.rateLimit.minuteRemaining,
+            monthRemaining: r.rateLimit.monthRemaining,
+          });
+        }
         succeeded++;
       } catch (error) {
         logger.warn("tenero.kv_write_failed", {


### PR DESCRIPTION
## Summary

Three cost-hygiene fixes from a Cloudflare $5/mo Workers plan audit (pricing verified against Cloudflare docs). Goal: keep the bill at $5 by closing the only realistic paths to overage.

### 1. `/api/health` — stop full KV list scans per hit
The endpoint ran two full cursor-paginated `kv.list()` prefix scans (`stx:` + `claim:`) on every request, with `no-store` so nothing was ever cached. List ops are the **smallest** KV quota on the paid plan (1M/mo, $5/M after), and this is a public endpoint polled by monitors and agents — cost also doubles automatically once the keyspace passes 1,000 keys/prefix.

Now: agent counts are served from `caches.default` (5-min TTL, via the existing `withEdgeCache` helper) and KV connectivity is probed with a single keys-read (10M/mo quota). **Response shape unchanged**, including the `agentCount` backwards-compat field; counts can be up to 5 min stale.

### 2. Tenero price refresh — write-on-change
The 5-min refresh wrote every token to KV every tick: ~458k writes/mo at 53 tokens, i.e. **~46% of the 1M/mo write quota** from one task. Now a comparison read (reads bill at 1/10th the write rate) gates the put: skip when the price is unchanged **and** the entry is under 1h old. The hourly forced rewrite keeps `fetchedAt` honest and renews the 24h TTL safety net, so a stable token can never silently expire. Verified no reader enforces a freshness threshold on `fetchedAt` before making this change. 3 new tests cover skip / stale-rewrite / changed-price-rewrite.

Trade-off: adds ~458k KV reads/mo against the 10M read quota — net strongly positive.

### 3. Cache-Control on the two fully uncached GET endpoints
- `/api/get-name`: deterministic (same address → same name, no storage reads), now `public, max-age=86400, s-maxage=604800, immutable`; self-doc response 1h/24h.
- `/api/capabilities`: `public, max-age=300, s-maxage=3600, stale-while-revalidate=86400` on all three response shapes, mirroring the `/api/agents` list cadence; errors stay uncached. Collapses the per-request `agents:index` KV read + per-agent record fan-out.

## Testing
- `npm run lint` clean (one pre-existing `<img>` warning on `app/page.tsx`)
- `npm run test`: 96 files / 1515 tests passed (incl. 3 new)
- `npm run build` passes