### PR TITLE
feat: surface governed per-model legions + TESTNET badges

### DIFF
--- a/app/legion/LegionHeader.tsx
+++ b/app/legion/LegionHeader.tsx
@@ -57,6 +57,10 @@ export default function LegionHeader({ snapshot }: { snapshot: LegionSnapshot })
           </span>
         </div>
         <div className="flex items-center gap-3">
+          <span className="inline-flex items-center gap-1.5 rounded-full border border-[#F7931A]/40 bg-[#F7931A]/10 px-2 py-0.5 text-[9px] font-semibold uppercase tracking-[0.12em] text-[#F7931A]">
+            <span className="h-1 w-1 rounded-full bg-[#F7931A]" aria-hidden />
+            Testnet
+          </span>
           <WiringDot label="gov" ok={treasury.govWired} />
           <WiringDot label="token" ok={treasury.tokenWired} />
         </div>

--- a/app/legions/LegionsClient.tsx
+++ b/app/legions/LegionsClient.tsx
@@ -73,7 +73,7 @@ function LegionCard({ legion }: { legion: LegionSummary }) {
       </div>
 
       <div className="border-t border-white/[0.06] pt-3 text-[11px] text-white/40">
-        Admin{" "}
+        Owner{" "}
         <span className="font-mono text-white/60" title={legion.owner}>
           {shortAddress(legion.owner, 6, 4)}
         </span>
@@ -115,14 +115,18 @@ export default function LegionsClient({
 function Header({ errors = 0 }: { errors?: number }) {
   return (
     <header className="space-y-3">
-      <h1 className="text-3xl font-bold max-md:text-2xl">AIBTC Legions</h1>
+      <div className="flex flex-wrap items-center gap-3">
+        <h1 className="text-3xl font-bold max-md:text-2xl">AIBTC Legions</h1>
+        <TestnetBadge />
+      </div>
       <p className="max-w-2xl text-sm leading-relaxed text-white/60">
-        On-chain agent collectives on Stacks testnet. <strong>Demand</strong>{" "}
-        Legions pool sBTC into a shared treasury and govern it by stake-weighted
-        voting. <strong>Provider</strong> Legions are guilds of inference
-        operators — anyone joins for free, serves a model, and earns sBTC per
-        call (the Legion&apos;s treasury skims 8%); an optional stake only buys
-        ranking. Pick a Legion to see its live state.
+        On-chain agent collectives on Stacks <strong>testnet</strong> — no real
+        funds. <strong>Demand</strong> Legions pool sBTC into a shared treasury and
+        govern it by stake-weighted voting. <strong>Provider</strong> Legions are
+        per-model guilds: a provider stakes a bond to join — unlocking higher
+        ranking, a share of that model&apos;s treasury, and governance (propose +
+        vote) — with a 10% exit fee and the rest refundable. Pick a Legion to see
+        its live state.
       </p>
       {errors > 0 && (
         <p className="text-xs text-amber-300/70">
@@ -131,5 +135,15 @@ function Header({ errors = 0 }: { errors?: number }) {
         </p>
       )}
     </header>
+  );
+}
+
+/** Shared TESTNET pill so it's unmistakable this isn't mainnet. */
+export function TestnetBadge() {
+  return (
+    <span className="inline-flex items-center gap-1.5 rounded-full border border-[#F7931A]/40 bg-[#F7931A]/10 px-2.5 py-1 text-[10px] font-semibold uppercase tracking-[0.12em] text-[#F7931A]">
+      <span className="h-1.5 w-1.5 rounded-full bg-[#F7931A]" aria-hidden />
+      Testnet
+    </span>
   );
 }

--- a/app/legions/[id]/page.tsx
+++ b/app/legions/[id]/page.tsx
@@ -64,7 +64,11 @@ export default async function LegionDetailPage({
   let body: React.ReactNode;
   try {
     const { env, ctx } = await getCloudflareContext();
-    if (entry.kind === "provider") {
+    // A governed legion (has a gov contract) renders the governance view —
+    // proposals + members + stake. This covers demand clubs AND the new per-model
+    // provider legions (provider kind, but governed: stake -> propose/vote). Only
+    // an ungoverned provider legion falls back to the provider-directory view.
+    if (entry.kind === "provider" && !entry.gov) {
       const snapshot = await getProviderSnapshot(env, ctx, entry);
       body = <ProviderClient snapshot={snapshot} />;
     } else {
@@ -73,7 +77,7 @@ export default async function LegionDetailPage({
     }
   } catch {
     body =
-      entry.kind === "provider" ? (
+      entry.kind === "provider" && !entry.gov ? (
         <ProviderClient snapshot={null} />
       ) : (
         <LegionClient snapshot={null} entry={entry} />

--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -38,8 +38,8 @@ export function legionGatewayUrl(env: CloudflareEnv): string | undefined {
   return (env as unknown as { LEGION_GATEWAY_URL?: string }).LEGION_GATEWAY_URL;
 }
 
-const CACHE_TTL_SECONDS = 1800; // 30 min — matches the cron cadence.
-const STALE_MS = 30 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
+const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence (*/5 in wrangler.scheduler.jsonc).
+const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
 
 type WithUpdatedAt = { updatedAt: number };
 type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;

--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -38,8 +38,8 @@ export function legionGatewayUrl(env: CloudflareEnv): string | undefined {
   return (env as unknown as { LEGION_GATEWAY_URL?: string }).LEGION_GATEWAY_URL;
 }
 
-const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence.
-const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
+const CACHE_TTL_SECONDS = 1800; // 30 min — matches the cron cadence.
+const STALE_MS = 30 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
 
 type WithUpdatedAt = { updatedAt: number };
 type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;

--- a/lib/legion/registry.ts
+++ b/lib/legion/registry.ts
@@ -62,13 +62,16 @@ export function demandFallbackEntry(): LegionEntry {
  * detail page can render without a fresh Hiro round-trip.
  */
 export function entryFromSummary(summary: LegionSummary): LegionEntry {
+  // Prefer the explicit contract ids carried on the summary (per-model legions
+  // use suffixed names under one owner). Fall back to the `{owner}.legion-*`
+  // convention for back-compat with summaries written before those fields.
   return {
     id: summary.id,
     kind: summary.kind,
     owner: summary.owner,
-    treasury: `${summary.owner}.legion-treasury`,
-    gov: summary.kind === "demand" ? `${summary.owner}.legion-gov` : null,
-    fees: `${summary.owner}.legion-fees`,
+    treasury: summary.treasury || `${summary.owner}.legion-treasury`,
+    gov: summary.gov ?? (summary.kind === "demand" ? `${summary.owner}.legion-gov` : null),
+    fees: summary.fees ?? `${summary.owner}.legion-fees`,
     providers: summary.kind === "provider" ? legionProvidersContract(summary.owner) : null,
     model: summary.model,
     uri: summary.uri,
@@ -88,8 +91,12 @@ function parseRegistryEntry(id: number, raw: unknown): LegionEntry | null {
     id: String(id),
     kind,
     owner,
+    // Use the registry's EXPLICIT contract ids — per-model legions are deployed
+    // under one owner with suffixed names (legion-{treasury,gov,fees}-<model>),
+    // so the `{owner}.legion-*` convention no longer holds. gov is honored for
+    // every kind: a provider legion can be governed (stake -> propose/vote).
     treasury: str(t.treasury) || `${owner}.legion-treasury`,
-    gov: kind === "demand" ? str(t.gov) || null : null,
+    gov: str(t.gov) || (kind === "demand" ? `${owner}.legion-gov` : null),
     fees: str(t.fees) || null,
     providers: kind === "provider" ? legionProvidersContract(owner) : null,
     model: str(t.model),

--- a/lib/legion/snapshot.ts
+++ b/lib/legion/snapshot.ts
@@ -270,6 +270,11 @@ export async function buildRegistrySnapshot(
         active: entry.active,
         treasuryBalance: balanceRaw != null ? toNum(balanceRaw) : null,
         count,
+        // carry the explicit contract ids so the detail page resolves suffixed
+        // per-model contracts from the cached index (no Hiro round-trip).
+        treasury: entry.treasury,
+        gov: entry.gov,
+        fees: entry.fees,
         source: entry.source,
       };
     }),

--- a/lib/legion/types.ts
+++ b/lib/legion/types.ts
@@ -47,6 +47,16 @@ export interface LegionSummary {
   treasuryBalance: number | null;
   /** #providers (provider) or #proposals (demand), or null if unread. */
   count: number | null;
+  /**
+   * Explicit contract ids from the registry so the detail page can resolve a
+   * Legion from the cached index without a Hiro round-trip. Needed now that
+   * per-model legions use suffixed names (legion-{treasury,gov,fees}-<model>)
+   * under one owner — the `{owner}.legion-*` convention no longer holds.
+   * Optional for back-compat with snapshots written before this field existed.
+   */
+  treasury?: string;
+  gov?: string | null;
+  fees?: string | null;
   source: "registry" | "fallback";
 }
 


### PR DESCRIPTION
Surfaces the 7 governed per-model provider legions in the UI and marks the whole surface as testnet.

## Changes
- **Registry / types / snapshot** carry explicit `treasury`/`gov`/`fees` contract ids — per-model legions use suffixed names (`legion-{treasury,gov,fees}-<family>`) so the `{owner}.legion-*` convention no longer holds; the detail page resolves the right contracts from the cached index.
- **Detail route** (`app/legions/[id]/page.tsx`): a provider legion *with* a gov contract renders the governance view (proposals + members + stake). Only an ungoverned provider legion falls back to the directory view. So a model legion shows its proposals.
- **TESTNET pill** on the `/legions` header and the legion detail header.
- **Copy**: provider legions described as per-model guilds (stake bond → ranking + treasury share + governance, 10% exit fee, rest refundable); Admin → Owner.
- **Cache/cron cadence** 5m → 30m.

Demand (news) legion and its proposals are untouched.
