### PR TITLE
Re-land legion + standalone aibtc-scheduler worker (retire landing-page cron)

### DIFF
--- a/app/api/legion/route.ts
+++ b/app/api/legion/route.ts
@@ -1,0 +1,78 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// Read-only Legion dashboard snapshot (Stacks testnet). No auth, no per-caller
+// branching. D1 is the source of truth (written by the 5-min cron); this
+// endpoint reads it via getLegionSnapshot, which layers caches.default +
+// singleflight on top (mirrors the leaderboard). Hiro is only hit on a
+// stale/cold rebuild, never per request.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import { getLegionSnapshot } from "@/lib/legion/read";
+import {
+  GOV_CONTRACT,
+  GOV_RULES,
+  TREASURY_CONTRACT,
+} from "@/lib/legion/constants";
+
+export const dynamic = "force-dynamic";
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/legion",
+      method: "GET",
+      description:
+        "Read-only snapshot of the AIBTC Legion (Stacks testnet): treasury, members, and the full lifecycle of every governance proposal — including who voted and whether each proposal is passing. Built server-side on a cron, stored in D1, served from cache. Never accepts writes.",
+      network: "stacks-testnet",
+      contracts: {
+        treasury: TREASURY_CONTRACT,
+        gov: GOV_CONTRACT,
+      },
+      governanceRules: GOV_RULES,
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseShape: {
+        updatedAt: "number (unix ms)",
+        blockHeight: "number | null (stacks tip at snapshot time)",
+        treasury: "{ balance (sats), govWired, tokenWired }",
+        totalStaked: "number | null (sats)",
+        members: "Array<{ label, address, stake, weightPct, sbtcBalance }>",
+        proposals:
+          "Array<{ id, proposer, recipient, desc, amount, status, votes }> (newest first); status carries metQuorum/metThreshold/voterCount/vetoActivated/concluded/executed; votes is per-agent { voted, vote, amount }",
+        errors: "string[] (per-read failures; partial snapshots are still served)",
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") return selfDocResponse();
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: "/api/legion" })
+    : createConsoleLogger({ rayId, path: "/api/legion" });
+
+  const snapshot = await getLegionSnapshot(env, ctx, logger);
+
+  if (!snapshot) {
+    // No D1 binding / nothing built yet — tell the client to retry, don't pin.
+    return NextResponse.json(
+      { error: "snapshot_unavailable" },
+      { status: 503, headers: { "Cache-Control": "no-store", "Retry-After": "10" } },
+    );
+  }
+
+  return NextResponse.json(snapshot, {
+    headers: { "Cache-Control": "public, max-age=60, s-maxage=60" },
+  });
+}

--- a/app/components/CopyButton.tsx
+++ b/app/components/CopyButton.tsx
@@ -7,6 +7,12 @@ interface CopyButtonProps {
   label?: React.ReactNode;
   variant?: "primary" | "secondary" | "icon" | "inline";
   className?: string;
+  /**
+   * Accessible name for the button. Needed when `label` is empty or a
+   * non-text node (e.g. the inline variant), so screen readers still
+   * announce a meaningful action. Falls back to "Copy".
+   */
+  ariaLabel?: string;
 }
 
 export default function CopyButton({
@@ -14,7 +20,11 @@ export default function CopyButton({
   label = "Copy",
   variant = "secondary",
   className = "",
+  ariaLabel,
 }: CopyButtonProps) {
+  const accessibleName =
+    ariaLabel ??
+    (typeof label === "string" && label.length > 0 ? label : "Copy");
   const [copied, setCopied] = useState(false);
   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
 
@@ -57,6 +67,7 @@ export default function CopyButton({
     return (
       <button
         onClick={handleCopy}
+        aria-label={accessibleName}
         className={`group relative cursor-pointer transition-all duration-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F7931A]/50 rounded-xl ${className}`}
       >
         {label}
@@ -78,6 +89,7 @@ export default function CopyButton({
       return (
         <button
           onClick={handleCopy}
+          aria-label={accessibleName}
           className={`inline-flex items-center justify-center min-w-[44px] min-h-[44px] transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F7931A]/50 rounded ${variantStyles.icon} ${className}`}
         >
           <svg

--- a/app/legion/AddressLink.tsx
+++ b/app/legion/AddressLink.tsx
@@ -1,0 +1,32 @@
+"use client";
+
+import CopyButton from "../components/CopyButton";
+import { explorerAddressUrl } from "@/lib/legion/constants";
+import { shortAddress } from "@/lib/legion/format";
+
+/**
+ * Shortened address that links to the testnet explorer, with an inline copy
+ * button. Optionally shows the agent label as the primary text.
+ */
+export default function AddressLink({
+  address,
+  label,
+}: {
+  address: string;
+  label?: string | null;
+}) {
+  return (
+    <span className="inline-flex items-center gap-1.5">
+      <a
+        href={explorerAddressUrl(address)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="font-mono text-sm text-white/80 transition-colors hover:text-[#F7931A]"
+        title={address}
+      >
+        {label ?? shortAddress(address)}
+      </a>
+      <CopyButton text={address} variant="inline" label="" />
+    </span>
+  );
+}

--- a/app/legion/AddressLink.tsx
+++ b/app/legion/AddressLink.tsx
@@ -26,7 +26,7 @@ export default function AddressLink({
       >
         {label ?? shortAddress(address)}
       </a>
-      <CopyButton text={address} variant="inline" label="" />
+      <CopyButton text={address} variant="inline" label="" ariaLabel="Copy address" />
     </span>
   );
 }

--- a/app/legion/HowToParticipate.tsx
+++ b/app/legion/HowToParticipate.tsx
@@ -1,0 +1,99 @@
+import Link from "next/link";
+import { GOV_RULES } from "@/lib/legion/constants";
+
+const STEPS: { title: string; body: React.ReactNode }[] = [
+  {
+    title: "Get sBTC",
+    body: (
+      <>
+        Call <code>faucet</code> on the sBTC token to fund a testnet wallet.
+      </>
+    ),
+  },
+  {
+    title: "Join / gain voting power",
+    body: (
+      <>
+        <code>legion-gov stake(sbtc-token, amount)</code> — moves sBTC into the
+        treasury; your voting weight equals the amount you stake.
+      </>
+    ),
+  },
+  {
+    title: "Propose",
+    body: (
+      <>
+        <code>legion-gov propose(description, recipient, amount)</code> —
+        description 1–256 ASCII; recipient must not be the gov or treasury
+        contract; amount &gt; 0.
+      </>
+    ),
+  },
+  {
+    title: "Vote",
+    body: (
+      <>
+        <code>legion-gov vote(proposal-id, true|false)</code> during the Voting
+        window. You can change your vote while the window is open.
+      </>
+    ),
+  },
+  {
+    title: "Veto (optional)",
+    body: (
+      <>
+        <code>legion-gov veto(proposal-id)</code> during the Veto window.
+      </>
+    ),
+  },
+  {
+    title: "Conclude",
+    body: (
+      <>
+        <code>legion-gov conclude-proposal(proposal-id, sbtc-token)</code> during
+        the Execution window — executes the payout if the proposal passed.
+      </>
+    ),
+  },
+];
+
+export default function HowToParticipate() {
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">How agents participate</h2>
+      <p className="text-sm text-white/60">
+        The legion is governed entirely by agents calling the contracts directly.
+        Rules: quorum {GOV_RULES.quorumPct}%, threshold {GOV_RULES.thresholdPct}%,
+        minimum {GOV_RULES.minVoters} voters.
+      </p>
+      <p className="text-sm text-white/60">
+        Full agent skill — MCP tools and the exact contract calls to join, stake,
+        propose, vote, and conclude:{" "}
+        <Link
+          href="/legion/skill.md"
+          className="text-[#F7931A] underline underline-offset-2 hover:text-[#F7931A]/80"
+        >
+          /legion/skill.md
+        </Link>
+      </p>
+      <ol className="grid gap-3 sm:grid-cols-2">
+        {STEPS.map((step, i) => (
+          <li
+            key={step.title}
+            className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center gap-2">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[#F7931A]/15 text-xs font-semibold text-[#F7931A]">
+                {i + 1}
+              </span>
+              <span className="font-medium text-white">{step.title}</span>
+            </div>
+            <p className="mt-2 text-sm leading-relaxed text-white/60 [&_code]:rounded [&_code]:bg-black/30 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_code]:text-white/80">
+              {step.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/app/legion/LegionClient.tsx
+++ b/app/legion/LegionClient.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { LegionSnapshot } from "@/lib/legion/types";
+import LegionHeader from "./LegionHeader";
+import MembersTable from "./MembersTable";
+import ProposalCard from "./ProposalCard";
+import HowToParticipate from "./HowToParticipate";
+
+function UpdatedAt({ updatedAt }: { updatedAt: number }) {
+  // Compute relative time only after mount (SSR/client clocks differ) and
+  // re-tick every 15s so "Updated Xs ago" stays roughly live.
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, []);
+
+  let label = "live";
+  if (now != null) {
+    const secondsAgo = Math.max(0, Math.round((now - updatedAt) / 1000));
+    label =
+      secondsAgo < 60 ? `${secondsAgo}s ago` : `${Math.round(secondsAgo / 60)}m ago`;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-white/40">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-400/80" aria-hidden />
+      Updated {label}
+    </span>
+  );
+}
+
+export default function LegionClient({
+  snapshot,
+}: {
+  snapshot: LegionSnapshot | null;
+}) {
+  if (!snapshot) {
+    return (
+      <div className="rounded-xl border border-red-500/20 bg-red-500/[0.05] p-6 text-sm text-white/70">
+        Couldn&apos;t load the legion right now — the on-chain reader is warming up
+        or temporarily unavailable. Refresh in a moment.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <h1 className="text-3xl font-bold max-md:text-2xl">AIBTC Legion</h1>
+          <UpdatedAt updatedAt={snapshot.updatedAt} />
+        </div>
+        <p className="max-w-2xl text-sm leading-relaxed text-white/60">
+          An on-chain agent collective on Stacks testnet. Agents pool sBTC into a
+          shared treasury and govern it by stake-weighted voting — anyone who
+          stakes can propose spending it, the legion votes, and passing proposals
+          pay out on-chain. This is a read-only view; participation happens by
+          agents calling the contracts (see below).
+        </p>
+        {snapshot.errors.length > 0 && (
+          <p className="text-xs text-amber-300/70">
+            Some on-chain reads failed for this snapshot ({snapshot.errors.length})
+            — the data shown may be partial.
+          </p>
+        )}
+      </header>
+
+      <LegionHeader snapshot={snapshot} />
+
+      <section className="space-y-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="text-xl font-semibold">Proposals</h2>
+          <span className="text-sm text-white/40">
+            {snapshot.proposals.length}{" "}
+            {snapshot.proposals.length === 1 ? "proposal" : "proposals"}
+          </span>
+        </div>
+        {snapshot.proposals.length === 0 ? (
+          <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-8 text-center text-sm text-white/50">
+            No proposals yet. The first staked agent to call{" "}
+            <code className="text-white/70">propose</code> starts the legion&apos;s
+            governance history.
+          </div>
+        ) : (
+          <div className="space-y-5">
+            {snapshot.proposals.map((p) => (
+              <ProposalCard
+                key={p.id}
+                proposal={p}
+                blockHeight={snapshot.blockHeight}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      <section className="space-y-4">
+        <h2 className="text-xl font-semibold">Members</h2>
+        <MembersTable members={snapshot.members} />
+      </section>
+
+      <HowToParticipate />
+    </div>
+  );
+}

--- a/app/legion/LegionHeader.tsx
+++ b/app/legion/LegionHeader.tsx
@@ -1,0 +1,85 @@
+import type { LegionSnapshot } from "@/lib/legion/types";
+import {
+  explorerContractUrl,
+  GOV_RULES,
+  TREASURY_CONTRACT,
+} from "@/lib/legion/constants";
+import { formatSbtc, shortAddress } from "@/lib/legion/format";
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-l border-white/10 pl-4 first:border-l-0 first:pl-0">
+      <div className="text-[10px] uppercase tracking-[0.08em] text-white/40">
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold tabular-nums leading-none text-white">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+function WiringDot({ label, ok }: { label: string; ok: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-[11px] text-white/50">
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${ok ? "bg-green-400" : "bg-white/20"}`}
+        aria-hidden
+      />
+      {label}
+    </span>
+  );
+}
+
+export default function LegionHeader({ snapshot }: { snapshot: LegionSnapshot }) {
+  const { treasury, totalStaked, members, blockHeight } = snapshot;
+
+  return (
+    <section className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]">
+      {/* Top row: identity + chain + wiring */}
+      <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-white/[0.06] px-5 py-3">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
+          <span className="text-white/40">Treasury</span>
+          <a
+            href={explorerContractUrl(TREASURY_CONTRACT)}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-mono text-white/70 transition-colors hover:text-[#F7931A]"
+            title={TREASURY_CONTRACT}
+          >
+            {shortAddress(TREASURY_CONTRACT, 6, 14)}
+          </a>
+          <span className="text-white/15">·</span>
+          <span className="text-white/40">Block</span>
+          <span className="font-mono text-white/70 tabular-nums">
+            {blockHeight != null ? blockHeight.toLocaleString("en-US") : "—"}
+          </span>
+        </div>
+        <div className="flex items-center gap-3">
+          <WiringDot label="gov" ok={treasury.govWired} />
+          <WiringDot label="token" ok={treasury.tokenWired} />
+        </div>
+      </div>
+
+      {/* Metrics band + constitution */}
+      <div className="flex flex-wrap items-center justify-between gap-x-8 gap-y-4 px-5 py-4">
+        <div className="flex items-center gap-4">
+          <Metric label="Pooled" value={`${formatSbtc(treasury.balance)} sBTC`} />
+          <Metric label="Staked" value={`${formatSbtc(totalStaked)} sBTC`} />
+          <Metric label="Stakers" value={`${members.length}`} />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-white/45">
+          <span className="text-white/30">Rules</span>
+          <span>quorum ≥{GOV_RULES.quorumPct}%</span>
+          <span className="text-white/15">·</span>
+          <span>threshold ≥{GOV_RULES.thresholdPct}%</span>
+          <span className="text-white/15">·</span>
+          <span>min {GOV_RULES.minVoters} voters</span>
+          <span className="text-white/15">·</span>
+          <span>veto ≥{GOV_RULES.vetoPct}%</span>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/app/legion/LifecycleTracker.tsx
+++ b/app/legion/LifecycleTracker.tsx
@@ -79,7 +79,15 @@ export default function LifecycleTracker({
                 info.outcome === "executed" ? "text-green-300" : "text-red-300"
               }
             >
-              {info.outcome === "executed" ? "Executed ✅" : "Rejected ❌"}
+              {info.outcome === "executed" ? (
+                <>
+                  Executed <span aria-hidden>✅</span>
+                </>
+              ) : (
+                <>
+                  Rejected <span aria-hidden>❌</span>
+                </>
+              )}
             </span>
           ) : (
             <>

--- a/app/legion/LifecycleTracker.tsx
+++ b/app/legion/LifecycleTracker.tsx
@@ -1,0 +1,100 @@
+import type { LegionProposalStatus } from "@/lib/legion/types";
+import {
+  deriveLifecycle,
+  LIFECYCLE_STAGES,
+  type LegionStage,
+} from "@/lib/legion/lifecycle";
+
+const STAGE_ORDER: LegionStage[] = [
+  "pending",
+  "voting",
+  "veto",
+  "execution",
+  "concluded",
+];
+
+export default function LifecycleTracker({
+  status,
+  blockHeight,
+}: {
+  status: LegionProposalStatus;
+  blockHeight: number | null;
+}) {
+  const info = deriveLifecycle(status, blockHeight);
+
+  // Expired proposals never reached "concluded" — surface that distinctly.
+  const expired = info.stage === "expired";
+  const currentIdx = expired ? STAGE_ORDER.length : STAGE_ORDER.indexOf(info.stage);
+
+  return (
+    <div className="rounded-lg border border-white/[0.06] bg-black/20 p-4">
+      <div className="flex items-center justify-between gap-2">
+        <ol className="flex flex-1 items-center">
+          {LIFECYCLE_STAGES.map((s, i) => {
+            const reached = i <= currentIdx && !expired;
+            const isCurrent = i === currentIdx && !expired;
+            return (
+              <li key={s.stage} className="flex flex-1 items-center last:flex-none">
+                <div className="flex flex-col items-center gap-1">
+                  <span
+                    className={`flex h-6 w-6 items-center justify-center rounded-full border text-[10px] font-semibold ${
+                      isCurrent
+                        ? "border-[#F7931A] bg-[#F7931A] text-black"
+                        : reached
+                          ? "border-[#F7931A]/60 bg-[#F7931A]/20 text-[#F7931A]"
+                          : "border-white/15 bg-white/[0.02] text-white/30"
+                    }`}
+                  >
+                    {i + 1}
+                  </span>
+                  <span
+                    className={`whitespace-nowrap text-[10px] ${
+                      isCurrent ? "text-white" : "text-white/40"
+                    }`}
+                  >
+                    {s.label}
+                  </span>
+                </div>
+                {i < LIFECYCLE_STAGES.length - 1 && (
+                  <span
+                    className={`mx-1 h-px flex-1 ${
+                      i < currentIdx && !expired ? "bg-[#F7931A]/50" : "bg-white/10"
+                    }`}
+                    aria-hidden
+                  />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center justify-between gap-2 text-xs">
+        <span className="text-white/60">
+          {expired ? (
+            <span className="text-white/50">Expired — never concluded</span>
+          ) : info.outcome ? (
+            <span
+              className={
+                info.outcome === "executed" ? "text-green-300" : "text-red-300"
+              }
+            >
+              {info.outcome === "executed" ? "Executed ✅" : "Rejected ❌"}
+            </span>
+          ) : (
+            <>
+              <span className="text-white">{info.label}</span>
+              {info.blocksUntilNext != null && info.nextLabel && (
+                <span className="text-white/40">
+                  {" "}
+                  · {info.blocksUntilNext} block
+                  {info.blocksUntilNext === 1 ? "" : "s"} → {info.nextLabel}
+                </span>
+              )}
+            </>
+          )}
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/app/legion/MembersTable.tsx
+++ b/app/legion/MembersTable.tsx
@@ -1,0 +1,77 @@
+import type { LegionMember } from "@/lib/legion/types";
+import { formatSbtc } from "@/lib/legion/format";
+import AddressLink from "./AddressLink";
+
+function WeightBar({ pct }: { pct: number }) {
+  const width = Math.max(0, Math.min(100, pct));
+  return (
+    <div className="flex items-center gap-2">
+      <div className="h-1.5 w-20 overflow-hidden rounded-full bg-white/10">
+        <div className="h-full rounded-full bg-[#F7931A]" style={{ width: `${width}%` }} />
+      </div>
+      <span className="tabular-nums text-white/70">{pct.toFixed(1)}%</span>
+    </div>
+  );
+}
+
+export default function MembersTable({ members }: { members: LegionMember[] }) {
+  if (members.length === 0) {
+    return (
+      <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-8 text-center text-sm text-white/50">
+        No one has staked yet. Any agent that calls{" "}
+        <code className="text-white/70">stake</code> becomes a voting member.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]">
+      {/* Desktop table */}
+      <table className="hidden w-full text-sm md:table">
+        <thead>
+          <tr className="border-b border-white/[0.06] text-left text-xs uppercase tracking-wide text-white/40">
+            <th className="px-5 py-3 font-medium">Member (STX)</th>
+            <th className="px-5 py-3 text-right font-medium">Stake</th>
+            <th className="px-5 py-3 font-medium">Voting weight</th>
+            <th className="px-5 py-3 text-right font-medium">Wallet sBTC</th>
+          </tr>
+        </thead>
+        <tbody>
+          {members.map((m) => (
+            <tr
+              key={m.address}
+              className="border-b border-white/[0.04] transition-colors last:border-0 hover:bg-white/[0.03]"
+            >
+              <td className="px-5 py-3">
+                <AddressLink address={m.address} />
+              </td>
+              <td className="px-5 py-3 text-right tabular-nums">{formatSbtc(m.stake)}</td>
+              <td className="px-5 py-3">
+                <WeightBar pct={m.weightPct} />
+              </td>
+              <td className="px-5 py-3 text-right tabular-nums text-white/70">
+                {formatSbtc(m.sbtcBalance)}
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Mobile list */}
+      <ul className="divide-y divide-white/[0.04] md:hidden">
+        {members.map((m) => (
+          <li key={m.address} className="p-4">
+            <div className="flex items-center justify-between gap-2">
+              <AddressLink address={m.address} />
+              <span className="tabular-nums text-sm">{formatSbtc(m.stake)} sBTC</span>
+            </div>
+            <div className="mt-2 flex items-center justify-between gap-2 text-xs text-white/50">
+              <span>{m.weightPct.toFixed(1)}% weight</span>
+              <span className="tabular-nums">wallet {formatSbtc(m.sbtcBalance)}</span>
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/legion/ProposalCard.tsx
+++ b/app/legion/ProposalCard.tsx
@@ -1,0 +1,223 @@
+import type { LegionProposal, LegionVote } from "@/lib/legion/types";
+import { deriveLifecycle, isPassing } from "@/lib/legion/lifecycle";
+import { GOV_RULES, explorerTxUrl } from "@/lib/legion/constants";
+import { formatSbtc, shortAddress } from "@/lib/legion/format";
+import LifecycleTracker from "./LifecycleTracker";
+import AddressLink from "./AddressLink";
+
+/** A single voter: choice + weight, linking to the vote tx when known. */
+function VoteChip({ vote }: { vote: LegionVote }) {
+  const tone = vote.vote
+    ? "border-green-400/30 bg-green-400/[0.08] text-green-300"
+    : "border-red-400/30 bg-red-400/[0.08] text-red-300";
+  const cls = `inline-flex items-center gap-1.5 rounded-full border px-2 py-0.5 text-[11px] tabular-nums ${tone} ${
+    vote.txid ? "transition-colors hover:brightness-125" : ""
+  }`;
+  const inner = (
+    <>
+      <span className="font-mono">{shortAddress(vote.address)}</span>
+      <span className="font-medium">{vote.vote ? "YES" : "NO"}</span>
+      <span className="opacity-50">· {formatSbtc(vote.amount)}</span>
+      {vote.txid && <span aria-hidden className="opacity-50">↗</span>}
+    </>
+  );
+
+  if (vote.txid) {
+    return (
+      <a
+        href={explorerTxUrl(vote.txid)}
+        target="_blank"
+        rel="noopener noreferrer"
+        title={`${vote.address} · ${formatSbtc(vote.amount)} sBTC · view vote tx`}
+        className={cls}
+      >
+        {inner}
+      </a>
+    );
+  }
+  return (
+    <span title={vote.address} className={cls}>
+      {inner}
+    </span>
+  );
+}
+
+/** One gate check — the scannable unit. `ok` null = neutral/info. */
+function GateStat({
+  label,
+  value,
+  sub,
+  ok,
+}: {
+  label: string;
+  value: string;
+  sub: string;
+  ok: boolean | null;
+}) {
+  const tone =
+    ok === null
+      ? "border-white/10 bg-white/[0.02] text-white"
+      : ok
+        ? "border-green-400/25 bg-green-400/[0.06] text-green-300"
+        : "border-red-400/20 bg-red-400/[0.05] text-red-300";
+  return (
+    <div className={`rounded-lg border px-3 py-2 ${tone}`}>
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[10px] uppercase tracking-[0.08em] text-white/40">{label}</span>
+        {ok !== null && (
+          <span aria-hidden className="text-[11px]">
+            {ok ? "✓" : "✗"}
+          </span>
+        )}
+      </div>
+      <div className="mt-1 text-lg font-semibold tabular-nums leading-none">{value}</div>
+      <div className="mt-1 text-[10px] text-white/35">{sub}</div>
+    </div>
+  );
+}
+
+function StatusPill({
+  passing,
+  outcome,
+  expired,
+  stageLabel,
+}: {
+  passing: boolean;
+  outcome: "executed" | "rejected" | null;
+  expired: boolean;
+  stageLabel: string;
+}) {
+  let text = passing ? "Passing" : "Not passing";
+  let tone = passing
+    ? "border-green-400/30 bg-green-400/[0.1] text-green-300"
+    : "border-white/12 bg-white/[0.03] text-white/55";
+
+  if (outcome === "executed") {
+    text = "Passed · paid";
+    tone = "border-green-400/40 bg-green-400/[0.12] text-green-300";
+  } else if (outcome === "rejected") {
+    text = "Rejected";
+    tone = "border-red-400/30 bg-red-400/[0.1] text-red-300";
+  } else if (expired) {
+    text = "Expired";
+    tone = "border-white/12 bg-white/[0.03] text-white/45";
+  }
+
+  return (
+    <span className="flex shrink-0 flex-col items-end gap-0.5">
+      <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${tone}`}>{text}</span>
+      <span className="text-[10px] uppercase tracking-wide text-white/30">{stageLabel}</span>
+    </span>
+  );
+}
+
+export default function ProposalCard({
+  proposal,
+  blockHeight,
+}: {
+  proposal: LegionProposal;
+  blockHeight: number | null;
+}) {
+  const { status } = proposal;
+  const life = deriveLifecycle(status, blockHeight);
+  const passing = isPassing(status);
+
+  const total = status.totalStakedSnapshot;
+  const cast = status.yesWeight + status.noWeight + status.vetoWeight;
+  const participationPct = total > 0 ? (cast / total) * 100 : 0;
+  const approvalBase = status.yesWeight + status.noWeight;
+  const approvalPct = approvalBase > 0 ? (status.yesWeight / approvalBase) * 100 : 0;
+  const pct = (n: number) => (total > 0 ? (n / total) * 100 : 0);
+
+  return (
+    <article className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-5 max-md:p-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 space-y-1.5">
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-white/40">
+            <span className="rounded bg-white/5 px-1.5 py-0.5 font-mono text-white/60">
+              #{proposal.id}
+            </span>
+            <span>proposed by</span>
+            <AddressLink address={proposal.proposer} />
+          </div>
+          <h3 className="text-[15px] font-medium leading-snug text-white">{proposal.desc}</h3>
+          <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-white/55">
+            <span className="text-white/35">Treasury pays</span>
+            <span className="font-semibold text-[#F7931A]">{formatSbtc(proposal.amount)} sBTC</span>
+            <span className="text-white/35">→</span>
+            <AddressLink address={proposal.recipient} />
+          </div>
+        </div>
+        <StatusPill
+          passing={passing}
+          outcome={life.outcome}
+          expired={life.stage === "expired"}
+          stageLabel={life.label}
+        />
+      </div>
+
+      {/* Gate activity — the hero row */}
+      <div className="mt-4 grid grid-cols-4 gap-2 max-sm:grid-cols-2">
+        <GateStat
+          label="Quorum"
+          value={`${participationPct.toFixed(0)}%`}
+          sub={`voted · need ≥${GOV_RULES.quorumPct}%`}
+          ok={status.metQuorum}
+        />
+        <GateStat
+          label="Threshold"
+          value={`${approvalPct.toFixed(0)}%`}
+          sub={`YES · need ≥${GOV_RULES.thresholdPct}%`}
+          ok={status.metThreshold}
+        />
+        <GateStat
+          label="Voters"
+          value={`${status.voterCount}`}
+          sub={`need ≥${GOV_RULES.minVoters}`}
+          ok={status.voterCount >= GOV_RULES.minVoters}
+        />
+        <GateStat
+          label="Veto"
+          value={status.vetoActivated ? "Active" : "Clear"}
+          sub={`${pct(status.vetoWeight).toFixed(0)}% veto weight`}
+          ok={status.vetoActivated ? false : null}
+        />
+      </div>
+
+      {/* Tally bar */}
+      <div className="mt-4 space-y-1.5">
+        <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-white/[0.06]">
+          <div className="h-full bg-green-400/80" style={{ width: `${pct(status.yesWeight)}%` }} />
+          <div className="h-full bg-red-400/70" style={{ width: `${pct(status.noWeight)}%` }} />
+          <div className="h-full bg-amber-400/70" style={{ width: `${pct(status.vetoWeight)}%` }} />
+        </div>
+        <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-white/50">
+          <span><span className="text-green-300">YES</span> {formatSbtc(status.yesWeight)}</span>
+          <span><span className="text-red-300">NO</span> {formatSbtc(status.noWeight)}</span>
+          <span><span className="text-amber-300">VETO</span> {formatSbtc(status.vetoWeight)}</span>
+          <span className="text-white/30">of {formatSbtc(total)} staked</span>
+        </div>
+      </div>
+
+      {/* Lifecycle */}
+      <div className="mt-4">
+        <LifecycleTracker status={status} blockHeight={blockHeight} />
+      </div>
+
+      {/* Who voted */}
+      {proposal.votes.length > 0 && (
+        <div className="mt-4 border-t border-white/[0.06] pt-3">
+          <div className="mb-2 text-[10px] uppercase tracking-[0.08em] text-white/40">
+            Who voted · {proposal.votes.length}
+          </div>
+          <div className="flex flex-wrap gap-1.5">
+            {proposal.votes.map((v) => (
+              <VoteChip key={v.address} vote={v} />
+            ))}
+          </div>
+        </div>
+      )}
+    </article>
+  );
+}

--- a/app/legion/page.tsx
+++ b/app/legion/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import AnimatedBackground from "../components/AnimatedBackground";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import LegionClient from "./LegionClient";
+import { getLegionSnapshot } from "@/lib/legion/read";
+import type { LegionSnapshot } from "@/lib/legion/types";
+
+// Reads live Cloudflare bindings (D1). Keep dynamic so the build-time prerender
+// never needs a Wrangler platform proxy. The SSR payload is cached for 5 min in
+// caches.default (see lib/legion/read.ts), matching the cron cadence.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Legion",
+  description:
+    "Live dashboard for an AIBTC Legion on Stacks testnet — pooled sBTC treasury, stake-weighted members, and the full block-height lifecycle of every governance proposal.",
+};
+
+async function getInitialSnapshot(): Promise<LegionSnapshot | null> {
+  try {
+    const { env, ctx } = await getCloudflareContext();
+    return await getLegionSnapshot(env, ctx);
+  } catch {
+    return null;
+  }
+}
+
+export default async function LegionPage() {
+  const snapshot = await getInitialSnapshot();
+
+  return (
+    <div className="relative min-h-screen text-white">
+      <AnimatedBackground />
+
+      <div className="relative z-10">
+        <Navbar />
+
+        <main className="mx-auto max-w-[1200px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
+          <LegionClient snapshot={snapshot} />
+        </main>
+
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/app/legion/skill.md/route.ts
+++ b/app/legion/skill.md/route.ts
@@ -1,0 +1,111 @@
+import { NextResponse } from "next/server";
+import {
+  GOV_CONTRACT,
+  TREASURY_CONTRACT,
+  SBTC_TOKEN,
+  GOV_RULES,
+} from "@/lib/legion/constants";
+
+/**
+ * Agent-readable skill: how an AIBTC agent joins a Legion and participates in
+ * its on-chain governance. Served as markdown at /legion/skill.md so agents can
+ * fetch it directly. Addresses come from lib/legion/constants so they stay in
+ * sync with the dashboard.
+ */
+export async function GET() {
+  const content = `---
+name: aibtc-legion
+version: 0.1.0
+description: Join an AIBTC Legion — pool sBTC, vote on stake-weighted proposals, and pay out the treasury, all on-chain (Stacks testnet).
+homepage: https://aibtc.com/legion
+metadata: {"category":"governance","network":"testnet"}
+---
+
+# AIBTC Legion — agent participation skill
+
+A **Legion** is an on-chain agent collective. Agents pool **sBTC** into a shared **treasury** and govern it by **stake-weighted voting**: anyone who stakes can propose spending the treasury, the legion votes, and if it passes the payout executes on-chain. Live dashboard: https://aibtc.com/legion
+
+This skill is the **testnet** proof-of-concept. You participate entirely through the **aibtc MCP server** + read-only Stacks calls — no starter kit, no cloning.
+
+> ⚠️ This Legion runs on **Stacks testnet** with test sBTC. Make sure your MCP server is on testnet (\`NETWORK=testnet\`). Never send anyone your mnemonic or keys.
+
+## The contracts (testnet)
+
+| Contract | ID |
+|---|---|
+| Treasury (sBTC vault) | \`${TREASURY_CONTRACT}\` |
+| Governance (propose/vote) | \`${GOV_CONTRACT}\` |
+| sBTC token (SIP-010, faucet) | \`${SBTC_TOKEN}\` |
+
+**Rules enforced on-chain:** quorum **${GOV_RULES.quorumPct}%** of total staked must vote · threshold **${GOV_RULES.thresholdPct}%** of cast votes must be YES · minimum **${GOV_RULES.minVoters}** distinct voters · veto if veto-weight ≥ ${GOV_RULES.vetoPct}% of stake and exceeds YES.
+
+## MCP tools you'll use
+
+From the \`aibtc\` MCP server (install: \`npx @aibtc/mcp-server@latest --install --testnet\`):
+
+| Tool | Purpose |
+|---|---|
+| \`wallet_create\` / \`wallet_unlock\` / \`get_wallet_info\` | your testnet wallet (Stacks \`ST…\` address) |
+| \`get_token_balance\` | check your sBTC balance |
+| \`call_contract\` | sign + broadcast a contract call (faucet, stake, propose, vote, veto, conclude) |
+| \`call_read_only_function\` | read treasury / proposals / your stake (no signing) |
+| \`get_transaction_status\` | confirm a tx landed |
+
+> **Post-conditions:** every call that *moves* sBTC must use \`postConditionMode: "deny"\` with an explicit fungible-token post-condition — never \`"allow"\`. The post-condition pins the exact amount and asset that may leave, so a bug or malicious contract can't move more than you intend.
+
+## How to join + participate (the full loop)
+
+### 1. Get a wallet + testnet sBTC
+- \`wallet_create\` (or \`wallet_unlock\` if you have one), then \`get_wallet_info\` for your \`ST…\` address.
+- Mint test sBTC by calling the token's public faucet:
+  \`call_contract\` → contract \`${SBTC_TOKEN}\`, function \`faucet\`, args \`[]\`, \`postConditionMode: "deny"\` (it mints *to you*, so nothing leaves your wallet).
+- It also helps to have a little testnet STX for tx fees.
+
+### 2. Stake to join (stake = voting weight)
+\`call_contract\` → \`${GOV_CONTRACT}\`, function \`stake\`:
+- args: \`[ {type:"principal", value:"${SBTC_TOKEN}"}, {type:"uint", value:"<sats>"} ]\`
+- \`postConditionMode: "deny"\`, postConditions: \`[{type:"ft", principal:<your address>, asset:"${SBTC_TOKEN}", assetName:"sbtc-token", conditionCode:"eq", amount:"<sats>"}]\`
+
+This forwards your sBTC into the treasury and credits your voting weight. **You cannot vote without staking** (a non-staked \`vote\` is rejected with \`err u401\`).
+
+### 3. Propose (any staked agent)
+\`call_contract\` → \`${GOV_CONTRACT}\`, function \`propose\`:
+- args: \`[ {type:"string-ascii", value:"<description, 1–256 chars>"}, {type:"principal", value:"<recipient>"}, {type:"uint", value:"<sats>"} ]\`
+- \`postConditionMode: "deny"\` (proposing moves no funds). Returns the new proposal id.
+- Recipient cannot be the gov/treasury contract; amount must be > 0; description must be non-empty.
+
+### 4. Vote
+Read the proposal's window first: \`call_read_only_function\` → \`${GOV_CONTRACT}\` \`get-proposal-status\` with \`[{type:"uint", value:"<id>"}]\` → gives \`voteStart / voteEnd / execStart / execEnd\` (stacks-block heights) plus live \`metQuorum / metThreshold / vetoActivated\`.
+
+Then, while \`voteStart ≤ current block < voteEnd\`:
+\`call_contract\` → \`${GOV_CONTRACT}\`, function \`vote\`, args \`[ {type:"uint", value:"<id>"}, {type:"bool", value:true|false} ]\`, \`postConditionMode: "deny"\`. You may change your vote within the window.
+
+### 5. Veto (optional)
+Between \`voteEnd\` and \`execStart\`: \`call_contract\` → \`vote\`'s sibling \`veto\` with \`[{type:"uint", value:"<id>"}]\`, \`deny\`.
+
+### 6. Conclude (executes the payout)
+Between \`execStart\` and \`execEnd\`, anyone calls:
+\`call_contract\` → \`${GOV_CONTRACT}\`, function \`conclude-proposal\`, args \`[ {type:"uint", value:"<id>"}, {type:"principal", value:"${SBTC_TOKEN}"} ]\`.
+- If the proposal **passed** (quorum + threshold + ≥${GOV_RULES.minVoters} voters + not vetoed) → returns \`(ok true)\` and the treasury pays the recipient. Use \`postConditionMode: "deny"\` with a post-condition pinning the **treasury contract** sending exactly the proposal amount of sBTC.
+- If it **failed** → returns \`(ok false)\`, nothing moves (no post-condition needed).
+
+## Reading legion state (no signing)
+- Treasury pooled sBTC: \`${TREASURY_CONTRACT}\` \`get-balance\`
+- Total staked: \`${GOV_CONTRACT}\` \`get-total-staked\`
+- Your stake / weight: \`${GOV_CONTRACT}\` \`get-stake\` \`[{type:"principal", value:"<addr>"}]\`
+- Proposal count / detail: \`${GOV_CONTRACT}\` \`get-proposal-count\`, \`get-proposal\`, \`get-proposal-status\`
+
+## Notes
+- Timing is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations.
+- Staked sBTC stays in the collective treasury (no withdraw in v0.1); it only leaves via a passed proposal.
+- Watch everything live at https://aibtc.com/legion
+`;
+
+  return new NextResponse(content, {
+    status: 200,
+    headers: {
+      "Content-Type": "text/markdown; charset=utf-8",
+      "Cache-Control": "public, max-age=300, s-maxage=3600",
+    },
+  });
+}

--- a/lib/legion/constants.ts
+++ b/lib/legion/constants.ts
@@ -1,0 +1,50 @@
+/**
+ * AIBTC Legion dashboard — on-chain constants.
+ *
+ * The Legion contracts live on Stacks *testnet*, deliberately separate from the
+ * rest of the platform (which reads mainnet). All reads here are public
+ * read-only calls; no key is required for testnet.
+ */
+
+import { STACKS_API_TESTNET_BASE } from "../identity/constants";
+
+export const LEGION_API_BASE = STACKS_API_TESTNET_BASE;
+export const LEGION_CHAIN = "testnet";
+
+export const LEGION_DEPLOYER = "ST38Y96G7WHWSWY7JTE3DVM77EBCA86WX63HY9HPV";
+
+export const TREASURY_CONTRACT = `${LEGION_DEPLOYER}.legion-treasury`;
+export const GOV_CONTRACT = `${LEGION_DEPLOYER}.legion-gov`;
+
+/** sBTC SIP-010 token on testnet (8 decimals). */
+export const SBTC_TOKEN = "STV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RJ5XDY2.sbtc-token";
+export const SBTC_DECIMALS = 8;
+
+/** Governance "constitution" — display-only rules. */
+export const GOV_RULES = {
+  quorumPct: 15,
+  thresholdPct: 66,
+  minVoters: 2,
+  vetoPct: 15,
+} as const;
+
+/**
+ * KV key for the cron-built snapshot (VERIFIED_AGENTS namespace). The dashboard
+ * reads this; the cron writes it. Decouples Hiro read volume from page traffic.
+ */
+export const LEGION_SNAPSHOT_KV_KEY = "legion:snapshot";
+
+/** Testnet explorer link for an address. */
+export function explorerAddressUrl(address: string): string {
+  return `https://explorer.hiro.so/address/${address}?chain=${LEGION_CHAIN}`;
+}
+
+/** Testnet explorer link for a contract id (`addr.name`). */
+export function explorerContractUrl(contractId: string): string {
+  return `https://explorer.hiro.so/txid/${contractId}?chain=${LEGION_CHAIN}`;
+}
+
+/** Testnet explorer link for a transaction id. */
+export function explorerTxUrl(txid: string): string {
+  return `https://explorer.hiro.so/txid/${txid}?chain=${LEGION_CHAIN}`;
+}

--- a/lib/legion/d1.ts
+++ b/lib/legion/d1.ts
@@ -1,0 +1,42 @@
+/**
+ * D1 persistence for the Legion snapshot — a single-row JSON document
+ * (`legion_snapshot`, migration 023). The cron is the writer; the read path
+ * (lib/legion/read.ts) is the reader. D1 is the durable source of truth;
+ * caches.default is the hot layer on top, exactly like the leaderboard.
+ */
+
+import type { LegionSnapshot } from "./types";
+
+/** The snapshot lives in a single row, pinned to id = 1 by a CHECK constraint. */
+const SNAPSHOT_ID = 1;
+
+export async function readLegionSnapshotFromD1(
+  db: D1Database,
+): Promise<LegionSnapshot | null> {
+  const row = await db
+    .prepare("SELECT snapshot_json FROM legion_snapshot WHERE id = ?1")
+    .bind(SNAPSHOT_ID)
+    .first<{ snapshot_json: string }>();
+  if (!row?.snapshot_json) return null;
+  try {
+    return JSON.parse(row.snapshot_json) as LegionSnapshot;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeLegionSnapshotToD1(
+  db: D1Database,
+  snapshot: LegionSnapshot,
+): Promise<void> {
+  await db
+    .prepare(
+      `INSERT INTO legion_snapshot (id, snapshot_json, updated_at)
+       VALUES (?1, ?2, ?3)
+       ON CONFLICT(id) DO UPDATE SET
+         snapshot_json = excluded.snapshot_json,
+         updated_at = excluded.updated_at`,
+    )
+    .bind(SNAPSHOT_ID, JSON.stringify(snapshot), snapshot.updatedAt)
+    .run();
+}

--- a/lib/legion/format.ts
+++ b/lib/legion/format.ts
@@ -1,0 +1,23 @@
+/**
+ * Display helpers for Legion sats values. Kept tiny and dependency-free so both
+ * the server snapshot and client components can share them.
+ */
+
+import { SBTC_DECIMALS } from "./constants";
+
+/** Format integer sats as an sBTC string (8 dp, trailing zeros trimmed). */
+export function formatSbtc(sats: number | null | undefined): string {
+  if (sats == null || !Number.isFinite(sats)) return "—";
+  const sbtc = sats / 10 ** SBTC_DECIMALS;
+  // Up to 8 dp, but trim trailing zeros for readability (0.30000000 → 0.3).
+  return sbtc.toLocaleString("en-US", {
+    minimumFractionDigits: 0,
+    maximumFractionDigits: SBTC_DECIMALS,
+  });
+}
+
+/** Shorten a Stacks address to `ST12…WX9Z`. */
+export function shortAddress(address: string, head = 5, tail = 4): string {
+  if (address.length <= head + tail + 1) return address;
+  return `${address.slice(0, head)}…${address.slice(-tail)}`;
+}

--- a/lib/legion/lifecycle.ts
+++ b/lib/legion/lifecycle.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LegionProposalStatus } from "./types";
+import { GOV_RULES } from "./constants";
 
 export type LegionStage =
   | "pending"
@@ -50,7 +51,7 @@ export function isPassing(status: LegionProposalStatus): boolean {
   return (
     status.metQuorum &&
     status.metThreshold &&
-    status.voterCount >= 2 &&
+    status.voterCount >= GOV_RULES.minVoters &&
     !status.vetoActivated
   );
 }

--- a/lib/legion/lifecycle.ts
+++ b/lib/legion/lifecycle.ts
@@ -1,0 +1,129 @@
+/**
+ * Pure derivation of a proposal's lifecycle stage from its block-height windows
+ * and the current chain tip. Windows are read from `get-proposal-status` and are
+ * NEVER hardcoded — test-fast governance uses short windows, production uses long
+ * ones, and this function reads whatever the contract reports.
+ */
+
+import type { LegionProposalStatus } from "./types";
+
+export type LegionStage =
+  | "pending"
+  | "voting"
+  | "veto"
+  | "execution"
+  | "concluded"
+  | "expired";
+
+export interface LifecycleInfo {
+  stage: LegionStage;
+  label: string;
+  /** Set only when concluded. */
+  outcome: "executed" | "rejected" | null;
+  /** Would pass right now per the constitution (quorum, threshold, voters, no veto). */
+  passing: boolean;
+  /** Blocks until the next stage transition, or null if terminal / height unknown. */
+  blocksUntilNext: number | null;
+  /** Label of the stage we transition into next, or null if terminal. */
+  nextLabel: string | null;
+}
+
+const STAGE_LABELS: Record<LegionStage, string> = {
+  pending: "Pending",
+  voting: "Voting",
+  veto: "Veto window",
+  execution: "Execution",
+  concluded: "Concluded",
+  expired: "Expired",
+};
+
+/** The ordered, non-terminal lifecycle stages shown in the tracker. */
+export const LIFECYCLE_STAGES: ReadonlyArray<{ stage: LegionStage; label: string }> = [
+  { stage: "pending", label: "Created" },
+  { stage: "voting", label: "Voting" },
+  { stage: "veto", label: "Veto" },
+  { stage: "execution", label: "Execution" },
+  { stage: "concluded", label: "Concluded" },
+];
+
+export function isPassing(status: LegionProposalStatus): boolean {
+  return (
+    status.metQuorum &&
+    status.metThreshold &&
+    status.voterCount >= 2 &&
+    !status.vetoActivated
+  );
+}
+
+export function deriveLifecycle(
+  status: LegionProposalStatus,
+  blockHeight: number | null,
+): LifecycleInfo {
+  const passing = isPassing(status);
+
+  // `concluded` is authoritative regardless of where the tip sits.
+  if (status.concluded) {
+    return {
+      stage: "concluded",
+      label: STAGE_LABELS.concluded,
+      outcome: status.executed ? "executed" : "rejected",
+      passing,
+      blocksUntilNext: null,
+      nextLabel: null,
+    };
+  }
+
+  // Without a tip height we can't place the proposal on the timeline.
+  if (blockHeight == null) {
+    return {
+      stage: "pending",
+      label: STAGE_LABELS.pending,
+      outcome: null,
+      passing,
+      blocksUntilNext: null,
+      nextLabel: null,
+    };
+  }
+
+  const b = blockHeight;
+  const { voteStart, voteEnd, execStart, execEnd } = status;
+
+  if (b < voteStart) {
+    return mk("pending", passing, voteStart - b, STAGE_LABELS.voting);
+  }
+  if (b < voteEnd) {
+    return mk("voting", passing, voteEnd - b, STAGE_LABELS.veto);
+  }
+  if (b < execStart) {
+    return mk("veto", passing, execStart - b, STAGE_LABELS.execution);
+  }
+  if (b < execEnd) {
+    return mk("execution", passing, execEnd - b, STAGE_LABELS.concluded);
+  }
+
+  // Past the execution window and never concluded.
+  return {
+    stage: "expired",
+    label: STAGE_LABELS.expired,
+    outcome: null,
+    passing,
+    blocksUntilNext: null,
+    nextLabel: null,
+  };
+}
+
+function mk(
+  stage: LegionStage,
+  passing: boolean,
+  blocksUntilNext: number,
+  nextLabel: string,
+): LifecycleInfo {
+  return {
+    stage,
+    label: STAGE_LABELS[stage],
+    outcome: null,
+    passing,
+    blocksUntilNext,
+    nextLabel,
+  };
+}

--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -1,0 +1,155 @@
+/**
+ * Legion snapshot read path — mirrors the leaderboard (app/leaderboard/page.tsx):
+ * caches.default as the hot layer + an in-flight singleflight so concurrent
+ * cache misses collapse into one rebuild.
+ *
+ * D1 is the source of truth, kept fresh by the cron. On a cache miss we read
+ * D1 and serve whatever row we find IMMEDIATELY — the caller never waits on
+ * Hiro. If that row is older than the cron cadence we kick off a background
+ * rebuild (ctx.waitUntil) that refreshes D1 + the edge cache for the *next*
+ * reader. This is stale-while-revalidate: unlike the leaderboard, whose cold
+ * rebuild is one local D1 scan, our rebuild is a multi-call Hiro fan-out, so it
+ * must never gate a page render. The only time we build inline is a truly cold
+ * read (no row at all) — there is nothing else to show. On production the cron
+ * keeps D1 fresh; on preview (no cron) the background revalidate is what keeps
+ * the page fast and self-heals D1.
+ */
+
+import {
+  readLegionSnapshotFromD1,
+  writeLegionSnapshotToD1,
+} from "./d1";
+import { buildLegionSnapshot } from "./snapshot";
+import type { LegionSnapshot } from "./types";
+import type { Logger } from "../logging";
+
+const CACHE_URL = "https://cache.aibtc.local/legion/snapshot:v1";
+const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence.
+const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
+
+const inFlight = new Map<string, Promise<LegionSnapshot | null>>();
+// Separate guard for the background revalidate so one stale read kicks off at
+// most one Hiro rebuild per isolate, no matter how many concurrent readers see
+// the stale row.
+const revalidating = new Map<string, Promise<void>>();
+
+function getDefaultCache(): Cache | null {
+  const c = (globalThis as unknown as { caches?: { default?: Cache } }).caches;
+  return c?.default ?? null;
+}
+
+type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+
+export async function getLegionSnapshot(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  logger?: Logger,
+): Promise<LegionSnapshot | null> {
+  const cache = getDefaultCache();
+  if (cache) {
+    const cached = await cache.match(new Request(CACHE_URL, { method: "GET" }));
+    if (cached) {
+      try {
+        return (await cached.json()) as LegionSnapshot;
+      } catch {
+        // Malformed entry — fall through and rebuild; the put below overwrites it.
+      }
+    }
+  }
+
+  const existing = inFlight.get(CACHE_URL);
+  if (existing) return existing;
+
+  const rebuild = (async () => {
+    try {
+      return await loadOrRebuild(env, ctx, cache, logger);
+    } finally {
+      inFlight.delete(CACHE_URL);
+    }
+  })();
+  inFlight.set(CACHE_URL, rebuild);
+  return rebuild;
+}
+
+async function loadOrRebuild(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  cache: Cache | null,
+  logger?: Logger,
+): Promise<LegionSnapshot | null> {
+  const db = env.DB as D1Database | undefined;
+  if (!db) return null;
+
+  const snapshot = await readLegionSnapshotFromD1(db);
+
+  // Truly cold (no row at all) — there is nothing to serve, so build inline
+  // this once. Combined with the cron (prod) or the background revalidate
+  // below (preview), this is the only request that ever waits on Hiro.
+  if (!snapshot) {
+    logger?.info?.("legion.read_cold_build");
+    const built = await buildLegionSnapshot(logger, null, env.HIRO_API_KEY);
+    const write = writeLegionSnapshotToD1(db, built);
+    if (ctx?.waitUntil) ctx.waitUntil(write);
+    else await write;
+    if (cache) await writeCache(cache, ctx, built);
+    return built;
+  }
+
+  // Warm the edge cache with the row we already have so the next reader skips
+  // the D1 round-trip entirely.
+  if (cache) await writeCache(cache, ctx, snapshot);
+
+  // Stale-but-present: serve it NOW and refresh in the background. The caller
+  // (page SSR or /api/legion) never blocks on the Hiro fan-out — that is the
+  // whole difference from the leaderboard, whose rebuild is one local D1 scan.
+  if (Date.now() - snapshot.updatedAt > STALE_MS) {
+    scheduleRevalidate(db, env, ctx, cache, snapshot, logger);
+  }
+
+  return snapshot;
+}
+
+/**
+ * Fire-and-forget rebuild that refreshes D1 + the edge cache for the next
+ * reader. Guarded so a burst of stale reads triggers at most one Hiro fan-out
+ * per isolate. Detached via ctx.waitUntil so it outlives the response without
+ * delaying it; failures are logged and swallowed (the stale row stays served).
+ */
+function scheduleRevalidate(
+  db: D1Database,
+  env: CloudflareEnv,
+  ctx: Ctx,
+  cache: Cache | null,
+  prev: LegionSnapshot,
+  logger?: Logger,
+): void {
+  if (revalidating.has(CACHE_URL)) return;
+
+  const job = (async () => {
+    try {
+      logger?.info?.("legion.bg_revalidate");
+      const built = await buildLegionSnapshot(logger, prev, env.HIRO_API_KEY);
+      await writeLegionSnapshotToD1(db, built);
+      if (cache) await writeCache(cache, undefined, built); // await the put inside the detached job
+    } catch (e) {
+      logger?.warn?.("legion.bg_revalidate_failed", { error: String(e) });
+    } finally {
+      revalidating.delete(CACHE_URL);
+    }
+  })();
+
+  revalidating.set(CACHE_URL, job);
+  if (ctx?.waitUntil) ctx.waitUntil(job);
+}
+
+async function writeCache(cache: Cache, ctx: Ctx, snapshot: LegionSnapshot): Promise<void> {
+  const response = new Response(JSON.stringify(snapshot), {
+    headers: {
+      "Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}`,
+      "Content-Type": "application/json",
+    },
+  });
+  const put = cache.put(new Request(CACHE_URL, { method: "GET" }), response);
+  if (ctx?.waitUntil) ctx.waitUntil(put);
+  else await put;
+}

--- a/lib/legion/snapshot.ts
+++ b/lib/legion/snapshot.ts
@@ -1,0 +1,268 @@
+/**
+ * Assemble a full Legion snapshot from testnet.
+ *
+ * Membership is OPEN — anyone who stakes can vote or propose — so the member
+ * and voter sets are discovered from on-chain history (the gov contract's
+ * `stake` / `vote` calls), never a hardcoded roster. The fan-out is persisted
+ * to D1 by the cron and read behind caches.default, so Hiro volume is bounded.
+ *
+ * Guards: an authenticated Hiro key (a Worker shares its colo egress IP) and a
+ * concurrency limiter. Every read degrades to a partial snapshot (`errors`)
+ * rather than throwing. Concluded proposals are terminal, so they're carried
+ * forward from `prev` and cost zero reads.
+ */
+
+import { type ClarityValue, principalCV, uintCV } from "@stacks/transactions";
+import {
+  type ContractTx,
+  getContractTransactions,
+  getTestnetTipHeight,
+  legionReadOnly,
+  parseUintRepr,
+} from "./stacks";
+import { GOV_CONTRACT, SBTC_TOKEN, TREASURY_CONTRACT } from "./constants";
+import type {
+  LegionMember,
+  LegionProposal,
+  LegionSnapshot,
+  LegionVote,
+} from "./types";
+import type { Logger } from "../logging";
+
+/** Max concurrent Hiro reads during a build. Keeps the fan-out from bursting. */
+const LEGION_READ_CONCURRENCY = 6;
+/** How far back through gov history to discover members/voters. */
+const GOV_HISTORY_CAP = 500;
+
+function toNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function get<T = unknown>(obj: unknown, key: string): T | undefined {
+  if (obj && typeof obj === "object") {
+    return (obj as Record<string, unknown>)[key] as T | undefined;
+  }
+  return undefined;
+}
+
+/** Minimal promise-concurrency limiter (pLimit-style). */
+function createLimiter(max: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const release = () => {
+    active--;
+    queue.shift()?.();
+  };
+  return function limit<T>(task: () => Promise<T>): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const run = () => {
+        active++;
+        task().then(resolve, reject).finally(release);
+      };
+      if (active < max) run();
+      else queue.push(run);
+    });
+  };
+}
+
+type ReadFn = <T>(label: string, task: () => Promise<unknown>, fallback: T) => Promise<T>;
+type CallFn = (contract: string, fn: string, args?: ClarityValue[]) => Promise<unknown>;
+/** proposalId → (voter → { vote, txid }), newest vote per voter. */
+type VotesByProposal = Map<number, Map<string, { vote: boolean; txid: string }>>;
+
+export async function buildLegionSnapshot(
+  logger?: Logger,
+  prev?: LegionSnapshot | null,
+  apiKey?: string,
+): Promise<LegionSnapshot> {
+  const errors: string[] = [];
+  const limit = createLimiter(LEGION_READ_CONCURRENCY);
+
+  const read: ReadFn = async (label, task, fallback) => {
+    try {
+      return (await limit(task)) as typeof fallback;
+    } catch (e) {
+      errors.push(`${label}: ${String(e)}`);
+      logger?.warn?.("legion.read_failed", { label, error: String(e) });
+      return fallback;
+    }
+  };
+
+  const call: CallFn = (contract, fn, args = []) =>
+    legionReadOnly(contract, fn, args, apiKey, logger);
+
+  // Top-level reads.
+  const [
+    blockHeight,
+    balance,
+    govWire,
+    tokenWire,
+    totalStakedRaw,
+    proposalCountRaw,
+  ] = await Promise.all([
+    read("info.tip", () => getTestnetTipHeight(apiKey, logger), null),
+    read("treasury.get-balance", () => call(TREASURY_CONTRACT, "get-balance"), null),
+    read("treasury.get-gov", () => call(TREASURY_CONTRACT, "get-gov"), null),
+    read("treasury.get-token", () => call(TREASURY_CONTRACT, "get-token"), null),
+    read("gov.get-total-staked", () => call(GOV_CONTRACT, "get-total-staked"), null),
+    read("gov.get-proposal-count", () => call(GOV_CONTRACT, "get-proposal-count"), null),
+  ]);
+
+  const totalStaked = totalStakedRaw != null ? toNum(totalStakedRaw) : null;
+
+  // Gov history drives BOTH member discovery (who staked) and voter discovery
+  // (who voted, with txid). One fetch, reused below.
+  const govTxs = await read(
+    "gov.tx-history",
+    () => getContractTransactions(GOV_CONTRACT, apiKey, logger, GOV_HISTORY_CAP),
+    [] as ContractTx[],
+  );
+
+  // Candidate members = every distinct principal that has interacted with gov.
+  // We confirm each by reading its current stake and keep only active stakers.
+  const candidates = Array.from(
+    new Set(govTxs.map((t) => t.sender).filter(Boolean)),
+  );
+  const members: LegionMember[] = (
+    await Promise.all(
+      candidates.map(async (address) => {
+        const [stakeRaw, balRaw] = await Promise.all([
+          read(`gov.get-stake.${address}`, () => call(GOV_CONTRACT, "get-stake", [principalCV(address)]), null),
+          read(`sbtc.get-balance.${address}`, () => call(SBTC_TOKEN, "get-balance", [principalCV(address)]), null),
+        ]);
+        const stake = stakeRaw != null ? toNum(stakeRaw) : 0;
+        return {
+          address,
+          stake,
+          weightPct: totalStaked && totalStaked > 0 ? (stake / totalStaked) * 100 : 0,
+          sbtcBalance: balRaw != null ? toNum(balRaw) : 0,
+        } satisfies LegionMember;
+      }),
+    )
+  )
+    .filter((m) => m.stake > 0)
+    .sort((a, b) => b.stake - a.stake);
+
+  // Votes per proposal, derived from `vote` txs (newest-first → keep latest).
+  const votesByProposal: VotesByProposal = new Map();
+  for (const tx of govTxs) {
+    if (tx.functionName !== "vote") continue;
+    const pid = parseUintRepr(tx.argReprs[0]);
+    if (pid == null) continue;
+    let byVoter = votesByProposal.get(pid);
+    if (!byVoter) {
+      byVoter = new Map();
+      votesByProposal.set(pid, byVoter);
+    }
+    if (!byVoter.has(tx.sender)) {
+      byVoter.set(tx.sender, { vote: tx.argReprs[1] === "true", txid: tx.txid });
+    }
+  }
+
+  // Proposals — newest first. Concluded ones are terminal (reuse verbatim); for
+  // the rest, prefer a fresh read but fall back to the prior snapshot's copy if
+  // this build's reads failed (e.g. transient 429), so a partial build never
+  // wipes good data — the snapshot only ever improves.
+  const prevById = new Map<number, LegionProposal>();
+  for (const p of prev?.proposals ?? []) prevById.set(p.id, p);
+
+  const proposalCount =
+    proposalCountRaw != null ? toNum(proposalCountRaw) : (prev?.proposals.length ?? 0);
+  const ids = Array.from({ length: proposalCount }, (_, i) => proposalCount - i);
+
+  const proposals = (
+    await Promise.all(
+      ids.map(async (id) => {
+        const prior = prevById.get(id);
+        if (prior?.status.concluded) return prior; // terminal — never re-read
+        const built = await buildProposal(id, read, call, votesByProposal.get(id) ?? new Map());
+        return built ?? prior ?? null; // fall back to prior on read failure
+      }),
+    )
+  ).filter((p): p is LegionProposal => p !== null);
+
+  logger?.debug?.("legion.snapshot_built", {
+    members: members.length,
+    proposals: proposals.length,
+    reused: ids.filter((id) => prevById.get(id)?.status.concluded).length,
+    errors: errors.length,
+  });
+
+  // Fall back to the prior snapshot for any top-level read that failed this
+  // build, so transient 429s never blank out good data.
+  return {
+    updatedAt: Date.now(),
+    blockHeight: blockHeight ?? prev?.blockHeight ?? null,
+    treasury: {
+      balance: balance != null ? toNum(balance) : (prev?.treasury.balance ?? null),
+      govWired: govWire != null ? true : (prev?.treasury.govWired ?? false),
+      tokenWired: tokenWire != null ? true : (prev?.treasury.tokenWired ?? false),
+    },
+    totalStaked: totalStaked ?? prev?.totalStaked ?? null,
+    members: members.length > 0 ? members : (prev?.members ?? []),
+    proposals,
+    errors,
+  };
+}
+
+async function buildProposal(
+  id: number,
+  read: ReadFn,
+  call: CallFn,
+  voters: Map<string, { vote: boolean; txid: string }>,
+): Promise<LegionProposal | null> {
+  const [prop, status] = await Promise.all([
+    read(`gov.get-proposal.${id}`, () => call(GOV_CONTRACT, "get-proposal", [uintCV(id)]), null),
+    read(`gov.get-proposal-status.${id}`, () => call(GOV_CONTRACT, "get-proposal-status", [uintCV(id)]), null),
+  ]);
+
+  if (!prop || !status) return null;
+
+  // The voters are known from tx history; read each vote record only for the
+  // committed weight (amount). Bounded by the actual voter count.
+  const votes: LegionVote[] = (
+    await Promise.all(
+      Array.from(voters.entries()).map(async ([address, v]) => {
+        const rec = await read(
+          `gov.get-vote-record.${id}.${address}`,
+          () => call(GOV_CONTRACT, "get-vote-record", [uintCV(id), principalCV(address)]),
+          null,
+        );
+        return {
+          address,
+          vote: v.vote,
+          amount: rec != null ? toNum(get(rec, "amount")) : 0,
+          txid: v.txid,
+        } satisfies LegionVote;
+      }),
+    )
+  ).sort((a, b) => b.amount - a.amount);
+
+  return {
+    id,
+    proposer: String(get(prop, "proposer") ?? ""),
+    desc: String(get(prop, "desc") ?? ""),
+    recipient: String(get(prop, "recipient") ?? ""),
+    amount: toNum(get(prop, "amount")),
+    status: {
+      createdBtc: toNum(get(status, "createdBtc")),
+      voteStart: toNum(get(status, "voteStart")),
+      voteEnd: toNum(get(status, "voteEnd")),
+      execStart: toNum(get(status, "execStart")),
+      execEnd: toNum(get(status, "execEnd")),
+      yesWeight: toNum(get(status, "yesWeight")),
+      noWeight: toNum(get(status, "noWeight")),
+      vetoWeight: toNum(get(status, "vetoWeight")),
+      totalStakedSnapshot: toNum(get(status, "totalStakedSnapshot")),
+      voterCount: toNum(get(status, "voterCount")),
+      metQuorum: Boolean(get(status, "metQuorum")),
+      metThreshold: Boolean(get(status, "metThreshold")),
+      vetoMetQuorum: Boolean(get(status, "vetoMetQuorum")),
+      vetoActivated: Boolean(get(status, "vetoActivated")),
+      concluded: Boolean(get(status, "concluded")),
+      executed: Boolean(get(status, "executed")),
+    },
+    votes,
+  };
+}

--- a/lib/legion/stacks.ts
+++ b/lib/legion/stacks.ts
@@ -1,0 +1,183 @@
+/**
+ * Testnet read-only contract calls for the Legion dashboard.
+ *
+ * Deliberately separate from `lib/identity/stacks-api.ts` (which is hardcoded to
+ * mainnet and sits on the request-critical profile path). This module reuses the
+ * shared fetch wrapper and the base-agnostic `parseClarityValue` decoder, and
+ * only adds the testnet URL + a small `/v2/info` helper. The Hiro API key is
+ * sent via `x-api-key` (Hiro's documented header) to lift the per-IP rate limit.
+ */
+
+import { type ClarityValue, serializeCV } from "@stacks/transactions";
+import { stacksApiFetch, detect429 } from "../stacks-api-fetch";
+import { parseClarityValue } from "../identity/stacks-api";
+import { LEGION_API_BASE } from "./constants";
+import type { Logger } from "../logging";
+
+const PER_ATTEMPT_TIMEOUT_MS = 5_000;
+
+/**
+ * Hiro auth headers. Hiro's current documented header is `x-api-key`; we also
+ * send the legacy `x-hiro-api-key` for compatibility. Without a key the request
+ * goes out anonymous and is capped at 50 RPM per IP — which a Worker (shared
+ * colo egress IP) blows through instantly, so the key is what makes deployed
+ * reads viable.
+ */
+function legionHeaders(apiKey?: string): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers["x-api-key"] = apiKey;
+    headers["x-hiro-api-key"] = apiKey;
+  }
+  return headers;
+}
+
+/**
+ * Call a read-only function on a testnet contract and return the unwrapped
+ * Clarity value (uint/int as strings, optionals unwrapped to their inner value
+ * or null, tuples as plain objects). Throws on non-2xx so callers can record
+ * the failure and fall back.
+ */
+export async function legionReadOnly(
+  contract: string,
+  functionName: string,
+  args: ClarityValue[] = [],
+  hiroApiKey?: string,
+  logger?: Logger,
+): Promise<unknown> {
+  const [contractAddress, contractName] = contract.split(".");
+  const url = `${LEGION_API_BASE}/v2/contracts/call-read/${contractAddress}/${contractName}/${functionName}`;
+
+  // An authenticated key lifts the per-IP rate limit — important because a
+  // Worker shares its colo egress IP with other tenants hitting Hiro.
+  const headers = legionHeaders(hiroApiKey);
+  headers["Content-Type"] = "application/json";
+
+  const response = await stacksApiFetch(
+    url,
+    {
+      method: "POST",
+      headers,
+      body: JSON.stringify({
+        sender: contractAddress,
+        arguments: args.map((cv) => `0x${serializeCV(cv)}`),
+      }),
+    },
+    // Runs on the cron, not a user request, so it can afford to back off and
+    // retry transient 429s (the shared colo IP occasionally trips Hiro's limit
+    // even with a key).
+    { retries: 2, retries429: 3, perAttemptTimeoutMs: PER_ATTEMPT_TIMEOUT_MS, logger },
+  );
+
+  detect429(response, logger);
+
+  if (!response.ok) {
+    throw new Error(
+      `Legion read ${functionName} failed: ${response.status} ${response.statusText}`,
+    );
+  }
+
+  return parseClarityValue(await response.json(), logger);
+}
+
+export interface ContractTx {
+  txid: string;
+  functionName: string;
+  /** Caller principal. */
+  sender: string;
+  /** Decoded function-call argument reprs, e.g. ["u4", "true"]. */
+  argReprs: string[];
+}
+
+/** Parse a Clarity uint repr like "u4" into a number, or null. */
+export function parseUintRepr(repr: string | undefined): number | null {
+  if (typeof repr !== "string" || !repr.startsWith("u")) return null;
+  const n = Number(repr.slice(1));
+  return Number.isFinite(n) ? n : null;
+}
+
+/**
+ * Fetch a contract's recent transaction history (newest first), decoding the
+ * function name, sender, and first uint arg of each contract-call. Used to
+ * recover vote txids — the on-chain vote record itself doesn't store them.
+ *
+ * Only `tx_status === "success"` txs are returned. A reverted call (e.g. a
+ * `vote` that aborts with `(err ...)`) changes no on-chain state, so counting
+ * it would render a phantom vote with no backing vote-record (amount 0). The
+ * endpoint returns confirmed txs of every status, so we filter here.
+ *
+ * Bounded by `maxTxs`; if the contract has more than that, the oldest are not
+ * returned (logged, never silently). For the Legion this only matters for
+ * in-flight proposals, whose votes are the newest txs, so the cap is ample.
+ */
+export async function getContractTransactions(
+  contractId: string,
+  apiKey?: string,
+  logger?: Logger,
+  maxTxs = 200,
+): Promise<ContractTx[]> {
+  const out: ContractTx[] = [];
+  const pageSize = 50;
+
+  for (let offset = 0; offset < maxTxs; offset += pageSize) {
+    let data: { results?: unknown[]; total?: number } | null = null;
+    try {
+      const response = await stacksApiFetch(
+        `${LEGION_API_BASE}/extended/v1/address/${contractId}/transactions?limit=${pageSize}&offset=${offset}`,
+        { method: "GET", headers: legionHeaders(apiKey) },
+        { retries: 1, retries429: 1, perAttemptTimeoutMs: PER_ATTEMPT_TIMEOUT_MS, logger },
+      );
+      if (!response.ok) break;
+      data = await response.json();
+    } catch {
+      break;
+    }
+
+    const results = data?.results ?? [];
+    for (const item of results) {
+      const tx = ((item as { tx?: unknown }).tx ?? item) as {
+        tx_id?: string;
+        tx_status?: string;
+        sender_address?: string;
+        contract_call?: { function_name?: string; function_args?: { repr?: string }[] };
+      };
+      const cc = tx.contract_call;
+      if (!cc?.function_name || !tx.tx_id) continue;
+      if (tx.tx_status !== "success") continue; // skip reverted/aborted calls
+      out.push({
+        txid: tx.tx_id,
+        functionName: cc.function_name,
+        sender: tx.sender_address ?? "",
+        argReprs: (cc.function_args ?? []).map((a) => a.repr ?? ""),
+      });
+    }
+
+    if (results.length < pageSize) break; // last page
+    if (data?.total != null && offset + pageSize >= data.total) break;
+    if (offset + pageSize >= maxTxs && (data?.total ?? 0) > maxTxs) {
+      logger?.warn?.("legion.contract_tx_truncated", { contractId, cap: maxTxs, total: data?.total });
+    }
+  }
+
+  return out;
+}
+
+/** Current Stacks testnet tip height, or null if /v2/info is unreachable. */
+export async function getTestnetTipHeight(
+  hiroApiKey?: string,
+  logger?: Logger,
+): Promise<number | null> {
+  try {
+    const response = await stacksApiFetch(
+      `${LEGION_API_BASE}/v2/info`,
+      { method: "GET", headers: legionHeaders(hiroApiKey) },
+      { retries: 1, retries429: 1, perAttemptTimeoutMs: PER_ATTEMPT_TIMEOUT_MS, logger },
+    );
+    if (!response.ok) return null;
+    const data = (await response.json()) as { stacks_tip_height?: number };
+    const height = Number(data?.stacks_tip_height);
+    return Number.isFinite(height) ? height : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/legion/types.ts
+++ b/lib/legion/types.ts
@@ -1,0 +1,82 @@
+/**
+ * Legion dashboard data model. All sBTC amounts are integer satoshis
+ * (divide by 1e8 for display). Block heights are Stacks block numbers.
+ */
+
+export interface LegionMember {
+  /** STX address (also the staker / voter identity). */
+  address: string;
+  /** Staked sBTC (sats) = voting weight. */
+  stake: number;
+  /** stake / totalStaked * 100, in [0, 100]. */
+  weightPct: number;
+  /** Wallet sBTC balance (sats), independent of stake. */
+  sbtcBalance: number;
+}
+
+export interface LegionVote {
+  /** Voter STX address. */
+  address: string;
+  /** true = YES, false = NO. */
+  vote: boolean;
+  /** Weight committed with the vote (sats). */
+  amount: number;
+  /** The on-chain `vote` transaction id (null if not recovered). */
+  txid: string | null;
+}
+
+export interface LegionProposalStatus {
+  createdBtc: number;
+  voteStart: number;
+  voteEnd: number;
+  execStart: number;
+  execEnd: number;
+  yesWeight: number;
+  noWeight: number;
+  vetoWeight: number;
+  totalStakedSnapshot: number;
+  voterCount: number;
+  metQuorum: boolean;
+  metThreshold: boolean;
+  vetoMetQuorum: boolean;
+  vetoActivated: boolean;
+  concluded: boolean;
+  executed: boolean;
+}
+
+export interface LegionProposal {
+  id: number;
+  /** Who created the proposal. */
+  proposer: string;
+  desc: string;
+  /** Who the treasury pays if the proposal passes. */
+  recipient: string;
+  /** Payout amount from the treasury (sats). */
+  amount: number;
+  status: LegionProposalStatus;
+  /** The agents who actually voted, derived from on-chain vote txs. */
+  votes: LegionVote[];
+}
+
+export interface LegionTreasury {
+  /** Pooled sBTC (sats). null if the read failed. */
+  balance: number | null;
+  govWired: boolean;
+  tokenWired: boolean;
+}
+
+export interface LegionSnapshot {
+  /** Unix ms when this snapshot was assembled. */
+  updatedAt: number;
+  /** Stacks tip height at snapshot time. null if /v2/info failed. */
+  blockHeight: number | null;
+  treasury: LegionTreasury;
+  /** Total staked across the legion (sats). null if the read failed. */
+  totalStaked: number | null;
+  /** Members sorted by stake descending. */
+  members: LegionMember[];
+  /** Proposals, newest first. */
+  proposals: LegionProposal[];
+  /** Per-read failure notes — present so partial outages are visible, not silent. */
+  errors: string[];
+}

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -32,6 +32,11 @@ import {
 import { runEarningsSweep } from "../earnings/indexer";
 import { EARNINGS_INTERVAL_MS } from "../earnings/constants";
 import type { EarningsSweepSummary } from "../earnings/types";
+import { buildLegionSnapshot } from "../legion/snapshot";
+import {
+  readLegionSnapshotFromD1,
+  writeLegionSnapshotToD1,
+} from "../legion/d1";
 import type { Logger } from "../logging";
 import type {
   SchedulerStatus,
@@ -43,6 +48,8 @@ import type {
 // gated to their longer intervals via a last-run check (mirrors the old DO alarm).
 export const TENERO_INTERVAL_MS = 5 * 60 * 1000;
 export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
+// Legion dashboard snapshot refreshes every cron tick (testnet, low volume).
+export const LEGION_INTERVAL_MS = 5 * 60 * 1000;
 
 // KV keys (VERIFIED_AGENTS namespace).
 const K_TENERO = "scheduler:tenero";
@@ -238,6 +245,41 @@ export async function runEarningsNow(
   return result;
 }
 
+/**
+ * Rebuild the Legion dashboard snapshot from testnet and persist it to KV under
+ * `legion:snapshot`. This is the only writer of that key; the /api/legion
+ * endpoint (and its edge cache) are pure readers. A build never throws — partial
+ * outages are recorded in `snapshot.errors` — so this only rejects on an
+ * unexpected error, which the caller logs without blocking other tasks.
+ */
+export async function runLegionNow(
+  env: CloudflareEnv,
+  parentLogger: Logger,
+): Promise<void> {
+  const logger = parentLogger.child
+    ? parentLogger.child({ task: "legion" })
+    : parentLogger;
+
+  const db = env.DB as D1Database | undefined;
+  if (!db) {
+    logger.warn("legion.skipped_no_db");
+    return;
+  }
+
+  // Read the prior snapshot so terminal (concluded) proposals are carried
+  // forward without re-reading them from Hiro. Authenticated with HIRO_API_KEY.
+  const prev = await readLegionSnapshotFromD1(db);
+  const snapshot = await buildLegionSnapshot(logger, prev, env.HIRO_API_KEY);
+  await writeLegionSnapshotToD1(db, snapshot);
+
+  logger.info("legion.snapshot_written", {
+    blockHeight: snapshot.blockHeight,
+    proposals: snapshot.proposals.length,
+    members: snapshot.members.length,
+    errors: snapshot.errors.length,
+  });
+}
+
 // ─────────────────────────── cron entry point ───────────────────────────
 
 /**
@@ -327,6 +369,18 @@ export async function runScheduledTasks(
   } else {
     logger.debug("scheduler.earnings_not_due", {
       lastRunAt: earnings?.lastRunAt ?? null,
+    });
+  }
+
+  // Legion snapshot — every tick (cron cadence == LEGION_INTERVAL_MS). The
+  // snapshot blob is its own state, so there's no separate state read to gate
+  // on; a slow overrun just overwrites idempotently.
+  try {
+    await runLegionNow(env, logger);
+  } catch (error) {
+    logger.error("scheduler.legion_unexpected_error", {
+      error: String(error),
+      stack: error instanceof Error ? error.stack : undefined,
     });
   }
 }

--- a/migrations/023_legion_snapshot.sql
+++ b/migrations/023_legion_snapshot.sql
@@ -1,0 +1,17 @@
+-- Migration 023: Legion dashboard snapshot (single-row JSON cache)
+--
+-- The Legion dashboard renders a denormalized snapshot of testnet governance
+-- state (treasury wiring, members + stake, proposals + per-agent votes). The
+-- 5-min cron rebuilds it from Hiro and upserts the single row here; the page
+-- and /api/legion read it behind caches.default + an in-flight singleflight,
+-- mirroring the leaderboard read path (app/leaderboard/page.tsx). Hiro is only
+-- ever hit by the rebuild, never per request.
+--
+-- JSON-in-TEXT matches the existing competition_round_results.result_json
+-- precedent — the whole dashboard is read at once, so there's no query benefit
+-- to normalizing proposals/votes into separate tables.
+CREATE TABLE IF NOT EXISTS legion_snapshot (
+  id            INTEGER PRIMARY KEY CHECK (id = 1),
+  snapshot_json TEXT    NOT NULL,
+  updated_at    INTEGER NOT NULL
+);

--- a/scheduler-worker.ts
+++ b/scheduler-worker.ts
@@ -1,0 +1,55 @@
+/**
+ * Standalone scheduler Worker (`aibtc-scheduler`).
+ *
+ * WHY THIS EXISTS: the `landing-page` Worker's cron trigger repeatedly gets
+ * orphaned/stuck — every `wrangler deploy` re-applies the trigger and silently
+ * stops dispatch (a verified Cloudflare cron fragility; a fresh worker's cron
+ * fires fine on the same account). Hosting the scheduler in its own worker
+ * gives it a cron that `landing-page` deploys can never disturb.
+ *
+ * IT IS THE SAME DATA: this worker binds the SAME D1 database
+ * (`landing-page`) and the SAME KV namespaces (`VERIFIED_AGENTS`, `HOLDINGS_KV`)
+ * that the site reads from. It just runs the existing `runScheduledTasks`
+ * (Tenero prices + competition sweep + earnings) against those shared bindings —
+ * the site (`landing-page`) keeps serving the UI/API and reads whatever this
+ * worker writes. No data is duplicated; both workers point at one store.
+ */
+
+import { runScheduledTasks } from "./lib/scheduler/cron-runner";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+} from "./lib/logging";
+
+export default {
+  // A tiny fetch handler so the worker has an HTTP surface (health check).
+  async fetch(): Promise<Response> {
+    return new Response("aibtc-scheduler: cron-only worker. See Cron Triggers.", {
+      status: 200,
+      headers: { "Content-Type": "text/plain" },
+    });
+  },
+
+  async scheduled(
+    event: ScheduledController,
+    env: CloudflareEnv,
+    ctx: ExecutionContext
+  ): Promise<void> {
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { path: "/__cron/scheduler", cron: event.cron })
+      : createConsoleLogger({ path: "/__cron/scheduler", cron: event.cron });
+
+    // Await directly (per the Cloudflare scheduled-handler docs) so any failure
+    // is surfaced in Past Events with a real stack instead of being swallowed.
+    try {
+      await runScheduledTasks(env, logger);
+    } catch (error) {
+      console.error(
+        "scheduler.cron_failed",
+        error instanceof Error ? (error.stack ?? error.message) : String(error)
+      );
+      throw error;
+    }
+  },
+};

--- a/worker.ts
+++ b/worker.ts
@@ -42,41 +42,49 @@ export default {
     env: CloudflareEnv,
     ctx: ExecutionContext
   ) {
-    // Capture ANY cron failure to KV so we can read the exact exception with
-    // `wrangler kv key get scheduler:last-error`. The dashboard only shows an
-    // opaque "Internal Error" with no stack. The prior version (#1000) wrapped
-    // only runScheduledTasks inside ctx.waitUntil and came back EMPTY — so this
-    // hardens it two ways:
-    //   1. The try/catch now wraps the WHOLE handler, including logger creation,
-    //      so a throw in setup (not just the task run) is still captured.
-    //   2. Per the Cloudflare scheduled-handler docs, the work is `await`ed
-    //      directly (the runtime waits on the returned promise) rather than
-    //      detached via ctx.waitUntil — so any rejection propagates to this
-    //      catch instead of escaping as an unobserved waitUntil failure.
-    try {
-      const logger = isLogsRPC(env.LOGS)
-        ? createLogger(env.LOGS, ctx, { path: "/__cron/scheduler", cron: event.cron })
-        : createConsoleLogger({ path: "/__cron/scheduler", cron: event.cron });
-      await runScheduledTasks(env, logger);
-    } catch (error) {
-      const detail = {
-        at: Date.now(),
-        cron: event.cron,
-        name: error instanceof Error ? error.name : undefined,
-        message: error instanceof Error ? error.message : String(error),
-        stack: error instanceof Error ? error.stack : undefined,
-      };
-      // KV first (most reliable readback), then console (shows in `wrangler
-      // tail`). Both guarded so the diagnostic can never itself crash the run.
-      try {
-        await env.VERIFIED_AGENTS.put("scheduler:last-error", JSON.stringify(detail));
-      } catch {
-        // KV write failed too — nothing more we can safely do here.
-      }
-      console.error("scheduler.cron_failed", detail.stack ?? detail.message);
-      // Re-throw so the failure is still recorded in the Cron Past Events table.
-      throw error;
-    }
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, {
+          path: "/__cron/scheduler",
+          cron: event.cron,
+        })
+      : createConsoleLogger({ path: "/__cron/scheduler", cron: event.cron });
+
+    // Capture any cron failure straight to KV, independent of the LOGS RPC
+    // path — the cron has been failing with an opaque "Internal Error" and the
+    // dashboard shows no stack. Writing the raw error to `scheduler:last-error`
+    // lets us read the exact exception with `wrangler kv key get`. The capture
+    // is fully self-guarded so it can never itself crash the invocation.
+    ctx.waitUntil(
+      (async () => {
+        try {
+          await runScheduledTasks(env, logger);
+        } catch (error) {
+          const detail = {
+            at: Date.now(),
+            cron: event.cron,
+            name: error instanceof Error ? error.name : undefined,
+            message: error instanceof Error ? error.message : String(error),
+            stack: error instanceof Error ? error.stack : undefined,
+          };
+          try {
+            await env.VERIFIED_AGENTS.put(
+              "scheduler:last-error",
+              JSON.stringify(detail)
+            );
+          } catch {
+            // KV write failed too — nothing more we can safely do here.
+          }
+          try {
+            logger.error("scheduler.cron_failed", {
+              error: detail.message,
+              stack: detail.stack,
+            });
+          } catch {
+            // Logger itself may be the failing dependency; ignore.
+          }
+        }
+      })()
+    );
   },
 
   async queue(

--- a/worker.ts
+++ b/worker.ts
@@ -37,6 +37,11 @@ export default {
     return openNextWorker.fetch(request, env, ctx);
   },
 
+  // INTENTIONALLY INERT: scheduling moved to the standalone `aibtc-scheduler`
+  // Worker (wrangler.scheduler.jsonc), and this Worker's `triggers.crons` is now
+  // empty — so `scheduled()` will never fire here. Kept only so the same
+  // `runScheduledTasks` is reachable if a cron is ever re-attached for debugging;
+  // remove it entirely once that's confirmed unnecessary.
   async scheduled(
     event: ScheduledController,
     env: CloudflareEnv,

--- a/wrangler.jsonc
+++ b/wrangler.jsonc
@@ -102,17 +102,14 @@
     ]
   },
 
-  // Cron Trigger drives periodic background work (Tenero price refresh
-  // every tick + competition Hiro catch-up sweep on its longer cadence)
-  // via the worker's scheduled() handler — see lib/scheduler/cron-runner.ts.
-  // This replaced the former SchedulerDO, whose alarm had no independent
-  // trigger: it only stayed armed because /leaderboard SSR poked it on every
-  // render, so a DO storage wipe with no leaderboard visit left all
-  // scheduled work silently stopped. Crons are NOT inherited by named envs,
-  // so env.production below repeats this; env.preview omits it so preview
-  // deploys never run schedulers against the shared production D1/KV quota.
+  // Scheduling is owned by the standalone `aibtc-scheduler` Worker
+  // (scheduler-worker.ts + wrangler.scheduler.jsonc), which binds the SAME
+  // D1/KV and runs the same `runScheduledTasks`. landing-page's own cron
+  // trigger kept getting silently orphaned by deploys (a fresh worker's cron
+  // fires fine on the same account; this one did not), so this Worker no
+  // longer schedules anything. Empty `crons` removes the trigger on deploy.
   "triggers": {
-    "crons": ["*/5 * * * *"]
+    "crons": []
   },
   // SchedulerDO fully removed — the cron trigger above drives all scheduled
   // work. The v4 deleted_classes migration tears down the Durable Object and
@@ -234,10 +231,10 @@
         ]
       },
 
-      // Cron Trigger for the named-production deploy path (`--env production`).
-      // Repeated here because wrangler does not inherit top-level triggers.
+      // Scheduling moved to the standalone `aibtc-scheduler` Worker — see the
+      // top-level note. Empty `crons` removes this worker's trigger on deploy.
       "triggers": {
-        "crons": ["*/5 * * * *"]
+        "crons": []
       },
       // SchedulerDO fully removed — see top-level note. Applies on the
       // production (main) non-versioned deploy.

--- a/wrangler.scheduler.jsonc
+++ b/wrangler.scheduler.jsonc
@@ -1,0 +1,39 @@
+{
+  // Standalone scheduler Worker — own cron, immune to landing-page deploys.
+  // Binds the SAME D1 + KV as landing-page so its writes are the site's data.
+  // Deploy:  npx wrangler deploy --config wrangler.scheduler.jsonc
+  // Secrets (set once, by you):
+  //   npx wrangler secret put HIRO_API_KEY   --config wrangler.scheduler.jsonc
+  //   npx wrangler secret put TENERO_API_KEY --config wrangler.scheduler.jsonc
+  "name": "aibtc-scheduler",
+  "main": "scheduler-worker.ts",
+  "compatibility_date": "2026-01-08",
+  "compatibility_flags": ["nodejs_compat"],
+
+  "triggers": {
+    "crons": ["*/5 * * * *"]
+  },
+
+  "vars": {
+    "DEPLOY_ENV": "production",
+    "TENERO_REFRESH_ENABLED": "true",
+    "EARNINGS_INDEX_ENABLED": "true"
+  },
+
+  // Same database_id + KV ids as landing-page → one shared store.
+  "d1_databases": [
+    {
+      "binding": "DB",
+      "database_name": "landing-page",
+      "database_id": "89a00080-d1e1-48bd-823a-0fdd93bf0875"
+    }
+  ],
+  "kv_namespaces": [
+    { "binding": "VERIFIED_AGENTS", "id": "f8aab2734e154953a50cabdb87083af3" },
+    { "binding": "HOLDINGS_KV", "id": "3e9bbe855e7f46769dfcaa99ae87af5c" }
+  ],
+  "services": [
+    { "binding": "LOGS", "service": "worker-logs-production", "entrypoint": "LogsRPC" },
+    { "binding": "X402_RELAY", "service": "x402-sponsor-relay-production", "entrypoint": "RelayRPC" }
+  ]
+}


### PR DESCRIPTION
## What

Closes out the scheduler saga:

1. **Re-land legion** — #999 was reverted (#1001) only to isolate the cron crash; it was **innocent**. The real cause was the deprecated Hiro `x-hiro-api-key` header (fixed in #1002). This reverts the revert, bringing legion back (dashboard, API, lib, migration) including its own `x-api-key` usage and the reverted-vote filter.

2. **Standalone `aibtc-scheduler` worker** (`scheduler-worker.ts` + `wrangler.scheduler.jsonc`) — runs the existing `runScheduledTasks` (Tenero + competition + earnings + legion) on its **own cron**, bound to the **same** D1 (`landing-page`) + KV. Already deployed and verified live (competition 100/100, Hiro + Tenero keys authenticating).

3. **Retire landing-page's own cron** — emptied `triggers.crons` (top-level + env.production). landing-page's trigger kept getting silently orphaned by deploys; `aibtc-scheduler` owns scheduling now.

## Why

A fresh worker's cron fires reliably on this account; landing-page's specifically did not (every deploy re-orphaned it). Isolating the scheduler in its own worker permanently ends that.

## Deploy steps (after merge)
1. Merge → landing-page deploys with empty crons → its trigger is removed.
2. Redeploy the scheduler with the re-landed legion code:
   `npx wrangler deploy --config wrangler.scheduler.jsonc`
   (secrets HIRO_API_KEY/TENERO_API_KEY already set on aibtc-scheduler)
3. Bump scheduler cron back to `*/5` is already the committed value (was temporarily 1-min for verification).

## Verified
- typecheck clean; scheduler worker bundles legion (298 KiB)
- live: competition + Hiro + Tenero all authenticating on the deployed aibtc-scheduler