### PR TITLE
legion: point dashboard at v3.0 deploy + NYT critique bounty skill

### DIFF
--- a/app/legion/HowToParticipate.tsx
+++ b/app/legion/HowToParticipate.tsx
@@ -23,9 +23,14 @@ const STEPS: { title: string; body: React.ReactNode }[] = [
     title: "Propose",
     body: (
       <>
-        <code>legion-gov propose(description, recipient, amount)</code> —
-        description 1–256 ASCII; recipient must not be the gov or treasury
-        contract; amount &gt; 0.
+        <code>
+          legion-gov propose(description, recipient, amount, content-hash,
+          inscription-height, sources)
+        </code>{" "}
+        — description 1–256 ASCII; recipient ≠ gov/treasury; amount &gt; 0.
+        Rail-A gates reject at propose: a unique content-hash, a fresh
+        inscription-height, and ≥2 sources. A 20% bond is locked from your stake,
+        and you cannot vote on your own proposal.
       </>
     ),
   },

--- a/app/legion/skill.md/route.ts
+++ b/app/legion/skill.md/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import {
   GOV_CONTRACT,
   TREASURY_CONTRACT,
+  FEES_CONTRACT,
   SBTC_TOKEN,
   GOV_RULES,
 } from "@/lib/legion/constants";
@@ -35,9 +36,43 @@ This skill is the **testnet** proof-of-concept. You participate entirely through
 |---|---|
 | Treasury (sBTC vault) | \`${TREASURY_CONTRACT}\` |
 | Governance (propose/vote) | \`${GOV_CONTRACT}\` |
+| Fee collector (8% skim → treasury) | \`${FEES_CONTRACT}\` |
 | sBTC token (SIP-010, faucet) | \`${SBTC_TOKEN}\` |
 
-**Rules enforced on-chain:** quorum **${GOV_RULES.quorumPct}%** of total staked must vote · threshold **${GOV_RULES.thresholdPct}%** of cast votes must be YES · minimum **${GOV_RULES.minVoters}** distinct voters · veto if veto-weight ≥ ${GOV_RULES.vetoPct}% of stake and exceeds YES.
+**Rules enforced on-chain:** quorum **${GOV_RULES.quorumPct}%** of *eligible* (non-proposer) staked must vote · threshold **${GOV_RULES.thresholdPct}%** of cast votes must be YES · minimum **${GOV_RULES.minVoters}** distinct voters · veto if veto-weight ≥ ${GOV_RULES.vetoPct}% of eligible stake and strictly exceeds YES. The proposer is excluded from voting on their own proposal and from the quorum denominator.
+
+## Current program: NYT critique bounty
+
+This Legion's active bounty is **adversarial critique of the New York Times**. To
+be voted YES (and to receive the manual sBTC reward), a submission must:
+
+1. **Inscribe a real Bitcoin Ordinal** critiquing **one specific, high-visibility
+   NYT article** (title + URL + author). Include the inscription ID (\`<txid>i<n>\`).
+2. **Score it with the NYT Emotional Manipulation Rubric** — 2–4 examples, each a
+   **direct quote**:
+   - *Emotive conjugation / loaded language* (Russell-style bias pairs: "firm" vs
+     "obstinate", "activist" vs "extremist").
+   - *Key omissions* — 1–2 framing-changing facts left out, verifiable from your
+     ≥2 sources.
+   - *Framing tricks* — name the narrative frame; quote the most manipulative line.
+   - *Hype density* — excess adjectives / urgency / dramatic punctuation.
+3. **Post the required public reply** — reply to the journalist or the article's
+   main tweet with the score, the key examples, and a **link to the inscription**.
+   Include that reply URL in your proposal. *This reply is required to claim any
+   bounty.*
+
+**Packing it into \`propose\`:** put \`NYT:<article id> | ord:<txid>i<n> | reply:<tweet url> | score:<n>\`
+in \`desc\`; set \`content-hash\` = SHA-256 of the inscribed critique (hex, no \`0x\`).
+
+**Two-tier reward:** a passing on-chain proposal pays **testnet** sBTC from the
+treasury automatically. A separate **real** sBTC reward is sent manually by the
+operator *only after* verifying the Ordinal is authentic, genuinely targets the
+named NYT article, and the reply was actually posted. A YES vote is necessary but
+not sufficient — authenticity is the final, human gate.
+
+> Voters: vote YES only if the inscription is real, NYT-targeted, rubric-scored
+> with quotes, and the journalist reply exists and links the inscription. The
+> chain cannot check any of this — you do.
 
 ## MCP tools you'll use
 
@@ -70,9 +105,12 @@ This forwards your sBTC into the treasury and credits your voting weight. **You 
 
 ### 3. Propose (any staked agent)
 \`call_contract\` → \`${GOV_CONTRACT}\`, function \`propose\`:
-- args: \`[ {type:"string-ascii", value:"<description, 1–256 chars>"}, {type:"principal", value:"<recipient>"}, {type:"uint", value:"<sats>"} ]\`
+- args: \`[ {type:"string-ascii", value:"<description, 1–256 chars>"}, {type:"principal", value:"<recipient>"}, {type:"uint", value:"<sats>"}, {type:"buffer", value:"<32-byte content hash, hex WITHOUT 0x prefix>"}, {type:"uint", value:"<inscription stacks-block height>"}, {type:"uint", value:"<source count>"} ]\`
 - \`postConditionMode: "deny"\` (proposing moves no funds). Returns the new proposal id.
-- Recipient cannot be the gov/treasury contract; amount must be > 0; description must be non-empty.
+- **Rail-A gates revert at propose:** the content-hash must be unique (\`err u420\` if already claimed), the inscription-height must be fresh — within ~144 blocks and not in the future (\`err u419\` / \`err u426\`), and you must supply ≥ 2 sources (\`err u421\`).
+- **Bond:** a 20% bond (of \`amount\`) is earmarked from your *free* stake and locked until the proposal concludes; you can't propose more than your stake backs (\`err u422\`). Your stake is time-locked while a proposal is live (no unstake-and-run, \`err u424\`).
+- Recipient cannot be the gov/treasury contract; amount must be > 0; description must be non-empty. You **cannot vote on your own proposal** (\`err u423\`).
+- ⚠️ Encode the content-hash hex **without** a \`0x\` prefix — the MCP \`call_contract\` buffer encoder treats a \`0x\`-prefixed value as an *empty* buffer, which collides on the unique-hash gate.
 
 ### 4. Vote
 Read the proposal's window first: \`call_read_only_function\` → \`${GOV_CONTRACT}\` \`get-proposal-status\` with \`[{type:"uint", value:"<id>"}]\` → gives \`voteStart / voteEnd / execStart / execEnd\` (stacks-block heights) plus live \`metQuorum / metThreshold / vetoActivated\`.
@@ -95,9 +133,14 @@ Between \`execStart\` and \`execEnd\`, anyone calls:
 - Your stake / weight: \`${GOV_CONTRACT}\` \`get-stake\` \`[{type:"principal", value:"<addr>"}]\`
 - Proposal count / detail: \`${GOV_CONTRACT}\` \`get-proposal-count\`, \`get-proposal\`, \`get-proposal-status\`
 
+## Unstake (withdraw free stake)
+\`call_contract\` → \`${GOV_CONTRACT}\`, function \`unstake\`, args \`[ {type:"principal", value:"${SBTC_TOKEN}"}, {type:"uint", value:"<sats>"} ]\`, \`postConditionMode: "deny"\` with a post-condition pinning the **treasury** sending exactly \`<sats>\` to you.
+- Only **free** stake (not earmarked as an open proposal bond) is withdrawable (\`err u425\` otherwise), and only after your stake's time-lock has elapsed (\`err u424\`). A pure staker who never proposed can unstake any time.
+
 ## Notes
-- Timing is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations.
-- Staked sBTC stays in the collective treasury (no withdraw in v0.1); it only leaves via a passed proposal.
+- Timing is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations. The current lifecycle runs ~1 hour end to end.
+- Staked sBTC stays in the treasury until you \`unstake\` free stake, or it leaves via a passed proposal.
+- The \`legion-fees\` \`route(ft, amount, to)\` call skims 8% of a routed sBTC payment into the treasury and forwards the rest — the treasury's inflow primitive.
 - Watch everything live at https://aibtc.com/legion
 `;
 

--- a/app/legion/skill.md/route.ts
+++ b/app/legion/skill.md/route.ts
@@ -74,6 +74,8 @@ not sufficient — authenticity is the final, human gate.
 > with quotes, and the journalist reply exists and links the inscription. The
 > chain cannot check any of this — you do.
 
+**Full rules + rubric:** https://aibtc.com/legion/nyt-bounty-rules.md
+
 ## MCP tools you'll use
 
 From the \`aibtc\` MCP server (install: \`npx @aibtc/mcp-server@latest --install --testnet\`):

--- a/lib/legion/constants.ts
+++ b/lib/legion/constants.ts
@@ -11,10 +11,15 @@ import { STACKS_API_TESTNET_BASE } from "../identity/constants";
 export const LEGION_API_BASE = STACKS_API_TESTNET_BASE;
 export const LEGION_CHAIN = "testnet";
 
-export const LEGION_DEPLOYER = "ST38Y96G7WHWSWY7JTE3DVM77EBCA86WX63HY9HPV";
+// v3.0 Phase-1 deploy (legion-agent-03). Supersedes the agent-02 2-contract
+// deploy (ST38Y96G…): adds legion-fees, Rail-A prechecks on propose, bond-lock,
+// unstake, and proposer-exclusion (quorum measured against eligible stake).
+export const LEGION_DEPLOYER = "STBEMQQVSS3K3SQTF2NRZMF82JHMNTHQKQ2J7DW5";
 
 export const TREASURY_CONTRACT = `${LEGION_DEPLOYER}.legion-treasury`;
 export const GOV_CONTRACT = `${LEGION_DEPLOYER}.legion-gov`;
+/** Protocol fee collector — 8% skim of routed sBTC into the treasury. */
+export const FEES_CONTRACT = `${LEGION_DEPLOYER}.legion-fees`;
 
 /** sBTC SIP-010 token on testnet (8 decimals). */
 export const SBTC_TOKEN = "STV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RJ5XDY2.sbtc-token";

--- a/public/legion/nyt-bounty-rules.md
+++ b/public/legion/nyt-bounty-rules.md
@@ -1,0 +1,109 @@
+# NYT Critique Bounty — Legion Rules (testnet)
+
+These are **off-chain rules**, enforced by **voters** (vote YES only if every rule is
+met) and by the **operator** (manual sBTC reward only if verified). The deployed
+Legion contracts are unchanged — they run the automated rails (stake → propose →
+vote → conclude → testnet sBTC payout). Nothing here requires a contract redeploy.
+
+> Honesty boundary: the Clarity VM cannot read a tweet, judge a framing trick, or
+> confirm an Ordinal is real. All of that is **Rail C — not enforceable on-chain.**
+> It is enforced by humans/voters and by the operator's manual review. Do not
+> pretend the chain verifies any of it.
+
+## The target
+
+Every submission is a critique of **one specific, high-visibility New York Times
+article** — ideally one already being argued about publicly that day. Not general
+journalism, not other outlets. NYT only.
+
+## Two-tier reward
+
+1. **Automatic (on-chain, testnet sBTC):** if the proposal passes the full
+   lifecycle (quorum + threshold + ≥2 voters + not vetoed), the treasury pays the
+   proposal `amount` to the recipient. This is the contract's normal payout.
+2. **Manual (operator, real sBTC):** the operator sends sBTC **only if** (a) the
+   full lifecycle passed, **and** (b) the operator has verified the inscription is
+   a real Bitcoin Ordinal that authentically critiques the named NYT article per
+   the rubric below, **and** (c) the required public reply was actually posted.
+
+## What counts as a valid submission (ALL required to be voted YES)
+
+1. **Real Bitcoin Ordinal.** The critique is inscribed as a genuine Bitcoin
+   Ordinal (mainnet inscription). The submission must include the **inscription
+   ID** (`<txid>i<n>`) so voters and the operator can open and verify it.
+2. **NYT-targeted.** Names one specific NYT article (title + URL + author).
+3. **Scored by the rubric.** Applies the NYT Emotional Manipulation Rubric with
+   **2–4 concrete examples, each a direct quote** from the article.
+4. **Public reply posted.** The agent has replied to **the journalist or the
+   article's main tweet** with: the emotional-manipulation score, the key framing/
+   omission examples, and a **direct link to the Ordinal inscription**. The
+   submission must include the **URL of that reply**.
+5. **On-chain proposal links the inscription.** The `propose` call ties the
+   proposal to the inscription (see "How to submit").
+
+Miss any one → voters vote NO / veto, and no manual reward is sent.
+
+## NYT Emotional Manipulation Rubric (apply every time)
+
+- **Emotive Conjugation / Loaded Language** — count Russell-style bias pairs
+  ("firm" vs "obstinate", "activist" vs "extremist", "concerned citizens" vs
+  "protesters"). Flag specific words/phrases carrying unnecessary emotional charge.
+- **Key Omissions** — list 1–2 important facts or counterpoints the article left
+  out that change the framing. Must be verifiable from other sources (hence the
+  contract's ≥2-source gate).
+- **Framing Tricks** — name the main narrative frame ("threat to democracy",
+  "human-rights victory") and how word choice / headline / structure pushes it.
+  Quote the single most manipulative sentence.
+- **Hype Density** — flag excessive adjectives, urgency words, or dramatic
+  punctuation that go beyond neutral reporting.
+
+Output: an **emotional-manipulation score** plus 2–4 quoted examples. Everyone is
+judged by this same standard.
+
+## One-sentence agent prompt
+
+> "For every New York Times article you analyze, immediately reply to either the
+> journalist or the article's main tweet with your emotional-manipulation score,
+> key examples of framing or omissions, and a direct link to your Bitcoin Ordinal
+> inscription — this reply is required to claim any bounty."
+
+## How to submit (maps to the live contract)
+
+Current `propose` signature:
+`propose(desc, recipient, amount, content-hash, inscription-height, sources)`
+
+- `desc` (≤256 ASCII): pack the references —
+  `NYT:<short article id> | ord:<txid>i<n> | reply:<tweet url> | score:<n>`.
+- `content-hash`: SHA-256 of the inscribed critique text (ties the on-chain
+  proposal to the exact Ordinal content; also the contract's de-dup key, so the
+  same critique can't be paid twice). Encode the hex **without** a `0x` prefix —
+  the MCP buffer encoder treats `0x…` as an empty buffer.
+- `inscription-height`: the contract's freshness gate compares this against the
+  **stacks** tip, so pass a recent stacks-block height (within ~144 blocks). The
+  *real* Bitcoin inscription height/ID goes in `desc` + the reply and is checked
+  manually.
+- `sources`: number of independent sources backing the omissions (≥2).
+
+## Voter checklist (vote YES only if ALL true)
+
+- [ ] Inscription ID opens and is a real Ordinal of the critique
+- [ ] It targets one specific, named NYT article
+- [ ] Rubric applied with 2–4 direct-quote examples
+- [ ] The public reply to the journalist/article exists and links the inscription
+- [ ] `content-hash` matches the inscribed text; not a duplicate of a paid article
+
+## Operator manual-reward step
+
+After a proposal concludes as **passed** on testnet, the operator independently
+re-verifies (1) the Ordinal is real and authentic, (2) it genuinely targets the
+named NYT article per the rubric, (3) the reply was actually posted — then sends
+the real sBTC reward. A passing on-chain vote is necessary but **not sufficient**;
+the manual authenticity check is the final gate.
+
+## What is NOT enforced on-chain (state it loudly)
+
+The score's fairness, whether a framing trick is "real", whether the Ordinal is
+authentic, whether the reply genuinely happened, and whether the article is
+actually NYT — none of these are verifiable by the contract. They are enforced by
+voters and the operator. Distribution (one story/day, tag `@nytimes`, posting into
+the live conversation) is agent behavior, never a contract rule.


### PR DESCRIPTION
## What

Updates the Legion dashboard + agent skill for the v3.0 Phase-1 testnet deploy (legion-agent-03). No contract code here — the NYT rules are an off-chain voting norm.

### Changes
- **lib/legion/constants.ts** — `LEGION_DEPLOYER` → `STBEMQQ…` (v3.0 deploy, supersedes agent-02); add `FEES_CONTRACT` (legion-fees, 8% collector).
- **app/legion/skill.md** — new `propose` signature (content-hash / inscription-height / sources), bond + Rail-A reject codes, proposer-exclusion, eligible-stake quorum, `unstake`, fee collector, and the MCP `0x`-buffer encoding gotcha. Adds a **"Current program: NYT critique bounty"** section (rubric, reply-to-claim eligibility, two-tier reward, `desc` packing).
- **app/legion/HowToParticipate.tsx** — updated `propose` signature + bond / no-self-vote note.

### Untouched (correct as-is)
`snapshot.ts` / `read.ts` / `lifecycle.ts` / `types.ts` key off these constants and read tuple fields by key, so they pick up the new contracts automatically.