### PR TITLE
fix: cron builds governance snapshot for governed provider legions

### DIFF
--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -301,7 +301,14 @@ export async function runLegionNow(
   for (const entry of entries) {
     if (!entry.active) continue;
     try {
-      if (entry.kind === "provider") {
+      // Build the detail snapshot the page actually reads. The page routes by
+      // governance: a legion WITH a gov contract renders the governance view
+      // (getLegionSnapshot → proposals + members + stake), so the cron must build a
+      // LegionSnapshot for it (which reads the gov contract). Only an UNGOVERNED
+      // provider legion gets the provider-directory snapshot. Keying off `kind`
+      // alone built a provider snapshot for governed model legions, so the gov was
+      // never read and `proposals`/`members` were never written.
+      if (entry.kind === "provider" && !entry.gov) {
         const prev = await readProviderSnapshotFromD1(db, entry.id);
         const snap = await buildProviderSnapshot(entry, prev, apiKey, logger, gatewayBase);
         await writeProviderSnapshotToD1(db, entry.id, snap);


### PR DESCRIPTION
**Bug:** `/legions/<id>` for a per-model legion crashed client-side (`undefined` reading `proposals`).

**Cause:** the page routes a legion to the governance view by **gov contract** (`getLegionSnapshot` → proposals/members), but `cron-runner` picked the snapshot type by **kind** alone. A governed *provider* legion (the model legions: `kind: provider`, but staked/proposable/votable) took the `buildProviderSnapshot` branch, which never reads the gov — so `proposals`/`members` were never written. The page then read a provider-shaped row from the shared `snapshot/<id>` key and crashed on `undefined.proposals`.

**Fix:** gate the provider branch on `kind === "provider" && !entry.gov`, so a governed legion follows the **same `buildLegionSnapshot` path the demand legion always has**. `buildLegionSnapshot` already reads `entry.gov`/`entry.treasury`, so it builds the right per-model data. No UI changes.