### PR TITLE
fix(scheduler): capture cron failures to KV for diagnosis

### DIFF
--- a/worker.ts
+++ b/worker.ts
@@ -49,13 +49,41 @@ export default {
         })
       : createConsoleLogger({ path: "/__cron/scheduler", cron: event.cron });
 
+    // Capture any cron failure straight to KV, independent of the LOGS RPC
+    // path — the cron has been failing with an opaque "Internal Error" and the
+    // dashboard shows no stack. Writing the raw error to `scheduler:last-error`
+    // lets us read the exact exception with `wrangler kv key get`. The capture
+    // is fully self-guarded so it can never itself crash the invocation.
     ctx.waitUntil(
-      runScheduledTasks(env, logger).catch((error) =>
-        logger.error("scheduler.cron_failed", {
-          error: String(error),
-          stack: error instanceof Error ? error.stack : undefined,
-        })
-      )
+      (async () => {
+        try {
+          await runScheduledTasks(env, logger);
+        } catch (error) {
+          const detail = {
+            at: Date.now(),
+            cron: event.cron,
+            name: error instanceof Error ? error.name : undefined,
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          };
+          try {
+            await env.VERIFIED_AGENTS.put(
+              "scheduler:last-error",
+              JSON.stringify(detail)
+            );
+          } catch {
+            // KV write failed too — nothing more we can safely do here.
+          }
+          try {
+            logger.error("scheduler.cron_failed", {
+              error: detail.message,
+              stack: detail.stack,
+            });
+          } catch {
+            // Logger itself may be the failing dependency; ignore.
+          }
+        }
+      })()
     );
   },
 


### PR DESCRIPTION
## Why

The production cron has been failing **every tick** with an opaque `Internal Error` and ~200ms CPU — no stack trace in the dashboard. As a result **all scheduled work is frozen**: Tenero prices, the competition sweep, the earnings indexer, and the legion snapshot have not updated since ~yesterday (confirmed via stale `scheduler:*` lastRunAt in KV).

Per the Cloudflare scheduled-handler docs this is an unhandled exception (not a timeout — the limit is 15 min, we die at 200ms), but we have no visibility into *which line* throws.

## What

Wrap the scheduled run in a fully self-guarded `try/catch` that writes the raw error (`name` + `message` + `stack`) to KV `scheduler:last-error`, **independent of the LOGS RPC path** (which may itself be the failing dependency). Switches the inner run to awaited execution inside `ctx.waitUntil` so a thrown task is observable.

This is diagnosis + hardening: a thrown task can no longer silently nuke the whole cron, and we can finally read the exact exception:

```bash
wrangler kv key get scheduler:last-error --binding VERIFIED_AGENTS --remote --text
```

## After deploy

1. Wait one cron tick (≤5 min)
2. Read `scheduler:last-error`
3. Fix the real root cause from the stack trace