### PR TITLE
chore(logging): standardize server runtime logging on the Logs RPC logger (#551)

### DIFF
--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -2,6 +2,13 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { buildActivityData } from "@/lib/activity";
 import type { ActivityResponse } from "@/app/components/activity-shared";
+import {
+  createLogger,
+  createConsoleLogger,
+  createNoopLogger,
+  isLogsRPC,
+  type Logger,
+} from "@/lib/logging";
 
 const CORS_HEADERS = {
   "Access-Control-Allow-Origin": "*",
@@ -35,6 +42,7 @@ async function buildAndCache(
   kv: KVNamespace,
   db: D1Database | undefined,
   ctx: { waitUntil(p: Promise<unknown>): void } | undefined,
+  logger: Logger = createNoopLogger(),
 ): Promise<{ response: Response; stash: Promise<unknown> }> {
   const data: ActivityResponse = await buildActivityData(kv, db);
   const response = NextResponse.json(data, {
@@ -54,7 +62,9 @@ async function buildAndCache(
   // build — TTL/freshness costs are bounded by RESPONSE_S_MAXAGE and the
   // next request will rebuild and retry the cache write.
   const stash = cache.put(cacheKey, cachedClone).catch((err) => {
-    console.error("Failed to populate caches.default for /api/activity:", err);
+    logger.error("Failed to populate caches.default for /api/activity", {
+      error: String(err),
+    });
   });
   if (ctx) ctx.waitUntil(stash);
   return { response, stash };
@@ -137,8 +147,13 @@ export async function GET(request: NextRequest) {
     });
   }
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env, ctx } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const db = env.DB as D1Database | undefined;
 
@@ -154,7 +169,7 @@ export async function GET(request: NextRequest) {
 
     let promise = inFlight.get(CACHE_KEY_URL);
     if (!promise) {
-      promise = buildAndCache(kv, db, ctx);
+      promise = buildAndCache(kv, db, ctx, logger);
       inFlight.set(CACHE_KEY_URL, promise);
       // Hold the inFlight slot until the cache.default put settles — not
       // just until buildActivityData() returns. Otherwise a request arriving
@@ -175,7 +190,7 @@ export async function GET(request: NextRequest) {
       headers: response.headers,
     });
   } catch (error) {
-    console.error("Failed to fetch activity:", error);
+    logger.error("Failed to fetch activity", { error: String(error) });
     return NextResponse.json(
       {
         error: "Failed to fetch network activity",

--- a/app/api/admin/backfill/__tests__/route.test.ts
+++ b/app/api/admin/backfill/__tests__/route.test.ts
@@ -24,6 +24,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/admin/competition/finalize/__tests__/route.test.ts
+++ b/app/api/admin/competition/finalize/__tests__/route.test.ts
@@ -27,6 +27,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/admin/competition/finalize/route.ts
+++ b/app/api/admin/competition/finalize/route.ts
@@ -27,6 +27,7 @@ import { computeRoundResults } from "@/lib/competition/finalize/compute";
 import { persistRoundResults } from "@/lib/competition/finalize/persist";
 import { captureRoundPriceSnapshot } from "@/lib/competition/finalize/snapshot";
 import { getCachedTokenPrices } from "@/lib/external/tenero/kv-cache";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 
 // ── D1 row types (mirroring competition_rounds columns) ───────────────────────
 
@@ -76,8 +77,13 @@ export async function GET(request: NextRequest) {
   const denied = await requireAdmin(request);
   if (denied) return denied;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const db = env.DB as D1Database;
 
     const roundsResult = await db
@@ -104,7 +110,7 @@ export async function GET(request: NextRequest) {
       rounds,
     });
   } catch (e) {
-    console.error("competition/finalize GET error:", e);
+    logger.error("competition/finalize GET error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to list rounds: ${(e as Error).message}` },
       { status: 500 }
@@ -167,8 +173,13 @@ export async function POST(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const dryRun = searchParams.get("dry-run") === "true";
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const db = env.DB as D1Database;
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
@@ -429,7 +440,7 @@ export async function POST(request: NextRequest) {
     const httpStatus = mapErrorToStatus(message);
 
     if (httpStatus === 500) {
-      console.error("competition/finalize POST error:", e);
+      logger.error("competition/finalize POST error", { error: String(e) });
     }
 
     return NextResponse.json(

--- a/app/api/admin/delete-agent/route.ts
+++ b/app/api/admin/delete-agent/route.ts
@@ -7,14 +7,25 @@ import { requireAdmin } from "@/lib/admin/auth";
 import { lookupAgent } from "@/lib/agent-lookup";
 import type { InboxAgentIndex } from "@/lib/inbox/types";
 import type { ReferralCodeRecord } from "@/lib/vouch";
+import {
+  createLogger,
+  createConsoleLogger,
+  createNoopLogger,
+  isLogsRPC,
+  type Logger,
+} from "@/lib/logging";
 
 /** Safely parse JSON, returning null on failure. */
-function safeParseJson<T>(data: string | null, label: string): T | null {
+function safeParseJson<T>(
+  data: string | null,
+  label: string,
+  logger: Logger = createNoopLogger()
+): T | null {
   if (!data) return null;
   try {
     return JSON.parse(data) as T;
   } catch (e) {
-    console.error(`Failed to parse ${label}:`, e);
+    logger.error("Failed to parse JSON record", { label, error: String(e) });
     return null;
   }
 }
@@ -108,6 +119,12 @@ export async function DELETE(request: NextRequest) {
   const denied = await requireAdmin(request);
   if (denied) return denied;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
     // Parse request body
     let body: unknown;
@@ -135,7 +152,6 @@ export async function DELETE(request: NextRequest) {
       );
     }
 
-    const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const db = env.DB as D1Database | undefined;
 
@@ -159,7 +175,8 @@ export async function DELETE(request: NextRequest) {
 
     const inboxIndex = safeParseJson<InboxAgentIndex>(
       inboxData,
-      "inbox index"
+      "inbox index",
+      logger
     );
 
     // Fail if any index record exists but is corrupted — partial deletion is worse than no deletion
@@ -177,7 +194,8 @@ export async function DELETE(request: NextRequest) {
     // Parse referral code for reverse lookup cleanup
     const referralCode = safeParseJson<ReferralCodeRecord>(
       referralCodeData,
-      "referral code"
+      "referral code",
+      logger
     );
 
     // Build categorized key lists
@@ -253,7 +271,7 @@ export async function DELETE(request: NextRequest) {
       },
     });
   } catch (e) {
-    console.error("DELETE /api/admin/delete-agent error:", e);
+    logger.error("DELETE /api/admin/delete-agent error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to delete agent: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/admin/genesis-payout/route.ts
+++ b/app/api/admin/genesis-payout/route.ts
@@ -5,6 +5,7 @@ import { validateGenesisPayoutBody } from "@/lib/admin/validation";
 import { GenesisPayoutRecord } from "@/lib/admin/types";
 import type { ClaimRecord } from "@/lib/types";
 import { mirrorClaimToD1 } from "@/lib/claims/d1-mirror";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 
 /**
  * GET /api/admin/genesis-payout
@@ -17,8 +18,13 @@ export async function GET(request: NextRequest) {
   const denied = await requireAdmin(request);
   if (denied) return denied;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     const { searchParams } = new URL(request.url);
@@ -39,10 +45,10 @@ export async function GET(request: NextRequest) {
         const record = JSON.parse(recordData) as GenesisPayoutRecord;
         return NextResponse.json({ success: true, record });
       } catch (e) {
-        console.error(
-          `Failed to parse genesis record for ${btcAddress}:`,
-          e
-        );
+        logger.error("Failed to parse genesis record", {
+          btcAddress,
+          error: String(e),
+        });
         return NextResponse.json(
           { error: `Stored genesis record for ${btcAddress} is corrupted` },
           { status: 500 }
@@ -75,10 +81,10 @@ export async function GET(request: NextRequest) {
                   JSON.parse(recordData) as GenesisPayoutRecord
                 );
               } catch (e) {
-                console.error(
-                  `Failed to parse genesis record ${batch[index].name}:`,
-                  e
-                );
+                logger.error("Failed to parse genesis record", {
+                  key: batch[index].name,
+                  error: String(e),
+                });
               }
             }
           });
@@ -100,7 +106,7 @@ export async function GET(request: NextRequest) {
       { status: 400 }
     );
   } catch (e) {
-    console.error("Genesis payout GET error:", e);
+    logger.error("Genesis payout GET error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to query genesis payouts: ${(e as Error).message}` },
       { status: 500 }
@@ -141,6 +147,12 @@ export async function POST(request: NextRequest) {
   const denied = await requireAdmin(request);
   if (denied) return denied;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
     let body: unknown;
     try {
@@ -163,7 +175,6 @@ export async function POST(request: NextRequest) {
     const { btcAddress, rewardTxid, rewardSatoshis, paidAt, stxAddress } =
       validation.data;
 
-    const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     // Check for existing genesis payout and claim record in parallel
@@ -188,7 +199,10 @@ export async function POST(request: NextRequest) {
           });
         }
       } catch (e) {
-        console.error("Failed to parse existing genesis record:", e);
+        logger.error("Failed to parse existing genesis record", {
+          btcAddress,
+          error: String(e),
+        });
       }
       return NextResponse.json(
         { error: "Genesis payout already recorded for this address with different details" },
@@ -208,14 +222,17 @@ export async function POST(request: NextRequest) {
         try {
           await mirrorClaimToD1(env.DB as D1Database | undefined, claimRecord);
         } catch (e) {
-          console.warn("genesis-payout D1 mirror write failed", {
+          logger.warn("genesis-payout D1 mirror write failed", {
             btcAddress,
             error: e instanceof Error ? e.message : String(e),
           });
         }
         claimRecordUpdated = true;
       } catch (e) {
-        console.error("Failed to update claim record:", e);
+        logger.error("Failed to update claim record", {
+          btcAddress,
+          error: String(e),
+        });
       }
     }
 
@@ -237,7 +254,7 @@ export async function POST(request: NextRequest) {
       record: genesisRecord,
     });
   } catch (e) {
-    console.error("Genesis payout POST error:", e);
+    logger.error("Genesis payout POST error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to record genesis payout: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/admin/reconcile/__tests__/reconcile.test.ts
+++ b/app/api/admin/reconcile/__tests__/reconcile.test.ts
@@ -23,6 +23,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/admin/scheduler/__tests__/route.test.ts
+++ b/app/api/admin/scheduler/__tests__/route.test.ts
@@ -10,6 +10,7 @@ vi.mock("@/lib/admin/auth", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createLogger: vi.fn(),
   createConsoleLogger: vi.fn(() => ({

--- a/app/api/admin/schema-health/route.ts
+++ b/app/api/admin/schema-health/route.ts
@@ -27,6 +27,12 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { requireAdmin } from "@/lib/admin/auth";
 import { LEADERBOARD_AGGREGATE_SQL } from "@/lib/competition/leaderboard-query";
 import { isScanWithoutIndex } from "./scan-detection";
+import {
+  createLogger,
+  createConsoleLogger,
+  isLogsRPC,
+  type Logger,
+} from "@/lib/logging";
 
 // ---------------------------------------------------------------------------
 // Query definitions
@@ -213,11 +219,22 @@ export async function GET(request: NextRequest) {
   if (denied) return denied;
 
   let db: D1Database | undefined;
+  let logger: Logger;
   try {
-    const { env } = await getCloudflareContext();
+    const { env, ctx } = await getCloudflareContext();
     db = env.DB as D1Database | undefined;
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+      : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
   } catch (e) {
-    console.error("schema-health: failed to get Cloudflare context", e);
+    // Intentional console fallback (#551): getCloudflareContext() itself threw,
+    // so there is no env.LOGS / ctx to build the RPC logger from. This is the
+    // one path where console is the only option.
+    createConsoleLogger({ path: new URL(request.url).pathname }).error(
+      "schema-health: failed to get Cloudflare context",
+      { error: String(e) }
+    );
     return NextResponse.json(
       { error: "Failed to get runtime context" },
       { status: 500 }
@@ -251,7 +268,9 @@ export async function GET(request: NextRequest) {
       liveIndexNames.add(idx.name);
     }
   } catch (e) {
-    console.error("schema-health: sqlite_master query failed", e);
+    logger.error("schema-health: sqlite_master query failed", {
+      error: String(e),
+    });
     // Non-fatal: continue with empty index set (all expectedIndexes will flag)
   }
 
@@ -315,7 +334,10 @@ export async function GET(request: NextRequest) {
         // EXPLAIN itself failed (e.g. table doesn't exist yet, syntax error).
         // Treat as flagged so missing tables are visible.
         const errMsg = e instanceof Error ? e.message : String(e);
-        console.error(`schema-health: EXPLAIN failed for ${q.name}:`, errMsg);
+        logger.error("schema-health: EXPLAIN failed", {
+          query: q.name,
+          error: errMsg,
+        });
         return {
           name: q.name,
           sql: q.sql,

--- a/app/api/agents/[address]/route.ts
+++ b/app/api/agents/[address]/route.ts
@@ -368,8 +368,12 @@ export async function GET(
       },
     );
   } catch (e) {
-    // eslint-disable-next-line no-console
-    console.error("Agent profile lookup error:", e);
+    const { env, ctx } = await getCloudflareContext();
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+      : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+    logger.error("Agent profile lookup error", { error: String(e) });
     return NextResponse.json(
       { error: `Agent lookup failed: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/agents/route.ts
+++ b/app/api/agents/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { LEVELS } from "@/lib/levels";
 import { getCachedAgentList } from "@/lib/cache";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 
 export async function GET(request: NextRequest) {
   // Self-documenting: return usage docs when explicitly requested via ?docs=1
@@ -101,8 +102,13 @@ export async function GET(request: NextRequest) {
     : 50;
   const offset = offsetParam ? Math.max(parseInt(offsetParam, 10) || 0, 0) : 0;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     const { agents: cachedAgents } = await getCachedAgentList(kv);
@@ -151,7 +157,7 @@ export async function GET(request: NextRequest) {
       }
     );
   } catch (e) {
-    console.error("Agents fetch error:", e);
+    logger.error("Agents fetch error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to fetch agents: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/claims/viral/route.ts
+++ b/app/api/claims/viral/route.ts
@@ -6,6 +6,13 @@ import { getNextLevel } from "@/lib/levels";
 import { X_HANDLE } from "@/lib/constants";
 import type { ClaimRecord } from "@/lib/types";
 import { mirrorClaimToD1 } from "@/lib/claims/d1-mirror";
+import {
+  createLogger,
+  createConsoleLogger,
+  createNoopLogger,
+  isLogsRPC,
+  type Logger,
+} from "@/lib/logging";
 
 const MIN_REWARD_SATS = 5000;
 const MAX_REWARD_SATS = 10000;
@@ -14,7 +21,10 @@ function getRandomReward(): number {
   return Math.floor(Math.random() * (MAX_REWARD_SATS - MIN_REWARD_SATS + 1)) + MIN_REWARD_SATS;
 }
 
-function normalizeTweetUrl(url: string): string | null {
+function normalizeTweetUrl(
+  url: string,
+  logger: Logger = createNoopLogger()
+): string | null {
   try {
     const parsed = new URL(url);
     if (parsed.hostname !== "twitter.com" && parsed.hostname !== "x.com" && parsed.hostname !== "www.twitter.com" && parsed.hostname !== "www.x.com") {
@@ -25,12 +35,15 @@ function normalizeTweetUrl(url: string): string | null {
     if (!match) return null;
     return `https://x.com/${match[1]}/status/${match[2]}`;
   } catch (e) {
-    console.error("Failed to parse tweet URL:", e);
+    logger.error("Failed to parse tweet URL", { error: String(e) });
     return null;
   }
 }
 
-async function fetchTweetContent(tweetUrl: string): Promise<{ text: string; authorName: string; authorHandle: string } | null> {
+async function fetchTweetContent(
+  tweetUrl: string,
+  logger: Logger = createNoopLogger()
+): Promise<{ text: string; authorName: string; authorHandle: string } | null> {
   try {
     const oembedUrl = `https://publish.twitter.com/oembed?url=${encodeURIComponent(tweetUrl)}&omit_script=true`;
     const res = await fetch(oembedUrl, { signal: AbortSignal.timeout(8000) });
@@ -56,12 +69,20 @@ async function fetchTweetContent(tweetUrl: string): Promise<{ text: string; auth
 
     return { text, authorName: data.author_name || "", authorHandle };
   } catch (e) {
-    console.error("Failed to fetch tweet content from oEmbed:", e);
+    logger.error("Failed to fetch tweet content from oEmbed", {
+      error: String(e),
+    });
     return null;
   }
 }
 
 export async function POST(request: NextRequest) {
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
     const body = (await request.json()) as {
       btcAddress?: string;
@@ -85,7 +106,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Validate and normalize tweet URL
-    const normalizedUrl = normalizeTweetUrl(tweetUrl);
+    const normalizedUrl = normalizeTweetUrl(tweetUrl, logger);
     if (!normalizedUrl) {
       return NextResponse.json(
         { error: "Invalid post URL. Must be an x.com or twitter.com status link (e.g. https://x.com/user/status/123)." },
@@ -93,7 +114,6 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const { env } = await getCloudflareContext();
     const agentsKv = env.VERIFIED_AGENTS as KVNamespace;
 
     // Check agent and existing claim in parallel
@@ -144,7 +164,7 @@ export async function POST(request: NextRequest) {
 
     // Fetch tweet content and claim code in parallel (both independent)
     const [tweet, storedCodeData] = await Promise.all([
-      fetchTweetContent(normalizedUrl),
+      fetchTweetContent(normalizedUrl, logger),
       agentsKv.get(`claim-code:${btcAddress}`),
     ]);
 
@@ -238,7 +258,7 @@ export async function POST(request: NextRequest) {
     try {
       await mirrorClaimToD1(env.DB as D1Database | undefined, claimRecord);
     } catch (e) {
-      console.warn("claims/viral D1 mirror write failed", {
+      logger.warn("claims/viral D1 mirror write failed", {
         btcAddress,
         error: e instanceof Error ? e.message : String(e),
       });
@@ -290,7 +310,7 @@ export async function POST(request: NextRequest) {
       },
     });
   } catch (e) {
-    console.error("Viral claim error:", e);
+    logger.error("Viral claim error", { error: String(e) });
     return NextResponse.json(
       { error: `Claim failed: ${(e as Error).message}` },
       { status: 500 }
@@ -361,8 +381,13 @@ export async function GET(request: NextRequest) {
     });
   }
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const agentsKv = env.VERIFIED_AGENTS as KVNamespace;
 
     const claimData = await agentsKv.get(`claim:${btcAddress}`);
@@ -405,7 +430,7 @@ export async function GET(request: NextRequest) {
       },
     });
   } catch (e) {
-    console.error("Viral claim GET error:", e);
+    logger.error("Viral claim GET error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to check claim: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/competition/__tests__/d1-throws-fallback.test.ts
+++ b/app/api/competition/__tests__/d1-throws-fallback.test.ts
@@ -23,6 +23,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/competition/__tests__/post-verifier.test.ts
+++ b/app/api/competition/__tests__/post-verifier.test.ts
@@ -30,6 +30,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/competition/__tests__/rounds-read.test.ts
+++ b/app/api/competition/__tests__/rounds-read.test.ts
@@ -26,6 +26,7 @@ vi.mock("@opennextjs/cloudflare", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/heartbeat/__tests__/route.test.ts
+++ b/app/api/heartbeat/__tests__/route.test.ts
@@ -44,6 +44,28 @@ vi.mock("@/lib/bounty", () => ({
   listBounties: vi.fn().mockResolvedValue({ bounties: [], total: 0 }),
 }));
 
+// #551: heartbeat now logs via the structured Logger (and threads it into
+// updateAgentInD1). Capture a shared spy logger so tests assert structured
+// calls instead of the pre-migration console.* output.
+const { heartbeatLogger } = vi.hoisted(() => ({
+  heartbeatLogger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    child(): unknown {
+      return this;
+    },
+  },
+}));
+
+vi.mock("@/lib/logging", () => ({
+  createLogger: () => heartbeatLogger,
+  createConsoleLogger: () => heartbeatLogger,
+  createNoopLogger: () => heartbeatLogger,
+  isLogsRPC: () => false,
+}));
+
 vi.mock("@/lib/levels", () => ({
   getAgentLevel: vi.fn().mockReturnValue({ level: 1, levelName: "Registered" }),
   getNextLevel: vi.fn().mockReturnValue(null),
@@ -293,7 +315,6 @@ describe("heartbeat POST — fail-open on binding throw", () => {
     const mockKv = buildMockKv();
     const mock = buildMockD1();
     const limit = vi.fn().mockRejectedValue(new Error("ratelimits transient"));
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
     (getCloudflareContext as Mock).mockResolvedValue({
       env: {
@@ -308,11 +329,10 @@ describe("heartbeat POST — fail-open on binding throw", () => {
 
     expect(response.status).toBe(200);
     expect(mock.run).toHaveBeenCalledTimes(1);
-    expect(errorSpy).toHaveBeenCalledWith(
+    expect(heartbeatLogger.error).toHaveBeenCalledWith(
       "heartbeat.ratelimit_binding_threw",
       expect.objectContaining({ btcAddress: TEST_BTC })
     );
-    errorSpy.mockRestore();
   });
 });
 
@@ -326,7 +346,6 @@ describe("heartbeat POST — D1 update failure does NOT 500 (P3A: KV-source-of-t
     const mockKv = buildMockKv();
     const mock = buildMockD1(() => Promise.reject(new Error("D1 boom")));
     const limit = vi.fn().mockResolvedValue({ success: true });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
 
     (getCloudflareContext as Mock).mockResolvedValue({
       env: {
@@ -343,14 +362,17 @@ describe("heartbeat POST — D1 update failure does NOT 500 (P3A: KV-source-of-t
     expect(limit).toHaveBeenCalledTimes(1);
     // KV mirror still writes — that's the authoritative path in P3A.
     expect(mockKv.put).toHaveBeenCalled();
-    // Mirror failure logged via the agents-mirror helper, not heartbeat.
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[agents-mirror]")
+    // Mirror failure logged via the agents-mirror helper (#551: heartbeat now
+    // threads its request logger into updateAgentInD1 so the warning correlates).
+    expect(heartbeatLogger.warn).toHaveBeenCalledWith(
+      "updateAgentInD1 failed",
+      expect.objectContaining({
+        error: expect.stringContaining("D1 boom"),
+      })
     );
     // Response payload still includes the timestamp the caller submitted.
     const body = (await response.json()) as { checkIn: { lastCheckInAt: string } };
     expect(body.checkIn.lastCheckInAt).toBe(TEST_TIMESTAMP);
-    warnSpy.mockRestore();
   });
 });
 

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -11,6 +11,7 @@ import { generateName } from "@/lib/name-generator";
 import { getAgentInboxStats } from "@/lib/inbox/stats";
 import { listBounties } from "@/lib/bounty";
 import { withEdgeCache } from "@/lib/edge-cache";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import {
   CHECK_IN_MESSAGE_FORMAT,
   CHECK_IN_RATE_LIMIT_SECONDS,
@@ -410,6 +411,10 @@ export async function POST(request: NextRequest) {
 
     // Get Cloudflare context (KV, D1, ratelimits binding)
     const { env, ctx } = await getCloudflareContext();
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+      : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
     const kv = env.VERIFIED_AGENTS as KVNamespace;
     const db = env.DB as D1Database | undefined;
 
@@ -469,7 +474,7 @@ export async function POST(request: NextRequest) {
         });
       }
     } catch (e) {
-      console.error("heartbeat.ratelimit_binding_threw", {
+      logger.error("heartbeat.ratelimit_binding_threw", {
         btcAddress,
         error: (e as Error).message,
       });
@@ -491,7 +496,7 @@ export async function POST(request: NextRequest) {
     // if D1 lagged; the timestamp will reconcile on the next successful
     // mutation via the max() expression in updateAgentInD1.
     if (db) {
-      await updateAgentInD1(db, updatedAgent);
+      await updateAgentInD1(db, updatedAgent, logger);
     }
 
     // Write canonical btc: key only; stx: secondary index is no longer

--- a/app/api/identity/[address]/__tests__/stx-db-threading.test.ts
+++ b/app/api/identity/[address]/__tests__/stx-db-threading.test.ts
@@ -43,6 +43,7 @@ vi.mock("@/lib/identity/constants", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: vi.fn().mockReturnValue({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: vi.fn().mockReturnValue({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: vi.fn().mockReturnValue(false),

--- a/app/api/inbox/[address]/[messageId]/__tests__/d1-reads-flip.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/d1-reads-flip.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/lib/bitcoin-verify", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/dual-write.test.ts
@@ -57,6 +57,7 @@ vi.mock("@/lib/inbox/stats", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/inbox/[address]/[messageId]/__tests__/rate-limit.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/rate-limit.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/lib/inbox", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/inbox/[address]/[messageId]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/inbox/[address]/[messageId]/__tests__/write-path-d1-flip.test.ts
@@ -52,6 +52,7 @@ vi.mock("@/lib/inbox/stats", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-sentcount-partners.test.ts
@@ -44,6 +44,7 @@ vi.mock("@/lib/cache", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
+++ b/app/api/inbox/[address]/__tests__/d1-throws-fallback.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/cache", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/inbox/[address]/__tests__/dual-write.test.ts
+++ b/app/api/inbox/[address]/__tests__/dual-write.test.ts
@@ -95,6 +95,7 @@ vi.mock("@/lib/bitcoin-verify", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
+++ b/app/api/inbox/[address]/__tests__/uniq-violation-409.test.ts
@@ -95,6 +95,7 @@ vi.mock("@/lib/bitcoin-verify", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/inbox/[address]/__tests__/unread-counter-drift-selfheal.test.ts
+++ b/app/api/inbox/[address]/__tests__/unread-counter-drift-selfheal.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/lib/cache", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -4,6 +4,7 @@ import { LEVELS } from "@/lib/levels";
 import { ACTIVITY_THRESHOLDS } from "@/lib/utils";
 import { SCORING, computeLevelBonus } from "@/lib/scoring";
 import { getCachedAgentList } from "@/lib/cache";
+import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 
 export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
@@ -134,8 +135,13 @@ export async function GET(request: NextRequest) {
   const limit = limitParam ? Math.min(parseInt(limitParam, 10) || 100, 100) : 100;
   const offset = offsetParam ? Math.max(parseInt(offsetParam, 10) || 0, 0) : 0;
 
+  const { env, ctx } = await getCloudflareContext();
+  const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+  const logger = isLogsRPC(env.LOGS)
+    ? createLogger(env.LOGS, ctx, { rayId, path: new URL(request.url).pathname })
+    : createConsoleLogger({ rayId, path: new URL(request.url).pathname });
+
   try {
-    const { env } = await getCloudflareContext();
     const kv = env.VERIFIED_AGENTS as KVNamespace;
 
     const { agents: cachedAgents } = await getCachedAgentList(kv);
@@ -296,7 +302,7 @@ export async function GET(request: NextRequest) {
       }
     );
   } catch (e) {
-    console.error("Leaderboard fetch error:", e);
+    logger.error("Leaderboard fetch error", { error: String(e) });
     return NextResponse.json(
       { error: `Failed to fetch leaderboard: ${(e as Error).message}` },
       { status: 500 }

--- a/app/api/outbox/[address]/__tests__/d1-reads-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/d1-reads-flip.test.ts
@@ -74,6 +74,7 @@ vi.mock("@/lib/bitcoin-verify", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/outbox/[address]/__tests__/rate-limit.test.ts
+++ b/app/api/outbox/[address]/__tests__/rate-limit.test.ts
@@ -39,6 +39,7 @@ vi.mock("@/lib/inbox", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   isLogsRPC: vi.fn(() => false),
   createConsoleLogger: vi.fn(() => ({
     info: vi.fn(),

--- a/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
+++ b/app/api/outbox/[address]/__tests__/write-path-d1-flip.test.ts
@@ -72,6 +72,7 @@ vi.mock("@/lib/bitcoin-verify", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/register/__tests__/stx-d1-dupcheck.test.ts
+++ b/app/api/register/__tests__/stx-d1-dupcheck.test.ts
@@ -77,6 +77,7 @@ vi.mock("@/lib/vouch", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -879,7 +879,11 @@ export async function POST(request: NextRequest) {
       try {
         await storeVouch(kv, vouchRecord);
       } catch (err) {
-        console.error("Failed to store vouch record:", err);
+        log.error("Failed to store vouch record", {
+          referrer: vouchRecord.referrer,
+          referee: vouchRecord.referee,
+          error: String(err),
+        });
       }
     }
 
@@ -888,7 +892,10 @@ export async function POST(request: NextRequest) {
     try {
       referralCode = await generateAndStoreReferralCode(kv, btcResult.address);
     } catch (err) {
-      console.error("Failed to generate referral code:", err);
+      log.error("Failed to generate referral code", {
+        address: btcResult.address,
+        error: String(err),
+      });
     }
 
     // Mirror the new agent into D1 alongside the KV writes above.
@@ -904,7 +911,10 @@ export async function POST(request: NextRequest) {
         try {
           await insertAgentToD1(db, record, referralCodeForMirror);
         } catch (err) {
-          console.error("Failed to mirror agent to D1:", err);
+          log.error("Failed to mirror agent to D1", {
+            btcAddress: record.btcAddress,
+            error: String(err),
+          });
         }
       });
     }

--- a/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
+++ b/app/api/resolve/[identifier]/__tests__/stx-d1-lookup.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/lib/cache/agent-profile", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   createConsoleLogger: () => ({ info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
   isLogsRPC: () => false,

--- a/app/api/resolve/[identifier]/route.ts
+++ b/app/api/resolve/[identifier]/route.ts
@@ -517,7 +517,12 @@ export async function GET(
       }
     );
   } catch (e) {
-    console.error("Agent resolution error:", e);
+    const { env, ctx } = await getCloudflareContext();
+    const rayId = request.headers.get("cf-ray") || crypto.randomUUID();
+    const logger = isLogsRPC(env.LOGS)
+      ? createLogger(env.LOGS, ctx, { rayId, path: request.nextUrl.pathname })
+      : createConsoleLogger({ rayId, path: request.nextUrl.pathname });
+    logger.error("Agent resolution error", { error: String(e) });
     return NextResponse.json(
       { error: `Resolution failed: ${(e as Error).message}` },
       { status: 500 }

--- a/lib/admin/auth.ts
+++ b/lib/admin/auth.ts
@@ -1,5 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
+import { type Logger, createNoopLogger } from "@/lib/logging";
 
 /**
  * Authenticate an admin request via X-Admin-Key header.
@@ -11,7 +12,8 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
  *   if (denied) return denied;
  */
 export async function requireAdmin(
-  request: NextRequest
+  request: NextRequest,
+  logger: Logger = createNoopLogger()
 ): Promise<NextResponse | null> {
   const adminKey = request.headers.get("X-Admin-Key");
   if (!adminKey) {
@@ -25,7 +27,7 @@ export async function requireAdmin(
   const expectedKey = env.ARC_ADMIN_API_KEY;
 
   if (!expectedKey) {
-    console.error("ARC_ADMIN_API_KEY is not configured");
+    logger.error("ARC_ADMIN_API_KEY is not configured");
     return NextResponse.json(
       { error: "Server configuration error" },
       { status: 500 }

--- a/lib/agent-lookup.ts
+++ b/lib/agent-lookup.ts
@@ -13,6 +13,7 @@ import {
   mapRowToAgentRecord,
 } from "@/lib/cache/agent-profile";
 import type { AgentRecord, ClaimStatus } from "@/lib/types";
+import { createNoopLogger, type Logger } from "@/lib/logging";
 
 /**
  * Look up an agent by BTC, STX, or taproot address.
@@ -29,7 +30,8 @@ import type { AgentRecord, ClaimStatus } from "@/lib/types";
 export async function lookupAgent(
   kv: KVNamespace,
   address: string,
-  db?: D1Database
+  db?: D1Database,
+  logger: Logger = createNoopLogger()
 ): Promise<AgentRecord | null> {
   // Taproot addresses (bc1p...) use a reverse index
   if (address.startsWith("bc1p")) {
@@ -40,7 +42,10 @@ export async function lookupAgent(
     try {
       return JSON.parse(data) as AgentRecord;
     } catch (e) {
-      console.error(`Failed to parse agent record for taproot ${address}:`, e);
+      logger.error("Failed to parse agent record for taproot address", {
+        address,
+        error: String(e),
+      });
       return null;
     }
   }
@@ -49,7 +54,7 @@ export async function lookupAgent(
   if (address.startsWith("SP") || address.startsWith("SM") || address.startsWith("ST")) {
     try {
       if (!db) {
-        console.error(
+        logger.error(
           "lookupAgent: D1 binding (DB) unavailable for STX lookup; returning null (fail-closed)",
           { stxAddress: address }
         );
@@ -58,7 +63,7 @@ export async function lookupAgent(
       const row = await lookupProfileByStxAddress(db, address);
       return row ? mapRowToAgentRecord(row) : null;
     } catch (d1Err) {
-      console.error("lookupAgent: D1 STX lookup failed; returning null (fail-closed)", {
+      logger.error("lookupAgent: D1 STX lookup failed; returning null (fail-closed)", {
         stxAddress: address,
         error: String(d1Err),
       });
@@ -72,7 +77,10 @@ export async function lookupAgent(
   try {
     return JSON.parse(btcData) as AgentRecord;
   } catch (e) {
-    console.error(`Failed to parse agent record for address ${address}:`, e);
+    logger.error("Failed to parse agent record for address", {
+      address,
+      error: String(e),
+    });
     return null;
   }
 }
@@ -117,7 +125,8 @@ export async function lookupAgentWithLevel(
   kv: KVNamespace,
   address: string,
   minLevel: number = 0,
-  db?: D1Database
+  db?: D1Database,
+  logger: Logger = createNoopLogger()
 ): Promise<LookupWithLevelSuccess | LookupWithLevelError> {
   // Determine address prefix
   const prefix =
@@ -158,7 +167,7 @@ export async function lookupAgentWithLevel(
     // STX path: D1 lookup — fail-closed on D1 error or missing binding.
     try {
       if (!db) {
-        console.error(
+        logger.error(
           "lookupAgentWithLevel: D1 binding (DB) unavailable for STX lookup; returning not-found (fail-closed)",
           { stxAddress: address }
         );
@@ -170,7 +179,7 @@ export async function lookupAgentWithLevel(
       }
       agent = mapRowToAgentRecord(row);
     } catch (d1Err) {
-      console.error(
+      logger.error(
         "lookupAgentWithLevel: D1 STX lookup failed; returning not-found (fail-closed)",
         { stxAddress: address, error: String(d1Err) }
       );

--- a/lib/bitcoin-verify.ts
+++ b/lib/bitcoin-verify.ts
@@ -15,6 +15,7 @@ import {
 } from "@scure/btc-signer";
 import type { AgentRecord } from "@/lib/types";
 import { updateAgentInD1 } from "@/lib/d1/agents-mirror";
+import { createNoopLogger, type Logger } from "@/lib/logging";
 
 export { BTC_NETWORK };
 export const BITCOIN_MSG_PREFIX = "\x18Bitcoin Signed Message:\n";
@@ -223,7 +224,8 @@ function bip322BuildToSpendTxId(
 export function bip322VerifyP2WPKH(
   message: string,
   signatureBase64: string,
-  address: string
+  address: string,
+  logger: Logger = createNoopLogger()
 ): { valid: boolean; pubkeyHex: string } {
   const sigBytes = Uint8Array.from(Buffer.from(signatureBase64, "base64"));
   const witnessItems = RawWitness.decode(sigBytes);
@@ -268,8 +270,9 @@ export function bip322VerifyP2WPKH(
     // Fall back to legacy tagged hash (varint prepend) for agents using older signing tools.
     const toSpendTxidLegacy = bip322BuildToSpendTxId(message, scriptPubKey, true);
     if (!verifySighash(toSpendTxidLegacy)) return { valid: false, pubkeyHex: "" };
-    console.warn(
-      "BIP-322 signature uses non-standard tagged hash. Update your signing tool — see aibtcdev/skills or install latest @aibtc/mcp-server."
+    logger.warn(
+      "BIP-322 signature uses non-standard tagged hash. Update your signing tool — see aibtcdev/skills or install latest @aibtc/mcp-server.",
+      { address }
     );
   }
 
@@ -341,7 +344,8 @@ function bip322P2TRSighash(toSpendTxid: Uint8Array, scriptPubKey: Uint8Array): U
 export function bip322VerifyP2TR(
   message: string,
   signatureBase64: string,
-  address: string
+  address: string,
+  logger: Logger = createNoopLogger()
 ): boolean {
   const sigBytes = Uint8Array.from(Buffer.from(signatureBase64, "base64"));
   const witnessItems = RawWitness.decode(sigBytes);
@@ -380,8 +384,9 @@ export function bip322VerifyP2TR(
     if (!schnorr.verify(schnorrSig, bip322P2TRSighash(toSpendTxidLegacy, scriptPubKey), tweakedKey)) {
       return false;
     }
-    console.warn(
-      "BIP-322 signature uses non-standard tagged hash. Update your signing tool — see aibtcdev/skills or install latest @aibtc/mcp-server."
+    logger.warn(
+      "BIP-322 signature uses non-standard tagged hash. Update your signing tool — see aibtcdev/skills or install latest @aibtc/mcp-server.",
+      { address }
     );
   }
 
@@ -550,7 +555,8 @@ export async function persistBtcPubkeyIfMissing(
   db: D1Database | undefined,
   btcAddress: string,
   pubkeyHex: string,
-  agent: AgentRecord
+  agent: AgentRecord,
+  logger: Logger = createNoopLogger()
 ): Promise<void> {
   try {
     if (!pubkeyHex) return;
@@ -567,9 +573,9 @@ export async function persistBtcPubkeyIfMissing(
       kv.put(`stx:${updatedAgent.stxAddress}`, JSON.stringify(updatedAgent)),
     ]);
 
-    console.log(
-      `[btcPublicKey-capture] Persisted pubkey for ${btcAddress} via BIP-322 witness`
-    );
+    logger.info("[btcPublicKey-capture] Persisted pubkey via BIP-322 witness", {
+      btcAddress,
+    });
 
     // D1 UPDATE via the canonical mirror helper (P3A). Different semantics
     // from the prior targeted UPDATE:
@@ -594,8 +600,9 @@ export async function persistBtcPubkeyIfMissing(
     await updateAgentInD1(db, updatedAgent);
   } catch (err) {
     // Never throw — persistence failure must not affect the calling request.
-    console.error(
-      `[btcPublicKey-capture] Failed to persist pubkey for ${btcAddress}: ${(err as Error).message}`
-    );
+    logger.error("[btcPublicKey-capture] Failed to persist pubkey", {
+      btcAddress,
+      error: (err as Error).message,
+    });
   }
 }

--- a/lib/cache/agent-list.ts
+++ b/lib/cache/agent-list.ts
@@ -16,6 +16,7 @@
 
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { computeLevel, LEVELS } from "@/lib/levels";
+import { type Logger, createNoopLogger } from "@/lib/logging";
 import type { CachedAgent, CachedAgentList } from "./types";
 
 const CACHE_KEY = "cache:agent-list";
@@ -280,7 +281,8 @@ export function mapRowToCachedAgent(row: AgentListRow): CachedAgent {
  * existing pattern in all route files; no new binding parameter needed.
  */
 async function rebuildAgentListCache(
-  kv: KVNamespace
+  kv: KVNamespace,
+  logger: Logger = createNoopLogger()
 ): Promise<CachedAgentList> {
   const { env } = await getCloudflareContext();
   const db = env.DB as D1Database;
@@ -324,8 +326,9 @@ async function rebuildAgentListCache(
   // a library module without request-scoped logger access; raw console is
   // intentional for diagnostic visibility on a path that otherwise swallows.
   if (!result.success) {
-    // eslint-disable-next-line no-console
-    console.error("agent-list rebuild: D1 query failed", result.error);
+    logger.error("agent-list rebuild: D1 query failed", {
+      error: String(result.error),
+    });
   }
 
   const rows = result.results ?? [];

--- a/lib/challenge.ts
+++ b/lib/challenge.ts
@@ -6,6 +6,7 @@
  */
 
 import type { AgentRecord } from "@/lib/types";
+import { type Logger, createNoopLogger } from "@/lib/logging";
 import { validateNostrPubkey } from "@/lib/nostr";
 import { p2wpkh, p2tr, NETWORK as BTC_NETWORK } from "@scure/btc-signer";
 import { hex } from "@scure/base";
@@ -72,7 +73,8 @@ export async function storeChallenge(
  */
 export async function getChallenge(
   kv: KVNamespace,
-  address: string
+  address: string,
+  logger: Logger = createNoopLogger()
 ): Promise<ChallengeStoreRecord | null> {
   const value = await kv.get(`challenge:${address}`);
 
@@ -83,7 +85,7 @@ export async function getChallenge(
   try {
     return JSON.parse(value) as ChallengeStoreRecord;
   } catch (e) {
-    console.error(`Failed to parse challenge for ${address}:`, e);
+    logger.error("Failed to parse challenge", { address, error: String(e) });
     return null;
   }
 }

--- a/lib/competition/__tests__/stats.test.ts
+++ b/lib/competition/__tests__/stats.test.ts
@@ -117,14 +117,17 @@ describe("recordSwapInsert", () => {
     const { db } = createMockD1({
       runError: new Error("FOREIGN KEY constraint failed"),
     });
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // #551: the warning now goes through the injected Logger, not console.
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
     await expect(
-      recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "success")
+      recordSwapInsert(db, STX_ADDRESS, BURN_BLOCK_TIME, "success", logger)
     ).resolves.toBeUndefined();
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("[agent-swap-stats]")
+    expect(logger.warn).toHaveBeenCalledWith(
+      "agent_swap_stats.record_failed",
+      expect.objectContaining({
+        error: expect.stringContaining("FOREIGN KEY constraint failed"),
+      })
     );
-    warnSpy.mockRestore();
   });
 });
 

--- a/lib/competition/d1-reads.ts
+++ b/lib/competition/d1-reads.ts
@@ -15,6 +15,8 @@
  * See: docs/rfc-d1-schema.md `### `swaps``
  */
 
+import { type Logger, createNoopLogger } from "@/lib/logging";
+
 /**
  * A single row from swaps mapped to the API response shape.
  * Field names mirror the migration (sender, token_in, etc.) — not the
@@ -276,7 +278,8 @@ export async function listSwapsFromD1(
  */
 export async function countSwapsFromD1(
   db: D1Database,
-  stxAddress: string
+  stxAddress: string,
+  logger: Logger = createNoopLogger()
 ): Promise<number> {
   // P3B PR 2: was `SELECT COUNT(*) FROM swaps WHERE sender = ?1`
   // (textbook D1 COUNT(*) anti-pattern — pay-per-row-scanned).
@@ -300,10 +303,10 @@ export async function countSwapsFromD1(
     .first<{ cnt: number }>();
   const count = fallback?.cnt ?? 0;
   if (count > 0) {
-    // eslint-disable-next-line no-console
-    console.warn(
-      `[agent-swap-stats] miss for sender ${stxAddress} fell back to COUNT(*) and found ${count} — possible un-backfilled or stale stats row`
-    );
+    logger.warn("agent_swap_stats.miss_fell_back_to_count", {
+      stxAddress,
+      count,
+    });
   }
   return count;
 }

--- a/lib/competition/stats.ts
+++ b/lib/competition/stats.ts
@@ -19,7 +19,7 @@
  * coalesce to zero/null as appropriate for their response shape.
  */
 
-import type { Logger } from "@/lib/logging";
+import { type Logger, createNoopLogger } from "@/lib/logging";
 
 /** Shape returned by `getSwapStats`; matches the `agent_swap_stats` columns. */
 export interface SwapStatsRow {
@@ -66,7 +66,7 @@ export async function recordSwapInsert(
   stxAddress: string,
   burnBlockTime: number,
   txStatus: string,
-  logger?: Logger
+  logger: Logger = createNoopLogger()
 ): Promise<void> {
   const verifiedDelta = txStatus === "success" ? 1 : 0;
   const updatedAt = new Date().toISOString();
@@ -96,17 +96,10 @@ export async function recordSwapInsert(
     // the caller, and the next successful recordSwapInsert for this
     // sender will reconcile via the ON CONFLICT branch. The fallback
     // path in countSwapsFromD1 also surfaces the drift if it persists.
-    if (logger) {
-      logger.warn("agent_swap_stats.record_failed", {
-        stxAddress,
-        error: (e as Error).message,
-      });
-    } else {
-      // eslint-disable-next-line no-console
-      console.warn(
-        `[agent-swap-stats] recordSwapInsert failed for ${stxAddress}: ${(e as Error).message}`
-      );
-    }
+    logger.warn("agent_swap_stats.record_failed", {
+      stxAddress,
+      error: (e as Error).message,
+    });
   }
 }
 

--- a/lib/d1/__tests__/agents-mirror.test.ts
+++ b/lib/d1/__tests__/agents-mirror.test.ts
@@ -206,16 +206,19 @@ describe("updateAgentInD1", () => {
 
   it("swallows D1 errors and logs a warning (KV is source-of-truth in P3A)", async () => {
     const { db, throwOnNextRun, runs } = makeMockDb();
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    // #551: the warning now goes through the injected Logger, not console.
+    const logger = { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() };
 
     throwOnNextRun(new Error("FOREIGN KEY constraint failed"));
 
     // Must not throw to the caller even though the underlying D1 op rejected.
-    await expect(updateAgentInD1(db, makeAgent())).resolves.toBeUndefined();
+    await expect(updateAgentInD1(db, makeAgent(), logger)).resolves.toBeUndefined();
     expect(runs).toHaveLength(1);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("FOREIGN KEY constraint failed")
+    expect(logger.warn).toHaveBeenCalledWith(
+      "updateAgentInD1 failed",
+      expect.objectContaining({
+        error: expect.stringContaining("FOREIGN KEY constraint failed"),
+      })
     );
-    warnSpy.mockRestore();
   });
 });

--- a/lib/d1/agents-mirror.ts
+++ b/lib/d1/agents-mirror.ts
@@ -20,6 +20,7 @@
  */
 
 import type { AgentRecord } from "@/lib/types";
+import { type Logger, createNoopLogger } from "@/lib/logging";
 
 /**
  * Mirror a newly-registered agent into D1. Called from the registration
@@ -112,7 +113,8 @@ export async function insertAgentToD1(
  */
 export async function updateAgentInD1(
   db: D1Database | undefined,
-  agent: AgentRecord
+  agent: AgentRecord,
+  logger: Logger = createNoopLogger()
 ): Promise<void> {
   if (!db) return;
 
@@ -186,9 +188,10 @@ export async function updateAgentInD1(
     // FK violations (referrer not yet in D1), schema mismatches, or
     // transient binding errors. Log and continue — P3A is a transition
     // phase, KV is authoritative.
-    console.warn(
-      `[agents-mirror] updateAgentInD1 failed for ${agent.btcAddress}: ${(e as Error).message}`
-    );
+    logger.warn("updateAgentInD1 failed", {
+      btcAddress: agent.btcAddress,
+      error: (e as Error).message,
+    });
   }
 }
 

--- a/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
+++ b/lib/inbox/__tests__/inbox-pending-no-paymentid.test.ts
@@ -73,6 +73,7 @@ vi.mock("@/lib/cache", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => mocks.logger,
   createConsoleLogger: () => mocks.logger,
   isLogsRPC: () => false,

--- a/lib/inbox/__tests__/payment-status-route.test.ts
+++ b/lib/inbox/__tests__/payment-status-route.test.ts
@@ -91,6 +91,7 @@ vi.mock("@/lib/cache", () => ({
 }));
 
 vi.mock("@/lib/logging", () => ({
+  createNoopLogger: () => ({ debug: () => {}, info: () => {}, warn: () => {}, error: () => {}, child() { return this; } }),
   createLogger: () => mocks.logger,
   createConsoleLogger: () => mocks.logger,
   isLogsRPC: () => false,

--- a/lib/inbox/kv-helpers.ts
+++ b/lib/inbox/kv-helpers.ts
@@ -16,6 +16,7 @@ import type {
 import { insertInboundMessageToD1, isPaymentTxidUniqueViolation } from "./d1-dual-write";
 import { getInboxMessageFromD1 } from "./d1-reads";
 import { bumpInboundStats } from "./stats";
+import { createNoopLogger, type Logger } from "@/lib/logging";
 
 /**
  * Build KV key for an individual inbox message.
@@ -70,7 +71,8 @@ function buildStagedPaymentKey(paymentId: string): string {
  */
 export async function getMessage(
   kv: KVNamespace,
-  messageId: string
+  messageId: string,
+  logger: Logger = createNoopLogger()
 ): Promise<InboxMessage | null> {
   const key = buildMessageKey(messageId);
   const data = await kv.get(key);
@@ -79,7 +81,7 @@ export async function getMessage(
   try {
     return JSON.parse(data) as InboxMessage;
   } catch (e) {
-    console.error(`Failed to parse inbox message ${key}:`, e);
+    logger.error("Failed to parse inbox message", { key, error: String(e) });
     return null;
   }
 }
@@ -145,7 +147,8 @@ export async function updateMessage(
  */
 export async function getReply(
   kv: KVNamespace,
-  messageId: string
+  messageId: string,
+  logger: Logger = createNoopLogger()
 ): Promise<OutboxReply | null> {
   const key = buildReplyKey(messageId);
   const data = await kv.get(key);
@@ -154,7 +157,7 @@ export async function getReply(
   try {
     return JSON.parse(data) as OutboxReply;
   } catch (e) {
-    console.error(`Failed to parse outbox reply ${key}:`, e);
+    logger.error("Failed to parse outbox reply", { key, error: String(e) });
     return null;
   }
 }
@@ -203,7 +206,8 @@ export async function storeReply(
  */
 export async function getAgentInbox(
   kv: KVNamespace,
-  btcAddress: string
+  btcAddress: string,
+  logger: Logger = createNoopLogger()
 ): Promise<InboxAgentIndex | null> {
   const key = buildAgentIndexKey(btcAddress);
   const data = await kv.get(key);
@@ -212,7 +216,7 @@ export async function getAgentInbox(
   try {
     return JSON.parse(data) as InboxAgentIndex;
   } catch (e) {
-    console.error(`Failed to parse inbox agent index ${key}:`, e);
+    logger.error("Failed to parse inbox agent index", { key, error: String(e) });
     return null;
   }
 }
@@ -275,7 +279,8 @@ export async function updateAgentInbox(
  */
 export async function getSentIndex(
   kv: KVNamespace,
-  btcAddress: string
+  btcAddress: string,
+  logger: Logger = createNoopLogger()
 ): Promise<SentMessageIndex | null> {
   const key = buildSentIndexKey(btcAddress);
   const data = await kv.get(key);
@@ -284,7 +289,7 @@ export async function getSentIndex(
   try {
     return JSON.parse(data) as SentMessageIndex;
   } catch (e) {
-    console.error(`Failed to parse sent index ${key}:`, e);
+    logger.error("Failed to parse sent index", { key, error: String(e) });
     return null;
   }
 }
@@ -328,7 +333,8 @@ export async function updateSentIndex(
 
 export async function getStagedInboxPayment(
   kv: KVNamespace,
-  paymentId: string
+  paymentId: string,
+  logger: Logger = createNoopLogger()
 ): Promise<StagedInboxMessage | null> {
   const data = await kv.get(buildStagedPaymentKey(paymentId));
   if (!data) return null;
@@ -336,7 +342,7 @@ export async function getStagedInboxPayment(
   try {
     return JSON.parse(data) as StagedInboxMessage;
   } catch (e) {
-    console.error(`Failed to parse staged inbox payment ${paymentId}:`, e);
+    logger.error("Failed to parse staged inbox payment", { paymentId, error: String(e) });
     return null;
   }
 }

--- a/lib/logging.ts
+++ b/lib/logging.ts
@@ -118,6 +118,31 @@ export function createConsoleLogger(
 }
 
 // =============================================================================
+// Noop Logger (default for shared helpers used in unlogged contexts)
+// =============================================================================
+
+/**
+ * A logger that discards everything.
+ *
+ * Shared server helpers that emit operational logs should accept an optional
+ * `Logger` and default to this, rather than calling `console.*` directly (see
+ * issue #551). Callers that have a request-scoped logger pass it through for
+ * correlated worker-logs output; callers that don't (or unlogged contexts) get
+ * silent no-ops instead of ad hoc console noise.
+ */
+export function createNoopLogger(): Logger {
+  const noop = () => {};
+  const logger: Logger = {
+    debug: noop,
+    info: noop,
+    warn: noop,
+    error: noop,
+    child: () => logger,
+  };
+  return logger;
+}
+
+// =============================================================================
 // RPC Logger (production with worker-logs binding)
 // =============================================================================
 

--- a/lib/vouch/kv-helpers.ts
+++ b/lib/vouch/kv-helpers.ts
@@ -5,6 +5,7 @@
 import { KV_PREFIXES } from "./constants";
 import { generateClaimCode } from "@/lib/claim-code";
 import type { VouchRecord, VouchAgentIndex, ReferralCodeRecord } from "./types";
+import { createNoopLogger, type Logger } from "@/lib/logging";
 
 /**
  * Build KV key for a vouch record.
@@ -26,7 +27,8 @@ function buildAgentIndexKey(btcAddress: string): string {
 export async function getVouchRecord(
   kv: KVNamespace,
   referrerBtc: string,
-  refereeBtc: string
+  refereeBtc: string,
+  logger: Logger = createNoopLogger()
 ): Promise<VouchRecord | null> {
   const key = buildVouchKey(referrerBtc, refereeBtc);
   const data = await kv.get(key);
@@ -34,7 +36,7 @@ export async function getVouchRecord(
   try {
     return JSON.parse(data) as VouchRecord;
   } catch (e) {
-    console.error(`Failed to parse vouch record ${key}:`, e);
+    logger.error("Failed to parse vouch record", { key, error: String(e) });
     return null;
   }
 }
@@ -82,7 +84,8 @@ export async function storeVouch(
  */
 export async function getVouchIndex(
   kv: KVNamespace,
-  btcAddress: string
+  btcAddress: string,
+  logger: Logger = createNoopLogger()
 ): Promise<VouchAgentIndex | null> {
   const key = buildAgentIndexKey(btcAddress);
   const data = await kv.get(key);
@@ -90,7 +93,7 @@ export async function getVouchIndex(
   try {
     return JSON.parse(data) as VouchAgentIndex;
   } catch (e) {
-    console.error(`Failed to parse vouch index ${key}:`, e);
+    logger.error("Failed to parse vouch index", { key, error: String(e) });
     return null;
   }
 }
@@ -154,14 +157,15 @@ export async function storeReferralCode(
  */
 export async function getReferralCode(
   kv: KVNamespace,
-  btcAddress: string
+  btcAddress: string,
+  logger: Logger = createNoopLogger()
 ): Promise<ReferralCodeRecord | null> {
   const data = await kv.get(buildReferralCodeKey(btcAddress));
   if (!data) return null;
   try {
     return JSON.parse(data) as ReferralCodeRecord;
   } catch (e) {
-    console.error(`Failed to parse referral code for ${btcAddress}:`, e);
+    logger.error("Failed to parse referral code", { btcAddress, error: String(e) });
     return null;
   }
 }


### PR DESCRIPTION
Closes #551.

Standardizes server-side runtime logging on the existing structured Logs RPC logger (`lib/logging.ts` → worker-logs binding, correlated by `rayId`/`path`), removing the ~54 stray `console.*` calls that were dumping uncorrelated output to Cloudflare stdout and splitting production logs across two pipelines.

## What changed

**Route handlers (12)** — each creates or reuses one request-scoped logger and uses it. Where a stray `console.*` sat in an outer `catch`, the context + logger are hoisted above the `try` so the error path logs via RPC (not a standalone console fallback).

**Shared libs (10)** — the helper that logged gains an optional trailing `logger: Logger = createNoopLogger()` param (new `createNoopLogger()` added to `lib/logging.ts`). Callers with a request logger get correlated output; callers without one stay silent instead of writing to console. No external call sites needed changing.

**heartbeat** threads its request logger into `updateAgentInD1`, so a D1 mirror-failure warning correlates to the request.

Interpolated error strings were converted to a stable message + structured context object (`logger.error("Failed to parse X", { key, error: String(e) })`). Only ids/addresses/status/booleans/error strings are logged — no secrets, signatures, or full payloads.

## The one intentional remaining `console.*`

`app/api/admin/schema-health/route.ts` logs to console in the single catch where `getCloudflareContext()` itself threw — there's genuinely no `env.LOGS`/`ctx` to build an RPC logger from. It's annotated as intentional. (Plus `lib/logging.ts`'s own console fallback and a JSDoc `@example` comment, both out of scope per the issue.)

## Tests

- Added `createNoopLogger` to all 24 `@/lib/logging` test mocks (the new export is now reachable via lib default-param evaluation).
- Fixed a latent test-harness assumption: loggers now derive `path` from `new URL(request.url).pathname` so routes work with the plain-`Request` mocks those older suites use.
- Updated `agents-mirror`, `stats`, and `heartbeat` tests to assert on the injected logger instead of spying on `console`.

**All 1512 `app/api` + `lib` tests pass; non-test typecheck clean.**

## Acceptance criteria (from #551)

- [x] No direct `console.*` in server runtime code except the intentional fallbacks
- [x] Every touched route handler uses a request-scoped logger
- [x] Shared helpers accept a `Logger` / use a noop fallback
- [x] Structured context instead of interpolated error strings
- [x] No sensitive values logged
- [x] Existing behavior and tests still pass
