### PR TITLE
feat(legions): match v1 provider model — free join, engage stake, no bond/slash

### DIFF
--- a/app/api/legions/[id]/route.ts
+++ b/app/api/legions/[id]/route.ts
@@ -39,7 +39,7 @@ function selfDocResponse(id: string) {
         entry:
           "{ id, kind ('demand'|'provider'), owner, treasury, gov, fees, providers, model, uri, active, source }",
         snapshot:
-          "Demand: { updatedAt, blockHeight, treasury, totalStaked, members, proposals, errors }. Provider: { updatedAt, blockHeight, treasuryBalance, minBond, providers, errors }.",
+          "Demand: { updatedAt, blockHeight, treasury, totalStaked, members, proposals, errors }. Provider: { updatedAt, blockHeight, treasuryBalance, minStake, totalStaked, providers: [{ address, name, model, endpoint, stake, health, flagged, active }], errors }.",
       },
       related: { index: "/api/legions", skill: "/legion/skill.md" },
     },

--- a/app/api/legions/route.ts
+++ b/app/api/legions/route.ts
@@ -19,7 +19,7 @@ function selfDocResponse() {
       endpoint: "/api/legions",
       method: "GET",
       description:
-        "Read-only index of every AIBTC Legion (Stacks testnet): demand Legions (pool + govern an sBTC treasury) and provider Legions (operators stake a bond, serve a model, earn sBTC per call). Sourced from the on-chain legion-registry, built server-side on a cron, stored in D1, served from cache. Fetch /api/legions/{id} for one Legion's full detail.",
+        "Read-only index of every AIBTC Legion (Stacks testnet): demand Legions (pool + govern an sBTC treasury) and provider Legions (operators join the gateway for free, serve a model, earn sBTC per call; an optional legion-engage stake buys ranking). Sourced from the on-chain legion-registry, built server-side on a cron, stored in D1, served from cache. Fetch /api/legions/{id} for one Legion's full detail.",
       network: "stacks-testnet",
       registry: REGISTRY_CONTRACT,
       queryParameters: {

--- a/app/legion/HowToProvide.tsx
+++ b/app/legion/HowToProvide.tsx
@@ -3,54 +3,31 @@ import { formatSbtc } from "@/lib/legion/format";
 import CopyButton from "../components/CopyButton";
 
 /**
- * Provider-Legion onboarding: get test sBTC, lock a bond + register, serve the
- * model, get paid. The demand-Legion equivalent is HowToParticipate. The exact
+ * Provider-Legion onboarding (v1): run the model, register with the gateway for
+ * FREE, get paid per call, and OPTIONALLY stake legion-engage to rank higher.
+ * No bond, no slash. The demand-Legion equivalent is HowToParticipate. The exact
  * typed contract call lives in /legion/skill.md.
  */
 
 export default function HowToProvide({
-  minBond,
+  minStake,
   model,
 }: {
-  minBond: number | null;
+  minStake: number | null;
   model: string;
 }) {
-  const bondLabel = minBond != null ? formatSbtc(minBond) : "the minimum";
-  const modelLabel = model || "qwen2.5-7b";
-  const registerCmd = `legion-providers.register("${modelLabel}", "https://your-endpoint:8000/v1", ${bondLabel})`;
+  const stakeLabel = minStake != null ? formatSbtc(minStake) : "the minimum";
   const dockerCmd = `docker run -p 8000:8000 vllm/vllm-openai --model Qwen/Qwen2.5-7B-Instruct`;
+  const connectCmd = `curl -fsSL https://<gateway>/connect.sh | WALLET=ST... MODELS=${model || "Qwen/Qwen2.5-7B-Instruct"} bash`;
+  const stakeCmd = `legion-engage.join("<sBTC token>", ${stakeLabel})`;
 
   const STEPS: { title: string; body: React.ReactNode }[] = [
     {
-      title: "Get test sBTC (30 seconds)",
+      title: "Run the model",
       body: (
         <>
-          Spin up a Stacks wallet and run the sBTC faucet → free test tokens land
-          in your wallet. No real money at risk.
-        </>
-      ),
-    },
-    {
-      title: "Lock bond + register (one paste)",
-      body: (
-        <>
-          Use <code>call_contract</code> →{" "}
-          <code>legion-providers register</code>:
-          <span className="mt-2 flex items-center gap-2">
-            <code className="flex-1 break-all">{registerCmd}</code>
-            <CopyButton text={registerCmd} variant="icon" label="" ariaLabel="Copy register command" />
-          </span>
-          Minimum {bondLabel} sBTC. This bond is slashed if your endpoint returns
-          errors or times out too often.
-        </>
-      ),
-    },
-    {
-      title: "Run the model once",
-      body: (
-        <>
-          One Docker command → your endpoint is live. We route paying calls to it
-          automatically.
+          One Docker command → your OpenAI-compatible endpoint is live. The
+          gateway routes paying calls to it automatically.
           <span className="mt-2 flex items-center gap-2">
             <code className="flex-1 break-all">{dockerCmd}</code>
             <CopyButton text={dockerCmd} variant="icon" label="" ariaLabel="Copy docker command" />
@@ -59,12 +36,42 @@ export default function HowToProvide({
       ),
     },
     {
-      title: "Get paid + climb the list",
+      title: "Register for free (one paste)",
       body: (
         <>
-          Every settled call = sBTC in your wallet, minus 8%. Your public{" "}
-          <code>jobs-ok</code> / <code>jobs-fail</code> counter decides how much
-          traffic you receive.
+          Register your endpoint with the gateway — <strong>no bond, no deposit</strong>.
+          Earning is free at the gateway.
+          <span className="mt-2 flex items-center gap-2">
+            <code className="flex-1 break-all">{connectCmd}</code>
+            <CopyButton text={connectCmd} variant="icon" label="" ariaLabel="Copy connect command" />
+          </span>
+        </>
+      ),
+    },
+    {
+      title: "Get paid per call",
+      body: (
+        <>
+          Every settled call = sBTC in your wallet, minus the Legion&apos;s 8%
+          treasury skim (you keep <strong>92%</strong>). Bad actors are{" "}
+          <strong>flagged + de-routed</strong> by the operator — there is no bond
+          to slash.
+        </>
+      ),
+    },
+    {
+      title: "Optional: stake to rank higher",
+      body: (
+        <>
+          Staking is <strong>optional</strong> and never required to earn — it only
+          buys ranking. Stake sBTC into <code>legion-engage</code> and the gateway
+          routes higher-staked providers first.
+          <span className="mt-2 flex items-center gap-2">
+            <code className="flex-1 break-all">{stakeCmd}</code>
+            <CopyButton text={stakeCmd} variant="icon" label="" ariaLabel="Copy stake command" />
+          </span>
+          Min {stakeLabel} sBTC. Fully refundable on <code>leave</code>, minus a
+          10% exit fee that goes to the treasury.
           <span className="mt-2 block text-xs text-white/40">
             Advanced:{" "}
             <Link

--- a/app/legion/ProviderClient.tsx
+++ b/app/legion/ProviderClient.tsx
@@ -57,17 +57,18 @@ export default function ProviderClient({
   if (!snapshot) {
     return (
       <div className="rounded-xl border border-red-500/20 bg-red-500/[0.05] p-6 text-sm text-white/70">
-        Couldn&apos;t load this provider Legion right now — the on-chain reader is
-        warming up or temporarily unavailable. Refresh in a moment.
+        Couldn&apos;t load this provider Legion right now — the reader is warming
+        up or temporarily unavailable. Refresh in a moment.
       </div>
     );
   }
 
-  const { entry, treasuryBalance, minBond, providers, blockHeight } = snapshot;
+  const { entry, treasuryBalance, minStake, totalStaked, providers, blockHeight } = snapshot;
   const activeCount = providers.filter((p) => p.active).length;
-  const totalJobs = providers.reduce((sum, p) => sum + p.jobsOk + p.jobsFail, 0);
-  const model = entry.model || "qwen2.5-7b";
-  const bondLabel = minBond != null ? formatSbtc(minBond) : "the minimum";
+  const stakedCount = providers.filter((p) => p.stake > 0).length;
+  const model = entry.model || "open models";
+  const minStakeLabel = minStake != null ? formatSbtc(minStake) : "the minimum";
+  const stakedLabel = formatSbtc(totalStaked);
   const pooledLabel = formatSbtc(treasuryBalance);
   const providerWord = providers.length === 1 ? "provider" : "providers";
 
@@ -75,15 +76,16 @@ export default function ProviderClient({
     <div className="space-y-8">
       <header className="space-y-5">
         <h1 className="max-w-4xl text-4xl font-bold leading-[1.1] tracking-tight text-white max-md:text-3xl">
-          Stake {bondLabel} sBTC. Host{" "}
+          Join for free. Host{" "}
           <span className="text-[#7DA2FF]">{model}</span>. Earn 92% every time an
           autonomous agent pays you sBTC to run a query instead of using OpenAI.
         </h1>
         <p className="max-w-3xl text-base leading-relaxed text-white/70">
-          The treasury takes 8%. Failed responses slash your bond. Live on Stacks
-          testnet — {providers.length} {providerWord}, {totalJobs}{" "}
-          {totalJobs === 1 ? "job" : "jobs"}, {pooledLabel} sBTC pooled. Real sBTC
-          on mainnet only after 5+ providers, visible payouts, and audits.
+          No bond, no deposit — earning is free at the gateway. The treasury takes
+          8%. An optional stake only buys ranking. Live on Stacks testnet —{" "}
+          {providers.length} {providerWord}, {stakedLabel} sBTC staked,{" "}
+          {pooledLabel} sBTC pooled. Real sBTC on mainnet only after more providers,
+          visible payouts, and audits.
         </p>
         <div className="flex flex-wrap gap-3">
           <a
@@ -92,7 +94,7 @@ export default function ProviderClient({
             rel="noopener noreferrer"
             className="inline-flex items-center gap-2 rounded-lg border border-[#7DA2FF]/40 bg-[#7DA2FF]/10 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-[#7DA2FF]/20"
           >
-            View treasury + provider on Hiro explorer
+            View treasury on Hiro explorer
             <span aria-hidden>↗</span>
           </a>
         </div>
@@ -106,16 +108,15 @@ export default function ProviderClient({
           <UpdatedAt updatedAt={snapshot.updatedAt} />
         </div>
         <p className="text-sm leading-relaxed text-white/60">
-          sBTC here is faucet money. Your real bond goes in only after we have 5+
-          providers, visible agent payouts, and public audits. Membership = bond —
-          no votes, no multisig.{" "}
+          sBTC here is faucet money. Joining is free — there is no bond and nothing
+          to slash. Bad providers are flagged and de-routed.{" "}
           <a
             href={RISKS_URL}
             className="text-amber-300/90 underline underline-offset-2 hover:text-amber-200"
           >
-            Slashing rules
+            How flagging + staking work
           </a>
-          . Treasury address and admin are on-chain and clickable right now.
+          . Treasury address is on-chain and clickable right now.
         </p>
       </div>
 
@@ -133,7 +134,7 @@ export default function ProviderClient({
               {shortAddress(entry.treasury, 6, 14)}
             </a>
             <span className="text-white/15">·</span>
-            <span className="text-white/40">Admin</span>
+            <span className="text-white/40">Owner</span>
             <span className="font-mono text-white/70" title={entry.owner}>
               {shortAddress(entry.owner, 6, 4)}
             </span>
@@ -148,7 +149,8 @@ export default function ProviderClient({
 
         <div className="flex flex-wrap items-center gap-4 px-5 py-4">
           <Metric label="Pooled" value={`${pooledLabel} sBTC`} />
-          <Metric label="Min bond" value={`${bondLabel} sBTC`} />
+          <Metric label="Staked" value={`${stakedLabel} sBTC`} />
+          <Metric label="Min stake" value={`${minStakeLabel} sBTC`} />
           <Metric label="Providers" value={`${providers.length}`} />
           <Metric label="Active" value={`${activeCount}`} />
         </div>
@@ -167,10 +169,12 @@ export default function ProviderClient({
       <div className="grid gap-3 rounded-xl border border-white/[0.08] bg-white/[0.02] p-4 text-sm sm:grid-cols-3">
         <div>
           <div className="text-[10px] uppercase tracking-[0.08em] text-white/40">
-            Last activity
+            Staked providers
           </div>
           <div className="mt-1 text-white/70">
-            {totalJobs === 0 ? "none yet (0 jobs)" : `${totalJobs} jobs settled`}
+            {stakedCount === 0
+              ? "none staked yet (staking is optional)"
+              : `${stakedCount} of ${providers.length} staked`}
           </div>
         </div>
         <div>
@@ -205,7 +209,7 @@ export default function ProviderClient({
                     {shortAddress(p.address, 6, 4)} ↗
                   </a>{" "}
                   <span className="text-white/50">
-                    — {formatSbtc(p.bond)} bonded, {p.jobsOk}/{p.jobsFail}
+                    — {p.stake > 0 ? `${formatSbtc(p.stake)} staked` : "unstaked"}
                   </span>
                 </li>
               ))}
@@ -216,8 +220,8 @@ export default function ProviderClient({
 
       <p className="text-sm leading-relaxed text-white/50">
         <span className="text-white/70">
-          First-mover upside: get in now while it&apos;s at {totalJobs}{" "}
-          {totalJobs === 1 ? "job" : "jobs"}.
+          First-mover upside: get in now while it&apos;s at {providers.length}{" "}
+          {providerWord}.
         </span>{" "}
         Example (illustrative): 100 calls/day at 100 sats/call = 10,000 sats/day;
         after the 8% treasury cut you keep ~9,200 sats (~0.000092 sBTC). Real rates
@@ -228,14 +232,14 @@ export default function ProviderClient({
         </span>
       </p>
 
-      <HowToProvide minBond={minBond} model={entry.model} />
+      <HowToProvide minStake={minStake} model={entry.model} />
 
       <div className="flex flex-wrap gap-3 border-t border-white/[0.08] pt-6">
         <a
           href={TRY_IT_HREF}
           className="inline-flex flex-1 items-center justify-center rounded-lg border border-[#7DA2FF]/40 bg-[#7DA2FF]/10 px-4 py-3 text-center text-sm font-medium text-white transition-colors hover:bg-[#7DA2FF]/20"
         >
-          Try it on testnet — faucet + exact commands
+          Join on testnet — faucet + exact commands
         </a>
         <a
           href={RISKS_URL}
@@ -247,8 +251,8 @@ export default function ProviderClient({
 
       {snapshot.errors.length > 0 && (
         <p className="text-xs text-amber-300/70">
-          Some on-chain reads failed for this snapshot ({snapshot.errors.length}) —
-          the data shown may be partial.
+          Some reads failed for this snapshot ({snapshot.errors.length}) — the data
+          shown may be partial.
         </p>
       )}
     </div>

--- a/app/legion/ProvidersTable.tsx
+++ b/app/legion/ProvidersTable.tsx
@@ -2,26 +2,30 @@ import type { ProviderRecord } from "@/lib/legion/types";
 import { formatSbtc } from "@/lib/legion/format";
 import AddressLink from "./AddressLink";
 
-function ActiveDot({ active }: { active: boolean }) {
+function StatusDot({ p }: { p: ProviderRecord }) {
+  const label = p.flagged ? "flagged" : p.active ? "active" : "down";
+  const color = p.flagged
+    ? "bg-red-400"
+    : p.active
+      ? "bg-green-400"
+      : "bg-white/20";
+  const text = p.flagged ? "text-red-400/80" : p.active ? "text-white/70" : "text-white/40";
   return (
     <span className="inline-flex items-center gap-1.5 text-xs">
-      <span
-        className={`h-1.5 w-1.5 rounded-full ${active ? "bg-green-400" : "bg-white/20"}`}
-        aria-hidden
-      />
-      <span className={active ? "text-white/70" : "text-white/40"}>
-        {active ? "active" : "inactive"}
-      </span>
+      <span className={`h-1.5 w-1.5 rounded-full ${color}`} aria-hidden />
+      <span className={text}>{label}</span>
     </span>
   );
 }
 
-function Jobs({ ok, fail }: { ok: number; fail: number }) {
+function Stake({ sats }: { sats: number }) {
   return (
     <span className="tabular-nums text-white/70">
-      <span className="text-green-400/80">{ok}</span>
-      <span className="text-white/30"> / </span>
-      <span className={fail > 0 ? "text-red-400/80" : "text-white/40"}>{fail}</span>
+      {sats > 0 ? (
+        `${formatSbtc(sats)} sBTC`
+      ) : (
+        <span className="text-white/30">unstaked</span>
+      )}
     </span>
   );
 }
@@ -34,8 +38,9 @@ export default function ProvidersTable({
   if (providers.length === 0) {
     return (
       <div className="rounded-xl border border-white/[0.08] bg-white/[0.02] p-8 text-center text-sm text-white/50">
-        No providers yet. Any operator that stakes the minimum bond and calls{" "}
-        <code className="text-white/70">register</code> joins the guild.
+        No providers yet. Anyone can join for <span className="text-white/70">free</span> —
+        register an endpoint with the gateway and start serving. An optional{" "}
+        <code className="text-white/70">legion-engage</code> stake ranks you higher.
       </div>
     );
   }
@@ -48,9 +53,8 @@ export default function ProvidersTable({
           <tr className="border-b border-white/[0.06] text-left text-xs uppercase tracking-wide text-white/40">
             <th className="px-5 py-3 font-medium" scope="col">Provider (STX)</th>
             <th className="px-5 py-3 font-medium" scope="col">Model</th>
-            <th className="px-5 py-3 text-right font-medium" scope="col">Bond</th>
+            <th className="px-5 py-3 text-right font-medium" scope="col">Stake</th>
             <th className="px-5 py-3 font-medium" scope="col">Status</th>
-            <th className="px-5 py-3 text-right font-medium" scope="col">Jobs (ok / fail)</th>
           </tr>
         </thead>
         <tbody>
@@ -62,13 +66,12 @@ export default function ProvidersTable({
               <td className="px-5 py-3">
                 <AddressLink address={p.address} />
               </td>
-              <td className="px-5 py-3 font-mono text-xs text-white/70">{p.model}</td>
-              <td className="px-5 py-3 text-right tabular-nums">{formatSbtc(p.bond)}</td>
-              <td className="px-5 py-3">
-                <ActiveDot active={p.active} />
+              <td className="px-5 py-3 font-mono text-xs text-white/70">{p.model || "—"}</td>
+              <td className="px-5 py-3 text-right tabular-nums">
+                <Stake sats={p.stake} />
               </td>
-              <td className="px-5 py-3 text-right">
-                <Jobs ok={p.jobsOk} fail={p.jobsFail} />
+              <td className="px-5 py-3">
+                <StatusDot p={p} />
               </td>
             </tr>
           ))}
@@ -81,15 +84,11 @@ export default function ProvidersTable({
           <li key={p.address} className="space-y-2 p-4">
             <div className="flex items-center justify-between gap-2">
               <AddressLink address={p.address} />
-              <span className="tabular-nums text-sm">{formatSbtc(p.bond)} sBTC</span>
+              <Stake sats={p.stake} />
             </div>
             <div className="flex items-center justify-between gap-2 text-xs text-white/50">
-              <span className="font-mono">{p.model}</span>
-              <ActiveDot active={p.active} />
-            </div>
-            <div className="flex items-center justify-between gap-2 text-xs text-white/50">
-              <span>jobs</span>
-              <Jobs ok={p.jobsOk} fail={p.jobsFail} />
+              <span className="font-mono">{p.model || "—"}</span>
+              <StatusDot p={p} />
             </div>
           </li>
         ))}

--- a/app/legion/risks/page.tsx
+++ b/app/legion/risks/page.tsx
@@ -7,7 +7,7 @@ import Footer from "../../components/Footer";
 export const metadata: Metadata = {
   title: "Provider Legion — Risk, Reward & Mainnet Criteria",
   description:
-    "The one-page risk/reward breakdown for AIBTC provider Legions: what you stake, how slashing works, what you earn, the exact mainnet criteria, and why it isn't a rug.",
+    "The one-page risk/reward breakdown for AIBTC provider Legions: joining is free, how flagging works, the optional engagement stake, what you earn, the exact mainnet criteria, and why it isn't a rug.",
 };
 
 const ROWS: { term: string; detail: React.ReactNode }[] = [
@@ -15,20 +15,34 @@ const ROWS: { term: string; detail: React.ReactNode }[] = [
     term: "What you put at risk",
     detail: (
       <>
-        Only your bond — and today that bond is testnet faucet money, not real
-        sBTC. It sits in the Legion&apos;s on-chain treasury contract, not with
-        us. The treasury and admin addresses are clickable on every Legion page.
+        Nothing to join — there is <strong>no bond and no slash</strong>. Earning
+        is free at the gateway. If you choose to stake (see below), it&apos;s
+        fully refundable minus a 10% exit fee, and today it&apos;s testnet faucet
+        money anyway. Treasury and owner addresses are clickable on every Legion
+        page.
       </>
     ),
   },
   {
-    term: "How slashing works",
+    term: "How enforcement works",
     detail: (
       <>
-        Endpoints that return errors or time out too often get slashed. Your
-        public <code>jobs-ok</code> / <code>jobs-fail</code> counter lives
-        on-chain and decides how much traffic you receive — reliability is the
-        whole game.
+        Bad providers are <strong>flagged</strong> by the marketplace operator,
+        which de-routes them everywhere and drops them from the catalog. There is
+        no on-chain slashing — reliability (health + reputation) is what keeps you
+        in the routing pool.
+      </>
+    ),
+  },
+  {
+    term: "The optional stake",
+    detail: (
+      <>
+        Staking sBTC into <code>legion-engage</code> is <strong>optional</strong>{" "}
+        and never required to earn — it only buys <strong>ranking</strong> (the
+        gateway routes higher-staked providers first). Withdraw any time with{" "}
+        <code>leave</code>: you get your stake back minus a 10% exit fee that goes
+        to the Legion treasury.
       </>
     ),
   },
@@ -37,8 +51,7 @@ const ROWS: { term: string; detail: React.ReactNode }[] = [
     detail: (
       <>
         92% of every settled call, paid in sBTC, per call, straight to your
-        wallet. The Legion treasury keeps 8%. No subscriptions, no lockups beyond
-        your bond.
+        wallet. The Legion treasury keeps 8%. No subscriptions, no lockups.
       </>
     ),
   },
@@ -46,9 +59,9 @@ const ROWS: { term: string; detail: React.ReactNode }[] = [
     term: "Mainnet criteria",
     detail: (
       <>
-        Real sBTC goes live only after <strong>5+ active providers</strong>,{" "}
+        Real sBTC goes live only after <strong>more active providers</strong>,{" "}
         <strong>visible agent payouts</strong>, and <strong>public audits</strong>.
-        Until every one of those is true, this is testnet only and your bond is
+        Until every one of those is true, this is testnet only and sBTC here is
         faucet money.
       </>
     ),
@@ -58,9 +71,10 @@ const ROWS: { term: string; detail: React.ReactNode }[] = [
     detail: (
       <>
         The contracts are read-only verifiable on the explorer; the treasury and
-        admin are on-chain and clickable now; bonds are held by the contract, not
-        a custodial wallet; and mainnet is explicitly gated on the criteria above.
-        Nothing here asks you to send real money to a wallet we control.
+        owner are on-chain and clickable now; joining costs nothing and any stake
+        is held by the contract (not a custodial wallet) and refundable; and
+        mainnet is explicitly gated on the criteria above. Nothing here asks you
+        to send real money to a wallet we control.
       </>
     ),
   },

--- a/app/legion/skill.md/route.ts
+++ b/app/legion/skill.md/route.ts
@@ -162,21 +162,24 @@ Between \`execStart\` and \`execEnd\`, anyone calls:
 
 ## Provider Legions — serve a model, earn per call
 
-A **provider Legion** is governed by \`{owner}.legion-providers\` instead of \`legion-gov\`. There is **no proposing or voting** — you join by staking a bond and serving inference. Find a provider Legion's \`owner\` (hence its \`legion-providers\` contract) from the registry / \`GET /api/legions\`.
+A **provider Legion** is a guild of inference operators. There is **no bond and no slash** — you join the gateway for **free** and earn sBTC per call. Bad providers are **flagged + de-routed** by the operator. An optional \`{owner}.legion-engage\` stake only buys **ranking** (the gateway routes higher-staked providers first). Find a provider Legion's \`owner\` (hence its \`legion-engage\` contract) from the registry / \`GET /api/legions\`.
 
 ### Read provider state (no signing)
-- Minimum bond: \`{owner}.legion-providers\` \`get-min-bond\` → uint (sats)
-- A provider's record: \`get-provider\` \`[{type:"principal", value:"<addr>"}]\` → \`(optional { model, endpoint, bond, active, jobs-ok, jobs-fail })\`
-- Whether active: \`is-active\` \`[{type:"principal", value:"<addr>"}]\`
-- Enumerate providers: there is no on-chain "list all" — scan the contract's \`register\` print events (\`GET /extended/v1/contract/{owner}.legion-providers/events\`) and dedupe, or just read \`GET https://aibtc.com/api/legions/{id}\` which does this for you.
+- Live provider directory: \`GET https://inference.aibtc.com/v1/providers\` → \`{ id, name, endpoint, payoutAddress, models, health, flagged }\` per provider.
+- Your engagement stake: \`{owner}.legion-engage\` \`get-stake\` \`[{type:"principal", value:"<addr>"}]\` → uint (sats)
+- Min stake / total staked: \`{owner}.legion-engage\` \`get-min-stake\`, \`get-total-staked\`
+- Or just read \`GET https://aibtc.com/api/legions/{id}\` — it merges the gateway directory + engage stakes for you.
 
-### Register as a provider
-1. Fund a wallet + get test sBTC (same faucet step as the demand flow). Have a model endpoint you can serve.
-2. \`call_contract\` → \`{owner}.legion-providers\`, function \`register\`, args \`[ {type:"string-ascii", value:"<model>"}, {type:"string-ascii", value:"<endpoint url>"}, {type:"uint", value:"<bond sats ≥ get-min-bond>"} ]\`, \`postConditionMode: "deny"\` with an \`ft\` post-condition pinning **your address** sending exactly \`<bond>\` sBTC into the treasury.
+### Join + serve (free)
+1. Fund a wallet + get test sBTC (same faucet step as the demand flow). Run an OpenAI-compatible endpoint (vLLM / HF endpoint).
+2. Register with the gateway for **free** — \`POST /v1/providers\` (or the \`connect.sh\` one-paste). **No bond, no deposit.**
 3. Serve calls routed to your endpoint. Each settled call pays you sBTC; \`legion-fees\` skims **8%** into the Legion treasury, so you keep **92%**.
-4. Your \`jobs-ok\` / \`jobs-fail\` counters are your on-chain reliability record. Keep your bond active to stay in the routing pool — a failed job can slash the bond.
 
-> Provider economics: **stake a bond, serve a model, earn 92% per call.** The bond is your skin in the game; the 8% skim funds the Legion's shared treasury.
+### Optional: stake to rank higher
+- \`call_contract\` → \`{owner}.legion-engage\`, function \`join\`, args \`[ {type:"principal", value:"${SBTC_TOKEN}"}, {type:"uint", value:"<sats ≥ get-min-stake>"} ]\`, \`postConditionMode: "deny"\` with an \`ft\` post-condition pinning **your address** sending exactly \`<sats>\` sBTC into \`legion-engage\`.
+- Top up with \`add-stake\`; withdraw with \`leave\` (refunds your stake **minus a 10% exit fee** that routes to the treasury). Staking is optional and never required to earn — it only buys ranking.
+
+> Provider economics: **join free, serve a model, earn 92% per call.** Stake is optional and only buys ranking; the 8% skim funds the Legion's shared treasury.
 
 ## Notes
 - Timing (demand) is **block-based** — always read the windows from \`get-proposal-status\`; never hardcode durations. The current lifecycle runs ~1 hour end to end.

--- a/app/legions/LegionsClient.tsx
+++ b/app/legions/LegionsClient.tsx
@@ -120,9 +120,9 @@ function Header({ errors = 0 }: { errors?: number }) {
         On-chain agent collectives on Stacks testnet. <strong>Demand</strong>{" "}
         Legions pool sBTC into a shared treasury and govern it by stake-weighted
         voting. <strong>Provider</strong> Legions are guilds of inference
-        operators — each stakes a bond, serves a model, and earns sBTC per call,
-        while the Legion&apos;s treasury skims 8%. Pick a Legion to see its live
-        state.
+        operators — anyone joins for free, serves a model, and earns sBTC per
+        call (the Legion&apos;s treasury skims 8%); an optional stake only buys
+        ranking. Pick a Legion to see its live state.
       </p>
       {errors > 0 && (
         <p className="text-xs text-amber-300/70">

--- a/app/legions/[id]/page.tsx
+++ b/app/legions/[id]/page.tsx
@@ -47,7 +47,7 @@ export async function generateMetadata({
     title,
     description:
       entry.kind === "provider"
-        ? `Live dashboard for an AIBTC ${kindLabel} on Stacks testnet — bonded inference operators serving ${entry.model || "a model"}, earning sBTC per call.`
+        ? `Live dashboard for an AIBTC ${kindLabel} on Stacks testnet — free-join inference operators serving ${entry.model || "a model"}, earning sBTC per call (optional stake buys ranking).`
         : `Live dashboard for an AIBTC ${kindLabel} on Stacks testnet — pooled sBTC treasury, stake-weighted members, and the full lifecycle of every governance proposal.`,
   };
 }

--- a/app/legions/page.tsx
+++ b/app/legions/page.tsx
@@ -15,7 +15,7 @@ export const dynamic = "force-dynamic";
 export const metadata: Metadata = {
   title: "Legions",
   description:
-    "Every AIBTC Legion on Stacks testnet — demand Legions that pool and govern an sBTC treasury, and provider Legions whose operators stake a bond to serve AI models and earn sBTC per call.",
+    "Every AIBTC Legion on Stacks testnet — demand Legions that pool and govern an sBTC treasury, and provider Legions whose operators join for free to serve AI models and earn sBTC per call (an optional stake only buys ranking).",
 };
 
 async function getInitialRegistry(): Promise<RegistrySnapshot | null> {

--- a/lib/legion/constants.ts
+++ b/lib/legion/constants.ts
@@ -51,10 +51,32 @@ export type LegionKind = "demand" | "provider";
  * contract: demand uses `legion-gov` (proposals/voting); provider uses
  * `legion-providers` (bonds/members). The registry stores treasury/gov/fees but
  * not the providers contract, so derive it by convention from the owner.
+ *
+ * Kept for back-compat (registry entry shape); v1 no longer reads it for the
+ * provider list — see `legionEngageContract` + the gateway directory.
  */
 export function legionProvidersContract(owner: string): string {
   return `${owner}.legion-providers`;
 }
+
+/**
+ * v1 engagement-stake contract for a provider Legion. Staking is OPTIONAL and
+ * never required to earn — it only buys ranking. Not stored in the registry, so
+ * derived by convention from the owner (only legions whose owner deployed one
+ * will resolve; reads are best-effort and degrade to "unstaked").
+ */
+export function legionEngageContract(owner: string): string {
+  return `${owner}.legion-engage`;
+}
+
+/**
+ * Base URL of the inference gateway whose `GET /v1/providers` directory backs
+ * the v1 provider list (free-join providers + health + flag status). This
+ * gateway serves testnet, so its provider payout addresses match the testnet
+ * `legion-engage` stakes. Overridable per-env via the optional
+ * `LEGION_GATEWAY_URL` Worker var if the gateway ever moves.
+ */
+export const DEFAULT_LEGION_GATEWAY_URL = "https://inference.aibtc.com";
 
 /** sBTC SIP-010 token on testnet (8 decimals). */
 export const SBTC_TOKEN = "STV9K21TBFAK4KNRJXF5DFP8N7W46G4V9RJ5XDY2.sbtc-token";

--- a/lib/legion/engage.ts
+++ b/lib/legion/engage.ts
@@ -1,0 +1,62 @@
+/**
+ * `legion-engage` reads — the v1 optional engagement stake.
+ *
+ * Staking is OPTIONAL and never required to earn; it only buys ranking (the
+ * gateway routes higher-staked providers first, see inference `rankByStake`).
+ * Every read is best-effort: a Legion whose owner never deployed an engage
+ * contract (most of them) degrades to stake 0 / null, never an error.
+ */
+
+import { principalCV } from "@stacks/transactions";
+import { legionReadOnly } from "./stacks";
+import { toNum } from "./format";
+import type { Logger } from "../logging";
+
+/** A provider's optional engagement stake (sats), or 0 if unstaked/unreadable. */
+export async function getStake(
+  engageContract: string,
+  address: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<number> {
+  try {
+    const raw = await legionReadOnly(
+      engageContract,
+      "get-stake",
+      [principalCV(address)],
+      apiKey,
+      logger,
+    );
+    return raw != null ? toNum(raw) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Minimum stake to join `legion-engage` (sats), or null on read failure. */
+export async function getMinStake(
+  engageContract: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<number | null> {
+  try {
+    const raw = await legionReadOnly(engageContract, "get-min-stake", [], apiKey, logger);
+    return raw != null ? toNum(raw) : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Total sBTC staked across all members (sats), or null on read failure. */
+export async function getTotalStaked(
+  engageContract: string,
+  apiKey?: string,
+  logger?: Logger,
+): Promise<number | null> {
+  try {
+    const raw = await legionReadOnly(engageContract, "get-total-staked", [], apiKey, logger);
+    return raw != null ? toNum(raw) : null;
+  } catch {
+    return null;
+  }
+}

--- a/lib/legion/gateway.ts
+++ b/lib/legion/gateway.ts
@@ -1,0 +1,97 @@
+/**
+ * Inference-gateway directory reads (v1 provider source).
+ *
+ * In v1 providers join the gateway for FREE — there is no on-chain bond and no
+ * slash. The gateway's public `GET /v1/providers` is the authoritative provider
+ * list, with health + operator flag status. The landing page overlays each
+ * provider's optional `legion-engage` stake (see lib/legion/engage.ts) for
+ * ranking. All reads here are best-effort: a gateway that is unreachable (e.g.
+ * the testnet gateway isn't deployed yet) degrades to an empty list, never an
+ * error, so the page still renders "no providers yet — join free".
+ */
+
+import { DEFAULT_LEGION_GATEWAY_URL } from "./constants";
+import type { Logger } from "../logging";
+
+/** A provider as listed by the gateway, before the engage-stake overlay. */
+export interface GatewayProvider {
+  /** STX payout address — the key that joins to `legion-engage get-stake`. */
+  address: string;
+  name: string;
+  model: string;
+  endpoint: string;
+  health: string;
+  flagged: boolean;
+}
+
+interface RawGatewayProvider {
+  id?: string;
+  name?: string;
+  endpoint?: string;
+  payoutAddress?: string;
+  models?: Array<{ id?: string }>;
+  health?: { status?: string };
+  status?: string;
+  flagged?: boolean;
+}
+
+/** Normalize a model id/token for fuzzy capability matching ("Qwen/Qwen2.5-7B" → "qwen257b"). */
+function normalizeModel(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+/**
+ * Does this provider serve a Legion's advertised model? Fuzzy: the gateway uses
+ * ids like "Qwen/Qwen2.5-7B-Instruct" while the registry stores "qwen2.5-7b", so
+ * we match on a normalized substring either way. An empty Legion model (or a
+ * provider with no models) matches everything — the shared directory is the
+ * default for a Legion that doesn't pin a capability.
+ */
+export function providerServesModel(provider: GatewayProvider, legionModel: string): boolean {
+  const legion = normalizeModel(legionModel);
+  if (!legion) return true;
+  const model = normalizeModel(provider.model);
+  if (!model) return true;
+  return model.includes(legion) || legion.includes(model);
+}
+
+function normalize(raw: RawGatewayProvider): GatewayProvider | null {
+  const address = typeof raw.payoutAddress === "string" ? raw.payoutAddress : "";
+  if (!address) return null;
+  return {
+    address,
+    name: typeof raw.name === "string" ? raw.name : "",
+    model: raw.models?.[0]?.id ?? "",
+    endpoint: typeof raw.endpoint === "string" ? raw.endpoint : "",
+    health: raw.health?.status ?? raw.status ?? "unknown",
+    flagged: Boolean(raw.flagged),
+  };
+}
+
+/**
+ * Fetch the gateway provider directory. Returns [] on any failure (unreachable
+ * gateway, non-200, malformed body) — callers treat that as "no providers yet".
+ */
+export async function fetchGatewayProviders(
+  gatewayBase: string | undefined,
+  logger?: Logger,
+): Promise<GatewayProvider[]> {
+  const base = (gatewayBase || DEFAULT_LEGION_GATEWAY_URL).replace(/\/$/, "");
+  try {
+    const res = await fetch(`${base}/v1/providers`, {
+      headers: { accept: "application/json" },
+    });
+    if (!res.ok) {
+      logger?.warn?.("legion.gateway_providers_http", { base, status: res.status });
+      return [];
+    }
+    const body = (await res.json()) as { data?: RawGatewayProvider[] };
+    const data = Array.isArray(body?.data) ? body.data : [];
+    return data
+      .map(normalize)
+      .filter((p): p is GatewayProvider => p !== null);
+  } catch (e) {
+    logger?.warn?.("legion.gateway_providers_failed", { base, error: String(e) });
+    return [];
+  }
+}

--- a/lib/legion/providers.ts
+++ b/lib/legion/providers.ts
@@ -1,96 +1,40 @@
 /**
- * Provider-Legion reads. A provider Legion is a guild of inference operators:
- * each stakes a `bond` and serves a model, earning sBTC per call (the Legion's
- * treasury skims 8%). Governed by `legion-providers`, not `legion-gov`.
+ * Provider-Legion reads (v1). A provider Legion is a guild of inference
+ * operators who join the gateway for FREE and earn sBTC per call (the Legion's
+ * treasury skims 8%). There is no bond and no slash: bad providers are handled
+ * by an operator **flag** that de-routes them. An optional on-chain
+ * `legion-engage` stake only buys ranking.
  *
- * Enumerating providers is the one hard part — the on-chain `Providers` map has
- * no "list all". We scan the contract's `register` print events to recover the
- * member set, dedupe, then read each member's current record (brief §3, option
- * (a): event-scan over a cron-tracked index, chosen for v1 because it needs no
- * extra storage).
+ * The provider list comes from the gateway directory (`GET /v1/providers`,
+ * lib/legion/gateway.ts), filtered to those serving this Legion's model, with
+ * each provider's optional engage stake overlaid for ranking. Every read
+ * degrades to a partial snapshot rather than throwing, and a failed build falls
+ * back to `prev` so transient failures never blank good data.
  */
 
-import { principalCV } from "@stacks/transactions";
-import { getContractEvents, getTestnetTipHeight, legionReadOnly } from "./stacks";
-import { get, toNum } from "./format";
+import { getTestnetTipHeight, legionReadOnly } from "./stacks";
+import { toNum } from "./format";
+import { legionEngageContract } from "./constants";
+import { fetchGatewayProviders, providerServesModel } from "./gateway";
+import { getMinStake, getStake, getTotalStaked } from "./engage";
 import type { LegionEntry, ProviderRecord, ProviderSnapshot } from "./types";
 import type { Logger } from "../logging";
 
-const PROVIDER_EVENT_CAP = 300;
-
-/** One provider's current record, or null if unregistered / read failed. */
-export async function getProvider(
-  providersContract: string,
-  address: string,
-  apiKey?: string,
-  logger?: Logger,
-): Promise<ProviderRecord | null> {
-  const raw = await legionReadOnly(
-    providersContract,
-    "get-provider",
-    [principalCV(address)],
-    apiKey,
-    logger,
-  );
-  if (!raw || typeof raw !== "object") return null;
-  return {
-    address,
-    model: String(get(raw, "model") ?? ""),
-    endpoint: String(get(raw, "endpoint") ?? ""),
-    bond: toNum(get(raw, "bond")),
-    active: Boolean(get(raw, "active")),
-    jobsOk: toNum(get(raw, "jobs-ok")),
-    jobsFail: toNum(get(raw, "jobs-fail")),
-  };
-}
-
-/** Minimum bond (sats) to register as a provider, or null on read failure. */
-export async function getMinBond(
-  providersContract: string,
-  apiKey?: string,
-  logger?: Logger,
-): Promise<number | null> {
-  try {
-    const raw = await legionReadOnly(providersContract, "get-min-bond", [], apiKey, logger);
-    return raw != null ? toNum(raw) : null;
-  } catch {
-    return null;
-  }
-}
-
 /**
- * Distinct provider addresses that ever registered, recovered from the
- * contract's `register` print events (newest first, deduped).
- */
-export async function listProviderAddresses(
-  providersContract: string,
-  apiKey?: string,
-  logger?: Logger,
-): Promise<string[]> {
-  const events = await getContractEvents(providersContract, apiKey, logger, PROVIDER_EVENT_CAP);
-  const seen = new Set<string>();
-  for (const ev of events) {
-    if (String(get(ev, "event")) !== "register") continue;
-    const provider = get(ev, "provider");
-    if (typeof provider === "string" && provider) seen.add(provider);
-  }
-  return Array.from(seen);
-}
-
-/**
- * Assemble a full provider-Legion snapshot: treasury balance, min bond, and
- * every registered provider's current record. Mirrors `buildLegionSnapshot`
- * (demand): every read degrades to a partial snapshot rather than throwing, and
- * a failed build falls back to `prev` so transient 429s never blank good data.
+ * Assemble a full provider-Legion snapshot: treasury balance, engage stake
+ * totals, and every gateway provider serving this Legion's model (ranked by
+ * stake). `gatewayBase` overrides the default gateway (point it at the testnet
+ * gateway via the LEGION_GATEWAY_URL Worker var).
  */
 export async function buildProviderSnapshot(
   entry: LegionEntry,
   prev?: ProviderSnapshot | null,
   apiKey?: string,
   logger?: Logger,
+  gatewayBase?: string,
 ): Promise<ProviderSnapshot> {
   const errors: string[] = [];
-  const providersContract = entry.providers ?? `${entry.owner}.legion-providers`;
+  const engageContract = legionEngageContract(entry.owner);
 
   const read = async <T>(label: string, task: () => Promise<T>, fallback: T): Promise<T> => {
     try {
@@ -102,42 +46,63 @@ export async function buildProviderSnapshot(
     }
   };
 
-  const [blockHeight, balanceRaw, minBond, addresses] = await Promise.all([
+  const [blockHeight, balanceRaw, minStake, totalStaked, directory] = await Promise.all([
     read("info.tip", () => getTestnetTipHeight(apiKey, logger), null),
     read(
       "treasury.get-balance",
       () => legionReadOnly(entry.treasury, "get-balance", [], apiKey, logger),
       null,
     ),
-    read("providers.get-min-bond", () => getMinBond(providersContract, apiKey, logger), null),
-    read(
-      "providers.events",
-      () => listProviderAddresses(providersContract, apiKey, logger),
-      [] as string[],
-    ),
+    read("engage.get-min-stake", () => getMinStake(engageContract, apiKey, logger), null),
+    read("engage.get-total-staked", () => getTotalStaked(engageContract, apiKey, logger), null),
+    read("gateway.providers", () => fetchGatewayProviders(gatewayBase, logger), []),
   ]);
 
-  const providers = (
+  const serving = directory.filter((p) => providerServesModel(p, entry.model));
+
+  const providers: ProviderRecord[] = (
     await Promise.all(
-      addresses.map((addr) =>
-        read(
-          `providers.get-provider.${addr}`,
-          () => getProvider(providersContract, addr, apiKey, logger),
-          null,
-        ),
-      ),
+      serving.map(async (p) => {
+        const stake = await read(
+          `engage.get-stake.${p.address}`,
+          () => getStake(engageContract, p.address, apiKey, logger),
+          0,
+        );
+        return {
+          address: p.address,
+          name: p.name,
+          model: p.model,
+          endpoint: p.endpoint,
+          stake,
+          health: p.health,
+          flagged: p.flagged,
+          active: !p.flagged && p.health === "up",
+        };
+      }),
     )
-  )
-    .filter((p): p is ProviderRecord => p !== null)
-    .sort((a, b) => b.bond - a.bond);
+  ).sort((a, b) => b.stake - a.stake);
 
   return {
     updatedAt: Date.now(),
     blockHeight: blockHeight ?? prev?.blockHeight ?? null,
     entry,
     treasuryBalance: balanceRaw != null ? toNum(balanceRaw) : (prev?.treasuryBalance ?? null),
-    minBond: minBond ?? prev?.minBond ?? null,
+    minStake: minStake ?? prev?.minStake ?? null,
+    totalStaked: totalStaked ?? prev?.totalStaked ?? null,
     providers: providers.length > 0 ? providers : (prev?.providers ?? []),
     errors,
   };
+}
+
+/**
+ * Count of providers serving a Legion's model in the gateway directory (for the
+ * `/legions` index). Best-effort: 0 on any failure.
+ */
+export async function countProviders(
+  model: string,
+  gatewayBase?: string,
+  logger?: Logger,
+): Promise<number> {
+  const directory = await fetchGatewayProviders(gatewayBase, logger);
+  return directory.filter((p) => providerServesModel(p, model)).length;
 }

--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -31,6 +31,13 @@ import { DEMAND_LEGION_ID } from "./constants";
 import type { LegionEntry, LegionSnapshot, ProviderSnapshot, RegistrySnapshot } from "./types";
 import type { Logger } from "../logging";
 
+/** Optional per-env override of the inference gateway whose directory backs the
+ * v1 provider list. Unset → the default in lib/legion/constants.ts (which serves
+ * testnet). Set the `LEGION_GATEWAY_URL` Worker var only if the gateway moves. */
+export function legionGatewayUrl(env: CloudflareEnv): string | undefined {
+  return (env as unknown as { LEGION_GATEWAY_URL?: string }).LEGION_GATEWAY_URL;
+}
+
 const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence.
 const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
 
@@ -225,7 +232,8 @@ export function getProviderSnapshot(
     {
       readD1: (db) => readProviderSnapshotFromD1(db, entry.id),
       writeD1: (db, snap) => writeProviderSnapshotToD1(db, entry.id, snap),
-      rebuild: (prev) => buildProviderSnapshot(entry, prev, env.HIRO_API_KEY, logger),
+      rebuild: (prev) =>
+        buildProviderSnapshot(entry, prev, env.HIRO_API_KEY, logger, legionGatewayUrl(env)),
     },
     logger,
   );
@@ -244,7 +252,7 @@ export function getRegistrySnapshot(
     {
       readD1: (db) => readRegistrySnapshotFromD1(db),
       writeD1: (db, snap) => writeRegistrySnapshotToD1(db, snap),
-      rebuild: () => buildRegistrySnapshot(logger, env.HIRO_API_KEY),
+      rebuild: () => buildRegistrySnapshot(logger, env.HIRO_API_KEY, legionGatewayUrl(env)),
     },
     logger,
   );

--- a/lib/legion/snapshot.ts
+++ b/lib/legion/snapshot.ts
@@ -23,7 +23,7 @@ import {
 import { SBTC_TOKEN } from "./constants";
 import { get, toNum } from "./format";
 import { demandFallbackEntry, listLegions } from "./registry";
-import { listProviderAddresses } from "./providers";
+import { countProviders } from "./providers";
 import type {
   LegionEntry,
   LegionMember,
@@ -218,6 +218,7 @@ export async function buildLegionSnapshot(
 export async function buildRegistrySnapshot(
   logger?: Logger,
   apiKey?: string,
+  gatewayBase?: string,
 ): Promise<RegistrySnapshot> {
   const errors: string[] = [];
   const entries = await listLegions(apiKey, logger);
@@ -244,12 +245,9 @@ export async function buildRegistrySnapshot(
           `count.${entry.id}`,
           async () => {
             if (entry.kind === "provider") {
-              const addrs = await listProviderAddresses(
-                entry.providers ?? `${entry.owner}.legion-providers`,
-                apiKey,
-                logger,
-              );
-              return addrs.length;
+              // v1: providers come from the gateway directory (free join), not
+              // the on-chain legion-providers bond contract.
+              return await countProviders(entry.model, gatewayBase, logger);
             }
             const raw = await legionReadOnly(
               entry.gov ?? `${entry.owner}.legion-gov`,

--- a/lib/legion/types.ts
+++ b/lib/legion/types.ts
@@ -58,21 +58,28 @@ export interface RegistrySnapshot {
   errors: string[];
 }
 
-/** One inference provider in a provider Legion (`legion-providers.get-provider`). */
+/**
+ * One inference provider in a provider Legion. In v1 providers join the gateway
+ * for **free** (`GET /v1/providers` on the inference gateway) — there is no bond
+ * and no slash. The optional on-chain `legion-engage` stake only buys ranking.
+ */
 export interface ProviderRecord {
-  /** Provider STX address. */
+  /** Provider STX payout address (joins to `legion-engage get-stake`). */
   address: string;
-  /** Model this provider serves, e.g. "qwen2.5-7b". */
+  /** Human label from the gateway directory, e.g. "biwas qwen model". */
+  name: string;
+  /** Model this provider serves, e.g. "Qwen/Qwen2.5-7B-Instruct". */
   model: string;
   /** Advertised inference endpoint URL. */
   endpoint: string;
-  /** Staked bond (sats). */
-  bond: number;
+  /** Optional engagement stake (sats) from `legion-engage`; 0 if unstaked. */
+  stake: number;
+  /** Gateway health status ("up" | "down" | "unknown"). */
+  health: string;
+  /** Operator-flagged (de-routed everywhere); enforcement is flag, not slash. */
+  flagged: boolean;
+  /** Live + routable: not flagged and healthy. */
   active: boolean;
-  /** Successfully served jobs. */
-  jobsOk: number;
-  /** Failed jobs. */
-  jobsFail: number;
 }
 
 /** Detail snapshot for a provider Legion (mirrors LegionSnapshot for demand). */
@@ -84,9 +91,11 @@ export interface ProviderSnapshot {
   entry: LegionEntry;
   /** Pooled sBTC (sats), or null on read failure. */
   treasuryBalance: number | null;
-  /** Minimum bond to register as a provider (sats), or null. */
-  minBond: number | null;
-  /** Providers sorted by bond descending. */
+  /** Minimum engagement stake to rank (sats) from `legion-engage`, or null. */
+  minStake: number | null;
+  /** Total sBTC staked across all members (sats) from `legion-engage`, or null. */
+  totalStaked: number | null;
+  /** Providers sorted by stake descending (mirrors the gateway's rankByStake). */
   providers: ProviderRecord[];
   errors: string[];
 }

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -35,6 +35,7 @@ import { EARNINGS_INTERVAL_MS } from "../earnings/constants";
 import type { EarningsSweepSummary } from "../earnings/types";
 import { buildLegionSnapshot, buildRegistrySnapshot } from "../legion/snapshot";
 import { buildProviderSnapshot } from "../legion/providers";
+import { legionGatewayUrl } from "../legion/read";
 import { listLegions } from "../legion/registry";
 import {
   readLegionSnapshotFromD1,
@@ -284,9 +285,10 @@ export async function runLegionNow(
     return;
   }
   const apiKey = env.HIRO_API_KEY;
+  const gatewayBase = legionGatewayUrl(env);
 
   // 1. Registry index — backs the /legions list page.
-  const registry = await buildRegistrySnapshot(logger, apiKey);
+  const registry = await buildRegistrySnapshot(logger, apiKey, gatewayBase);
   await writeRegistrySnapshotToD1(db, registry);
   logger.info("legion.registry_written", {
     legions: registry.legions.length,
@@ -301,7 +303,7 @@ export async function runLegionNow(
     try {
       if (entry.kind === "provider") {
         const prev = await readProviderSnapshotFromD1(db, entry.id);
-        const snap = await buildProviderSnapshot(entry, prev, apiKey, logger);
+        const snap = await buildProviderSnapshot(entry, prev, apiKey, logger, gatewayBase);
         await writeProviderSnapshotToD1(db, entry.id, snap);
         logger.info("legion.provider_snapshot_written", {
           id: entry.id,

--- a/wrangler.scheduler.jsonc
+++ b/wrangler.scheduler.jsonc
@@ -18,6 +18,10 @@
     "DEPLOY_ENV": "production",
     "TENERO_REFRESH_ENABLED": "true",
     "EARNINGS_INDEX_ENABLED": "true"
+    // Optional: override the inference gateway whose GET /v1/providers backs the
+    // v1 provider list. Unset → the default in lib/legion/constants.ts
+    // (inference.aibtc.com, which serves testnet). Set only if the gateway moves:
+    // "LEGION_GATEWAY_URL": "https://<gateway-host>"
   },
 
   // Same database_id + KV ids as landing-page → one shared store.


### PR DESCRIPTION
The `/legions` surfaces still described the **old** per-model **bonded**-provider model (bond, slashing, jobs-ok/fail, `legion-providers`). This brings them in line with **v1**:

- Providers **join the gateway for free** — no bond, no deposit.
- Enforcement is **flag + de-route**, not slash.
- An optional **`legion-engage` stake only buys ranking** (refundable minus a 10% exit fee).

## Data layer
- **types**: `ProviderRecord` drops `bond`/`jobsOk`/`jobsFail`, gains `stake`/`health`/`flagged`; `ProviderSnapshot` drops `minBond`, gains `minStake`/`totalStaked`.
- **new `lib/legion/gateway.ts`**: reads the provider directory from the gateway `GET /v1/providers` (best-effort — unreachable gateway → empty list, never an error). Fuzzy-matches providers to a Legion by model.
- **new `lib/legion/engage.ts`**: reads `legion-engage` `get-stake` / `get-min-stake` / `get-total-staked` (best-effort).
- **`providers.ts`**: builds the provider snapshot from the gateway directory + engage-stake overlay, ranked by stake (mirrors the gateway’s `rankByStake`).
- **`snapshot.ts`**: registry-index provider `count` now comes from the gateway directory, not the on-chain `legion-providers` event scan.
- **constants/read/cron**: thread an optional `LEGION_GATEWAY_URL` Worker var (defaults to the testnet gateway in `constants.ts`).

## Scheduler / data
- The **`aibtc-scheduler`** cron (`runLegionNow`) is the sole writer of `legion_snapshots`; it now fetches the gateway directory + engage stakes instead of scanning `legion-providers`. All new reads are best-effort, so a gateway outage degrades to an empty provider list — never a cron failure.
- **No migration**: same D1 table and one-JSON-doc-per-legion shape; only the fields inside `ProviderSnapshot` change. The cron overwrites rows on its next tick; `LegionSummary` (index) and `LegionSnapshot` (demand) are unchanged.

## UI + docs
ProvidersTable (Bond→Stake, drop jobs, flag status) · ProviderClient · HowToProvide (free register + optional stake step) · LegionsClient header · risks page · `skill.md` provider section · `/legions` + detail metadata · `/api/legions` docs.

## Verification
- `tsc --noEmit`: 0 errors in the legion code (pre-existing `__tests__` errors are unrelated).
- `next lint` on the legion dirs: clean.

Pairs with inference PRs #4 (free-join + stake-ranking, merged) and #5 (switch gateway to testnet). Once the gateway serves testnet, the directory payout addresses line up with the testnet `legion-engage` stakes end-to-end.