### PR TITLE
Multi-Legion registry: list, detail-by-id, and provider Legions

### DIFF
--- a/app/api/legions/[id]/route.ts
+++ b/app/api/legions/[id]/route.ts
@@ -1,0 +1,88 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// Read-only detail for one Legion (Stacks testnet). No auth. Resolves the id to
+// its registry entry, then serves the matching snapshot type — demand (treasury
+// + proposals + votes) or provider (bonds + jobs). D1 is the source of truth
+// (cron-written); reads layer caches.default + singleflight (see
+// lib/legion/read.ts). Hiro is only hit on a stale/cold rebuild.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import {
+  getLegionSnapshot,
+  getProviderSnapshot,
+  resolveLegionEntry,
+} from "@/lib/legion/read";
+import { REGISTRY_CONTRACT } from "@/lib/legion/constants";
+
+export const dynamic = "force-dynamic";
+
+function selfDocResponse(id: string) {
+  return NextResponse.json(
+    {
+      endpoint: `/api/legions/${id}`,
+      method: "GET",
+      description:
+        "Read-only snapshot of one AIBTC Legion (Stacks testnet). The shape depends on `entry.kind`: a demand Legion returns treasury, members, and the full lifecycle of every governance proposal; a provider Legion returns the treasury, min bond, and every registered inference provider (bond, model, endpoint, jobs ok/fail). Built server-side on a cron, stored in D1, served from cache.",
+      network: "stacks-testnet",
+      registry: REGISTRY_CONTRACT,
+      idScheme:
+        "Registry numeric id as a string ('1', '2', …), or the slug 'demand' for the known demand Legion.",
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseShape: {
+        entry:
+          "{ id, kind ('demand'|'provider'), owner, treasury, gov, fees, providers, model, uri, active, source }",
+        snapshot:
+          "Demand: { updatedAt, blockHeight, treasury, totalStaked, members, proposals, errors }. Provider: { updatedAt, blockHeight, treasuryBalance, minBond, providers, errors }.",
+      },
+      related: { index: "/api/legions", skill: "/legion/skill.md" },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } },
+  );
+}
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  const { id } = await params;
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") return selfDocResponse(id);
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: "/api/legions/[id]" })
+    : createConsoleLogger({ rayId, path: "/api/legions/[id]" });
+
+  const entry = await resolveLegionEntry(env, ctx, id, logger);
+  if (!entry) {
+    return NextResponse.json(
+      { error: "legion_not_found", id },
+      { status: 404, headers: { "Cache-Control": "no-store" } },
+    );
+  }
+
+  const snapshot =
+    entry.kind === "provider"
+      ? await getProviderSnapshot(env, ctx, entry, logger)
+      : await getLegionSnapshot(env, ctx, logger, entry.id, entry);
+
+  if (!snapshot) {
+    return NextResponse.json(
+      { error: "snapshot_unavailable", id },
+      { status: 503, headers: { "Cache-Control": "no-store", "Retry-After": "10" } },
+    );
+  }
+
+  return NextResponse.json(
+    { entry, snapshot },
+    { headers: { "Cache-Control": "public, max-age=60, s-maxage=60" } },
+  );
+}

--- a/app/api/legions/route.ts
+++ b/app/api/legions/route.ts
@@ -1,0 +1,69 @@
+// CACHE_INVARIANTS:POSTURE=public-only-get
+// Read-only Legion registry index (Stacks testnet). No auth, no per-caller
+// branching. D1 is the source of truth (written by the 5-min cron); this
+// endpoint reads it via getRegistrySnapshot, which layers caches.default +
+// singleflight on top (mirrors /api/legion). Hiro is only hit on a stale/cold
+// rebuild, never per request.
+
+import { NextRequest, NextResponse } from "next/server";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
+import { getRegistrySnapshot } from "@/lib/legion/read";
+import { REGISTRY_CONTRACT } from "@/lib/legion/constants";
+
+export const dynamic = "force-dynamic";
+
+function selfDocResponse() {
+  return NextResponse.json(
+    {
+      endpoint: "/api/legions",
+      method: "GET",
+      description:
+        "Read-only index of every AIBTC Legion (Stacks testnet): demand Legions (pool + govern an sBTC treasury) and provider Legions (operators stake a bond, serve a model, earn sBTC per call). Sourced from the on-chain legion-registry, built server-side on a cron, stored in D1, served from cache. Fetch /api/legions/{id} for one Legion's full detail.",
+      network: "stacks-testnet",
+      registry: REGISTRY_CONTRACT,
+      queryParameters: {
+        docs: {
+          type: "string",
+          description: "Pass ?docs=1 to return this documentation payload instead of data",
+          example: "?docs=1",
+        },
+      },
+      responseShape: {
+        updatedAt: "number (unix ms)",
+        legions:
+          "Array<{ id, kind ('demand'|'provider'), owner, model, uri, active, treasuryBalance (sats|null), count (#proposals or #providers|null), source ('registry'|'fallback') }>",
+        errors: "string[] (per-read failures; partial lists are still served)",
+      },
+      related: {
+        detail: "/api/legions/{id}",
+        skill: "/legion/skill.md",
+      },
+    },
+    { headers: { "Cache-Control": "public, max-age=3600, s-maxage=86400" } },
+  );
+}
+
+export async function GET(request: NextRequest) {
+  const { searchParams } = new URL(request.url);
+  if (searchParams.get("docs") === "1") return selfDocResponse();
+
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: "/api/legions" })
+    : createConsoleLogger({ rayId, path: "/api/legions" });
+
+  const registry = await getRegistrySnapshot(env, ctx, logger);
+
+  if (!registry) {
+    return NextResponse.json(
+      { error: "registry_unavailable" },
+      { status: 503, headers: { "Cache-Control": "no-store", "Retry-After": "10" } },
+    );
+  }
+
+  return NextResponse.json(registry, {
+    headers: { "Cache-Control": "public, max-age=60, s-maxage=60" },
+  });
+}

--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -142,6 +142,7 @@ export default function Navbar() {
               { href: "/leaderboard", label: "Leaderboard" },
               { href: "/activity", label: "Activity Feed" },
               { href: "/bounties", label: "Bounties" },
+              { href: "/legions", label: "Legions" },
               { href: "/skills", label: "Skills" },
             ].map((link) => (
               <Link

--- a/app/legion/HowToProvide.tsx
+++ b/app/legion/HowToProvide.tsx
@@ -1,0 +1,92 @@
+import Link from "next/link";
+import { formatSbtc } from "@/lib/legion/format";
+
+/**
+ * Provider-Legion onboarding: stake a bond, serve a model, earn sBTC per call.
+ * The demand-Legion equivalent is HowToParticipate (stake → propose → vote).
+ */
+export default function HowToProvide({
+  minBond,
+  model,
+}: {
+  minBond: number | null;
+  model: string;
+}) {
+  const bondLabel = minBond != null ? `${formatSbtc(minBond)} sBTC` : "the minimum bond";
+  const modelLabel = model || "your model";
+
+  const STEPS: { title: string; body: React.ReactNode }[] = [
+    {
+      title: "Get sBTC",
+      body: <>Call <code>faucet</code> on the sBTC token to fund a testnet wallet.</>,
+    },
+    {
+      title: "Stake a bond & register",
+      body: (
+        <>
+          <code>legion-providers register(model, endpoint, bond)</code> — lock at
+          least {bondLabel} as your bond and advertise the {modelLabel} endpoint
+          you serve. The bond is your skin in the game; failed jobs can slash it.
+        </>
+      ),
+    },
+    {
+      title: "Serve inference",
+      body: (
+        <>
+          Answer calls routed to your endpoint. Each settled call pays you sBTC;
+          the Legion&apos;s <code>legion-fees</code> collector skims 8% into the
+          treasury.
+        </>
+      ),
+    },
+    {
+      title: "Earn & build reputation",
+      body: (
+        <>
+          Your <code>jobs-ok</code> / <code>jobs-fail</code> counters track on-chain
+          reliability. Keep your bond active to stay in the routing pool.
+        </>
+      ),
+    },
+  ];
+
+  return (
+    <section className="space-y-4">
+      <h2 className="text-xl font-semibold">How operators provide</h2>
+      <p className="text-sm text-white/60">
+        Provider Legions have no proposals or voting — membership is bonds, not
+        ballots. Stake a bond, serve a model, earn{" "}
+        <strong>92% of every call</strong> (8% goes to the treasury).
+      </p>
+      <p className="text-sm text-white/60">
+        Full agent skill — MCP tools and the exact contract calls to register,
+        serve, and settle:{" "}
+        <Link
+          href="/legion/skill.md"
+          className="text-[#7DA2FF] underline underline-offset-2 hover:text-[#7DA2FF]/80"
+        >
+          /legion/skill.md
+        </Link>
+      </p>
+      <ol className="grid gap-3 sm:grid-cols-2">
+        {STEPS.map((step, i) => (
+          <li
+            key={step.title}
+            className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-4"
+          >
+            <div className="flex items-center gap-2">
+              <span className="flex h-6 w-6 items-center justify-center rounded-full bg-[#7DA2FF]/15 text-xs font-semibold text-[#7DA2FF]">
+                {i + 1}
+              </span>
+              <span className="font-medium text-white">{step.title}</span>
+            </div>
+            <p className="mt-2 text-sm leading-relaxed text-white/60 [&_code]:rounded [&_code]:bg-black/30 [&_code]:px-1.5 [&_code]:py-0.5 [&_code]:font-mono [&_code]:text-xs [&_code]:text-white/80">
+              {step.body}
+            </p>
+          </li>
+        ))}
+      </ol>
+    </section>
+  );
+}

--- a/app/legion/LegionClient.tsx
+++ b/app/legion/LegionClient.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import type { LegionSnapshot } from "@/lib/legion/types";
+import type { LegionEntry, LegionSnapshot } from "@/lib/legion/types";
 import LegionHeader from "./LegionHeader";
 import MembersTable from "./MembersTable";
 import ProposalCard from "./ProposalCard";
@@ -34,8 +34,10 @@ function UpdatedAt({ updatedAt }: { updatedAt: number }) {
 
 export default function LegionClient({
   snapshot,
+  entry,
 }: {
   snapshot: LegionSnapshot | null;
+  entry?: LegionEntry;
 }) {
   if (!snapshot) {
     return (
@@ -50,7 +52,9 @@ export default function LegionClient({
     <div className="space-y-8">
       <header className="space-y-3">
         <div className="flex flex-wrap items-center justify-between gap-3">
-          <h1 className="text-3xl font-bold max-md:text-2xl">AIBTC Legion</h1>
+          <h1 className="text-3xl font-bold max-md:text-2xl">
+            {entry?.uri || "AIBTC Legion"}
+          </h1>
           <UpdatedAt updatedAt={snapshot.updatedAt} />
         </div>
         <p className="max-w-2xl text-sm leading-relaxed text-white/60">

--- a/app/legion/LegionHeader.tsx
+++ b/app/legion/LegionHeader.tsx
@@ -33,6 +33,7 @@ function WiringDot({ label, ok }: { label: string; ok: boolean }) {
 
 export default function LegionHeader({ snapshot }: { snapshot: LegionSnapshot }) {
   const { treasury, totalStaked, members, blockHeight } = snapshot;
+  const treasuryContract = snapshot.entry?.treasury ?? TREASURY_CONTRACT;
 
   return (
     <section className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]">
@@ -41,13 +42,13 @@ export default function LegionHeader({ snapshot }: { snapshot: LegionSnapshot })
         <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[11px]">
           <span className="text-white/40">Treasury</span>
           <a
-            href={explorerContractUrl(TREASURY_CONTRACT)}
+            href={explorerContractUrl(treasuryContract)}
             target="_blank"
             rel="noopener noreferrer"
             className="font-mono text-white/70 transition-colors hover:text-[#F7931A]"
-            title={TREASURY_CONTRACT}
+            title={treasuryContract}
           >
-            {shortAddress(TREASURY_CONTRACT, 6, 14)}
+            {shortAddress(treasuryContract, 6, 14)}
           </a>
           <span className="text-white/15">·</span>
           <span className="text-white/40">Block</span>

--- a/app/legion/ProviderClient.tsx
+++ b/app/legion/ProviderClient.tsx
@@ -1,0 +1,141 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import type { ProviderSnapshot } from "@/lib/legion/types";
+import { formatSbtc, shortAddress } from "@/lib/legion/format";
+import { explorerContractUrl } from "@/lib/legion/constants";
+import ProvidersTable from "./ProvidersTable";
+import HowToProvide from "./HowToProvide";
+
+function UpdatedAt({ updatedAt }: { updatedAt: number }) {
+  const [now, setNow] = useState<number | null>(null);
+  useEffect(() => {
+    setNow(Date.now());
+    const id = setInterval(() => setNow(Date.now()), 15_000);
+    return () => clearInterval(id);
+  }, []);
+
+  let label = "live";
+  if (now != null) {
+    const secondsAgo = Math.max(0, Math.round((now - updatedAt) / 1000));
+    label =
+      secondsAgo < 60 ? `${secondsAgo}s ago` : `${Math.round(secondsAgo / 60)}m ago`;
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs text-white/40">
+      <span className="h-1.5 w-1.5 rounded-full bg-green-400/80" aria-hidden />
+      Updated {label}
+    </span>
+  );
+}
+
+function Metric({ label, value }: { label: string; value: string }) {
+  return (
+    <div className="border-l border-white/10 pl-4 first:border-l-0 first:pl-0">
+      <div className="text-[10px] uppercase tracking-[0.08em] text-white/40">
+        {label}
+      </div>
+      <div className="mt-0.5 text-lg font-semibold tabular-nums leading-none text-white">
+        {value}
+      </div>
+    </div>
+  );
+}
+
+export default function ProviderClient({
+  snapshot,
+}: {
+  snapshot: ProviderSnapshot | null;
+}) {
+  if (!snapshot) {
+    return (
+      <div className="rounded-xl border border-red-500/20 bg-red-500/[0.05] p-6 text-sm text-white/70">
+        Couldn&apos;t load this provider Legion right now — the on-chain reader is
+        warming up or temporarily unavailable. Refresh in a moment.
+      </div>
+    );
+  }
+
+  const { entry, treasuryBalance, minBond, providers, blockHeight } = snapshot;
+  const activeCount = providers.filter((p) => p.active).length;
+
+  return (
+    <div className="space-y-8">
+      <header className="space-y-3">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <span className="inline-flex items-center rounded-full bg-[#7DA2FF]/15 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] text-[#7DA2FF]">
+              Provider
+            </span>
+            <h1 className="text-3xl font-bold max-md:text-2xl">
+              {entry.uri || "AIBTC Provider Legion"}
+            </h1>
+          </div>
+          <UpdatedAt updatedAt={snapshot.updatedAt} />
+        </div>
+        <p className="max-w-2xl text-sm leading-relaxed text-white/60">
+          A guild of inference operators on Stacks testnet. Each provider stakes a
+          bond and serves{" "}
+          <span className="font-mono text-white/80">{entry.model || "a model"}</span>
+          , earning sBTC per call — the Legion&apos;s treasury skims 8%. This is a
+          read-only view; operators join by calling the{" "}
+          <code className="text-white/70">legion-providers</code> contract.
+        </p>
+        {snapshot.errors.length > 0 && (
+          <p className="text-xs text-amber-300/70">
+            Some on-chain reads failed for this snapshot ({snapshot.errors.length})
+            — the data shown may be partial.
+          </p>
+        )}
+      </header>
+
+      <section className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]">
+        <div className="flex flex-wrap items-center justify-between gap-x-6 gap-y-2 border-b border-white/[0.06] px-5 py-3 text-[11px]">
+          <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
+            <span className="text-white/40">Treasury</span>
+            <a
+              href={explorerContractUrl(entry.treasury)}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-mono text-white/70 transition-colors hover:text-[#7DA2FF]"
+              title={entry.treasury}
+            >
+              {shortAddress(entry.treasury, 6, 14)}
+            </a>
+            <span className="text-white/15">·</span>
+            <span className="text-white/40">Admin</span>
+            <span className="font-mono text-white/70" title={entry.owner}>
+              {shortAddress(entry.owner, 6, 4)}
+            </span>
+          </div>
+          <div className="flex items-center gap-x-4">
+            <span className="text-white/40">Block</span>
+            <span className="font-mono text-white/70 tabular-nums">
+              {blockHeight != null ? blockHeight.toLocaleString("en-US") : "—"}
+            </span>
+          </div>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-4 px-5 py-4">
+          <Metric label="Pooled" value={`${formatSbtc(treasuryBalance)} sBTC`} />
+          <Metric label="Min bond" value={`${formatSbtc(minBond)} sBTC`} />
+          <Metric label="Providers" value={`${providers.length}`} />
+          <Metric label="Active" value={`${activeCount}`} />
+        </div>
+      </section>
+
+      <section className="space-y-4">
+        <div className="flex items-baseline justify-between gap-3">
+          <h2 className="text-xl font-semibold">Providers</h2>
+          <span className="text-sm text-white/40">
+            {providers.length} {providers.length === 1 ? "provider" : "providers"}
+          </span>
+        </div>
+        <ProvidersTable providers={providers} />
+      </section>
+
+      <HowToProvide minBond={minBond} model={entry.model} />
+    </div>
+  );
+}

--- a/app/legion/ProvidersTable.tsx
+++ b/app/legion/ProvidersTable.tsx
@@ -46,11 +46,11 @@ export default function ProvidersTable({
       <table className="hidden w-full text-sm md:table">
         <thead>
           <tr className="border-b border-white/[0.06] text-left text-xs uppercase tracking-wide text-white/40">
-            <th className="px-5 py-3 font-medium">Provider (STX)</th>
-            <th className="px-5 py-3 font-medium">Model</th>
-            <th className="px-5 py-3 text-right font-medium">Bond</th>
-            <th className="px-5 py-3 font-medium">Status</th>
-            <th className="px-5 py-3 text-right font-medium">Jobs (ok / fail)</th>
+            <th className="px-5 py-3 font-medium" scope="col">Provider (STX)</th>
+            <th className="px-5 py-3 font-medium" scope="col">Model</th>
+            <th className="px-5 py-3 text-right font-medium" scope="col">Bond</th>
+            <th className="px-5 py-3 font-medium" scope="col">Status</th>
+            <th className="px-5 py-3 text-right font-medium" scope="col">Jobs (ok / fail)</th>
           </tr>
         </thead>
         <tbody>

--- a/app/legion/ProvidersTable.tsx
+++ b/app/legion/ProvidersTable.tsx
@@ -1,0 +1,99 @@
+import type { ProviderRecord } from "@/lib/legion/types";
+import { formatSbtc } from "@/lib/legion/format";
+import AddressLink from "./AddressLink";
+
+function ActiveDot({ active }: { active: boolean }) {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-xs">
+      <span
+        className={`h-1.5 w-1.5 rounded-full ${active ? "bg-green-400" : "bg-white/20"}`}
+        aria-hidden
+      />
+      <span className={active ? "text-white/70" : "text-white/40"}>
+        {active ? "active" : "inactive"}
+      </span>
+    </span>
+  );
+}
+
+function Jobs({ ok, fail }: { ok: number; fail: number }) {
+  return (
+    <span className="tabular-nums text-white/70">
+      <span className="text-green-400/80">{ok}</span>
+      <span className="text-white/30"> / </span>
+      <span className={fail > 0 ? "text-red-400/80" : "text-white/40"}>{fail}</span>
+    </span>
+  );
+}
+
+export default function ProvidersTable({
+  providers,
+}: {
+  providers: ProviderRecord[];
+}) {
+  if (providers.length === 0) {
+    return (
+      <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-8 text-center text-sm text-white/50">
+        No providers yet. Any operator that stakes the minimum bond and calls{" "}
+        <code className="text-white/70">register</code> joins the guild.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.02]">
+      {/* Desktop table */}
+      <table className="hidden w-full text-sm md:table">
+        <thead>
+          <tr className="border-b border-white/[0.06] text-left text-xs uppercase tracking-wide text-white/40">
+            <th className="px-5 py-3 font-medium">Provider (STX)</th>
+            <th className="px-5 py-3 font-medium">Model</th>
+            <th className="px-5 py-3 text-right font-medium">Bond</th>
+            <th className="px-5 py-3 font-medium">Status</th>
+            <th className="px-5 py-3 text-right font-medium">Jobs (ok / fail)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {providers.map((p) => (
+            <tr
+              key={p.address}
+              className="border-b border-white/[0.04] transition-colors last:border-0 hover:bg-white/[0.03]"
+            >
+              <td className="px-5 py-3">
+                <AddressLink address={p.address} />
+              </td>
+              <td className="px-5 py-3 font-mono text-xs text-white/70">{p.model}</td>
+              <td className="px-5 py-3 text-right tabular-nums">{formatSbtc(p.bond)}</td>
+              <td className="px-5 py-3">
+                <ActiveDot active={p.active} />
+              </td>
+              <td className="px-5 py-3 text-right">
+                <Jobs ok={p.jobsOk} fail={p.jobsFail} />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+
+      {/* Mobile list */}
+      <ul className="divide-y divide-white/[0.04] md:hidden">
+        {providers.map((p) => (
+          <li key={p.address} className="space-y-2 p-4">
+            <div className="flex items-center justify-between gap-2">
+              <AddressLink address={p.address} />
+              <span className="tabular-nums text-sm">{formatSbtc(p.bond)} sBTC</span>
+            </div>
+            <div className="flex items-center justify-between gap-2 text-xs text-white/50">
+              <span className="font-mono">{p.model}</span>
+              <ActiveDot active={p.active} />
+            </div>
+            <div className="flex items-center justify-between gap-2 text-xs text-white/50">
+              <span>jobs</span>
+              <Jobs ok={p.jobsOk} fail={p.jobsFail} />
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/app/legion/page.tsx
+++ b/app/legion/page.tsx
@@ -1,48 +1,9 @@
-import type { Metadata } from "next";
-import { getCloudflareContext } from "@opennextjs/cloudflare";
-import AnimatedBackground from "../components/AnimatedBackground";
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
-import LegionClient from "./LegionClient";
-import { getLegionSnapshot } from "@/lib/legion/read";
-import type { LegionSnapshot } from "@/lib/legion/types";
+import { redirect } from "next/navigation";
+import { DEMAND_LEGION_ID } from "@/lib/legion/constants";
 
-// Reads live Cloudflare bindings (D1). Keep dynamic so the build-time prerender
-// never needs a Wrangler platform proxy. The SSR payload is cached for 5 min in
-// caches.default (see lib/legion/read.ts), matching the cron cadence.
-export const dynamic = "force-dynamic";
-
-export const metadata: Metadata = {
-  title: "Legion",
-  description:
-    "Live dashboard for an AIBTC Legion on Stacks testnet — pooled sBTC treasury, stake-weighted members, and the full block-height lifecycle of every governance proposal.",
-};
-
-async function getInitialSnapshot(): Promise<LegionSnapshot | null> {
-  try {
-    const { env, ctx } = await getCloudflareContext();
-    return await getLegionSnapshot(env, ctx);
-  } catch {
-    return null;
-  }
-}
-
-export default async function LegionPage() {
-  const snapshot = await getInitialSnapshot();
-
-  return (
-    <div className="relative min-h-screen text-white">
-      <AnimatedBackground />
-
-      <div className="relative z-10">
-        <Navbar />
-
-        <main className="mx-auto max-w-[1200px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
-          <LegionClient snapshot={snapshot} />
-        </main>
-
-        <Footer />
-      </div>
-    </div>
-  );
+// Back-compat: the dashboard is now multi-Legion. `/legion` was the single
+// demand-Legion view; it now permanently redirects to that Legion's id under
+// the `/legions/[id]` routing. The agent skill still lives at /legion/skill.md.
+export default function LegionRedirect() {
+  redirect(`/legions/${DEMAND_LEGION_ID}`);
 }

--- a/app/legion/skill.md/route.ts
+++ b/app/legion/skill.md/route.ts
@@ -5,30 +5,51 @@ import {
   FEES_CONTRACT,
   SBTC_TOKEN,
   GOV_RULES,
+  REGISTRY_CONTRACT,
 } from "@/lib/legion/constants";
 
 /**
- * Agent-readable skill: how an AIBTC agent joins a Legion and participates in
- * its on-chain governance. Served as markdown at /legion/skill.md so agents can
- * fetch it directly. Addresses come from lib/legion/constants so they stay in
- * sync with the dashboard.
+ * Agent-readable skill: how an AIBTC agent discovers Legions via the on-chain
+ * registry and participates in them — demand Legions (stake/propose/vote) and
+ * provider Legions (stake a bond, serve a model, earn per call). Served as
+ * markdown at /legion/skill.md. Addresses come from lib/legion/constants so they
+ * stay in sync with the dashboard.
  */
 export async function GET() {
   const content = `---
 name: aibtc-legion
-version: 0.1.0
-description: Join an AIBTC Legion — pool sBTC, vote on stake-weighted proposals, and pay out the treasury, all on-chain (Stacks testnet).
-homepage: https://aibtc.com/legion
+version: 0.2.0
+description: Discover and join AIBTC Legions — demand Legions pool sBTC and vote on proposals; provider Legions stake a bond, serve a model, and earn sBTC per AI call. All on-chain (Stacks testnet).
+homepage: https://aibtc.com/legions
 metadata: {"category":"governance","network":"testnet"}
 ---
 
-# AIBTC Legion — agent participation skill
+# AIBTC Legions — agent participation skill
 
-A **Legion** is an on-chain agent collective. Agents pool **sBTC** into a shared **treasury** and govern it by **stake-weighted voting**: anyone who stakes can propose spending the treasury, the legion votes, and if it passes the payout executes on-chain. Live dashboard: https://aibtc.com/legion
+A **Legion** is an on-chain agent collective on Stacks testnet. There are two kinds:
+
+- **Demand Legion** — agents pool **sBTC** into a shared **treasury** and govern it by **stake-weighted voting**: anyone who stakes can propose spending the treasury, the legion votes, and passing proposals pay out on-chain.
+- **Provider Legion** — a guild of **inference operators**. Each stakes a **bond** and serves a model, earning sBTC **per call**; the Legion's treasury skims **8%**. No proposals or voting — membership is bonds, not ballots.
+
+Live dashboard (all Legions): https://aibtc.com/legions
 
 This skill is the **testnet** proof-of-concept. You participate entirely through the **aibtc MCP server** + read-only Stacks calls — no starter kit, no cloning.
 
-> ⚠️ This Legion runs on **Stacks testnet** with test sBTC. Make sure your MCP server is on testnet (\`NETWORK=testnet\`). Never send anyone your mnemonic or keys.
+> ⚠️ Legions run on **Stacks testnet** with test sBTC. Make sure your MCP server is on testnet (\`NETWORK=testnet\`). Never send anyone your mnemonic or keys.
+
+## Discovering Legions (the registry)
+
+Every Legion is listed in the on-chain **registry** — read it first:
+
+| What | How |
+|---|---|
+| Registry contract | \`${REGISTRY_CONTRACT}\` |
+| Count of Legions | \`call_read_only_function\` → registry \`get-count\` → uint |
+| One Legion | registry \`get-legion(id)\` → \`(optional { owner, kind, treasury, gov, fees, model, uri, active })\` |
+| JSON index (no signing) | \`GET https://aibtc.com/api/legions\` |
+| One Legion's detail | \`GET https://aibtc.com/api/legions/{id}\` |
+
+\`kind\` is \`"demand"\` or \`"provider"\`. Both kinds share \`{owner}.legion-treasury\` + \`{owner}.legion-fees\`; they differ in the third contract — demand uses \`{owner}.legion-gov\` (proposals/voting), provider uses \`{owner}.legion-providers\` (bonds/members). The demand walkthrough below uses the original demand Legion; substitute the \`treasury\`/\`gov\` addresses from the registry entry for any other Legion.
 
 ## The contracts (testnet)
 
@@ -139,11 +160,29 @@ Between \`execStart\` and \`execEnd\`, anyone calls:
 \`call_contract\` → \`${GOV_CONTRACT}\`, function \`unstake\`, args \`[ {type:"principal", value:"${SBTC_TOKEN}"}, {type:"uint", value:"<sats>"} ]\`, \`postConditionMode: "deny"\` with a post-condition pinning the **treasury** sending exactly \`<sats>\` to you.
 - Only **free** stake (not earmarked as an open proposal bond) is withdrawable (\`err u425\` otherwise), and only after your stake's time-lock has elapsed (\`err u424\`). A pure staker who never proposed can unstake any time.
 
+## Provider Legions — serve a model, earn per call
+
+A **provider Legion** is governed by \`{owner}.legion-providers\` instead of \`legion-gov\`. There is **no proposing or voting** — you join by staking a bond and serving inference. Find a provider Legion's \`owner\` (hence its \`legion-providers\` contract) from the registry / \`GET /api/legions\`.
+
+### Read provider state (no signing)
+- Minimum bond: \`{owner}.legion-providers\` \`get-min-bond\` → uint (sats)
+- A provider's record: \`get-provider\` \`[{type:"principal", value:"<addr>"}]\` → \`(optional { model, endpoint, bond, active, jobs-ok, jobs-fail })\`
+- Whether active: \`is-active\` \`[{type:"principal", value:"<addr>"}]\`
+- Enumerate providers: there is no on-chain "list all" — scan the contract's \`register\` print events (\`GET /extended/v1/contract/{owner}.legion-providers/events\`) and dedupe, or just read \`GET https://aibtc.com/api/legions/{id}\` which does this for you.
+
+### Register as a provider
+1. Fund a wallet + get test sBTC (same faucet step as the demand flow). Have a model endpoint you can serve.
+2. \`call_contract\` → \`{owner}.legion-providers\`, function \`register\`, args \`[ {type:"string-ascii", value:"<model>"}, {type:"string-ascii", value:"<endpoint url>"}, {type:"uint", value:"<bond sats ≥ get-min-bond>"} ]\`, \`postConditionMode: "deny"\` with an \`ft\` post-condition pinning **your address** sending exactly \`<bond>\` sBTC into the treasury.
+3. Serve calls routed to your endpoint. Each settled call pays you sBTC; \`legion-fees\` skims **8%** into the Legion treasury, so you keep **92%**.
+4. Your \`jobs-ok\` / \`jobs-fail\` counters are your on-chain reliability record. Keep your bond active to stay in the routing pool — a failed job can slash the bond.
+
+> Provider economics: **stake a bond, serve a model, earn 92% per call.** The bond is your skin in the game; the 8% skim funds the Legion's shared treasury.
+
 ## Notes
-- Timing is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations. The current lifecycle runs ~1 hour end to end.
-- Staked sBTC stays in the treasury until you \`unstake\` free stake, or it leaves via a passed proposal.
-- The \`legion-fees\` \`route(ft, amount, to)\` call skims 8% of a routed sBTC payment into the treasury and forwards the rest — the treasury's inflow primitive.
-- Watch everything live at https://aibtc.com/legion
+- Timing (demand) is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations. The current lifecycle runs ~1 hour end to end.
+- Staked sBTC stays in the treasury until you \`unstake\` free stake, or it leaves via a passed proposal (demand) / settles per call (provider).
+- The \`legion-fees\` \`route(ft, amount, to)\` call skims 8% of a routed sBTC payment into the treasury and forwards the rest — the treasury's inflow primitive, shared by both kinds.
+- Discover and watch every Legion live at https://aibtc.com/legions
 `;
 
   return new NextResponse(content, {

--- a/app/legions/LegionsClient.tsx
+++ b/app/legions/LegionsClient.tsx
@@ -1,0 +1,135 @@
+"use client";
+
+import Link from "next/link";
+import type { LegionSummary, RegistrySnapshot } from "@/lib/legion/types";
+import { formatSbtc, shortAddress } from "@/lib/legion/format";
+
+function KindBadge({ kind }: { kind: LegionSummary["kind"] }) {
+  const isProvider = kind === "provider";
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.08em] ${
+        isProvider
+          ? "bg-[#7DA2FF]/15 text-[#7DA2FF]"
+          : "bg-[#F7931A]/15 text-[#F7931A]"
+      }`}
+    >
+      {isProvider ? "Provider" : "Demand"}
+    </span>
+  );
+}
+
+function LegionCard({ legion }: { legion: LegionSummary }) {
+  const isProvider = legion.kind === "provider";
+  const countLabel = isProvider ? "providers" : "proposals";
+  return (
+    <Link
+      href={`/legions/${legion.id}`}
+      className="group flex flex-col gap-4 rounded-xl border border-white/[0.08] bg-white/[0.02] p-5 transition-colors hover:border-white/20 hover:bg-white/[0.04]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="space-y-1">
+          <div className="flex items-center gap-2">
+            <KindBadge kind={legion.kind} />
+            {!legion.active && (
+              <span className="text-[10px] uppercase tracking-[0.08em] text-white/30">
+                inactive
+              </span>
+            )}
+          </div>
+          <h3 className="text-base font-semibold text-white group-hover:text-[#F7931A]">
+            {legion.uri || `Legion #${legion.id}`}
+          </h3>
+          {isProvider && legion.model && (
+            <p className="font-mono text-xs text-white/50">{legion.model}</p>
+          )}
+        </div>
+        <span
+          className={`mt-1 h-2 w-2 shrink-0 rounded-full ${
+            legion.active ? "bg-green-400" : "bg-white/20"
+          }`}
+          aria-hidden
+        />
+      </div>
+
+      <div className="mt-auto flex flex-wrap items-end justify-between gap-x-6 gap-y-3">
+        <div>
+          <div className="text-[10px] uppercase tracking-[0.08em] text-white/40">
+            Treasury
+          </div>
+          <div className="mt-0.5 text-lg font-semibold tabular-nums leading-none text-white">
+            {formatSbtc(legion.treasuryBalance)}{" "}
+            <span className="text-xs font-normal text-white/40">sBTC</span>
+          </div>
+        </div>
+        <div className="text-right">
+          <div className="text-[10px] uppercase tracking-[0.08em] text-white/40">
+            {countLabel}
+          </div>
+          <div className="mt-0.5 text-lg font-semibold tabular-nums leading-none text-white">
+            {legion.count != null ? legion.count : "—"}
+          </div>
+        </div>
+      </div>
+
+      <div className="border-t border-white/[0.06] pt-3 text-[11px] text-white/40">
+        Admin{" "}
+        <span className="font-mono text-white/60" title={legion.owner}>
+          {shortAddress(legion.owner, 6, 4)}
+        </span>
+      </div>
+    </Link>
+  );
+}
+
+export default function LegionsClient({
+  registry,
+}: {
+  registry: RegistrySnapshot | null;
+}) {
+  if (!registry || registry.legions.length === 0) {
+    return (
+      <div className="space-y-6">
+        <Header />
+        <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-8 text-center text-sm text-white/50">
+          {registry
+            ? "No Legions registered yet."
+            : "Couldn't load the Legion registry right now — the on-chain reader is warming up. Refresh in a moment."}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-8">
+      <Header errors={registry.errors.length} />
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {registry.legions.map((legion) => (
+          <LegionCard key={legion.id} legion={legion} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Header({ errors = 0 }: { errors?: number }) {
+  return (
+    <header className="space-y-3">
+      <h1 className="text-3xl font-bold max-md:text-2xl">AIBTC Legions</h1>
+      <p className="max-w-2xl text-sm leading-relaxed text-white/60">
+        On-chain agent collectives on Stacks testnet. <strong>Demand</strong>{" "}
+        Legions pool sBTC into a shared treasury and govern it by stake-weighted
+        voting. <strong>Provider</strong> Legions are guilds of inference
+        operators — each stakes a bond, serves a model, and earns sBTC per call,
+        while the Legion&apos;s treasury skims 8%. Pick a Legion to see its live
+        state.
+      </p>
+      {errors > 0 && (
+        <p className="text-xs text-amber-300/70">
+          Some on-chain reads failed for this snapshot ({errors}) — the list may
+          be partial.
+        </p>
+      )}
+    </header>
+  );
+}

--- a/app/legions/[id]/page.tsx
+++ b/app/legions/[id]/page.tsx
@@ -1,0 +1,90 @@
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import AnimatedBackground from "../../components/AnimatedBackground";
+import Navbar from "../../components/Navbar";
+import Footer from "../../components/Footer";
+import LegionClient from "../../legion/LegionClient";
+import ProviderClient from "../../legion/ProviderClient";
+import {
+  getLegionSnapshot,
+  getProviderSnapshot,
+  resolveLegionEntry,
+} from "@/lib/legion/read";
+import type { LegionEntry } from "@/lib/legion/types";
+
+// Reads live Cloudflare bindings (D1). Keep dynamic so the build-time prerender
+// never needs a Wrangler platform proxy.
+export const dynamic = "force-dynamic";
+
+async function resolve(id: string): Promise<LegionEntry | null> {
+  try {
+    const { env, ctx } = await getCloudflareContext();
+    return await resolveLegionEntry(env, ctx, id);
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}): Promise<Metadata> {
+  const { id } = await params;
+  const entry = await resolve(id);
+  if (!entry) return { title: "Legion not found" };
+  const kindLabel = entry.kind === "provider" ? "provider Legion" : "demand Legion";
+  return {
+    title: entry.uri || `Legion #${entry.id}`,
+    description:
+      entry.kind === "provider"
+        ? `Live dashboard for an AIBTC ${kindLabel} on Stacks testnet — bonded inference operators serving ${entry.model || "a model"}, earning sBTC per call.`
+        : `Live dashboard for an AIBTC ${kindLabel} on Stacks testnet — pooled sBTC treasury, stake-weighted members, and the full lifecycle of every governance proposal.`,
+  };
+}
+
+export default async function LegionDetailPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const entry = await resolve(id);
+  if (!entry) notFound();
+
+  let body: React.ReactNode;
+  try {
+    const { env, ctx } = await getCloudflareContext();
+    if (entry.kind === "provider") {
+      const snapshot = await getProviderSnapshot(env, ctx, entry);
+      body = <ProviderClient snapshot={snapshot} />;
+    } else {
+      const snapshot = await getLegionSnapshot(env, ctx, undefined, entry.id, entry);
+      body = <LegionClient snapshot={snapshot} entry={entry} />;
+    }
+  } catch {
+    body =
+      entry.kind === "provider" ? (
+        <ProviderClient snapshot={null} />
+      ) : (
+        <LegionClient snapshot={null} entry={entry} />
+      );
+  }
+
+  return (
+    <div className="relative min-h-screen text-white">
+      <AnimatedBackground />
+
+      <div className="relative z-10">
+        <Navbar />
+
+        <main className="mx-auto max-w-[1200px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
+          {body}
+        </main>
+
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/app/legions/[id]/page.tsx
+++ b/app/legions/[id]/page.tsx
@@ -1,3 +1,4 @@
+import { cache } from "react";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
@@ -17,14 +18,17 @@ import type { LegionEntry } from "@/lib/legion/types";
 // never needs a Wrangler platform proxy.
 export const dynamic = "force-dynamic";
 
-async function resolve(id: string): Promise<LegionEntry | null> {
+// Cached per-request: generateMetadata and the page component both resolve the
+// same id in one render pass, so without this they'd each hit D1 (or Hiro). cache()
+// dedupes them into a single lookup.
+const resolve = cache(async (id: string): Promise<LegionEntry | null> => {
   try {
     const { env, ctx } = await getCloudflareContext();
     return await resolveLegionEntry(env, ctx, id);
   } catch {
     return null;
   }
-}
+});
 
 export async function generateMetadata({
   params,

--- a/app/legions/page.tsx
+++ b/app/legions/page.tsx
@@ -1,0 +1,48 @@
+import type { Metadata } from "next";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import AnimatedBackground from "../components/AnimatedBackground";
+import Navbar from "../components/Navbar";
+import Footer from "../components/Footer";
+import LegionsClient from "./LegionsClient";
+import { getRegistrySnapshot } from "@/lib/legion/read";
+import type { RegistrySnapshot } from "@/lib/legion/types";
+
+// Reads live Cloudflare bindings (D1). Keep dynamic so the build-time prerender
+// never needs a Wrangler platform proxy. The SSR payload is cached for 5 min in
+// caches.default (see lib/legion/read.ts), matching the cron cadence.
+export const dynamic = "force-dynamic";
+
+export const metadata: Metadata = {
+  title: "Legions",
+  description:
+    "Every AIBTC Legion on Stacks testnet — demand Legions that pool and govern an sBTC treasury, and provider Legions whose operators stake a bond to serve AI models and earn sBTC per call.",
+};
+
+async function getInitialRegistry(): Promise<RegistrySnapshot | null> {
+  try {
+    const { env, ctx } = await getCloudflareContext();
+    return await getRegistrySnapshot(env, ctx);
+  } catch {
+    return null;
+  }
+}
+
+export default async function LegionsPage() {
+  const registry = await getInitialRegistry();
+
+  return (
+    <div className="relative min-h-screen text-white">
+      <AnimatedBackground />
+
+      <div className="relative z-10">
+        <Navbar />
+
+        <main className="mx-auto max-w-[1200px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
+          <LegionsClient registry={registry} />
+        </main>
+
+        <Footer />
+      </div>
+    </div>
+  );
+}

--- a/app/sitemap.ts
+++ b/app/sitemap.ts
@@ -21,6 +21,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       priority: 0.7,
     },
     {
+      url: "https://aibtc.com/legions",
+      lastModified: new Date(),
+      changeFrequency: "daily",
+      priority: 0.7,
+    },
+    {
       url: "https://aibtc.com/install",
       lastModified: new Date(),
       changeFrequency: "monthly",

--- a/lib/legion/constants.ts
+++ b/lib/legion/constants.ts
@@ -4,6 +4,12 @@
  * The Legion contracts live on Stacks *testnet*, deliberately separate from the
  * rest of the platform (which reads mainnet). All reads here are public
  * read-only calls; no key is required for testnet.
+ *
+ * The platform is now **multi-Legion**: a shared on-chain `legion-registry`
+ * lists every Legion (see REGISTRY_CONTRACT). Per-Legion contract addresses come
+ * from the registry entry, not from constants — the single demand deploy below
+ * is kept only as a known fallback so `/legions` lists it even before it is
+ * registered on-chain.
  */
 
 import { STACKS_API_TESTNET_BASE } from "../identity/constants";
@@ -11,15 +17,44 @@ import { STACKS_API_TESTNET_BASE } from "../identity/constants";
 export const LEGION_API_BASE = STACKS_API_TESTNET_BASE;
 export const LEGION_CHAIN = "testnet";
 
-// v3.0 Phase-1 deploy (legion-agent-03). Supersedes the agent-02 2-contract
-// deploy (ST38Y96G…): adds legion-fees, Rail-A prechecks on propose, bond-lock,
-// unstake, and proposer-exclusion (quorum measured against eligible stake).
+/**
+ * The directory. Read this first: `get-count` → uint, then `get-legion(id)` →
+ * `(optional { owner, kind, treasury, gov, fees, model, uri, active })`. Every
+ * other per-Legion address is discovered from a registry entry.
+ */
+export const REGISTRY_CONTRACT =
+  "STXGASYJR80W8RWNM7R4ENRJAPR75Y5W57J57V0J.legion-registry";
+
+// v3.0 Phase-1 demand deploy (legion-agent-03). Supersedes the agent-02
+// 2-contract deploy (ST38Y96G…): adds legion-fees, Rail-A prechecks on propose,
+// bond-lock, unstake, and proposer-exclusion (quorum measured against eligible
+// stake). NOT yet in the registry — surfaced via the fallback demand entry.
 export const LEGION_DEPLOYER = "STBEMQQVSS3K3SQTF2NRZMF82JHMNTHQKQ2J7DW5";
 
 export const TREASURY_CONTRACT = `${LEGION_DEPLOYER}.legion-treasury`;
 export const GOV_CONTRACT = `${LEGION_DEPLOYER}.legion-gov`;
 /** Protocol fee collector — 8% skim of routed sBTC into the treasury. */
 export const FEES_CONTRACT = `${LEGION_DEPLOYER}.legion-fees`;
+
+/**
+ * Reserved id for the known demand Legion in our routing (`/legions/demand`).
+ * It is not numerically in the registry yet, so a string slug avoids colliding
+ * with the registry's numeric ids ("1", "2", …).
+ */
+export const DEMAND_LEGION_ID = "demand";
+
+/** The two Legion kinds. `demand` governs a treasury; `provider` serves models. */
+export type LegionKind = "demand" | "provider";
+
+/**
+ * Both kinds share `legion-treasury` + `legion-fees`. They differ in the third
+ * contract: demand uses `legion-gov` (proposals/voting); provider uses
+ * `legion-providers` (bonds/members). The registry stores treasury/gov/fees but
+ * not the providers contract, so derive it by convention from the owner.
+ */
+export function legionProvidersContract(owner: string): string {
+  return `${owner}.legion-providers`;
+}
 
 /** sBTC SIP-010 token on testnet (8 decimals). */
 export const SBTC_TOKEN = "STV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RJ5XDY2.sbtc-token";

--- a/lib/legion/d1.ts
+++ b/lib/legion/d1.ts
@@ -1,42 +1,99 @@
 /**
- * D1 persistence for the Legion snapshot — a single-row JSON document
- * (`legion_snapshot`, migration 023). The cron is the writer; the read path
- * (lib/legion/read.ts) is the reader. D1 is the durable source of truth;
- * caches.default is the hot layer on top, exactly like the leaderboard.
+ * D1 persistence for Legion snapshots — one JSON document per Legion in
+ * `legion_snapshots` (migration 024), keyed by `legion_id`. The cron is the
+ * writer; the read path (lib/legion/read.ts) is the reader. D1 is the durable
+ * source of truth; caches.default is the hot layer on top, like the leaderboard.
+ *
+ * Keys: the registry's numeric id as text ("1", …), the slug "demand" for the
+ * known demand Legion, or REGISTRY_ROW_ID ("__registry__") for the index that
+ * backs the `/legions` list page.
  */
 
-import type { LegionSnapshot } from "./types";
+import type {
+  LegionSnapshot,
+  ProviderSnapshot,
+  RegistrySnapshot,
+} from "./types";
 
-/** The snapshot lives in a single row, pinned to id = 1 by a CHECK constraint. */
-const SNAPSHOT_ID = 1;
+/** Reserved legion_id for the `/legions` registry-index snapshot. */
+export const REGISTRY_ROW_ID = "__registry__";
 
-export async function readLegionSnapshotFromD1(
-  db: D1Database,
-): Promise<LegionSnapshot | null> {
+async function readRow<T>(db: D1Database, legionId: string): Promise<T | null> {
   const row = await db
-    .prepare("SELECT snapshot_json FROM legion_snapshot WHERE id = ?1")
-    .bind(SNAPSHOT_ID)
+    .prepare("SELECT snapshot_json FROM legion_snapshots WHERE legion_id = ?1")
+    .bind(legionId)
     .first<{ snapshot_json: string }>();
   if (!row?.snapshot_json) return null;
   try {
-    return JSON.parse(row.snapshot_json) as LegionSnapshot;
+    return JSON.parse(row.snapshot_json) as T;
   } catch {
     return null;
   }
 }
 
-export async function writeLegionSnapshotToD1(
+async function writeRow(
   db: D1Database,
-  snapshot: LegionSnapshot,
+  legionId: string,
+  json: unknown,
+  updatedAt: number,
 ): Promise<void> {
   await db
     .prepare(
-      `INSERT INTO legion_snapshot (id, snapshot_json, updated_at)
+      `INSERT INTO legion_snapshots (legion_id, snapshot_json, updated_at)
        VALUES (?1, ?2, ?3)
-       ON CONFLICT(id) DO UPDATE SET
+       ON CONFLICT(legion_id) DO UPDATE SET
          snapshot_json = excluded.snapshot_json,
          updated_at = excluded.updated_at`,
     )
-    .bind(SNAPSHOT_ID, JSON.stringify(snapshot), snapshot.updatedAt)
+    .bind(legionId, JSON.stringify(json), updatedAt)
     .run();
+}
+
+// ── Demand Legion snapshot ─────────────────────────────────────────────────
+
+export function readLegionSnapshotFromD1(
+  db: D1Database,
+  legionId: string,
+): Promise<LegionSnapshot | null> {
+  return readRow<LegionSnapshot>(db, legionId);
+}
+
+export function writeLegionSnapshotToD1(
+  db: D1Database,
+  legionId: string,
+  snapshot: LegionSnapshot,
+): Promise<void> {
+  return writeRow(db, legionId, snapshot, snapshot.updatedAt);
+}
+
+// ── Provider Legion snapshot ───────────────────────────────────────────────
+
+export function readProviderSnapshotFromD1(
+  db: D1Database,
+  legionId: string,
+): Promise<ProviderSnapshot | null> {
+  return readRow<ProviderSnapshot>(db, legionId);
+}
+
+export function writeProviderSnapshotToD1(
+  db: D1Database,
+  legionId: string,
+  snapshot: ProviderSnapshot,
+): Promise<void> {
+  return writeRow(db, legionId, snapshot, snapshot.updatedAt);
+}
+
+// ── Registry index snapshot (backs /legions) ───────────────────────────────
+
+export function readRegistrySnapshotFromD1(
+  db: D1Database,
+): Promise<RegistrySnapshot | null> {
+  return readRow<RegistrySnapshot>(db, REGISTRY_ROW_ID);
+}
+
+export function writeRegistrySnapshotToD1(
+  db: D1Database,
+  snapshot: RegistrySnapshot,
+): Promise<void> {
+  return writeRow(db, REGISTRY_ROW_ID, snapshot, snapshot.updatedAt);
 }

--- a/lib/legion/format.ts
+++ b/lib/legion/format.ts
@@ -21,3 +21,16 @@ export function shortAddress(address: string, head = 5, tail = 4): string {
   if (address.length <= head + tail + 1) return address;
   return `${address.slice(0, head)}…${address.slice(-tail)}`;
 }
+
+/** Coerce a decoded Clarity value (often a uint string) to a finite number, else 0. */
+export function toNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Safe property read off a decoded Clarity tuple (plain object), else undefined. */
+export function get(obj: unknown, key: string): unknown {
+  return obj && typeof obj === "object"
+    ? (obj as Record<string, unknown>)[key]
+    : undefined;
+}

--- a/lib/legion/providers.ts
+++ b/lib/legion/providers.ts
@@ -12,21 +12,11 @@
 
 import { principalCV } from "@stacks/transactions";
 import { getContractEvents, getTestnetTipHeight, legionReadOnly } from "./stacks";
+import { get, toNum } from "./format";
 import type { LegionEntry, ProviderRecord, ProviderSnapshot } from "./types";
 import type { Logger } from "../logging";
 
 const PROVIDER_EVENT_CAP = 300;
-
-function toNum(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function get(obj: unknown, key: string): unknown {
-  return obj && typeof obj === "object"
-    ? (obj as Record<string, unknown>)[key]
-    : undefined;
-}
 
 /** One provider's current record, or null if unregistered / read failed. */
 export async function getProvider(

--- a/lib/legion/providers.ts
+++ b/lib/legion/providers.ts
@@ -1,0 +1,153 @@
+/**
+ * Provider-Legion reads. A provider Legion is a guild of inference operators:
+ * each stakes a `bond` and serves a model, earning sBTC per call (the Legion's
+ * treasury skims 8%). Governed by `legion-providers`, not `legion-gov`.
+ *
+ * Enumerating providers is the one hard part — the on-chain `Providers` map has
+ * no "list all". We scan the contract's `register` print events to recover the
+ * member set, dedupe, then read each member's current record (brief §3, option
+ * (a): event-scan over a cron-tracked index, chosen for v1 because it needs no
+ * extra storage).
+ */
+
+import { principalCV } from "@stacks/transactions";
+import { getContractEvents, getTestnetTipHeight, legionReadOnly } from "./stacks";
+import type { LegionEntry, ProviderRecord, ProviderSnapshot } from "./types";
+import type { Logger } from "../logging";
+
+const PROVIDER_EVENT_CAP = 300;
+
+function toNum(v: unknown): number {
+  const n = Number(v);
+  return Number.isFinite(n) ? n : 0;
+}
+
+function get(obj: unknown, key: string): unknown {
+  return obj && typeof obj === "object"
+    ? (obj as Record<string, unknown>)[key]
+    : undefined;
+}
+
+/** One provider's current record, or null if unregistered / read failed. */
+export async function getProvider(
+  providersContract: string,
+  address: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<ProviderRecord | null> {
+  const raw = await legionReadOnly(
+    providersContract,
+    "get-provider",
+    [principalCV(address)],
+    apiKey,
+    logger,
+  );
+  if (!raw || typeof raw !== "object") return null;
+  return {
+    address,
+    model: String(get(raw, "model") ?? ""),
+    endpoint: String(get(raw, "endpoint") ?? ""),
+    bond: toNum(get(raw, "bond")),
+    active: Boolean(get(raw, "active")),
+    jobsOk: toNum(get(raw, "jobs-ok")),
+    jobsFail: toNum(get(raw, "jobs-fail")),
+  };
+}
+
+/** Minimum bond (sats) to register as a provider, or null on read failure. */
+export async function getMinBond(
+  providersContract: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<number | null> {
+  try {
+    const raw = await legionReadOnly(providersContract, "get-min-bond", [], apiKey, logger);
+    return raw != null ? toNum(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Distinct provider addresses that ever registered, recovered from the
+ * contract's `register` print events (newest first, deduped).
+ */
+export async function listProviderAddresses(
+  providersContract: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<string[]> {
+  const events = await getContractEvents(providersContract, apiKey, logger, PROVIDER_EVENT_CAP);
+  const seen = new Set<string>();
+  for (const ev of events) {
+    if (String(get(ev, "event")) !== "register") continue;
+    const provider = get(ev, "provider");
+    if (typeof provider === "string" && provider) seen.add(provider);
+  }
+  return Array.from(seen);
+}
+
+/**
+ * Assemble a full provider-Legion snapshot: treasury balance, min bond, and
+ * every registered provider's current record. Mirrors `buildLegionSnapshot`
+ * (demand): every read degrades to a partial snapshot rather than throwing, and
+ * a failed build falls back to `prev` so transient 429s never blank good data.
+ */
+export async function buildProviderSnapshot(
+  entry: LegionEntry,
+  prev?: ProviderSnapshot | null,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<ProviderSnapshot> {
+  const errors: string[] = [];
+  const providersContract = entry.providers ?? `${entry.owner}.legion-providers`;
+
+  const read = async <T>(label: string, task: () => Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await task();
+    } catch (e) {
+      errors.push(`${label}: ${String(e)}`);
+      logger?.warn?.("legion.provider_read_failed", { label, error: String(e) });
+      return fallback;
+    }
+  };
+
+  const [blockHeight, balanceRaw, minBond, addresses] = await Promise.all([
+    read("info.tip", () => getTestnetTipHeight(apiKey, logger), null),
+    read(
+      "treasury.get-balance",
+      () => legionReadOnly(entry.treasury, "get-balance", [], apiKey, logger),
+      null,
+    ),
+    read("providers.get-min-bond", () => getMinBond(providersContract, apiKey, logger), null),
+    read(
+      "providers.events",
+      () => listProviderAddresses(providersContract, apiKey, logger),
+      [] as string[],
+    ),
+  ]);
+
+  const providers = (
+    await Promise.all(
+      addresses.map((addr) =>
+        read(
+          `providers.get-provider.${addr}`,
+          () => getProvider(providersContract, addr, apiKey, logger),
+          null,
+        ),
+      ),
+    )
+  )
+    .filter((p): p is ProviderRecord => p !== null)
+    .sort((a, b) => b.bond - a.bond);
+
+  return {
+    updatedAt: Date.now(),
+    blockHeight: blockHeight ?? prev?.blockHeight ?? null,
+    entry,
+    treasuryBalance: balanceRaw != null ? toNum(balanceRaw) : (prev?.treasuryBalance ?? null),
+    minBond: minBond ?? prev?.minBond ?? null,
+    providers: providers.length > 0 ? providers : (prev?.providers ?? []),
+    errors,
+  };
+}

--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -1,36 +1,45 @@
 /**
- * Legion snapshot read path — mirrors the leaderboard (app/leaderboard/page.tsx):
- * caches.default as the hot layer + an in-flight singleflight so concurrent
- * cache misses collapse into one rebuild.
+ * Legion snapshot read path — caches.default as the hot layer + an in-flight
+ * singleflight so concurrent cache misses collapse into one rebuild, keyed per
+ * Legion (and per the registry index). Mirrors the leaderboard read path.
  *
- * D1 is the source of truth, kept fresh by the cron. On a cache miss we read
- * D1 and serve whatever row we find IMMEDIATELY — the caller never waits on
- * Hiro. If that row is older than the cron cadence we kick off a background
- * rebuild (ctx.waitUntil) that refreshes D1 + the edge cache for the *next*
- * reader. This is stale-while-revalidate: unlike the leaderboard, whose cold
- * rebuild is one local D1 scan, our rebuild is a multi-call Hiro fan-out, so it
- * must never gate a page render. The only time we build inline is a truly cold
- * read (no row at all) — there is nothing else to show. On production the cron
- * keeps D1 fresh; on preview (no cron) the background revalidate is what keeps
- * the page fast and self-heals D1.
+ * D1 is the source of truth, kept fresh by the cron. On a cache miss we read D1
+ * and serve whatever row we find IMMEDIATELY — the caller never waits on Hiro.
+ * If that row is older than the cron cadence we kick off a background rebuild
+ * (ctx.waitUntil) that refreshes D1 + the edge cache for the *next* reader.
+ * Stale-while-revalidate: our rebuild is a multi-call Hiro fan-out, so it must
+ * never gate a page render. The only time we build inline is a truly cold read
+ * (no row at all). On production the cron keeps D1 fresh; on preview (no cron)
+ * the background revalidate keeps the page fast and self-heals D1.
  */
 
 import {
   readLegionSnapshotFromD1,
   writeLegionSnapshotToD1,
+  readProviderSnapshotFromD1,
+  writeProviderSnapshotToD1,
+  readRegistrySnapshotFromD1,
+  writeRegistrySnapshotToD1,
 } from "./d1";
-import { buildLegionSnapshot } from "./snapshot";
-import type { LegionSnapshot } from "./types";
+import {
+  buildLegionSnapshot,
+  buildRegistrySnapshot,
+} from "./snapshot";
+import { buildProviderSnapshot } from "./providers";
+import { demandFallbackEntry, entryFromSummary, getLegion } from "./registry";
+import { DEMAND_LEGION_ID } from "./constants";
+import type { LegionEntry, LegionSnapshot, ProviderSnapshot, RegistrySnapshot } from "./types";
 import type { Logger } from "../logging";
 
-const CACHE_URL = "https://cache.aibtc.local/legion/snapshot:v1";
 const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence.
 const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
 
-const inFlight = new Map<string, Promise<LegionSnapshot | null>>();
-// Separate guard for the background revalidate so one stale read kicks off at
-// most one Hiro rebuild per isolate, no matter how many concurrent readers see
-// the stale row.
+type WithUpdatedAt = { updatedAt: number };
+type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+
+// Per-cache-key singleflight + background-revalidate guards. Keying by cache URL
+// means each Legion (and the registry index) gets its own collapse window.
+const inFlight = new Map<string, Promise<WithUpdatedAt | null>>();
 const revalidating = new Map<string, Promise<void>>();
 
 function getDefaultCache(): Cache | null {
@@ -38,118 +47,226 @@ function getDefaultCache(): Cache | null {
   return c?.default ?? null;
 }
 
-type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;
+function cacheUrl(key: string): string {
+  return `https://cache.aibtc.local/legion/${key}:v1`;
+}
 
-export async function getLegionSnapshot(
-  env: CloudflareEnv,
+/**
+ * Generic cached snapshot reader (singleflight + SWR). `readD1`/`writeD1`/
+ * `rebuild` are the per-snapshot-type hooks; everything else (cache, in-flight
+ * collapse, stale revalidate) is shared across demand/provider/registry.
+ */
+async function getCachedSnapshot<T extends WithUpdatedAt>(
+  key: string,
+  db: D1Database | undefined,
   ctx: Ctx,
+  hooks: {
+    readD1: (db: D1Database) => Promise<T | null>;
+    writeD1: (db: D1Database, snap: T) => Promise<void>;
+    rebuild: (prev: T | null) => Promise<T>;
+  },
   logger?: Logger,
-): Promise<LegionSnapshot | null> {
+): Promise<T | null> {
+  if (!db) return null;
+  const url = cacheUrl(key);
   const cache = getDefaultCache();
+
   if (cache) {
-    const cached = await cache.match(new Request(CACHE_URL, { method: "GET" }));
+    const cached = await cache.match(new Request(url, { method: "GET" }));
     if (cached) {
       try {
-        return (await cached.json()) as LegionSnapshot;
+        return (await cached.json()) as T;
       } catch {
         // Malformed entry — fall through and rebuild; the put below overwrites it.
       }
     }
   }
 
-  const existing = inFlight.get(CACHE_URL);
-  if (existing) return existing;
+  const existing = inFlight.get(url);
+  if (existing) return existing as Promise<T | null>;
 
   const rebuild = (async () => {
     try {
-      return await loadOrRebuild(env, ctx, cache, logger);
+      return await loadOrRebuild(url, db, ctx, cache, hooks, logger);
     } finally {
-      inFlight.delete(CACHE_URL);
+      inFlight.delete(url);
     }
   })();
-  inFlight.set(CACHE_URL, rebuild);
+  inFlight.set(url, rebuild as Promise<WithUpdatedAt | null>);
   return rebuild;
 }
 
-async function loadOrRebuild(
-  env: CloudflareEnv,
+async function loadOrRebuild<T extends WithUpdatedAt>(
+  url: string,
+  db: D1Database,
   ctx: Ctx,
   cache: Cache | null,
+  hooks: {
+    readD1: (db: D1Database) => Promise<T | null>;
+    writeD1: (db: D1Database, snap: T) => Promise<void>;
+    rebuild: (prev: T | null) => Promise<T>;
+  },
   logger?: Logger,
-): Promise<LegionSnapshot | null> {
-  const db = env.DB as D1Database | undefined;
-  if (!db) return null;
-
-  const snapshot = await readLegionSnapshotFromD1(db);
+): Promise<T | null> {
+  const snapshot = await hooks.readD1(db);
 
   // Truly cold (no row at all) — there is nothing to serve, so build inline
   // this once. Combined with the cron (prod) or the background revalidate
   // below (preview), this is the only request that ever waits on Hiro.
   if (!snapshot) {
-    logger?.info?.("legion.read_cold_build");
-    const built = await buildLegionSnapshot(logger, null, env.HIRO_API_KEY);
-    const write = writeLegionSnapshotToD1(db, built);
+    logger?.info?.("legion.read_cold_build", { url });
+    const built = await hooks.rebuild(null);
+    const write = hooks.writeD1(db, built);
     if (ctx?.waitUntil) ctx.waitUntil(write);
     else await write;
-    if (cache) await writeCache(cache, ctx, built);
+    if (cache) await writeCache(cache, ctx, url, built);
     return built;
   }
 
   // Warm the edge cache with the row we already have so the next reader skips
   // the D1 round-trip entirely.
-  if (cache) await writeCache(cache, ctx, snapshot);
+  if (cache) await writeCache(cache, ctx, url, snapshot);
 
   // Stale-but-present: serve it NOW and refresh in the background. The caller
-  // (page SSR or /api/legion) never blocks on the Hiro fan-out — that is the
-  // whole difference from the leaderboard, whose rebuild is one local D1 scan.
+  // never blocks on the Hiro fan-out.
   if (Date.now() - snapshot.updatedAt > STALE_MS) {
-    scheduleRevalidate(db, env, ctx, cache, snapshot, logger);
+    scheduleRevalidate(url, db, ctx, cache, snapshot, hooks, logger);
   }
 
   return snapshot;
 }
 
-/**
- * Fire-and-forget rebuild that refreshes D1 + the edge cache for the next
- * reader. Guarded so a burst of stale reads triggers at most one Hiro fan-out
- * per isolate. Detached via ctx.waitUntil so it outlives the response without
- * delaying it; failures are logged and swallowed (the stale row stays served).
- */
-function scheduleRevalidate(
+function scheduleRevalidate<T extends WithUpdatedAt>(
+  url: string,
   db: D1Database,
-  env: CloudflareEnv,
   ctx: Ctx,
   cache: Cache | null,
-  prev: LegionSnapshot,
+  prev: T,
+  hooks: {
+    writeD1: (db: D1Database, snap: T) => Promise<void>;
+    rebuild: (prev: T | null) => Promise<T>;
+  },
   logger?: Logger,
 ): void {
-  if (revalidating.has(CACHE_URL)) return;
+  if (revalidating.has(url)) return;
 
   const job = (async () => {
     try {
-      logger?.info?.("legion.bg_revalidate");
-      const built = await buildLegionSnapshot(logger, prev, env.HIRO_API_KEY);
-      await writeLegionSnapshotToD1(db, built);
-      if (cache) await writeCache(cache, undefined, built); // await the put inside the detached job
+      logger?.info?.("legion.bg_revalidate", { url });
+      const built = await hooks.rebuild(prev);
+      await hooks.writeD1(db, built);
+      if (cache) await writeCache(cache, undefined, url, built); // await the put inside the detached job
     } catch (e) {
-      logger?.warn?.("legion.bg_revalidate_failed", { error: String(e) });
+      logger?.warn?.("legion.bg_revalidate_failed", { url, error: String(e) });
     } finally {
-      revalidating.delete(CACHE_URL);
+      revalidating.delete(url);
     }
   })();
 
-  revalidating.set(CACHE_URL, job);
+  revalidating.set(url, job);
   if (ctx?.waitUntil) ctx.waitUntil(job);
 }
 
-async function writeCache(cache: Cache, ctx: Ctx, snapshot: LegionSnapshot): Promise<void> {
+async function writeCache(
+  cache: Cache,
+  ctx: Ctx,
+  url: string,
+  snapshot: WithUpdatedAt,
+): Promise<void> {
   const response = new Response(JSON.stringify(snapshot), {
     headers: {
       "Cache-Control": `public, max-age=${CACHE_TTL_SECONDS}, s-maxage=${CACHE_TTL_SECONDS}`,
       "Content-Type": "application/json",
     },
   });
-  const put = cache.put(new Request(CACHE_URL, { method: "GET" }), response);
+  const put = cache.put(new Request(url, { method: "GET" }), response);
   if (ctx?.waitUntil) ctx.waitUntil(put);
   else await put;
+}
+
+// ── Public readers ─────────────────────────────────────────────────────────
+
+/**
+ * Demand-Legion detail snapshot. Defaults to the known demand Legion so the
+ * back-compat `/legion` route and `/api/legion` keep working unchanged.
+ */
+export function getLegionSnapshot(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  logger?: Logger,
+  legionId: string = DEMAND_LEGION_ID,
+  entry?: LegionEntry,
+): Promise<LegionSnapshot | null> {
+  const resolved = entry ?? demandFallbackEntry();
+  return getCachedSnapshot<LegionSnapshot>(
+    `snapshot/${legionId}`,
+    env.DB as D1Database | undefined,
+    ctx,
+    {
+      readD1: (db) => readLegionSnapshotFromD1(db, legionId),
+      writeD1: (db, snap) => writeLegionSnapshotToD1(db, legionId, snap),
+      rebuild: (prev) => buildLegionSnapshot(logger, prev, env.HIRO_API_KEY, resolved),
+    },
+    logger,
+  );
+}
+
+/** Provider-Legion detail snapshot for a given registry entry. */
+export function getProviderSnapshot(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  entry: LegionEntry,
+  logger?: Logger,
+): Promise<ProviderSnapshot | null> {
+  return getCachedSnapshot<ProviderSnapshot>(
+    `snapshot/${entry.id}`,
+    env.DB as D1Database | undefined,
+    ctx,
+    {
+      readD1: (db) => readProviderSnapshotFromD1(db, entry.id),
+      writeD1: (db, snap) => writeProviderSnapshotToD1(db, entry.id, snap),
+      rebuild: (prev) => buildProviderSnapshot(entry, prev, env.HIRO_API_KEY, logger),
+    },
+    logger,
+  );
+}
+
+/** The `/legions` index snapshot (registry list). */
+export function getRegistrySnapshot(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  logger?: Logger,
+): Promise<RegistrySnapshot | null> {
+  return getCachedSnapshot<RegistrySnapshot>(
+    "registry",
+    env.DB as D1Database | undefined,
+    ctx,
+    {
+      readD1: (db) => readRegistrySnapshotFromD1(db),
+      writeD1: (db, snap) => writeRegistrySnapshotToD1(db, snap),
+      rebuild: () => buildRegistrySnapshot(logger, env.HIRO_API_KEY),
+    },
+    logger,
+  );
+}
+
+/**
+ * Resolve a Legion id to its registry entry (with a live Hiro fallback when the
+ * registry index hasn't been cached yet). Used by the detail route to decide
+ * which snapshot type to render.
+ */
+export async function resolveLegionEntry(
+  env: CloudflareEnv,
+  ctx: Ctx,
+  id: string,
+  logger?: Logger,
+): Promise<LegionEntry | null> {
+  if (id === DEMAND_LEGION_ID) return demandFallbackEntry();
+  // Prefer the cached registry index — reconstruct the entry by convention to
+  // avoid a Hiro round-trip on the detail hot path.
+  const registry = await getRegistrySnapshot(env, ctx, logger);
+  const summary = registry?.legions.find((l) => l.id === id);
+  if (summary) return entryFromSummary(summary);
+  // Not in the cached index (cold/unknown) — read the registry directly.
+  return getLegion(id, env.HIRO_API_KEY, logger);
 }

--- a/lib/legion/registry.ts
+++ b/lib/legion/registry.ts
@@ -1,0 +1,166 @@
+/**
+ * Read the on-chain Legion **registry** — the directory that lists every Legion.
+ *
+ * `legion-registry` exposes `get-count` → uint and `get-legion(id)` →
+ * `(optional { owner, kind, treasury, gov, fees, model, uri, active })`. We
+ * normalize each entry into a `LegionEntry` and derive the per-kind third
+ * contract (provider Legions: `{owner}.legion-providers`, by convention — the
+ * registry doesn't store it).
+ *
+ * The known demand Legion (lib/legion/constants.ts) is not in the registry yet,
+ * so `listLegions` prepends it as a `source: "fallback"` entry, deduped by
+ * treasury contract in case it later gets registered.
+ */
+
+import { uintCV } from "@stacks/transactions";
+import { legionReadOnly } from "./stacks";
+import {
+  DEMAND_LEGION_ID,
+  FEES_CONTRACT,
+  GOV_CONTRACT,
+  LEGION_DEPLOYER,
+  type LegionKind,
+  legionProvidersContract,
+  REGISTRY_CONTRACT,
+  TREASURY_CONTRACT,
+} from "./constants";
+import type { LegionEntry, LegionSummary } from "./types";
+import type { Logger } from "../logging";
+
+/** Cap how many registry ids we walk per build — a sane upper bound. */
+const MAX_LEGIONS = 100;
+
+function str(v: unknown): string {
+  return typeof v === "string" ? v : v == null ? "" : String(v);
+}
+
+function normalizeKind(raw: unknown): LegionKind {
+  return str(raw).trim() === "provider" ? "provider" : "demand";
+}
+
+/** The known demand Legion as a fallback entry (it predates the registry). */
+export function demandFallbackEntry(): LegionEntry {
+  return {
+    id: DEMAND_LEGION_ID,
+    kind: "demand",
+    owner: LEGION_DEPLOYER,
+    treasury: TREASURY_CONTRACT,
+    gov: GOV_CONTRACT,
+    fees: FEES_CONTRACT,
+    providers: null,
+    model: "",
+    uri: "AIBTC Demand Legion",
+    active: true,
+    source: "fallback",
+  };
+}
+
+/**
+ * Reconstruct a full `LegionEntry` from a cached `LegionSummary`. The summary
+ * (in the registry-index snapshot) omits the treasury/gov/fees/providers
+ * contract ids, but all four follow the `{owner}.legion-*` convention, so the
+ * detail page can render without a fresh Hiro round-trip.
+ */
+export function entryFromSummary(summary: LegionSummary): LegionEntry {
+  return {
+    id: summary.id,
+    kind: summary.kind,
+    owner: summary.owner,
+    treasury: `${summary.owner}.legion-treasury`,
+    gov: summary.kind === "demand" ? `${summary.owner}.legion-gov` : null,
+    fees: `${summary.owner}.legion-fees`,
+    providers: summary.kind === "provider" ? legionProvidersContract(summary.owner) : null,
+    model: summary.model,
+    uri: summary.uri,
+    active: summary.active,
+    source: summary.source,
+  };
+}
+
+/** Map a decoded registry tuple to a normalized `LegionEntry`, or null. */
+function parseRegistryEntry(id: number, raw: unknown): LegionEntry | null {
+  if (!raw || typeof raw !== "object") return null;
+  const t = raw as Record<string, unknown>;
+  const owner = str(t.owner);
+  if (!owner) return null;
+  const kind = normalizeKind(t.kind);
+  return {
+    id: String(id),
+    kind,
+    owner,
+    treasury: str(t.treasury) || `${owner}.legion-treasury`,
+    gov: kind === "demand" ? str(t.gov) || null : null,
+    fees: str(t.fees) || null,
+    providers: kind === "provider" ? legionProvidersContract(owner) : null,
+    model: str(t.model),
+    uri: str(t.uri),
+    active: Boolean(t.active),
+    source: "registry",
+  };
+}
+
+/** Number of Legions registered on-chain (0 if the read fails). */
+async function getCount(apiKey?: string, logger?: Logger): Promise<number> {
+  try {
+    const raw = await legionReadOnly(REGISTRY_CONTRACT, "get-count", [], apiKey, logger);
+    const n = Number(raw);
+    return Number.isFinite(n) && n >= 0 ? Math.min(n, MAX_LEGIONS) : 0;
+  } catch (e) {
+    logger?.warn?.("legion.registry_count_failed", { error: String(e) });
+    return 0;
+  }
+}
+
+/** A single registry entry by numeric id, or null. */
+async function getRegistryLegion(
+  id: number,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<LegionEntry | null> {
+  try {
+    const raw = await legionReadOnly(
+      REGISTRY_CONTRACT,
+      "get-legion",
+      [uintCV(id)],
+      apiKey,
+      logger,
+    );
+    return parseRegistryEntry(id, raw);
+  } catch (e) {
+    logger?.warn?.("legion.registry_get_failed", { id, error: String(e) });
+    return null;
+  }
+}
+
+/**
+ * All Legions: the fallback demand entry first, then every active+inactive
+ * registry entry (1..count). Deduped by treasury so a later-registered demand
+ * Legion doesn't appear twice.
+ */
+export async function listLegions(
+  apiKey?: string,
+  logger?: Logger,
+): Promise<LegionEntry[]> {
+  const count = await getCount(apiKey, logger);
+  const ids = Array.from({ length: count }, (_, i) => i + 1);
+  const fetched = await Promise.all(ids.map((id) => getRegistryLegion(id, apiKey, logger)));
+  const registryEntries = fetched.filter((e): e is LegionEntry => e !== null);
+
+  const fallback = demandFallbackEntry();
+  const haveDemandInRegistry = registryEntries.some(
+    (e) => e.treasury === fallback.treasury,
+  );
+  return haveDemandInRegistry ? registryEntries : [fallback, ...registryEntries];
+}
+
+/** One Legion by id. `"demand"` → the fallback; numeric → the registry. */
+export async function getLegion(
+  id: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<LegionEntry | null> {
+  if (id === DEMAND_LEGION_ID) return demandFallbackEntry();
+  const numId = Number(id);
+  if (!Number.isInteger(numId) || numId < 1) return null;
+  return getRegistryLegion(numId, apiKey, logger);
+}

--- a/lib/legion/snapshot.ts
+++ b/lib/legion/snapshot.ts
@@ -21,6 +21,7 @@ import {
   parseUintRepr,
 } from "./stacks";
 import { SBTC_TOKEN } from "./constants";
+import { get, toNum } from "./format";
 import { demandFallbackEntry, listLegions } from "./registry";
 import { listProviderAddresses } from "./providers";
 import type {
@@ -38,18 +39,6 @@ import type { Logger } from "../logging";
 const LEGION_READ_CONCURRENCY = 6;
 /** How far back through gov history to discover members/voters. */
 const GOV_HISTORY_CAP = 500;
-
-function toNum(v: unknown): number {
-  const n = Number(v);
-  return Number.isFinite(n) ? n : 0;
-}
-
-function get<T = unknown>(obj: unknown, key: string): T | undefined {
-  if (obj && typeof obj === "object") {
-    return (obj as Record<string, unknown>)[key] as T | undefined;
-  }
-  return undefined;
-}
 
 /** Minimal promise-concurrency limiter (pLimit-style). */
 function createLimiter(max: number) {

--- a/lib/legion/snapshot.ts
+++ b/lib/legion/snapshot.ts
@@ -20,12 +20,17 @@ import {
   legionReadOnly,
   parseUintRepr,
 } from "./stacks";
-import { GOV_CONTRACT, SBTC_TOKEN, TREASURY_CONTRACT } from "./constants";
+import { SBTC_TOKEN } from "./constants";
+import { demandFallbackEntry, listLegions } from "./registry";
+import { listProviderAddresses } from "./providers";
 import type {
+  LegionEntry,
   LegionMember,
   LegionProposal,
   LegionSnapshot,
+  LegionSummary,
   LegionVote,
+  RegistrySnapshot,
 } from "./types";
 import type { Logger } from "../logging";
 
@@ -75,9 +80,16 @@ export async function buildLegionSnapshot(
   logger?: Logger,
   prev?: LegionSnapshot | null,
   apiKey?: string,
+  entry?: LegionEntry,
 ): Promise<LegionSnapshot> {
   const errors: string[] = [];
   const limit = createLimiter(LEGION_READ_CONCURRENCY);
+
+  // Per-Legion contracts come from the registry entry; fall back to the known
+  // demand deploy so callers that predate multi-Legion keep working.
+  const legion = entry ?? demandFallbackEntry();
+  const TREASURY_CONTRACT = legion.treasury;
+  const GOV_CONTRACT = legion.gov ?? `${legion.owner}.legion-gov`;
 
   const read: ReadFn = async (label, task, fallback) => {
     try {
@@ -176,7 +188,7 @@ export async function buildLegionSnapshot(
       ids.map(async (id) => {
         const prior = prevById.get(id);
         if (prior?.status.concluded) return prior; // terminal — never re-read
-        const built = await buildProposal(id, read, call, votesByProposal.get(id) ?? new Map());
+        const built = await buildProposal(id, GOV_CONTRACT, read, call, votesByProposal.get(id) ?? new Map());
         return built ?? prior ?? null; // fall back to prior on read failure
       }),
     )
@@ -193,6 +205,7 @@ export async function buildLegionSnapshot(
   // build, so transient 429s never blank out good data.
   return {
     updatedAt: Date.now(),
+    entry: legion,
     blockHeight: blockHeight ?? prev?.blockHeight ?? null,
     treasury: {
       balance: balance != null ? toNum(balance) : (prev?.treasury.balance ?? null),
@@ -206,15 +219,93 @@ export async function buildLegionSnapshot(
   };
 }
 
+/**
+ * Build the `/legions` index: every Legion from the registry (plus the fallback
+ * demand entry), each with its treasury balance and a headline count
+ * (#proposals for demand, #providers for provider). Lightweight by design — one
+ * balance read + one count read per Legion — so it stays cheap as Legions grow.
+ * Every read degrades to null rather than throwing.
+ */
+export async function buildRegistrySnapshot(
+  logger?: Logger,
+  apiKey?: string,
+): Promise<RegistrySnapshot> {
+  const errors: string[] = [];
+  const entries = await listLegions(apiKey, logger);
+
+  const read = async <T>(label: string, task: () => Promise<T>, fallback: T): Promise<T> => {
+    try {
+      return await task();
+    } catch (e) {
+      errors.push(`${label}: ${String(e)}`);
+      logger?.warn?.("legion.registry_summary_read_failed", { label, error: String(e) });
+      return fallback;
+    }
+  };
+
+  const legions: LegionSummary[] = await Promise.all(
+    entries.map(async (entry): Promise<LegionSummary> => {
+      const [balanceRaw, count] = await Promise.all([
+        read(
+          `treasury.get-balance.${entry.id}`,
+          () => legionReadOnly(entry.treasury, "get-balance", [], apiKey, logger),
+          null as unknown,
+        ),
+        read(
+          `count.${entry.id}`,
+          async () => {
+            if (entry.kind === "provider") {
+              const addrs = await listProviderAddresses(
+                entry.providers ?? `${entry.owner}.legion-providers`,
+                apiKey,
+                logger,
+              );
+              return addrs.length;
+            }
+            const raw = await legionReadOnly(
+              entry.gov ?? `${entry.owner}.legion-gov`,
+              "get-proposal-count",
+              [],
+              apiKey,
+              logger,
+            );
+            return raw != null ? toNum(raw) : null;
+          },
+          null as number | null,
+        ),
+      ]);
+      return {
+        id: entry.id,
+        kind: entry.kind,
+        owner: entry.owner,
+        model: entry.model,
+        uri: entry.uri,
+        active: entry.active,
+        treasuryBalance: balanceRaw != null ? toNum(balanceRaw) : null,
+        count,
+        source: entry.source,
+      };
+    }),
+  );
+
+  logger?.debug?.("legion.registry_snapshot_built", {
+    legions: legions.length,
+    errors: errors.length,
+  });
+
+  return { updatedAt: Date.now(), legions, errors };
+}
+
 async function buildProposal(
   id: number,
+  govContract: string,
   read: ReadFn,
   call: CallFn,
   voters: Map<string, { vote: boolean; txid: string }>,
 ): Promise<LegionProposal | null> {
   const [prop, status] = await Promise.all([
-    read(`gov.get-proposal.${id}`, () => call(GOV_CONTRACT, "get-proposal", [uintCV(id)]), null),
-    read(`gov.get-proposal-status.${id}`, () => call(GOV_CONTRACT, "get-proposal-status", [uintCV(id)]), null),
+    read(`gov.get-proposal.${id}`, () => call(govContract, "get-proposal", [uintCV(id)]), null),
+    read(`gov.get-proposal-status.${id}`, () => call(govContract, "get-proposal-status", [uintCV(id)]), null),
   ]);
 
   if (!prop || !status) return null;
@@ -226,7 +317,7 @@ async function buildProposal(
       Array.from(voters.entries()).map(async ([address, v]) => {
         const rec = await read(
           `gov.get-vote-record.${id}.${address}`,
-          () => call(GOV_CONTRACT, "get-vote-record", [uintCV(id), principalCV(address)]),
+          () => call(govContract, "get-vote-record", [uintCV(id), principalCV(address)]),
           null,
         );
         return {

--- a/lib/legion/stacks.ts
+++ b/lib/legion/stacks.ts
@@ -162,6 +162,57 @@ export async function getContractTransactions(
   return out;
 }
 
+/**
+ * Fetch a contract's `print` events (smart-contract logs), newest first, and
+ * decode each payload into a plain JS value via `parseClarityValue`. Used to
+ * enumerate provider Legions — the `Providers` map has no on-chain "list all",
+ * so we scan `register` print events and dedupe (brief §3 option (a)).
+ *
+ * Bounded by `maxEvents`; non-`smart_contract_log` events are skipped. Returns
+ * `[]` (never throws) so a build degrades to a partial snapshot.
+ */
+export async function getContractEvents(
+  contractId: string,
+  apiKey?: string,
+  logger?: Logger,
+  maxEvents = 200,
+): Promise<unknown[]> {
+  const out: unknown[] = [];
+  const pageSize = 50;
+
+  for (let offset = 0; offset < maxEvents; offset += pageSize) {
+    let data: { results?: unknown[] } | null = null;
+    try {
+      const response = await stacksApiFetch(
+        `${LEGION_API_BASE}/extended/v1/contract/${contractId}/events?limit=${pageSize}&offset=${offset}`,
+        { method: "GET", headers: legionHeaders(apiKey) },
+        { retries: 1, retries429: 1, perAttemptTimeoutMs: PER_ATTEMPT_TIMEOUT_MS, logger },
+      );
+      if (!response.ok) break;
+      data = await response.json();
+    } catch {
+      break;
+    }
+
+    const results = data?.results ?? [];
+    for (const item of results) {
+      const ev = item as {
+        event_type?: string;
+        contract_log?: { value?: { hex?: string } };
+      };
+      if (ev.event_type !== "smart_contract_log") continue;
+      const hex = ev.contract_log?.value?.hex;
+      if (!hex) continue;
+      const decoded = parseClarityValue({ okay: true, result: hex }, logger);
+      if (decoded != null) out.push(decoded);
+    }
+
+    if (results.length < pageSize) break; // last page
+  }
+
+  return out;
+}
+
 /** Current Stacks testnet tip height, or null if /v2/info is unreachable. */
 export async function getTestnetTipHeight(
   hiroApiKey?: string,

--- a/lib/legion/types.ts
+++ b/lib/legion/types.ts
@@ -3,6 +3,94 @@
  * (divide by 1e8 for display). Block heights are Stacks block numbers.
  */
 
+import type { LegionKind } from "./constants";
+
+/**
+ * A registry entry — one Legion as listed by `legion-registry.get-legion(id)`,
+ * normalized for our use. `id` is the registry's numeric id as a string, or the
+ * reserved slug `"demand"` for the known-but-unregistered demand Legion.
+ */
+export interface LegionEntry {
+  id: string;
+  kind: LegionKind;
+  /** Deployer / admin principal. */
+  owner: string;
+  /** `{owner}.legion-treasury` — shared by both kinds. */
+  treasury: string;
+  /** Governance contract — present for demand Legions, null for provider. */
+  gov: string | null;
+  /** Fee collector — usually present (8% skim → treasury). */
+  fees: string | null;
+  /** `{owner}.legion-providers` — present for provider Legions only. */
+  providers: string | null;
+  /** Advertised model, e.g. "qwen2.5-7b" (provider) or "" (demand). */
+  model: string;
+  /** Human label from the registry `uri` field. */
+  uri: string;
+  active: boolean;
+  /** Where this entry came from: the on-chain registry, or our constant fallback. */
+  source: "registry" | "fallback";
+}
+
+/**
+ * Compact per-Legion row for the `/legions` index. `count` is #providers for a
+ * provider Legion or #proposals for a demand Legion; `treasuryBalance` is sats.
+ */
+export interface LegionSummary {
+  id: string;
+  kind: LegionKind;
+  owner: string;
+  model: string;
+  uri: string;
+  active: boolean;
+  /** Pooled sBTC (sats), or null if the read failed. */
+  treasuryBalance: number | null;
+  /** #providers (provider) or #proposals (demand), or null if unread. */
+  count: number | null;
+  source: "registry" | "fallback";
+}
+
+/** The `/legions` index snapshot — the registry list, cron-built. */
+export interface RegistrySnapshot {
+  updatedAt: number;
+  legions: LegionSummary[];
+  /** Per-read failure notes; partial lists are still served. */
+  errors: string[];
+}
+
+/** One inference provider in a provider Legion (`legion-providers.get-provider`). */
+export interface ProviderRecord {
+  /** Provider STX address. */
+  address: string;
+  /** Model this provider serves, e.g. "qwen2.5-7b". */
+  model: string;
+  /** Advertised inference endpoint URL. */
+  endpoint: string;
+  /** Staked bond (sats). */
+  bond: number;
+  active: boolean;
+  /** Successfully served jobs. */
+  jobsOk: number;
+  /** Failed jobs. */
+  jobsFail: number;
+}
+
+/** Detail snapshot for a provider Legion (mirrors LegionSnapshot for demand). */
+export interface ProviderSnapshot {
+  /** Unix ms when assembled. */
+  updatedAt: number;
+  blockHeight: number | null;
+  /** The registry entry this snapshot was built from. */
+  entry: LegionEntry;
+  /** Pooled sBTC (sats), or null on read failure. */
+  treasuryBalance: number | null;
+  /** Minimum bond to register as a provider (sats), or null. */
+  minBond: number | null;
+  /** Providers sorted by bond descending. */
+  providers: ProviderRecord[];
+  errors: string[];
+}
+
 export interface LegionMember {
   /** STX address (also the staker / voter identity). */
   address: string;
@@ -68,6 +156,12 @@ export interface LegionTreasury {
 export interface LegionSnapshot {
   /** Unix ms when this snapshot was assembled. */
   updatedAt: number;
+  /**
+   * The registry entry this snapshot was built from. Optional for back-compat
+   * with snapshots written before multi-Legion; readers fall back to the demand
+   * constants when absent.
+   */
+  entry?: LegionEntry;
   /** Stacks tip height at snapshot time. null if /v2/info failed. */
   blockHeight: number | null;
   treasury: LegionTreasury;

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -33,10 +33,15 @@ import {
 import { runEarningsSweep } from "../earnings/indexer";
 import { EARNINGS_INTERVAL_MS } from "../earnings/constants";
 import type { EarningsSweepSummary } from "../earnings/types";
-import { buildLegionSnapshot } from "../legion/snapshot";
+import { buildLegionSnapshot, buildRegistrySnapshot } from "../legion/snapshot";
+import { buildProviderSnapshot } from "../legion/providers";
+import { listLegions } from "../legion/registry";
 import {
   readLegionSnapshotFromD1,
   writeLegionSnapshotToD1,
+  readProviderSnapshotFromD1,
+  writeProviderSnapshotToD1,
+  writeRegistrySnapshotToD1,
 } from "../legion/d1";
 import type { Logger } from "../logging";
 import type {
@@ -255,11 +260,15 @@ export async function runEarningsNow(
 }
 
 /**
- * Rebuild the Legion dashboard snapshot from testnet and persist it to KV under
- * `legion:snapshot`. This is the only writer of that key; the /api/legion
- * endpoint (and its edge cache) are pure readers. A build never throws — partial
- * outages are recorded in `snapshot.errors` — so this only rejects on an
- * unexpected error, which the caller logs without blocking other tasks.
+ * Rebuild every Legion's dashboard snapshot from testnet and persist them to D1
+ * (table `legion_snapshots`, keyed by legion id). This is the only writer of
+ * those rows; the page + /api/legions endpoints (and their edge cache) are pure
+ * readers. The cron:
+ *   1. reads the registry → builds the `/legions` index snapshot, then
+ *   2. builds one detail snapshot per active Legion, branching on kind
+ *      (demand → proposals/votes; provider → bonds/jobs).
+ * A build never throws — partial outages are recorded in `errors` — so a single
+ * Legion's failure is logged and skipped without blocking the others.
  */
 export async function runLegionNow(
   env: CloudflareEnv,
@@ -274,19 +283,49 @@ export async function runLegionNow(
     logger.warn("legion.skipped_no_db");
     return;
   }
+  const apiKey = env.HIRO_API_KEY;
 
-  // Read the prior snapshot so terminal (concluded) proposals are carried
-  // forward without re-reading them from Hiro. Authenticated with HIRO_API_KEY.
-  const prev = await readLegionSnapshotFromD1(db);
-  const snapshot = await buildLegionSnapshot(logger, prev, env.HIRO_API_KEY);
-  await writeLegionSnapshotToD1(db, snapshot);
-
-  logger.info("legion.snapshot_written", {
-    blockHeight: snapshot.blockHeight,
-    proposals: snapshot.proposals.length,
-    members: snapshot.members.length,
-    errors: snapshot.errors.length,
+  // 1. Registry index — backs the /legions list page.
+  const registry = await buildRegistrySnapshot(logger, apiKey);
+  await writeRegistrySnapshotToD1(db, registry);
+  logger.info("legion.registry_written", {
+    legions: registry.legions.length,
+    errors: registry.errors.length,
   });
+
+  // 2. Per-Legion detail snapshots. Walk every entry (registry + demand
+  // fallback). Skip inactive Legions — they stay listed but aren't refreshed.
+  const entries = await listLegions(apiKey, logger);
+  for (const entry of entries) {
+    if (!entry.active) continue;
+    try {
+      if (entry.kind === "provider") {
+        const prev = await readProviderSnapshotFromD1(db, entry.id);
+        const snap = await buildProviderSnapshot(entry, prev, apiKey, logger);
+        await writeProviderSnapshotToD1(db, entry.id, snap);
+        logger.info("legion.provider_snapshot_written", {
+          id: entry.id,
+          providers: snap.providers.length,
+          errors: snap.errors.length,
+        });
+      } else {
+        // Read the prior snapshot so terminal (concluded) proposals are carried
+        // forward without re-reading them from Hiro.
+        const prev = await readLegionSnapshotFromD1(db, entry.id);
+        const snap = await buildLegionSnapshot(logger, prev, apiKey, entry);
+        await writeLegionSnapshotToD1(db, entry.id, snap);
+        logger.info("legion.snapshot_written", {
+          id: entry.id,
+          blockHeight: snap.blockHeight,
+          proposals: snap.proposals.length,
+          members: snap.members.length,
+          errors: snap.errors.length,
+        });
+      }
+    } catch (e) {
+      logger.warn("legion.snapshot_failed", { id: entry.id, error: String(e) });
+    }
+  }
 }
 
 // ─────────────────────────── cron entry point ───────────────────────────

--- a/migrations/024_legion_snapshots.sql
+++ b/migrations/024_legion_snapshots.sql
@@ -1,0 +1,19 @@
+-- Migration 024: per-Legion snapshot cache (multi-Legion).
+--
+-- Supersedes the single-row `legion_snapshot` (migration 023), which assumed
+-- exactly one Legion. The platform is now multi-Legion: a shared on-chain
+-- registry lists many Legions (demand + provider kinds). The 5-min cron rebuilds
+-- one denormalized snapshot per Legion plus a small registry index, and upserts
+-- them here keyed by `legion_id`. The page + /api/legions read behind
+-- caches.default + an in-flight singleflight (lib/legion/read.ts), so Hiro is
+-- only hit on a rebuild, never per request.
+--
+-- legion_id is the registry's numeric id as text ("1", "2", …), the slug
+-- "demand" for the known demand Legion, or "__registry__" for the index row.
+-- JSON-in-TEXT matches migration 023's precedent — each snapshot is read whole,
+-- so there's no query benefit to normalizing proposals/providers into tables.
+CREATE TABLE IF NOT EXISTS legion_snapshots (
+  legion_id     TEXT    PRIMARY KEY,
+  snapshot_json TEXT    NOT NULL,
+  updated_at    INTEGER NOT NULL
+);


### PR DESCRIPTION
## What

The `/legion` dashboard was hardcoded to one demand Legion. The platform is now **multi-Legion**: a shared on-chain `legion-registry` lists many Legions, including a new **provider** kind (inference operators who stake a bond and earn sBTC per call). This PR reads the registry, lists every Legion, renders each by id, and branches the UI on kind.

## How it's structured

**Backend (`lib/legion/`)**
- `registry.ts` — `listLegions()` / `getLegion()` read `legion-registry` (`get-count` + `get-legion(id)`); the existing demand deploy is kept as a `source:"fallback"` entry, deduped by treasury.
- `providers.ts` — provider record reads + `get-min-bond`; provider enumeration via a `register`-event scan (the on-chain `Providers` map has no list-all); `buildProviderSnapshot()`.
- `snapshot.ts` — `buildLegionSnapshot()` now reads gov/treasury from the registry entry; `buildRegistrySnapshot()` builds the `/legions` index.
- `d1.ts` + **migration `024`** — per-Legion keyed `legion_snapshots` table (replaces the single-row `legion_snapshot`).
- `read.ts` — caches.default + singleflight + stale-while-revalidate, generalized and keyed per Legion; `getRegistrySnapshot` / `getProviderSnapshot` / `resolveLegionEntry`.
- `cron-runner.ts` — `runLegionNow` writes the registry index + one snapshot per active Legion, branching on kind.

**Frontend / API**
- `/legions` index (cards + kind badges) and `/legions/[id]` detail branching **demand** (proposals/votes) vs **provider** (`ProvidersTable`: bond, model, jobs ok/fail + `HowToProvide`).
- `/legion` → **redirects to `/legions/demand`** (back-compat); `/api/legion` unchanged.
- `/api/legions` + `/api/legions/[id]` (self-documenting).
- `skill.md` extended with registry discovery + provider onboarding; Navbar + sitemap add `/legions`.

## Verification

- Typecheck clean (changed files), lint clean, production build passes.
- Ran the real worker locally (`npm run preview`, workerd + miniflare) against **live testnet**, local D1 only:
  - `/api/legions` → both Legions, **0 errors** (demand: 493,900 sats / 9 proposals; provider #1 `qwen2.5-7b`: 200 sats / 1 provider).
  - `/api/legions/1` (provider) and `/api/legions/demand` (demand) return correct, kind-branched detail; provider contract derived correctly, real provider record.
  - `/legions`, `/legions/1`, `/legions/demand` render; `/legion` 307→`/legions/demand`; unknown id 404; back-compat `/api/legion` 200.
  - Cold-read self-heal wrote all three D1 rows (`__registry__`, `demand`, `1`), exercising the cron write-path shape too.
- All four contracts verified live on testnet before writing the parsers, so types match real on-chain shapes.

## Deploy notes

- Migration **`024` has already been applied to remote D1** (only pending migration; plain `CREATE TABLE`). The table starts empty and is populated lazily by the first read (cold build) or the scheduler.
- Refresh is already wired: the standalone `aibtc-scheduler` worker (`scheduler-worker.ts`, cron `*/5`) runs `runScheduledTasks` → `runLegionNow` every tick against the shared D1, so the rows refresh automatically once both workers are deployed with this code.
