### PR TITLE
fix: inbox drift (#995), legion faucet (#1016), challenge hardening (#770), competition sweep gate (#933), tenero token-set observability (#1025)

### DIFF
--- a/app/api/challenge/route.ts
+++ b/app/api/challenge/route.ts
@@ -17,6 +17,7 @@ import {
   getAvailableActions,
 } from "@/lib/challenge";
 import { verifyBitcoinSignature } from "@/lib/bitcoin-verify";
+import { shouldFailClosed } from "@/lib/env";
 import { updateAgentInD1 } from "@/lib/d1/agents-mirror";
 import {
   publicKeyFromSignatureRsv,
@@ -188,21 +189,38 @@ export async function GET(request: NextRequest) {
     const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
-    // Rate limiting via RATE_LIMIT_STRICT binding (1 req / 60s). Mirrors inbox fail-open/fail-closed.
-    // Semantics change from prior 6/10min KV-RMW documented in PR #769.
-    const ip = request.headers.get("cf-connecting-ip") || request.headers.get("x-forwarded-for") || "unknown";
+    // Rate limiting via RATE_LIMIT_STRICT binding (1 req / 60s). Mirrors the
+    // inbox/outbox fail-open/fail-closed pattern. Semantics change from prior
+    // 6/10min KV-RMW documented in PR #769; hardening from #770.
+    //
+    // IP derivation: on a Cloudflare Worker `cf-connecting-ip` is always injected
+    // by the edge and cannot be client-overridden, so it is the only trustworthy
+    // source. `x-forwarded-for` is client-spoofable and is only honored in local
+    // dev (where cf-connecting-ip is absent) so an attacker can't shard themselves
+    // into fresh buckets. When no IP is available we skip the limit rather than
+    // collapse every caller into one shared "unknown" bucket (self-DoS).
+    const ip =
+      request.headers.get("cf-connecting-ip") ||
+      (shouldFailClosed(env) ? null : request.headers.get("x-forwarded-for"));
     let rateLimited = false;
-    try {
-      const { success } = await env.RATE_LIMIT_STRICT.limit({ key: `challenge:${ip}` });
-      rateLimited = !success;
-    } catch {
-      // Binding unavailable. Fail closed in production/preview to preserve the prior
-      // KV-backed limit's security guarantee; fail open only in local dev (no DEPLOY_ENV).
-      if (env.DEPLOY_ENV) {
-        return NextResponse.json(
-          { error: "Rate limit unavailable. Please try again." },
-          { status: 503 }
-        );
+    if (ip) {
+      try {
+        const { success } = await env.RATE_LIMIT_STRICT.limit({ key: `challenge:${ip}` });
+        rateLimited = !success;
+      } catch {
+        // Binding unavailable. Fail closed in production/preview to preserve the
+        // prior KV-backed limit's security guarantee; fail open only in local dev.
+        // shouldFailClosed() (not `if (env.DEPLOY_ENV)`) so an empty-string
+        // DEPLOY_ENV still fails closed instead of silently failing open.
+        if (shouldFailClosed(env)) {
+          return NextResponse.json(
+            { error: "Rate limit unavailable. Please try again." },
+            {
+              status: 503,
+              headers: { "Retry-After": String(RATE_LIMIT_RETRY_AFTER) },
+            }
+          );
+        }
       }
     }
 

--- a/app/api/competition/tracked-tokens/route.ts
+++ b/app/api/competition/tracked-tokens/route.ts
@@ -1,5 +1,5 @@
 // CACHE_INVARIANTS:POSTURE=public-only-get
-// Public read of the dynamic token set the SchedulerDO refreshes Tenero
+// Public read of the dynamic token set the cron task refreshes Tenero
 // prices for. Derived from the `swaps` table on each request — see
 // `lib/external/tenero/tokens.ts:getActiveTokenIds`. Read-only, no auth.
 
@@ -17,7 +17,7 @@ function selfDocResponse() {
       endpoint: "/api/competition/tracked-tokens",
       method: "GET",
       description:
-        "The Tenero refresh set the SchedulerDO uses on each tick. Union of the always-include static core and distinct token_in / token_out from successful agent/cron swaps in D1, junk-filtered for shape, ranked by trade count, capped at MAX_TRACKED_TOKENS. Falls back to the static core on D1 query failure.",
+        "The Tenero refresh set the cron task uses on each tick. Union of the always-include static core and distinct token_in / token_out from successful agent/cron swaps in D1, junk-filtered for shape, ranked by trade count, capped at MAX_TRACKED_TOKENS. Falls back to the static core on D1 query failure.",
       queryParameters: {
         docs: {
           type: "string",
@@ -29,7 +29,7 @@ function selfDocResponse() {
         tokens: "string[] — the active set (static core ∪ dynamic discovery)",
         count: "number — length of tokens",
         source:
-          "'dynamic' when D1 derivation succeeded, 'static-fallback' on failure or missing binding",
+          "'dynamic' when D1 derivation added tokens, 'static-fallback' when the core is the whole set (empty table / full dedup / missing binding), 'db-error' when the D1 query threw and we fell back",
         staticCore: "string[] — the always-include core that backs the fallback",
         maxTracked: "number — upper bound on dynamic discovery per tick (MAX_TRACKED_TOKENS)",
       },
@@ -41,7 +41,7 @@ function selfDocResponse() {
       notes: [
         "Dynamic discovery falls back to STATIC_TOKEN_IDS when there's no DB binding or the query throws.",
         "Tokens are ordered with the static core first, then dynamic entries by descending trade count.",
-        "The set is recomputed on each SchedulerDO tick (5 min cadence); this endpoint reports what the *next* tick would use.",
+        "The set is recomputed on each cron refresh tick; this endpoint reports what the *next* tick would use.",
       ],
     },
     {
@@ -59,16 +59,18 @@ export async function GET(request: NextRequest) {
 
   const { env } = await getCloudflareContext({ async: true });
   const db = env.DB as D1Database | undefined;
-  const tokens = await getActiveTokenIds(db);
+  const { tokenIds: tokens, degraded } = await getActiveTokenIds(db);
 
-  // `getActiveTokenIds` falls back to STATIC_TOKEN_IDS on any failure; we
-  // can't distinguish "fallback" from "static core happened to win" without
-  // a side-channel, so the heuristic is: if the result has more tokens than
-  // the static core, dynamic discovery added something; if it equals the
-  // core exactly we couldn't add anything (could be empty table OR DB error
-  // — both are functionally "static-fallback" from a consumer perspective).
-  const source: "dynamic" | "static-fallback" =
-    tokens.length > STATIC_TOKEN_IDS.length ? "dynamic" : "static-fallback";
+  // `getActiveTokenIds` reports `degraded: true` when the D1 lookup threw and it
+  // fell back to the static core (#1025) — that's now distinguishable from a
+  // legitimate static-only result. Otherwise: more tokens than the core means
+  // dynamic discovery added something; exactly the core means an empty table or
+  // full dedup.
+  const source: "dynamic" | "static-fallback" | "db-error" = degraded
+    ? "db-error"
+    : tokens.length > STATIC_TOKEN_IDS.length
+      ? "dynamic"
+      : "static-fallback";
 
   return NextResponse.json(
     {

--- a/app/api/inbox/[address]/__tests__/unread-counter-drift-selfheal.test.ts
+++ b/app/api/inbox/[address]/__tests__/unread-counter-drift-selfheal.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Issue #995 — unreadCount counter drift self-heal regression test.
+ *
+ * The maintained agent_inbox_stats.unread_count can drift above the actual
+ * count of unread message rows (the write-path bump/decrement helpers are
+ * best-effort, fire-and-forget with swallowed errors). When it does, the GET
+ * handler returns phantom unreads that no PATCH can clear because they exist
+ * only in the counter, not as message rows.
+ *
+ * The GET handler self-heals: when the unread view is fetched at offset 0 and
+ * the first page is not full, the entire unread set has been enumerated, so the
+ * true unread count is exactly the number of returned rows. When the counter
+ * disagrees, the handler recomputes this agent's stats and returns the
+ * corrected values.
+ *
+ * See: app/api/inbox/[address]/route.ts (GET self-heal) and
+ * lib/inbox/stats.ts (recomputeAgentStats).
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import { NextRequest } from "next/server";
+
+// ---- module mocks (must be declared before route imports) -------------------
+
+vi.mock("@opennextjs/cloudflare", () => ({
+  getCloudflareContext: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-lookup", () => ({
+  lookupAgent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  listInboxMessagesFromD1: vi.fn(),
+  listOutboxRepliesFromD1: vi.fn(),
+  fetchRepliesForMessages: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/stats", () => ({
+  getAgentInboxStats: vi.fn(),
+  recomputeAgentStats: vi.fn(),
+  bumpInboundStats: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/cache", () => ({
+  invalidateAgentListCache: vi.fn(),
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+  isLogsRPC: () => false,
+}));
+
+vi.mock("@/lib/inbox", () => ({
+  validateInboxMessage: vi.fn(),
+  verifyInboxPayment: vi.fn(),
+  verifyTxidPayment: vi.fn(),
+  storeMessage: vi.fn(),
+  storeStagedInboxPayment: vi.fn(),
+  updateAgentInbox: vi.fn(),
+  updateSentIndex: vi.fn(),
+  INBOX_PRICE_SATS: 100,
+  REDEEMED_TXID_TTL_SECONDS: 7776000,
+  RELAY_CIRCUIT_BREAKER_RETRY_AFTER_SECONDS: 300,
+  buildInboxPaymentRequirements: vi.fn(),
+  buildSenderAuthMessage: vi.fn(),
+  DEFAULT_RELAY_URL: "https://x402-relay.aibtc.com",
+  enqueueInboxReconciliation: vi.fn(),
+}));
+
+vi.mock("@/lib/bitcoin-verify", () => ({
+  verifyBitcoinSignature: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/payment-logging", () => ({
+  getPaymentRepoVersion: vi.fn().mockReturnValue("1.0.0"),
+  logPaymentEvent: vi.fn(),
+}));
+
+vi.mock("@/lib/inbox/d1-dual-write", () => ({
+  insertInboundMessageToD1: vi.fn().mockResolvedValue({ changes: 1 }),
+  isPaymentTxidUniqueViolation: () => false,
+}));
+
+// ---- imports after mocks ----------------------------------------------------
+
+import { GET } from "../route";
+import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { lookupAgent } from "@/lib/agent-lookup";
+import {
+  listInboxMessagesFromD1,
+  listOutboxRepliesFromD1,
+  fetchRepliesForMessages,
+} from "@/lib/inbox/d1-reads";
+import { getAgentInboxStats, recomputeAgentStats } from "@/lib/inbox/stats";
+
+// ---- shared fixtures --------------------------------------------------------
+
+const TEST_ADDR = "bc1qxj5jtv8jwm7zv2nczn2xfq9agjgj0sqpsxn43h";
+const TEST_AGENT = {
+  btcAddress: TEST_ADDR,
+  stxAddress: "SP3EPDH1E2Y1M4W5GCK4YEJPQ9VW3APJB4Z1QEBNC",
+  pubKey: "02deadbeef".padEnd(66, "0"),
+  registeredAt: "2026-03-01T00:00:00.000Z",
+  level: 2,
+};
+
+function buildUnreadRequest(): NextRequest {
+  return new NextRequest(
+    `https://aibtc.com/api/inbox/${TEST_ADDR}?status=unread&limit=10`,
+    { method: "GET" }
+  );
+}
+
+function buildContext() {
+  return { params: Promise.resolve({ address: TEST_ADDR }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+
+  (getCloudflareContext as Mock).mockReturnValue({
+    env: {
+      DB: { prepare: vi.fn() } as unknown as D1Database,
+      VERIFIED_AGENTS: {} as KVNamespace,
+    },
+    ctx: { waitUntil: vi.fn() },
+  });
+
+  (lookupAgent as Mock).mockResolvedValue(TEST_AGENT);
+  (fetchRepliesForMessages as Mock).mockResolvedValue(new Map());
+  (listOutboxRepliesFromD1 as Mock).mockResolvedValue([]);
+});
+
+describe("Issue #995 — unreadCount drift self-heal", () => {
+  it("recomputes and returns the corrected count when the counter drifts above the actual unread rows", async () => {
+    // Counter claims 3 unread, but the unread list (offset 0, non-full page) is empty.
+    (getAgentInboxStats as Mock).mockResolvedValue({
+      receivedCount: 23,
+      unreadCount: 3,
+      sentCount: 17,
+      lastMessageAt: "2026-06-11T17:38:00.000Z",
+      lastSentAt: "2026-06-11T17:38:00.000Z",
+    });
+    (listInboxMessagesFromD1 as Mock).mockResolvedValue([]); // no unread rows exist
+    (recomputeAgentStats as Mock).mockResolvedValue({
+      receivedCount: 23,
+      unreadCount: 0,
+      sentCount: 17,
+      lastMessageAt: "2026-06-11T17:38:00.000Z",
+      lastSentAt: "2026-06-11T17:38:00.000Z",
+    });
+
+    const res = await GET(buildUnreadRequest(), buildContext());
+
+    expect(res.status).toBe(200);
+    expect(recomputeAgentStats).toHaveBeenCalledWith(expect.anything(), TEST_ADDR);
+    const body = await res.json();
+    expect(body.inbox.unreadCount).toBe(0);
+    // status=unread → totalCount tracks the unread predicate
+    expect(body.inbox.totalCount).toBe(0);
+  });
+
+  it("does NOT recompute when the counter matches the enumerated unread rows", async () => {
+    (getAgentInboxStats as Mock).mockResolvedValue({
+      receivedCount: 5,
+      unreadCount: 2,
+      sentCount: 0,
+      lastMessageAt: "2026-06-11T17:38:00.000Z",
+      lastSentAt: null,
+    });
+    // Two unread rows returned on a non-full page — matches the counter.
+    (listInboxMessagesFromD1 as Mock).mockResolvedValue([
+      { messageId: "m1", fromAddress: TEST_AGENT.stxAddress, sentAt: "2026-06-11T10:00:00.000Z" },
+      { messageId: "m2", fromAddress: TEST_AGENT.stxAddress, sentAt: "2026-06-11T11:00:00.000Z" },
+    ]);
+
+    const res = await GET(buildUnreadRequest(), buildContext());
+
+    expect(res.status).toBe(200);
+    expect(recomputeAgentStats).not.toHaveBeenCalled();
+    const body = await res.json();
+    expect(body.inbox.unreadCount).toBe(2);
+  });
+
+  it("does NOT recompute on a full page (cannot prove the unread set is fully enumerated)", async () => {
+    (getAgentInboxStats as Mock).mockResolvedValue({
+      receivedCount: 30,
+      unreadCount: 25,
+      sentCount: 0,
+      lastMessageAt: "2026-06-11T17:38:00.000Z",
+      lastSentAt: null,
+    });
+    // A full page (limit=10) — more unread rows may exist beyond this page.
+    (listInboxMessagesFromD1 as Mock).mockResolvedValue(
+      Array.from({ length: 10 }, (_, i) => ({
+        messageId: `m${i}`,
+        fromAddress: TEST_AGENT.stxAddress,
+        sentAt: "2026-06-11T10:00:00.000Z",
+      }))
+    );
+
+    const res = await GET(buildUnreadRequest(), buildContext());
+
+    expect(res.status).toBe(200);
+    expect(recomputeAgentStats).not.toHaveBeenCalled();
+  });
+});

--- a/app/api/inbox/[address]/route.ts
+++ b/app/api/inbox/[address]/route.ts
@@ -31,7 +31,7 @@ import {
   logPaymentEvent,
 } from "@/lib/inbox/payment-logging";
 import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "@/lib/inbox/d1-dual-write";
-import { bumpInboundStats, getAgentInboxStats } from "@/lib/inbox/stats";
+import { bumpInboundStats, getAgentInboxStats, recomputeAgentStats } from "@/lib/inbox/stats";
 import {
   listInboxMessagesFromD1,
   listSentMessagesFromD1,
@@ -187,9 +187,13 @@ export async function GET(
   { params }: { params: Promise<{ address: string }> }
 ) {
   const { address } = await params;
-  const { env } = await getCloudflareContext();
+  const { env, ctx } = await getCloudflareContext();
   const kv = env.VERIFIED_AGENTS as KVNamespace;
   const db = env.DB as D1Database | undefined;
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+    : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
 
   // Look up agent
   const agent = await lookupAgent(kv, address, db);
@@ -396,6 +400,40 @@ export async function GET(
     ]);
   } catch (e) {
     return d1TransientResponse("Inbox database temporarily unavailable. Please retry shortly.");
+  }
+
+  // Self-heal unread-counter drift (issue #995). When the unread view is
+  // fetched at offset 0 and the first page is not full, we have enumerated the
+  // entire unread set, so the true unread count is exactly receivedMessages.length
+  // — for free, with no extra query. The maintained unread_count is best-effort
+  // (write-path bump/decrement are fire-and-forget with swallowed errors), so a
+  // dropped decrement leaves it over-counted, surfacing as phantom unreads that
+  // no PATCH can clear (they exist only in the counter, not as message rows).
+  // When we can prove drift, recompute this one agent's stats and use the
+  // corrected values. This runs only on the (rare) drifted request, so it does
+  // not reintroduce a COUNT(*) hot path.
+  if (
+    db &&
+    includeReceived &&
+    statusFilter === "unread" &&
+    offset === 0 &&
+    receivedMessages.length < limit &&
+    agentStats.unreadCount !== receivedMessages.length
+  ) {
+    logger.warn("inbox.unread_counter_drift_detected", {
+      btcAddress: agent.btcAddress,
+      counterUnread: agentStats.unreadCount,
+      actualUnread: receivedMessages.length,
+    });
+    try {
+      agentStats = await recomputeAgentStats(db, agent.btcAddress);
+    } catch (e) {
+      // Fail-open: keep the (possibly drifted) counter rather than 500.
+      logger.error("inbox.unread_counter_recompute_failed", {
+        btcAddress: agent.btcAddress,
+        error: String(e),
+      });
+    }
   }
 
   const unreadCount = agentStats.unreadCount;

--- a/app/legion/HowToProvide.tsx
+++ b/app/legion/HowToProvide.tsx
@@ -64,8 +64,10 @@ export default function HowToProvide({
       body: (
         <>
           Staking is <strong>optional</strong> and never required to earn — it only
-          buys ranking. Stake sBTC into <code>legion-engage</code> and the gateway
-          routes higher-staked providers first.
+          buys ranking. Need testnet sBTC first? Call <code>faucet</code> on the
+          sBTC token to fund your wallet — it mints to you, so nothing leaves it.
+          Then stake sBTC into <code>legion-engage</code> and the gateway routes
+          higher-staked providers first.
           <span className="mt-2 flex items-center gap-2">
             <code className="flex-1 break-all">{stakeCmd}</code>
             <CopyButton text={stakeCmd} variant="icon" label="" ariaLabel="Copy stake command" />

--- a/cloudflare-env.d.ts
+++ b/cloudflare-env.d.ts
@@ -28,4 +28,5 @@ interface CloudflareEnv {
   TENERO_REFRESH_ENABLED?: "true"; // Explicit production-only gate for the cron Tenero refresh
   TENERO_API_KEY?: string; // Optional Tenero API key (x-api-key header); raises rate limits above the shared web-ui-ip tier
   EARNINGS_INDEX_ENABLED?: "true"; // Gate for the cron earnings indexer (issue #978); ships dormant, set "true" to enable
+  COMPETITION_SWEEP_ENABLED?: "true" | "false"; // Kill-switch for the cron competition Hiro catch-up sweep (issue #933); defaults ON, set "false" to disable
 }

--- a/lib/competition/scheduler.ts
+++ b/lib/competition/scheduler.ts
@@ -79,6 +79,24 @@ interface AddressTxEntry {
   };
 }
 
+/**
+ * Zeroed summary returned when the sweep is skipped (e.g. gated off via
+ * COMPETITION_SWEEP_ENABLED). Keeps the disabled path's shape identical to a
+ * real run so callers and KV state don't need to special-case it.
+ */
+export function disabledCompetitionSummary(): CompetitionSchedulerSummary {
+  return {
+    scanned: 0,
+    found: 0,
+    inserted: 0,
+    alreadyKnown: 0,
+    rejected: 0,
+    rejectionReasons: emptyRejectionReasons(),
+    pending: 0,
+    cursor: null,
+  };
+}
+
 function emptyRejectionReasons(): CompetitionSchedulerRejectionReasons {
   return {
     sender_not_registered: 0,

--- a/lib/external/tenero/__tests__/tokens.test.ts
+++ b/lib/external/tenero/__tests__/tokens.test.ts
@@ -71,21 +71,26 @@ describe("isValidTokenId", () => {
 });
 
 describe("getActiveTokenIds", () => {
-  it("falls back to STATIC_TOKEN_IDS when no DB binding is provided", async () => {
+  it("falls back to STATIC_TOKEN_IDS (not degraded) when no DB binding is provided", async () => {
     const result = await getActiveTokenIds(undefined);
-    expect(result).toEqual(STATIC_TOKEN_IDS);
+    expect(result.tokenIds).toEqual(STATIC_TOKEN_IDS);
+    // Missing binding is an expected env condition, not a failure worth alerting.
+    expect(result.degraded).toBe(false);
   });
 
-  it("falls back to STATIC_TOKEN_IDS when the D1 query throws", async () => {
+  it("falls back to STATIC_TOKEN_IDS AND flags degraded when the D1 query throws", async () => {
     const db = createFakeDb({ throws: true });
     const result = await getActiveTokenIds(db);
-    expect(result).toEqual(STATIC_TOKEN_IDS);
+    expect(result.tokenIds).toEqual(STATIC_TOKEN_IDS);
+    // #1025: a real DB failure must be observable, not masked as low activity.
+    expect(result.degraded).toBe(true);
   });
 
-  it("returns just the static core when the swaps table is empty", async () => {
+  it("returns just the static core (not degraded) when the swaps table is empty", async () => {
     const db = createFakeDb({ rows: [] });
     const result = await getActiveTokenIds(db);
-    expect(result).toEqual(STATIC_TOKEN_IDS);
+    expect(result.tokenIds).toEqual(STATIC_TOKEN_IDS);
+    expect(result.degraded).toBe(false);
   });
 
   it("unions dynamic rows with the static core, preserving static-first order", async () => {
@@ -97,14 +102,15 @@ describe("getActiveTokenIds", () => {
     });
     const result = await getActiveTokenIds(db);
     // Static core first, then dynamic entries in the order D1 returned them.
-    expect(result.slice(0, STATIC_TOKEN_IDS.length)).toEqual(STATIC_TOKEN_IDS);
-    expect(result).toContain(
+    expect(result.tokenIds.slice(0, STATIC_TOKEN_IDS.length)).toEqual(STATIC_TOKEN_IDS);
+    expect(result.tokenIds).toContain(
       "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.usda-token::usda"
     );
-    expect(result).toContain(
+    expect(result.tokenIds).toContain(
       "SP2C2YFP12AJZB4MABJBAJ55XECVS7E4PMMZ89YZR.aeusdc-token::aeusdc"
     );
-    expect(result.length).toBe(STATIC_TOKEN_IDS.length + 2);
+    expect(result.tokenIds.length).toBe(STATIC_TOKEN_IDS.length + 2);
+    expect(result.degraded).toBe(false);
   });
 
   it("deduplicates when a dynamic row repeats a static core entry", async () => {
@@ -116,8 +122,10 @@ describe("getActiveTokenIds", () => {
     });
     const result = await getActiveTokenIds(db);
     // No duplicates — static-core entries are NOT re-added.
-    expect(result.length).toBe(STATIC_TOKEN_IDS.length);
-    expect(result).toEqual(STATIC_TOKEN_IDS);
+    expect(result.tokenIds.length).toBe(STATIC_TOKEN_IDS.length);
+    expect(result.tokenIds).toEqual(STATIC_TOKEN_IDS);
+    // Full dedup into the core is a legitimate result, not a DB failure.
+    expect(result.degraded).toBe(false);
   });
 
   it("filters out malformed token ids from the dynamic set", async () => {
@@ -131,13 +139,14 @@ describe("getActiveTokenIds", () => {
     });
     const result = await getActiveTokenIds(db);
     // Only `SPABCDE…real-token::real` should join the static core.
-    expect(result).toContain(
+    expect(result.tokenIds).toContain(
       "SPQC38PW542EQJ5M11CR25P7BS1CA6QT4TBXGB3M.real-token::real"
     );
-    expect(result).not.toContain("unknown");
-    expect(result).not.toContain("");
-    expect(result).not.toContain("STX");
-    expect(result.length).toBe(STATIC_TOKEN_IDS.length + 1);
+    expect(result.tokenIds).not.toContain("unknown");
+    expect(result.tokenIds).not.toContain("");
+    expect(result.tokenIds).not.toContain("STX");
+    expect(result.tokenIds.length).toBe(STATIC_TOKEN_IDS.length + 1);
+    expect(result.degraded).toBe(false);
   });
 
   it("uses the MAX_TRACKED_TOKENS bound when calling prepare().bind()", async () => {

--- a/lib/external/tenero/index.ts
+++ b/lib/external/tenero/index.ts
@@ -8,6 +8,7 @@ export {
   MAX_TRACKED_TOKENS,
   getActiveTokenIds,
   isValidTokenId,
+  type ActiveTokenIdsResult,
 } from "./tokens";
 export {
   getStablecoinUsdFallback,

--- a/lib/external/tenero/tokens.ts
+++ b/lib/external/tenero/tokens.ts
@@ -1,11 +1,12 @@
 /**
- * Token-id source for the SchedulerDO's Tenero price-refresh task.
+ * Token-id source for the cron Tenero price-refresh task
+ * (`lib/scheduler/cron-runner.ts`; the former SchedulerDO was removed).
  *
  * Two sources, in priority order:
  *
  *   1. STATIC_TOKEN_IDS — a small always-include core set (STX + sBTC + stSTX).
  *      Acts as a safe fallback when the swaps table is empty (cold start) or
- *      D1 query fails, so the SchedulerDO can still keep popular tokens warm.
+ *      D1 query fails, so the refresh task can still keep popular tokens warm.
  *
  *   2. Distinct token_in / token_out from the `swaps` table, restricted to
  *      successful agent/cron swaps, junk-filtered (no `"unknown"`, must match
@@ -31,7 +32,7 @@ export const STATIC_TOKEN_IDS: readonly string[] = [
 ];
 
 /**
- * Maximum number of distinct tokens to refresh per SchedulerDO tick. Bounds
+ * Maximum number of distinct tokens to refresh per cron tick. Bounds
  * the Tenero quota cost so a memecoin-trading spree can't blow the monthly
  * budget. At 50 tokens × 12 ticks/hr × 24 × 30 ≈ 432k requests/month — fine
  * once authenticated; the unauthenticated tier (50k/month) would burst the
@@ -62,20 +63,39 @@ interface TrackedTokenRow {
 }
 
 /**
+ * Result of {@link getActiveTokenIds}. `degraded` distinguishes a real D1 query
+ * failure (fell back to the static core, and callers should log/alert) from a
+ * legitimate result that simply resolved to the static core (empty swaps table,
+ * or every dynamic id deduped into the core). Without this flag the two are
+ * byte-identical, which silently masked DB failures as normal low activity
+ * (issue #1025).
+ *
+ * A missing D1 binding is NOT degraded — it's an expected condition in local
+ * dev / preview-without-DB, not a failure worth alerting on.
+ */
+export interface ActiveTokenIdsResult {
+  tokenIds: readonly string[];
+  degraded: boolean;
+}
+
+/**
  * Derive the active token-refresh set from the swaps table. Returns the union
  * of STATIC_TOKEN_IDS (always-include core) and the top-{MAX_TRACKED_TOKENS}
  * tokens by trade count from successful agent/cron swaps, deduplicated.
  *
  * Falls back to STATIC_TOKEN_IDS on:
- *   - missing D1 binding (local dev, preview without DB)
- *   - D1 query failure (transient DB issue shouldn't blow the refresh)
+ *   - missing D1 binding (local dev, preview without DB) — `degraded: false`
+ *   - D1 query failure (transient DB issue shouldn't blow the refresh) —
+ *     `degraded: true` so the caller can surface the degradation
  *
- * Pure async function — no logging, no side effects. Caller wires logging.
+ * Pure async function — no logging, no side effects. The caller inspects
+ * `degraded` and wires logging/alerting. Driven by the cron price-refresh task
+ * (`lib/scheduler/cron-runner.ts`) and read by `/api/competition/tracked-tokens`.
  */
 export async function getActiveTokenIds(
   db: D1Database | undefined
-): Promise<readonly string[]> {
-  if (!db) return STATIC_TOKEN_IDS;
+): Promise<ActiveTokenIdsResult> {
+  if (!db) return { tokenIds: STATIC_TOKEN_IDS, degraded: false };
 
   let dynamic: string[] = [];
   try {
@@ -108,12 +128,14 @@ export async function getActiveTokenIds(
       .map((r) => r.id)
       .filter((id): id is string => typeof id === "string" && isValidTokenId(id));
   } catch {
-    return STATIC_TOKEN_IDS;
+    // Real DB failure — flag it so the caller can log/alert rather than
+    // silently degrading the refresh set to the 3-token core.
+    return { tokenIds: STATIC_TOKEN_IDS, degraded: true };
   }
 
   // Union with the static core. Set semantics; preserve insertion order
   // (static first, then dynamic) so the static tokens lead the refresh loop
   // and stay warm even if the loop is cut short by rate-limiting mid-run.
   const merged = new Set<string>([...STATIC_TOKEN_IDS, ...dynamic]);
-  return Array.from(merged);
+  return { tokenIds: Array.from(merged), degraded: false };
 }

--- a/lib/inbox/stats.ts
+++ b/lib/inbox/stats.ts
@@ -236,6 +236,91 @@ export async function decrementUnreadStats(
     .run();
 }
 
+/**
+ * Recompute and persist a single agent's inbox stats from inbox_messages.
+ *
+ * Single-address counterpart to rebuildAllStats(): aggregates the live
+ * received/unread/sent counts for one btc_address and UPSERTs the corrected
+ * row into agent_inbox_stats, returning the corrected stats.
+ *
+ * Used as a read-path self-heal (issue #995) when the maintained unread_count
+ * is proven to have drifted from the actual `read_at IS NULL` row count. The
+ * write-path bump/decrement helpers are best-effort (fire-and-forget with
+ * swallowed errors), so a dropped decrement leaves the counter permanently
+ * over-counted, surfacing as "phantom" unreads that no PATCH can clear because
+ * they exist only in the counter, not as message rows.
+ *
+ * Scoped to one address (predicated on to_btc_address / from_btc_address), so
+ * it does not reintroduce the full-table COUNT(*) hot-path antipattern that the
+ * maintained counters exist to avoid — it only runs when drift is detected.
+ */
+export async function recomputeAgentStats(
+  db: D1Database,
+  btcAddress: string
+): Promise<AgentInboxStats> {
+  const now = new Date().toISOString();
+
+  const inbound = await db
+    .prepare(
+      `SELECT
+         COUNT(*) AS received_count,
+         COUNT(CASE WHEN read_at IS NULL THEN 1 END) AS unread_count,
+         MAX(sent_at) AS last_message_at
+       FROM inbox_messages
+       WHERE is_reply = 0 AND to_btc_address = ?`
+    )
+    .bind(btcAddress)
+    .first<{
+      received_count: number;
+      unread_count: number;
+      last_message_at: string | null;
+    }>();
+
+  const sent = await db
+    .prepare(
+      `SELECT COUNT(*) AS sent_count, MAX(sent_at) AS last_sent_at
+       FROM inbox_messages
+       WHERE is_reply = 1 AND from_btc_address = ?`
+    )
+    .bind(btcAddress)
+    .first<{ sent_count: number; last_sent_at: string | null }>();
+
+  const stats: AgentInboxStats = {
+    receivedCount: inbound?.received_count ?? 0,
+    unreadCount: inbound?.unread_count ?? 0,
+    sentCount: sent?.sent_count ?? 0,
+    lastMessageAt: inbound?.last_message_at ?? null,
+    lastSentAt: sent?.last_sent_at ?? null,
+  };
+
+  await db
+    .prepare(
+      `INSERT INTO agent_inbox_stats
+         (btc_address, received_count, unread_count, sent_count,
+          last_message_at, last_sent_at, updated_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(btc_address) DO UPDATE SET
+         received_count  = excluded.received_count,
+         unread_count    = excluded.unread_count,
+         sent_count      = excluded.sent_count,
+         last_message_at = excluded.last_message_at,
+         last_sent_at    = excluded.last_sent_at,
+         updated_at      = excluded.updated_at`
+    )
+    .bind(
+      btcAddress,
+      stats.receivedCount,
+      stats.unreadCount,
+      stats.sentCount,
+      stats.lastMessageAt,
+      stats.lastSentAt,
+      now
+    )
+    .run();
+
+  return stats;
+}
+
 // ---------------------------------------------------------------------------
 // Backfill / repair
 // ---------------------------------------------------------------------------

--- a/lib/scheduler/__tests__/competition-gate.test.ts
+++ b/lib/scheduler/__tests__/competition-gate.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Issue #933 — competition sweep kill-switch regression test.
+ *
+ * runCompetitionNow() must skip the Hiro catch-up sweep (which shares the single
+ * HIRO_API_KEY with reputation/identity lookups) when COMPETITION_SWEEP_ENABLED
+ * is explicitly "false", returning a zeroed summary without touching Hiro. The
+ * gate defaults ON — only an explicit "false" disables it — so an unset var
+ * preserves current behavior.
+ */
+
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+
+// Mock only runCompetitionScheduler; keep disabledCompetitionSummary real.
+vi.mock("../../competition/scheduler", async (importActual) => {
+  const actual = await importActual<typeof import("../../competition/scheduler")>();
+  return {
+    ...actual,
+    runCompetitionScheduler: vi.fn().mockResolvedValue(actual.disabledCompetitionSummary()),
+  };
+});
+
+import { runCompetitionNow } from "../cron-runner";
+import { runCompetitionScheduler } from "../../competition/scheduler";
+
+function buildEnv(overrides: Record<string, unknown> = {}): CloudflareEnv {
+  return {
+    DB: { prepare: vi.fn() },
+    HIRO_API_KEY: "test-key",
+    VERIFIED_AGENTS: { put: vi.fn().mockResolvedValue(undefined) },
+    ...overrides,
+  } as unknown as CloudflareEnv;
+}
+
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never;
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("Issue #933 — competition sweep gate", () => {
+  it("skips the sweep when COMPETITION_SWEEP_ENABLED='false'", async () => {
+    const env = buildEnv({ COMPETITION_SWEEP_ENABLED: "false" });
+
+    const result = await runCompetitionNow(env, logger);
+
+    expect(runCompetitionScheduler).not.toHaveBeenCalled();
+    expect(result).toMatchObject({ scanned: 0, found: 0, inserted: 0, cursor: null });
+    // still persists lastRunAt so the slow cadence is respected while dormant
+    expect((env.VERIFIED_AGENTS.put as Mock)).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the sweep when the var is unset (default ON)", async () => {
+    const env = buildEnv();
+
+    await runCompetitionNow(env, logger);
+
+    expect(runCompetitionScheduler).toHaveBeenCalledTimes(1);
+  });
+
+  it("runs the sweep when explicitly 'true'", async () => {
+    const env = buildEnv({ COMPETITION_SWEEP_ENABLED: "true" });
+
+    await runCompetitionNow(env, logger);
+
+    expect(runCompetitionScheduler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -171,8 +171,14 @@ export async function runTeneroNow(
     };
   }
 
-  const tokenIds = await getActiveTokenIds(env.DB);
-  logger.info("tenero.token_set_resolved", { count: tokenIds.length });
+  const { tokenIds, degraded } = await getActiveTokenIds(env.DB);
+  if (degraded) {
+    // D1 lookup failed and we fell back to the 3-token static core. Surface it
+    // as an error (#1025) — otherwise the shrunken refresh set is invisible and
+    // every non-core token's price silently goes stale.
+    logger.error("tenero.token_set_d1_failed", { count: tokenIds.length });
+  }
+  logger.info("tenero.token_set_resolved", { count: tokenIds.length, degraded });
 
   const { result, rateLimited, rateLimitBackoffMs } = await runTeneroTask({
     logger,

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -28,6 +28,7 @@ import {
 } from "./tenero-task";
 import {
   runCompetitionScheduler,
+  disabledCompetitionSummary,
   type CompetitionSchedulerSummary,
 } from "../competition/scheduler";
 import { runEarningsSweep } from "../earnings/indexer";
@@ -60,7 +61,13 @@ import type {
 // interval or upgrade the Tenero plan. The minute cap is handled separately by
 // TENERO_REQUEST_SPACING_MS (inter-request spacing within a run).
 export const TENERO_INTERVAL_MS = 60 * 60 * 1000;
-export const COMPETITION_INTERVAL_MS = 15 * 60 * 1000;
+// Competition Hiro catch-up sweep — HOURLY. Widened from 15 min (#933): the
+// sweep shares the single HIRO_API_KEY with reputation/identity lookups, and a
+// 15-min cadence monopolized that budget and 429-starved those endpoints. The
+// agent self-submit fast path (POST /api/competition/trades) is the primary
+// ingestion route; this sweep is only catch-up, so 4x fewer Hiro calls is a
+// safe trade. Can be gated off entirely via COMPETITION_SWEEP_ENABLED="false".
+export const COMPETITION_INTERVAL_MS = 60 * 60 * 1000;
 // Legion dashboard snapshot refreshes every cron tick (testnet, low volume).
 export const LEGION_INTERVAL_MS = 15 * 60 * 1000;
 
@@ -214,6 +221,26 @@ export async function runCompetitionNow(
   const logger = parentLogger.child
     ? parentLogger.child({ task: "competition" })
     : parentLogger;
+
+  // Operator kill-switch (#933). Defaults ON — only an explicit "false" disables
+  // the sweep — so the sunset throttle is available without changing behavior on
+  // an unset var. When off, agent self-submit (POST /api/competition/trades)
+  // remains the ingestion path.
+  if (env.COMPETITION_SWEEP_ENABLED === "false") {
+    logger.warn("competition.sweep_skipped_disabled", {
+      deployEnv: env.DEPLOY_ENV ?? "unset",
+    });
+    const result = disabledCompetitionSummary();
+    await env.VERIFIED_AGENTS.put(
+      K_COMPETITION,
+      JSON.stringify({
+        lastRunAt: Date.now(),
+        result,
+        consecutiveFailures: 0,
+      } satisfies CompetitionState)
+    );
+    return result;
+  }
 
   const result = await runCompetitionScheduler(
     { DB: env.DB, HIRO_API_KEY: env.HIRO_API_KEY },

--- a/wrangler.scheduler.jsonc
+++ b/wrangler.scheduler.jsonc
@@ -17,7 +17,10 @@
   "vars": {
     "DEPLOY_ENV": "production",
     "TENERO_REFRESH_ENABLED": "true",
-    "EARNINGS_INDEX_ENABLED": "true"
+    "EARNINGS_INDEX_ENABLED": "true",
+    // Competition Hiro catch-up sweep (issue #933). Defaults ON; set "false" to
+    // disable the sweep during competition sunset without a redeploy of code.
+    "COMPETITION_SWEEP_ENABLED": "true"
     // Optional: override the inference gateway whose GET /v1/providers backs the
     // v1 provider list. Unset → the default in lib/legion/constants.ts
     // (inference.aibtc.com, which serves testnet). Set only if the gateway moves:


### PR DESCRIPTION
Issue-triage pass: validated each candidate against current code, reproduced in-code, and fixed the live defects. Skipped issues that were already resolved, out-of-repo, features, or docs-only (see triage notes at the bottom).

## Fixes

### #995 — Inbox `unreadCount` drift (phantom unreads) ✅
`GET /api/inbox/[address]` returned `unreadCount` straight from the denormalized `agent_inbox_stats.unread_count` counter (`route.ts:401`). That counter can drift above the actual `read_at IS NULL` row count because the write-path bump/decrement helpers are best-effort (`ctx.waitUntil` + swallowed `.catch()`), and nothing auto-reconciles — surfacing as unreads no PATCH can clear (they exist only in the counter, not as message rows).

**Fix:** read-path self-heal. When the unread view is fetched at offset 0 and the page isn't full, the entire unread set has been enumerated for free, so the true count is known. On a mismatch, the new single-address `recomputeAgentStats()` corrects the stored counter and returns the right value. Respects the team's no-`COUNT(*)`-on-hot-path rule (only fires on detected drift); the corrected counter then propagates to heartbeat and `status=all`.

### #1016 — Legion provider faucet cold-visitor cliff ✅
The originally-reported step-1 was already removed by the v1 provider-model refactor (#1018/#1019), but the provider CTA still promised "faucet + exact commands" while the `HowToProvide` section it anchors to had no faucet guidance. Added the repo-canonical faucet instruction (call `faucet` on the sBTC token) to the optional-stake step, matching sibling `HowToParticipate.tsx`.

### #770 — `/api/challenge` rate-limit hardening ✅
- Fail-closed now uses `shouldFailClosed(env)` instead of `if (env.DEPLOY_ENV)` — an empty-string `DEPLOY_ENV` was failing **open**.
- 503 on binding outage now sends `Retry-After`.
- IP bucket no longer collapses every IP-less caller into one shared `"unknown"` key (self-DoS).
- `x-forwarded-for` fallback is dev-only — `cf-connecting-ip` is the only trustworthy source on a CF Worker.

### #933 — Competition Hiro sweep 429-starving reputation/identity ✅
The sweep runs on the scheduler worker sharing the single `HIRO_API_KEY` with reputation/identity lookups, with no gate. Widened cadence 15min → 60min (4x fewer Hiro calls) and added a `COMPETITION_SWEEP_ENABLED` kill-switch (defaults **ON**; set `"false"` to disable during sunset). Agent self-submit via `POST /api/competition/trades` remains the primary ingestion path.

### #1025 — `getActiveTokenIds` masked D1 failures as a 3-token fallback ✅
The function swallowed D1 errors in a bare `catch` and returned `STATIC_TOKEN_IDS` — byte-identical to a legitimate static-only result — so a DB failure silently staled every non-core token's price with no signal. Return is now `{ tokenIds, degraded }`: a real query failure sets `degraded: true` (missing binding stays `false`), the Tenero cron logs `tenero.token_set_d1_failed`, and `/api/competition/tracked-tokens` reports `source: "db-error"`. Drive-by: refreshed stale `SchedulerDO` / "5 min cadence" doc references.

## Tests
New/updated regression tests for #995, #933, and #1025. All touched-area tests pass; typecheck + lint clean.

## Triage notes (no code change)
- **#1012** — all 3 findings are in the `legion-gov` Clarity contracts / `@aibtc/mcp-server`, not this repo.
- **#809** — RESOLVED/OBSOLETE: P&L column removed in #978 rework, `SchedulerDO` deleted for a cron worker, sBTC asset-id already corrected to `::sbtc-token`.
- **#781** — DOCS-ONLY and the docs already exist (`docs/edge-cache-pr-checklist.md` §7); zone-CDN `s-maxage` behavior is intentional.
