### PR TITLE
chore(navbar): remove Legions link

### DIFF
--- a/app/components/Navbar.tsx
+++ b/app/components/Navbar.tsx
@@ -142,7 +142,6 @@ export default function Navbar() {
               { href: "/leaderboard", label: "Leaderboard" },
               { href: "/activity", label: "Activity Feed" },
               { href: "/bounties", label: "Bounties" },
-              { href: "/legions", label: "Legions" },
               { href: "/skills", label: "Skills" },
             ].map((link) => (
               <Link


### PR DESCRIPTION
Removes the `/legions` link from the navbar (multi-Legion pages not shipped to nav yet). Diff is a single line in `app/components/Navbar.tsx`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)