### PR TITLE
fix(hiro): authenticate with x-api-key — fixes frozen cron/scheduler

### DIFF
--- a/lib/balances/btc.ts
+++ b/lib/balances/btc.ts
@@ -65,7 +65,11 @@ async function fetchL1Sats(btcAddress: string): Promise<number> {
 async function fetchL2Sats(stxAddress: string, hiroApiKey?: string): Promise<number> {
   const url = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/balances`;
   const headers: Record<string, string> = { Accept: "application/json" };
-  if (hiroApiKey) headers["x-hiro-api-key"] = hiroApiKey;
+  if (hiroApiKey) {
+    // `x-api-key` is Hiro's documented header; `x-hiro-api-key` is deprecated.
+    headers["x-api-key"] = hiroApiKey;
+    headers["x-hiro-api-key"] = hiroApiKey;
+  }
   const res = await fetch(url, { headers });
   if (!res.ok) return 0;
   const body = (await res.json()) as {

--- a/lib/competition/scheduler.ts
+++ b/lib/competition/scheduler.ts
@@ -111,7 +111,13 @@ async function fetchAddressTxs(
 ): Promise<AddressTxEntry[]> {
   const url = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/transactions?limit=${HIRO_TX_PAGE_LIMIT}`;
   const headers: Record<string, string> = { Accept: "application/json" };
-  if (env.HIRO_API_KEY) headers["x-hiro-api-key"] = env.HIRO_API_KEY;
+  if (env.HIRO_API_KEY) {
+    // `x-api-key` is Hiro's documented header; `x-hiro-api-key` is deprecated
+    // and stopped authenticating — sending only it makes the sweep anonymous,
+    // which gets 429-rate-limited on the shared Worker IP and stalls the cron.
+    headers["x-api-key"] = env.HIRO_API_KEY;
+    headers["x-hiro-api-key"] = env.HIRO_API_KEY;
+  }
 
   try {
     const response = await stacksApiFetch(url, { method: "GET", headers }, { logger });

--- a/lib/competition/verify.ts
+++ b/lib/competition/verify.ts
@@ -210,7 +210,11 @@ export async function fetchTxFromHiro(
 > {
   const url = `${STACKS_API_BASE}/extended/v1/tx/${txid}`;
   const headers: Record<string, string> = { Accept: "application/json" };
-  if (env.HIRO_API_KEY) headers["x-hiro-api-key"] = env.HIRO_API_KEY;
+  if (env.HIRO_API_KEY) {
+    // `x-api-key` is Hiro's documented header; `x-hiro-api-key` is deprecated.
+    headers["x-api-key"] = env.HIRO_API_KEY;
+    headers["x-hiro-api-key"] = env.HIRO_API_KEY;
+  }
 
   let response: Response;
   try {

--- a/lib/stacks-api-fetch.ts
+++ b/lib/stacks-api-fetch.ts
@@ -24,7 +24,12 @@ import type { Logger } from "./logging";
 export function buildHiroHeaders(hiroApiKey?: string): Record<string, string> {
   const headers: Record<string, string> = {};
   if (hiroApiKey) {
-    headers["X-Hiro-API-Key"] = hiroApiKey;
+    // Hiro's documented header is `x-api-key`. The legacy `x-hiro-api-key` was
+    // deprecated and stopped authenticating (~June 2026) — sending only it makes
+    // requests anonymous → 429 rate-limiting on the shared Worker IP. Send the
+    // documented header (plus the legacy one for safety).
+    headers["x-api-key"] = hiroApiKey;
+    headers["x-hiro-api-key"] = hiroApiKey;
   }
   return headers;
 }


### PR DESCRIPTION
## Root cause (confirmed via live cron logs)

The production cron has been throwing **'Internal Error'** every tick and freezing all scheduled work (competition, earnings) since ~June 16. Live dashboard logs traced it to the **competition sweep getting `429` rate-limited on every Hiro request**, retrying, and the retry storm **killing the whole cron invocation mid-run** — an uncatchable runtime kill, which is why it showed as an opaque 'Internal Error' with no stack and our KV error-capture stayed empty.

Why 429s: **Hiro deprecated the `x-hiro-api-key` header (~mid-June 2026).** Requests sending only it authenticate as **anonymous** → strict per-IP rate limit on the Worker's shared colo IP → constant 429. (This also matches the dashboard showing the Hiro key with no recent request attribution.)

The **legion** path was already fixed for this on June 17 (`9c86295`), but the other four Hiro call sites were missed.

## Fix

Send Hiro's documented `x-api-key` header (plus the legacy one for safety) at all four sites:
- `lib/stacks-api-fetch.ts` `buildHiroHeaders` (shared — identity, inbox, etc.)
- `lib/balances/btc.ts`
- `lib/competition/verify.ts`
- `lib/competition/scheduler.ts` ← the cron-killing sweep

## After deploy

competition's Hiro requests authenticate → no 429 storm → the sweep completes → the cron run finishes → **competition/earnings start advancing again and the scheduler recovers.**

## Follow-ups (separate)
- Tenero key shows no requests after June 8 — verify `TENERO_API_KEY` is valid/passed (Tenero already uses `x-api-key`, so different cause).
- Clear the stale tenero 24h backoff: `wrangler kv key delete scheduler:tenero`.
- Re-land legion (#999 was reverted to isolate this; it was innocent).