### PR TITLE
fix(deps): pin ws >=8.21.0 to patch CVE-2026-48779 DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14851,9 +14851,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.18.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-      "integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -42,7 +42,8 @@
     "flatted": ">=3.4.0",
     "picomatch": ">=4.0.4",
     "path-to-regexp": ">=8.4.0",
-    "axios": ">=1.17.0"
+    "axios": ">=1.17.0",
+    "ws": ">=8.21.0"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20260212.0",


### PR DESCRIPTION
## Summary

- `ws@8.18.0` (transitive via `miniflare`) is vulnerable to memory exhaustion DoS via high-volume tiny WebSocket fragments (CVE-2026-48779, CVSS 7.5)
- Adds `"ws": ">=8.21.0"` to npm `overrides` in `package.json`, following the existing override pattern
- `npm ls ws` confirms the resolved version is now `8.21.0`

Closes Dependabot alert #125.

## Risk assessment

`ws` is used by `miniflare` for local dev/preview only — not the Cloudflare Workers production runtime. The DoS vector requires an attacker-controlled WebSocket client connecting to a running `miniflare` instance, which is dev-machine-local by default. Production risk is nil; dev environment risk is patched.

## Test plan

- [x] `npm ls ws` shows `ws@8.21.0` (no longer `8.18.0`)
- [ ] CI build passes

🤖 Generated with [Claude Code](https://claude.ai/claude-code)