### PR TITLE
chore: legion cron 5m -> 15m (cut Hiro usage)

### DIFF
--- a/lib/legion/read.ts
+++ b/lib/legion/read.ts
@@ -38,8 +38,8 @@ export function legionGatewayUrl(env: CloudflareEnv): string | undefined {
   return (env as unknown as { LEGION_GATEWAY_URL?: string }).LEGION_GATEWAY_URL;
 }
 
-const CACHE_TTL_SECONDS = 300; // 5 min — matches the cron cadence (*/5 in wrangler.scheduler.jsonc).
-const STALE_MS = 5 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
+const CACHE_TTL_SECONDS = 900; // 15 min — matches the cron cadence (*/15 in wrangler.scheduler.jsonc).
+const STALE_MS = 15 * 60 * 1000; // rebuild from Hiro once the D1 row is older than this.
 
 type WithUpdatedAt = { updatedAt: number };
 type Ctx = { waitUntil?: (p: Promise<unknown>) => void } | undefined;

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -301,7 +301,14 @@ export async function runLegionNow(
   for (const entry of entries) {
     if (!entry.active) continue;
     try {
-      if (entry.kind === "provider") {
+      // Build the detail snapshot the page actually reads. The page routes by
+      // governance: a legion WITH a gov contract renders the governance view
+      // (getLegionSnapshot → proposals + members + stake), so the cron must build a
+      // LegionSnapshot for it (which reads the gov contract). Only an UNGOVERNED
+      // provider legion gets the provider-directory snapshot. Keying off `kind`
+      // alone built a provider snapshot for governed model legions, so the gov was
+      // never read and `proposals`/`members` were never written.
+      if (entry.kind === "provider" && !entry.gov) {
         const prev = await readProviderSnapshotFromD1(db, entry.id);
         const snap = await buildProviderSnapshot(entry, prev, apiKey, logger, gatewayBase);
         await writeProviderSnapshotToD1(db, entry.id, snap);

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -62,7 +62,7 @@ import type {
 export const TENERO_INTERVAL_MS = 60 * 60 * 1000;
 export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
 // Legion dashboard snapshot refreshes every cron tick (testnet, low volume).
-export const LEGION_INTERVAL_MS = 5 * 60 * 1000;
+export const LEGION_INTERVAL_MS = 15 * 60 * 1000;
 
 // KV keys (VERIFIED_AGENTS namespace).
 const K_TENERO = "scheduler:tenero";

--- a/wrangler.scheduler.jsonc
+++ b/wrangler.scheduler.jsonc
@@ -11,7 +11,7 @@
   "compatibility_flags": ["nodejs_compat"],
 
   "triggers": {
-    "crons": ["*/5 * * * *"]
+    "crons": ["*/15 * * * *"]
   },
 
   "vars": {


### PR DESCRIPTION
The legion snapshot rebuild is the only Hiro consumer and runs every cron tick unthrottled. Other tasks already self-gate at >=15m (competition 15m, earnings 30m, tenero hourly), so widening the cron `*/5` -> `*/15` only slows the legion task (3x fewer Hiro reads) with no effect on the rest. Read-side cache window + `LEGION_INTERVAL_MS` aligned to 15m so off-tick page reads don't trigger extra Hiro rebuilds.