### PR TITLE
perf(cost): cut cron Hiro fan-out, coalesce heartbeat KV writes, drop redundant D1 scans

### DIFF
--- a/app/api/bounties/[id]/route.ts
+++ b/app/api/bounties/[id]/route.ts
@@ -53,7 +53,8 @@ export async function GET(
     db,
     bounty.id,
     20,
-    0
+    0,
+    bounty.submissionCount
   );
 
   // Winner block — populated whenever the bounty has acceptedAt (i.e. on

--- a/app/api/bounties/[id]/submissions/route.ts
+++ b/app/api/bounties/[id]/submissions/route.ts
@@ -39,7 +39,13 @@ export async function GET(
   const limit = clampInt(url.searchParams.get("limit"), 20, 1, 100);
   const offset = clampInt(url.searchParams.get("offset"), 0, 0, 100_000);
 
-  const { submissions, total } = await listSubmissionsForBounty(db, id, limit, offset);
+  const { submissions, total } = await listSubmissionsForBounty(
+    db,
+    id,
+    limit,
+    offset,
+    bounty.submissionCount
+  );
   const nextOffset = offset + submissions.length < total ? offset + submissions.length : null;
 
   return NextResponse.json(

--- a/app/api/competition/tracked-tokens/route.ts
+++ b/app/api/competition/tracked-tokens/route.ts
@@ -82,7 +82,11 @@ export async function GET(request: NextRequest) {
     },
     {
       headers: {
-        "Cache-Control": "public, max-age=60, s-maxage=60",
+        // 5 min. The active set is derived from an unbounded full-scan GROUP BY
+        // over the swaps table (getActiveTokenIds), so cache-misses are the
+        // expensive path; the set only shifts as agents trade new tokens, which
+        // is slow, so a longer TTL cuts scan frequency ~5x with no real staleness.
+        "Cache-Control": "public, max-age=300, s-maxage=300",
       },
     }
   );

--- a/app/api/heartbeat/__tests__/route.test.ts
+++ b/app/api/heartbeat/__tests__/route.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/lib/name-generator", () => ({
 vi.mock("@/lib/heartbeat", () => ({
   CHECK_IN_MESSAGE_FORMAT: "AIBTC Check-In | {timestamp}",
   CHECK_IN_RATE_LIMIT_SECONDS: 60,
+  HEARTBEAT_KV_WRITE_COALESCE_MS: 60 * 60 * 1000,
   buildCheckInMessage: vi.fn().mockReturnValue("AIBTC Check-In | 2026-01-01T00:00:00.000Z"),
   validateCheckInBody: vi.fn().mockReturnValue({ data: {} }),
 }));
@@ -373,6 +374,56 @@ describe("heartbeat POST — D1 update failure does NOT 500 (P3A: KV-source-of-t
     // Response payload still includes the timestamp the caller submitted.
     const body = (await response.json()) as { checkIn: { lastCheckInAt: string } };
     expect(body.checkIn.lastCheckInAt).toBe(TEST_TIMESTAMP);
+  });
+});
+
+describe("heartbeat POST — btc: KV write coalescing (cost)", () => {
+  function contextWith(mockKv: KVNamespace, db: unknown) {
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: {
+        VERIFIED_AGENTS: mockKv,
+        DB: db,
+        RATE_LIMIT_CHECKIN: {
+          limit: vi.fn().mockResolvedValue({ success: true }),
+        } as unknown as RateLimit,
+      },
+      ctx: { waitUntil: vi.fn() },
+    });
+  }
+
+  it("skips the btc: KV write when stored lastActiveAt is recent (D1 still written)", async () => {
+    const mockKv = buildMockKv();
+    const mock = buildMockD1();
+    const recent = new Date(Date.now() - 60_000).toISOString(); // 1 min ago
+    (lookupAgentWithLevel as Mock).mockResolvedValue({
+      ...buildSuccessAgent(),
+      agent: { ...buildSuccessAgent().agent, lastActiveAt: recent },
+    });
+    contextWith(mockKv, mock.db);
+
+    const response = await POST(buildPostRequest());
+
+    expect(response.status).toBe(200);
+    // D1 remains the source of truth — always written.
+    expect(mock.run).toHaveBeenCalled();
+    // The redundant KV write is coalesced away.
+    expect(mockKv.put).not.toHaveBeenCalled();
+  });
+
+  it("writes the btc: KV record when stored lastActiveAt is stale", async () => {
+    const mockKv = buildMockKv();
+    const mock = buildMockD1();
+    const stale = new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(); // 2h ago
+    (lookupAgentWithLevel as Mock).mockResolvedValue({
+      ...buildSuccessAgent(),
+      agent: { ...buildSuccessAgent().agent, lastActiveAt: stale },
+    });
+    contextWith(mockKv, mock.db);
+
+    const response = await POST(buildPostRequest());
+
+    expect(response.status).toBe(200);
+    expect(mockKv.put).toHaveBeenCalled();
   });
 });
 

--- a/app/api/heartbeat/route.ts
+++ b/app/api/heartbeat/route.ts
@@ -15,6 +15,7 @@ import { createLogger, createConsoleLogger, isLogsRPC } from "@/lib/logging";
 import {
   CHECK_IN_MESSAGE_FORMAT,
   CHECK_IN_RATE_LIMIT_SECONDS,
+  HEARTBEAT_KV_WRITE_COALESCE_MS,
   buildCheckInMessage,
   validateCheckInBody,
   type HeartbeatOrientation,
@@ -499,15 +500,28 @@ export async function POST(request: NextRequest) {
       await updateAgentInD1(db, updatedAgent, logger);
     }
 
-    // Write canonical btc: key only; stx: secondary index is no longer
-    // refreshed by heartbeat (P4.2 — drops ~30–40K KV writes/day).
-    // Other writers (vouch / register / identity / challenge / verify) still
-    // refresh stx:, so the secondary index does not stop being updated — just
-    // not on every 5-min check-in. Identical JSON across both sides per
-    // inventory, so this is data-lossless.
-    // Phase 2.5 Step 4 — unreadCount served from D1 live SELECT COUNT(*).
+    // Coalesce the canonical btc: KV write (cost). On a check-in the ONLY
+    // fields that change are lastActiveAt/lastCheckInAt, and D1 (written above)
+    // is the source of truth for every aggregate consumer (agents list /
+    // activity / leaderboard all rebuild from D1). The KV btc: record only
+    // backs direct single-agent lookups, which don't need sub-hour lastActiveAt
+    // freshness. `agent` was read from the KV btc: record above, so its
+    // lastActiveAt is the currently-stored KV value — skip the write while that
+    // value is recent, cutting the highest-volume heartbeat write ~12x (from
+    // once/5min to ~once/hour per agent). A first-ever or unparseable timestamp
+    // forces the write.
+    // (stx: secondary index is not refreshed by heartbeat since P4.2; other
+    // writers keep it current.)
+    const prevActiveMs = agent.lastActiveAt ? Date.parse(agent.lastActiveAt) : NaN;
+    const kvWriteNeeded =
+      !Number.isFinite(prevActiveMs) ||
+      Date.now() - prevActiveMs >= HEARTBEAT_KV_WRITE_COALESCE_MS;
+
+    // Phase 2.5 Step 4 — unreadCount served from D1 maintained counter.
     const [, unreadCount, openBounties] = await Promise.all([
-      kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent)),
+      kvWriteNeeded
+        ? kv.put(`btc:${btcAddress}`, JSON.stringify(updatedAgent))
+        : Promise.resolve(),
       fetchUnreadCount(db, btcAddress),
       fetchOpenBounties(db),
     ]);

--- a/app/api/vouch/[address]/__tests__/stx-db-threading.test.ts
+++ b/app/api/vouch/[address]/__tests__/stx-db-threading.test.ts
@@ -30,11 +30,17 @@ vi.mock("@/lib/name-generator", () => ({
   generateName: vi.fn().mockReturnValue("MockAgent"),
 }));
 
+vi.mock("@/lib/cache", () => ({
+  getCachedAgentList: vi.fn(),
+}));
+
 // ---- imports after mocks ----------------------------------------------------
 
 import { GET } from "../route";
 import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
+import { getVouchIndex } from "@/lib/vouch";
+import { getCachedAgentList } from "@/lib/cache";
 
 // ---- fixtures ---------------------------------------------------------------
 
@@ -114,6 +120,55 @@ describe("vouch/[address] GET — STX address db threading (PR #788)", () => {
     expect(response.status).toBe(404);
     // Confirm db was still passed (fail-closed path, not the pre-fix silent null path)
     expect(lookupAgent).toHaveBeenCalledWith(mockKv, TEST_STX, mockDb);
+  });
+
+  it("resolves referees from the cached agent list in one read, not one kv.get per referee (cost)", async () => {
+    const mockKv = buildMockKv();
+    const mockDb = buildMockDb();
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { VERIFIED_AGENTS: mockKv, DB: mockDb },
+    });
+    (lookupAgent as Mock).mockResolvedValue(makeAgentRecord());
+    (getVouchIndex as Mock).mockResolvedValue({
+      refereeAddresses: ["bc1qreferee1", "bc1qreferee2"],
+    });
+    (getCachedAgentList as Mock).mockResolvedValue({
+      agents: [
+        { btcAddress: "bc1qreferee1", displayName: "Referee One", verifiedAt: "2026-02-01T00:00:00.000Z" },
+        // bc1qreferee2 intentionally absent → falls back to generated name.
+      ],
+      stats: { total: 1, genesisCount: 0, messageCount: 0 },
+    });
+
+    const request = new NextRequest(`http://localhost/api/vouch/${TEST_STX}`);
+    const response = await GET(request, { params: Promise.resolve({ address: TEST_STX }) });
+
+    expect(response.status).toBe(200);
+    // Single batched read regardless of referee count — no N+1.
+    expect(getCachedAgentList).toHaveBeenCalledTimes(1);
+    const body = (await response.json()) as {
+      vouchedFor: { agents: { btcAddress: string; displayName: string; registeredAt: string | null }[] };
+    };
+    expect(body.vouchedFor.agents).toEqual([
+      { btcAddress: "bc1qreferee1", displayName: "Referee One", registeredAt: "2026-02-01T00:00:00.000Z" },
+      { btcAddress: "bc1qreferee2", displayName: "MockAgent", registeredAt: null },
+    ]);
+  });
+
+  it("does not read the cached agent list when the agent has vouched for nobody (cost)", async () => {
+    const mockKv = buildMockKv();
+    const mockDb = buildMockDb();
+    (getCloudflareContext as Mock).mockResolvedValue({
+      env: { VERIFIED_AGENTS: mockKv, DB: mockDb },
+    });
+    (lookupAgent as Mock).mockResolvedValue(makeAgentRecord());
+    (getVouchIndex as Mock).mockResolvedValue(null); // no referees
+
+    const request = new NextRequest(`http://localhost/api/vouch/${TEST_STX}`);
+    const response = await GET(request, { params: Promise.resolve({ address: TEST_STX }) });
+
+    expect(response.status).toBe(200);
+    expect(getCachedAgentList).not.toHaveBeenCalled();
   });
 
   it("accepts ST... testnet addresses (ST prefix fix)", async () => {

--- a/app/api/vouch/[address]/route.ts
+++ b/app/api/vouch/[address]/route.ts
@@ -3,6 +3,7 @@ import { getCloudflareContext } from "@opennextjs/cloudflare";
 import { lookupAgent } from "@/lib/agent-lookup";
 import { generateName } from "@/lib/name-generator";
 import { getVouchIndex, MAX_REFERRALS } from "@/lib/vouch";
+import { getCachedAgentList } from "@/lib/cache";
 
 /** Lightweight address format check — must look like a BTC or STX address. */
 function isValidAddressFormat(address: string): boolean {
@@ -76,17 +77,29 @@ export async function GET(
     const totalCount = allReferees.length;
     const paginatedReferees = allReferees.slice(offset, offset + limit);
 
-    const vouchedForAgents = await Promise.all(
-      paginatedReferees.map(async (refereeBtc) => {
-        const referee = await lookupAgent(kv, refereeBtc);
+    // Resolve referee display info from the cached agent list (1 KV read + O(1)
+    // Map lookups) instead of one kv.get(`btc:`) per referee (N+1, up to `limit`
+    // reads). A referee not yet in the snapshot falls back to a generated name —
+    // the same fallback the prior per-key lookup used when the record was missing.
+    // Skip the cache read entirely when the agent has vouched for nobody (the
+    // common case) — no referees to resolve.
+    let vouchedForAgents: {
+      btcAddress: string;
+      displayName: string;
+      registeredAt: string | null;
+    }[] = [];
+    if (paginatedReferees.length > 0) {
+      const { agents: cachedAgents } = await getCachedAgentList(kv);
+      const agentByBtc = new Map(cachedAgents.map((a) => [a.btcAddress, a]));
+      vouchedForAgents = paginatedReferees.map((refereeBtc) => {
+        const referee = agentByBtc.get(refereeBtc);
         return {
           btcAddress: refereeBtc,
-          displayName:
-            referee?.displayName || generateName(refereeBtc),
+          displayName: referee?.displayName || generateName(refereeBtc),
           registeredAt: referee?.verifiedAt || null,
         };
-      })
-    );
+      });
+    }
 
     return NextResponse.json(
       {

--- a/app/bounties/[id]/page.tsx
+++ b/app/bounties/[id]/page.tsx
@@ -34,7 +34,7 @@ async function fetchBountyDetail(id: string): Promise<BountyDetailData | null> {
 
     const now = new Date();
     const status = bountyStatus(bounty, now);
-    const { submissions, total } = await listSubmissionsForBounty(db, id, 20, 0);
+    const { submissions, total } = await listSubmissionsForBounty(db, id, 20, 0, bounty.submissionCount);
 
     let winner: BountyWinner | undefined;
     if (bounty.acceptedSubmissionId && bounty.acceptedAt) {

--- a/lib/bounty/d1-helpers.ts
+++ b/lib/bounty/d1-helpers.ts
@@ -429,15 +429,24 @@ export async function listSubmissionsForBounty(
   db: D1Database,
   bountyId: string,
   limit = 20,
-  offset = 0
+  offset = 0,
+  knownTotal?: number
 ): Promise<ListSubmissionsResult> {
   const cappedLimit = Math.min(Math.max(limit, 1), 100);
   const cappedOffset = Math.max(offset, 0);
 
-  const countRow = await db
-    .prepare(`SELECT COUNT(*) AS cnt FROM bounty_submissions WHERE bounty_id = ?`)
-    .bind(bountyId)
-    .first<{ cnt: number }>();
+  // Prefer the parent bounty's maintained `submission_count` (bumped
+  // transactionally on every insert — see insertSubmission) when the caller
+  // supplies it, avoiding a COUNT(*) scan of all submissions per request.
+  // Every caller already loads the bounty, so this is a pure win.
+  let total = knownTotal;
+  if (total === undefined) {
+    const countRow = await db
+      .prepare(`SELECT COUNT(*) AS cnt FROM bounty_submissions WHERE bounty_id = ?`)
+      .bind(bountyId)
+      .first<{ cnt: number }>();
+    total = countRow?.cnt ?? 0;
+  }
 
   const pageRows = await db
     .prepare(
@@ -451,7 +460,7 @@ export async function listSubmissionsForBounty(
 
   return {
     submissions: (pageRows.results ?? []).map(rowToSubmission),
-    total: countRow?.cnt ?? 0,
+    total,
   };
 }
 

--- a/lib/heartbeat/constants.ts
+++ b/lib/heartbeat/constants.ts
@@ -45,3 +45,16 @@ export const CHECK_IN_TIMESTAMP_WINDOW_MS = 5 * 60 * 1000;
  * the binding's `period` value.
  */
 export const CHECK_IN_RATE_LIMIT_SECONDS = 60;
+
+/**
+ * Coalescing window for the canonical `btc:` KV write on check-in (cost).
+ *
+ * Heartbeat writes the agent record to KV once per check-in, but the only
+ * fields that change are lastActiveAt/lastCheckInAt, and D1 (written every
+ * check-in) is the source of truth for all aggregate consumers. The KV record
+ * only backs direct single-agent lookups, which tolerate ~1h staleness on the
+ * activity timestamp. Skipping the KV write while the stored timestamp is
+ * younger than this window cuts the highest-volume heartbeat write ~12x
+ * (once/5min → ~once/hour per agent).
+ */
+export const HEARTBEAT_KV_WRITE_COALESCE_MS = 60 * 60 * 1000;

--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -37,7 +37,7 @@ import type { EarningsSweepSummary } from "../earnings/types";
 import { buildLegionSnapshot, buildRegistrySnapshot } from "../legion/snapshot";
 import { buildProviderSnapshot } from "../legion/providers";
 import { legionGatewayUrl } from "../legion/read";
-import { listLegions } from "../legion/registry";
+import { entryFromSummary } from "../legion/registry";
 import {
   readLegionSnapshotFromD1,
   writeLegionSnapshotToD1,
@@ -52,8 +52,9 @@ import type {
   SchedulerTask,
 } from "./rpc-types";
 
-// Cadences. The cron fires every TENERO_INTERVAL_MS; competition + earnings are
-// gated to their longer intervals via a last-run check (mirrors the old DO alarm).
+// Cadences. The cron fires every 30 min (wrangler.scheduler.jsonc); every task
+// is gated to its own interval via a last-run check (mirrors the old DO alarm) —
+// Tenero / competition / Legion hourly, earnings every 30 min.
 // Tenero refresh cadence — HOURLY, sized to the monthly API budget. The Starter
 // plan allows 10,000 req/month; at ~13 active tokens that's 13 × 24 × ~30 ≈
 // 9.4k/mo, safely under. (Was 5 min ≈ 112k/mo — 11× over, which exhausted the
@@ -68,13 +69,20 @@ export const TENERO_INTERVAL_MS = 60 * 60 * 1000;
 // ingestion route; this sweep is only catch-up, so 4x fewer Hiro calls is a
 // safe trade. Can be gated off entirely via COMPETITION_SWEEP_ENABLED="false".
 export const COMPETITION_INTERVAL_MS = 60 * 60 * 1000;
-// Legion dashboard snapshot refreshes every cron tick (testnet, low volume).
-export const LEGION_INTERVAL_MS = 15 * 60 * 1000;
+// Legion snapshot — HOURLY (widened from every-tick). The snapshot fans out
+// a large, mostly-uncached set of Hiro reads per tick (per-member stake+balance,
+// per-proposal status, per-voter records) on the SAME shared HIRO_API_KEY as
+// identity/reputation and the competition sweep. Running it every 15 min
+// dominated the Hiro budget; the underlying state (stakes/proposals/votes) moves
+// on-chain slowly, so hourly is ample. The /legions pages read the D1 snapshot
+// behind caches.default, so freshness is unchanged for readers within that TTL.
+export const LEGION_INTERVAL_MS = 60 * 60 * 1000;
 
 // KV keys (VERIFIED_AGENTS namespace).
 const K_TENERO = "scheduler:tenero";
 const K_COMPETITION = "scheduler:competition";
 const K_EARNINGS = "scheduler:earnings";
+const K_LEGION = "scheduler:legion";
 const K_PAUSED = "scheduler:paused-until";
 
 interface TeneroState {
@@ -328,9 +336,12 @@ export async function runLegionNow(
     errors: registry.errors.length,
   });
 
-  // 2. Per-Legion detail snapshots. Walk every entry (registry + demand
-  // fallback). Skip inactive Legions — they stay listed but aren't refreshed.
-  const entries = await listLegions(apiKey, logger);
+  // 2. Per-Legion detail snapshots. Reuse the entries buildRegistrySnapshot
+  // already resolved (via entryFromSummary) instead of re-walking the registry
+  // with a second listLegions() call — that duplicate walk was a full
+  // get-count + N×get-legion Hiro round-trip per tick for zero added data.
+  // Skip inactive Legions — they stay listed but aren't refreshed.
+  const entries = registry.legions.map(entryFromSummary);
   for (const entry of entries) {
     if (!entry.active) continue;
     try {
@@ -395,10 +406,11 @@ export async function runScheduledTasks(
     return;
   }
 
-  const [tenero, competition, earnings] = await Promise.all([
+  const [tenero, competition, earnings, legion] = await Promise.all([
     readJson<TeneroState>(kv, K_TENERO),
     readJson<CompetitionState>(kv, K_COMPETITION),
     readJson<EarningsState>(kv, K_EARNINGS),
+    readJson<{ lastRunAt?: number }>(kv, K_LEGION),
   ]);
 
   // Tenero — every tick, unless inside a rate-limit backoff window.
@@ -462,15 +474,25 @@ export async function runScheduledTasks(
     });
   }
 
-  // Legion snapshot — every tick (cron cadence == LEGION_INTERVAL_MS). The
-  // snapshot blob is its own state, so there's no separate state read to gate
-  // on; a slow overrun just overwrites idempotently.
-  try {
-    await runLegionNow(env, logger);
-  } catch (error) {
-    logger.error("scheduler.legion_unexpected_error", {
-      error: String(error),
-      stack: error instanceof Error ? error.stack : undefined,
+  // Legion snapshot — on its (now hourly) cadence, gated like the other tasks
+  // so it no longer runs on every tick. `scheduler:legion` carries only
+  // `lastRunAt` (the D1 snapshots are the real output); a slow overrun still
+  // overwrites idempotently.
+  const legionDue =
+    (legion?.lastRunAt ?? 0) + LEGION_INTERVAL_MS <= now + 1_000;
+  if (legionDue) {
+    try {
+      await runLegionNow(env, logger);
+      await kv.put(K_LEGION, JSON.stringify({ lastRunAt: now }));
+    } catch (error) {
+      logger.error("scheduler.legion_unexpected_error", {
+        error: String(error),
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+    }
+  } else {
+    logger.debug("scheduler.legion_not_due", {
+      lastRunAt: legion?.lastRunAt ?? null,
     });
   }
 }

--- a/wrangler.scheduler.jsonc
+++ b/wrangler.scheduler.jsonc
@@ -11,7 +11,11 @@
   "compatibility_flags": ["nodejs_compat"],
 
   "triggers": {
-    "crons": ["*/15 * * * *"]
+    // Every 30 min. Earnings (30-min cadence) runs on each tick; the hourly
+    // tasks (Tenero / competition / Legion) are gated by their own lastRunAt so
+    // they run every other tick. Widened from */15 once Legion was gated to
+    // hourly — nothing needs a 15-min tick anymore (cost: 2x fewer wakeups).
+    "crons": ["*/30 * * * *"]
   },
 
   "vars": {


### PR DESCRIPTION
Cost-optimization pass from a 3-axis audit (D1 rows-scanned, KV ops, external Hiro/subrequest calls). The codebase is already well-optimized (maintained counters, edge-cached GETs, ratelimits bindings), so these are the remaining real offenders. No user-visible behavior change beyond the bounded staleness noted per item.

## 🔴 Legion cron — biggest win (external Hiro cost)
The Legion snapshot was the **one ungated scheduler task** — it ran its large per-member (stake+balance), per-proposal (status), and per-voter (record) Hiro fan-out on **every 15-min tick**, on the **shared `HIRO_API_KEY`** that also feeds identity/reputation (~475k reads/mo for a single legion). This is literally why the cron fired every 15 min.
- **Gate it to hourly** via a `scheduler:legion` `lastRunAt` check, exactly like Tenero/competition/earnings.
- **Widen the cron `*/15` → `*/30`** — earnings (30-min) still runs each tick; the hourly tasks gate themselves. Nothing needs a 15-min wakeup now.
- **Dedupe the double `listLegions()` walk**: reuse the entries `buildRegistrySnapshot` already resolved (`entryFromSummary`) instead of a second `get-count + N×get-legion` round-trip per run. (overlaps #1021)
- **Net: ~4× fewer Legion Hiro reads**; stops it starving the shared key. `/legions` pages read the D1 snapshot behind `caches.default`, so reader freshness is unchanged.

## 🔴 Heartbeat KV write — highest-volume KV write
Heartbeat wrote the full `btc:` agent record to KV on **every check-in** (every agent, ~every 5 min), but the only changing fields are `lastActiveAt`/`lastCheckInAt`, and **D1 (written every check-in) is the source of truth** for all aggregate consumers (agents list / activity / leaderboard rebuild from D1).
- **Coalesce**: skip the KV write while the stored `lastActiveAt` is < 1h old → ~**12× fewer** heartbeat KV writes (once/5min → ~once/hour per agent).
- **Tradeoff**: a direct `btc:` lookup can see a ≤1h-stale `lastActiveAt`; D1 always has the fresh value. No aggregate reads `lastActiveAt` from KV.

## 🟡 D1 redundant scans
- **`listSubmissionsForBounty`**: dropped the per-request `COUNT(*)` scan; use the parent bounty's maintained `submission_count` (every caller already loads the bounty).
- **`tracked-tokens`**: raised cache `60s → 300s` in front of `getActiveTokenIds`' unbounded `swaps` GROUP BY (the token set shifts slowly; the cron scan is hourly).

## 🟡 KV N+1
- **`vouch/[address]`**: resolve referee display info from the cached agent list (**1 read + Map lookups**) instead of one `kv.get(btc:)` per referee; and **skip the read entirely** when the agent has vouched for nobody (the common case).

## Deliberately left (bounded / low-frequency — follow-up candidates)
- **capabilities** N+1 — re-validates capabilities against the source `btc:` record and is behind a 1h edge cache (amplitude capped).
- **inbox sent-view** N+1 and **referral-code** POST N+1 — bounded page size / low frequency.
These want a shared "resolve many agents" helper; out of scope here to keep the PR safe.

## Testing
+4 tests (heartbeat coalesce ×2, vouch batching ×2). **All 1516 app/api + lib tests pass; non-test typecheck clean.** This PR produces a Cloudflare Workers **preview URL** — worth spot-checking `/legions`, `/api/vouch/[addr]`, `/api/bounties/[id]/submissions`, and a heartbeat POST against real bindings before merge.

## Not included
Full KV→D1 authoritative migration (making D1 the source of truth for durable records) is a separate phased effort under #652 — this PR only *reduces* KV/D1/Hiro cost without changing which store is authoritative.
