### PR TITLE
fix(tenero): respect 10/min + 10k/month — hourly cadence + request spacing

### DIFF
--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -23,6 +23,7 @@ import { getActiveTokenIds } from "../external/tenero";
 import {
   runTeneroTask,
   TENERO_MINUTE_QUOTA_BACKOFF_MS,
+  TENERO_REQUEST_SPACING_MS,
   type TeneroRunResult,
 } from "./tenero-task";
 import {
@@ -46,7 +47,13 @@ import type {
 
 // Cadences. The cron fires every TENERO_INTERVAL_MS; competition + earnings are
 // gated to their longer intervals via a last-run check (mirrors the old DO alarm).
-export const TENERO_INTERVAL_MS = 5 * 60 * 1000;
+// Tenero refresh cadence — HOURLY, sized to the monthly API budget. The Starter
+// plan allows 10,000 req/month; at ~13 active tokens that's 13 × 24 × ~30 ≈
+// 9.4k/mo, safely under. (Was 5 min ≈ 112k/mo — 11× over, which exhausted the
+// month in ~2 days.) If the active-token count grows materially, raise this
+// interval or upgrade the Tenero plan. The minute cap is handled separately by
+// TENERO_REQUEST_SPACING_MS (inter-request spacing within a run).
+export const TENERO_INTERVAL_MS = 60 * 60 * 1000;
 export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
 // Legion dashboard snapshot refreshes every cron tick (testnet, low volume).
 export const LEGION_INTERVAL_MS = 5 * 60 * 1000;
@@ -159,6 +166,8 @@ export async function runTeneroNow(
     kv,
     tokenIds,
     apiKey: lookupTeneroApiKey(env),
+    // Pace fetches under the per-minute API cap so a full sweep never 429s.
+    spacingMs: TENERO_REQUEST_SPACING_MS,
   });
 
   const prev =

--- a/lib/scheduler/tenero-task.ts
+++ b/lib/scheduler/tenero-task.ts
@@ -35,6 +35,12 @@ export interface TeneroTaskDeps {
   apiKey?: string;
   /** Test injection point. Defaults to `Date.now`. */
   now?: () => number;
+  /**
+   * Delay (ms) between token fetches to stay under Tenero's per-minute cap.
+   * Production passes `TENERO_REQUEST_SPACING_MS`; defaults to 0 (no delay) so
+   * tests run instantly.
+   */
+  spacingMs?: number;
 }
 
 export interface TeneroTaskOutcome {
@@ -56,6 +62,19 @@ export const TENERO_MINUTE_QUOTA_BACKOFF_MS = 5 * 60 * 1000;
 export const TENERO_MONTH_QUOTA_BACKOFF_MS = 24 * 60 * 60 * 1000;
 
 /**
+ * Inter-request spacing to stay under Tenero's per-minute API cap (Starter plan
+ * = 10 req/min). ~6.6s between fetches → ≤~9/min, so a full token sweep never
+ * trips the minute limit — no more `minute_quota_exhausted` mid-run breaks or
+ * 429 backoffs. Production passes this via `deps.spacingMs`; the pure task
+ * defaults to 0 (no delay) so tests stay instant.
+ */
+export const TENERO_REQUEST_SPACING_MS = 6_600;
+
+function sleep(ms: number): Promise<void> {
+  return ms > 0 ? new Promise((resolve) => setTimeout(resolve, ms)) : Promise.resolve();
+}
+
+/**
  * Skip the KV rewrite when the fetched price equals the cached one and the
  * cached entry is younger than this. KV writes are the tightest paid-plan
  * quota (1M/mo; this task alone was ~458k/mo at 53 tokens × 5-min cadence)
@@ -70,6 +89,7 @@ export async function runTeneroTask(
 ): Promise<TeneroTaskOutcome> {
   const { logger, kv, tokenIds, apiKey } = deps;
   const now = deps.now ?? Date.now;
+  const spacingMs = deps.spacingMs ?? 0;
   const startedAt = now();
 
   logger.info("tenero.refresh_started", { tokenCount: tokenIds.length });
@@ -81,7 +101,12 @@ export async function runTeneroTask(
   let rateLimited = false;
   let rateLimitBackoffMs: number | undefined;
 
+  let firstToken = true;
   for (const tokenId of tokenIds) {
+    // Pace requests under the per-minute API cap (see TENERO_REQUEST_SPACING_MS).
+    if (!firstToken) await sleep(spacingMs);
+    firstToken = false;
+
     const r = await fetchTokenPriceUsd(tokenId, logger, apiKey);
     lastMinuteRemaining = r.rateLimit.minuteRemaining ?? lastMinuteRemaining;
     lastMonthRemaining = r.rateLimit.monthRemaining ?? lastMonthRemaining;


### PR DESCRIPTION
## Problem

Tenero Starter plan has **two** limits and the scheduler was blowing both:
- **10,000 req/month** — tenero ran every 5 min × 13 tokens ≈ **112k/month (11× over)**; would exhaust the month in ~2 days and take prices offline.
- **10 req/min** — the sweep fired all 13 tokens back-to-back, hit the per-minute cap, broke mid-run, and backed off (the `minute_quota_exhausted_mid_run` warnings).

## Fix (in the shared scheduler lib — applies to aibtc-scheduler)

- **Monthly budget → cadence.** `TENERO_INTERVAL_MS` 5 min → **60 min** (hourly). 13 × 24 × ~30 ≈ **9.4k/month**, under the 10k cap. Comment documents the math; raise the interval (or upgrade the plan) if the active-token count grows.
- **Per-minute → spacing.** `TENERO_REQUEST_SPACING_MS` (~6.6s) between fetches → a full sweep stays ≤~9/min and never trips the cap. Wired as a `deps.spacingMs` param: production (`runTeneroNow`) passes it; the pure task defaults to **0** so the 9 existing tests run instantly (verified).

Existing minute/month backoffs stay as safety nets.

## Tradeoff
Prices refresh **hourly** instead of every 5 min — fine for the competition cache (the live leaderboard pulls Tenero client-side). Upgrade the plan if you want 5-min freshness.

## After merge
Redeploy the scheduler: `npx wrangler deploy --config wrangler.scheduler.jsonc`

## Not included
Hiro/competition pacing — those 429s should clear now that #1003 removed the duplicate scheduler (halved the request rate). Revisit only if they persist with one scheduler.