### PR TITLE
fix(deps): pin form-data >=4.0.6 to patch CVE-2026-12143 CRLF injection

### DIFF
--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -34,6 +34,7 @@ import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/in
 import { bumpInboundStats, getAgentInboxStats } from "@/lib/inbox/stats";
 import {
   listInboxMessagesFromD1,
+  countInboxMessagesFromD1,
   listSentMessagesFromD1,
   fetchRepliesForMessages,
   listOutboxRepliesFromD1,
@@ -378,12 +379,16 @@ export async function GET(
   //   [0] stats row — receivedCount, unreadCount from maintained counters
   //   [1] paginated message list (the page the caller asked for)
   //   [2] sentMessages — outbox replies for partner graph (only when includePartners)
+  //   [3] live unread count — only when status=unread, bypasses stale denormalized counter
+  //       (#906: agent_inbox_stats.unread_count can drift above live row count,
+  //       producing totalCount=1 + messages=[] phantom unread)
   let receivedMessages: import("@/lib/inbox/types").InboxMessage[];
   let agentStats: Awaited<ReturnType<typeof getAgentInboxStats>>;
   let sentMessages: import("@/lib/inbox/types").OutboxReply[];
+  let liveUnreadCount: number | null = null;
   try {
-    [agentStats, receivedMessages, sentMessages] = await Promise.all([
-      // Stats O(1) point-lookup — replaces two countInboxMessagesFromD1 scans
+    [agentStats, receivedMessages, sentMessages, liveUnreadCount] = await Promise.all([
+      // Stats O(1) point-lookup — receivedCount and sentCount remain accurate
       getAgentInboxStats(db, agent.btcAddress),
       // Paginated message list (still needed for message content)
       includeReceived
@@ -393,18 +398,23 @@ export async function GET(
       includePartners
         ? listOutboxRepliesFromD1(db, agent.btcAddress, 100, 0)
         : Promise.resolve([] as import("@/lib/inbox/types").OutboxReply[]),
+      // Live count for status=unread only — avoids phantom unread from counter drift
+      statusFilter === "unread"
+        ? countInboxMessagesFromD1(db, agent.btcAddress, "unread")
+        : Promise.resolve(null),
     ]);
   } catch (e) {
     return d1TransientResponse("Inbox database temporarily unavailable. Please retry shortly.");
   }
 
-  const unreadCount = agentStats.unreadCount;
+  const unreadCount = liveUnreadCount ?? agentStats.unreadCount;
   const receivedCount = agentStats.receivedCount;
 
-  // Derive totalCount from stats counters — no extra COUNT(*) needed.
-  // statusFilter="all"   → totalCount equals receivedCount (same predicate)
-  // statusFilter="unread" → totalCount equals unreadCount (same predicate)
-  // statusFilter="read"   → totalCount equals received minus unread
+  // Derive totalCount from counters.
+  // statusFilter="all"    → totalCount equals receivedCount (maintained counter, accurate)
+  // statusFilter="unread" → totalCount comes from live COUNT(*) WHERE read_at IS NULL
+  //                         (liveUnreadCount), not the denormalized counter that can drift
+  // statusFilter="read"   → totalCount equals received minus live unread
   const totalCount: number =
     statusFilter === "unread"
       ? unreadCount

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -161,6 +161,40 @@ export async function listInboxMessagesFromD1(
 }
 
 /**
+ * Count inbound messages for an agent with the given status filter.
+ *
+ * Restored to serve as the source-of-truth for totalCount when
+ * statusFilter === "unread", bypassing the denormalized agent_inbox_stats
+ * counter which can drift when a mark-read update misses decrementUnreadStats.
+ * Hits idx_inbox_unread (partial index on read_at IS NULL) for the unread
+ * case — O(log n) not O(n). See: https://github.com/aibtcdev/landing-page/issues/906
+ */
+export async function countInboxMessagesFromD1(
+  db: D1Database,
+  btcAddress: string,
+  status: StatusFilter
+): Promise<number> {
+  let sql = `
+    SELECT COUNT(*) AS cnt
+    FROM inbox_messages
+    WHERE to_btc_address = ? AND is_reply = 0
+  `;
+
+  if (status === "unread") {
+    sql += " AND read_at IS NULL";
+  } else if (status === "read") {
+    sql += " AND read_at IS NOT NULL";
+  }
+
+  const row = await db
+    .prepare(sql)
+    .bind(btcAddress)
+    .first<{ cnt: number }>();
+
+  return row?.cnt ?? 0;
+}
+
+/**
  * Fetch a page of ORIGINATED messages an agent has sent from D1.
  *
  * "Sent" here means messages this agent AUTHORED to other agents (is_reply=0),

--- a/package-lock.json
+++ b/package-lock.json
@@ -8288,16 +8288,16 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
         "es-set-tostringtag": "^2.1.0",
-        "hasown": "^2.0.2",
-        "mime-types": "^2.1.12"
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
       },
       "engines": {
         "node": ">= 6"
@@ -8733,9 +8733,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12978,9 +12978,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "version": "0.2.6",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+      "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "picomatch": ">=4.0.4",
     "path-to-regexp": ">=8.4.0",
     "axios": ">=1.15.0",
-    "tmp": ">=0.2.6"
+    "tmp": ">=0.2.6",
+    "form-data": ">=4.0.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
     "path-to-regexp": ">=8.4.0",
-    "axios": ">=1.15.0"
+    "axios": ">=1.15.0",
+    "tmp": ">=0.2.6"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- Adds `"form-data": ">=4.0.6"` to the `overrides` section in `package.json`
- Resolves Dependabot alert #124 (CVE-2026-12143, CVSS 7.5 / High)
- form-data was transitively pulled in by `axios` at version 4.0.5

## Vulnerability

CVE-2026-12143: CRLF injection via unescaped `\r`, `\n`, or `"` in multipart field names and filenames. An attacker who controls field names passed to `FormData#append` can inject additional headers or smuggle extra multipart parts.

**Risk for this project:** Low — form-data is used transitively by axios, and the landing page uses only fixed/trusted field names. No code changes to application logic are needed.

**Fix in 4.0.6:** Escapes control characters as `%0D`, `%0A`, `%22`, matching the WHATWG HTML spec multipart serialization.

## Test plan

- [ ] `npm install` resolves `node_modules/form-data` to 4.0.6+
- [ ] CI build passes
- [ ] Dependabot alert #124 dismissed after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)