### PR TITLE
perf(cost): cache profile sBTC balance, index competition results by agent

### DIFF
--- a/app/agents/[address]/page.tsx
+++ b/app/agents/[address]/page.tsx
@@ -336,7 +336,8 @@ export default async function AgentProfilePage({
     const btcBalance = await fetchBtcBalance(
       agentWithIdentity.btcAddress,
       agentWithIdentity.stxAddress,
-      env.HIRO_API_KEY
+      env.HIRO_API_KEY,
+      kv
     );
 
     return (

--- a/lib/balances/__tests__/btc.test.ts
+++ b/lib/balances/__tests__/btc.test.ts
@@ -1,0 +1,125 @@
+/**
+ * L2 (sBTC) balance cache — the cost fix that collapses repeat profile views
+ * into one metered Hiro call. Locks three behaviors:
+ *   1. cache hit returns without calling Hiro
+ *   2. a real answer (incl. genuine 0) is written to KV with a TTL
+ *   3. a transient upstream failure is NOT cached (next view retries)
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { fetchBtcBalance } from "../btc";
+
+const STX = "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
+const BTC = "bc1qexampleexampleexampleexampleexampleex";
+
+function mockKv(initial: Record<string, string> = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    get: vi.fn(async (k: string) => store.get(k) ?? null),
+    put: vi.fn(async (k: string, v: string) => {
+      store.set(k, v);
+    }),
+    delete: vi.fn(),
+    list: vi.fn(),
+    getWithMetadata: vi.fn(),
+    __store: store,
+  } as unknown as KVNamespace & { __store: Map<string, string> };
+}
+
+/** Build a Hiro /balances response with the given sBTC balance string. */
+function balancesResponse(sbtcBalance: string) {
+  // Asset id must match SBTC_ASSET_ID built in btc.ts from SBTC_CONTRACTS.mainnet.
+  return {
+    ok: true,
+    json: async () => ({
+      fungible_tokens: {
+        "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token": {
+          balance: sbtcBalance,
+        },
+      },
+    }),
+  };
+}
+
+beforeEach(() => {
+  vi.restoreAllMocks();
+});
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchBtcBalance — L2 sBTC cache", () => {
+  it("serves the L2 balance from KV without calling Hiro on a cache hit", async () => {
+    const kv = mockKv({ [`cache:sbtc-balance:${STX}`]: "123456" });
+    const fetchSpy = vi.fn(async (url: string) => {
+      // L1 leg (mempool.space) is allowed; L2 (Hiro) must NOT be hit.
+      if (url.includes("mempool.space")) {
+        return { ok: true, json: async () => ({ chain_stats: {} }) };
+      }
+      throw new Error("Hiro should not be called on an L2 cache hit");
+    });
+    vi.stubGlobal("fetch", fetchSpy);
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l2Sats).toBe(123456);
+    // No Hiro call — only the L1 mempool.space fetch happened.
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("/balances"),
+      expect.anything(),
+    );
+  });
+
+  it("writes a fresh L2 answer (incl. genuine 0) to KV with a TTL", async () => {
+    const kv = mockKv();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("mempool.space")) {
+          return { ok: true, json: async () => ({ chain_stats: {} }) };
+        }
+        return balancesResponse("0"); // genuine zero balance
+      }),
+    );
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l2Sats).toBe(0);
+    expect(kv.put).toHaveBeenCalledWith(
+      `cache:sbtc-balance:${STX}`,
+      "0",
+      { expirationTtl: 90 },
+    );
+  });
+
+  it("does NOT cache a transient Hiro failure", async () => {
+    const kv = mockKv();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("mempool.space")) {
+          return { ok: true, json: async () => ({ chain_stats: {} }) };
+        }
+        return { ok: false, json: async () => ({}) }; // Hiro 5xx/429
+      }),
+    );
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l2Sats).toBe(0);
+    // Nothing written — the next profile view will retry the upstream.
+    expect(kv.put).not.toHaveBeenCalled();
+  });
+
+  it("still works with no KV binding (falls straight through to Hiro)", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (url: string) => {
+        if (url.includes("mempool.space")) {
+          return { ok: true, json: async () => ({ chain_stats: {} }) };
+        }
+        return balancesResponse("777");
+      }),
+    );
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key");
+    expect(bal.l2Sats).toBe(777);
+  });
+});

--- a/lib/balances/__tests__/btc.test.ts
+++ b/lib/balances/__tests__/btc.test.ts
@@ -1,7 +1,7 @@
 /**
- * L2 (sBTC) balance cache — the cost fix that collapses repeat profile views
- * into one metered Hiro call. Locks three behaviors:
- *   1. cache hit returns without calling Hiro
+ * Balance caches — the cost fix that collapses repeat profile views into one
+ * upstream call per leg (L1 mempool.space + L2 Hiro). Locks, for each leg:
+ *   1. cache hit returns without calling upstream
  *   2. a real answer (incl. genuine 0) is written to KV with a TTL
  *   3. a transient upstream failure is NOT cached (next view retries)
  */
@@ -11,6 +11,8 @@ import { fetchBtcBalance } from "../btc";
 
 const STX = "SP2J6ZY48GV1EZ5V2V5RB9MP66SW86PYKKNRV9EJ7";
 const BTC = "bc1qexampleexampleexampleexampleexampleex";
+const L1_KEY = `cache:btc-balance:${BTC}`;
+const L2_KEY = `cache:sbtc-balance:${STX}`;
 
 function mockKv(initial: Record<string, string> = {}) {
   const store = new Map(Object.entries(initial));
@@ -26,19 +28,41 @@ function mockKv(initial: Record<string, string> = {}) {
   } as unknown as KVNamespace & { __store: Map<string, string> };
 }
 
-/** Build a Hiro /balances response with the given sBTC balance string. */
-function balancesResponse(sbtcBalance: string) {
-  // Asset id must match SBTC_ASSET_ID built in btc.ts from SBTC_CONTRACTS.mainnet.
+/** mempool.space (L1) response: funded − spent = balance sats. */
+function l1Ok(sats: number) {
+  return {
+    ok: true,
+    json: async () => ({ chain_stats: { funded_txo_sum: sats, spent_txo_sum: 0 } }),
+  };
+}
+/** Hiro (L2) /balances response with the given sBTC balance string. */
+function l2Ok(sbtcBalance: string) {
   return {
     ok: true,
     json: async () => ({
       fungible_tokens: {
+        // Must match SBTC_ASSET_ID built in btc.ts from SBTC_CONTRACTS.mainnet.
         "SM3VDXK3WZZSA84XXFKAFAF15NNZX32CTSG82JFQ4.sbtc-token::sbtc-token": {
           balance: sbtcBalance,
         },
       },
     }),
   };
+}
+const FAIL = { ok: false, json: async () => ({}) };
+
+/**
+ * Stub global fetch, routing each leg to a provided response. Defaults to a
+ * failing response so a test that only cares about one leg doesn't
+ * accidentally cache the other.
+ */
+function stubFetch(opts: { l1?: unknown; l2?: unknown }) {
+  const spy = vi.fn(async (url: string) => {
+    if (url.includes("mempool.space")) return opts.l1 ?? FAIL;
+    return opts.l2 ?? FAIL; // Hiro /balances
+  });
+  vi.stubGlobal("fetch", spy);
+  return spy;
 }
 
 beforeEach(() => {
@@ -48,21 +72,13 @@ afterEach(() => {
   vi.unstubAllGlobals();
 });
 
-describe("fetchBtcBalance — L2 sBTC cache", () => {
+describe("fetchBtcBalance — L2 (sBTC / Hiro) cache", () => {
   it("serves the L2 balance from KV without calling Hiro on a cache hit", async () => {
-    const kv = mockKv({ [`cache:sbtc-balance:${STX}`]: "123456" });
-    const fetchSpy = vi.fn(async (url: string) => {
-      // L1 leg (mempool.space) is allowed; L2 (Hiro) must NOT be hit.
-      if (url.includes("mempool.space")) {
-        return { ok: true, json: async () => ({ chain_stats: {} }) };
-      }
-      throw new Error("Hiro should not be called on an L2 cache hit");
-    });
-    vi.stubGlobal("fetch", fetchSpy);
+    const kv = mockKv({ [L2_KEY]: "123456" });
+    const fetchSpy = stubFetch({ l1: l1Ok(0), l2: l2Ok("999") });
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
     expect(bal.l2Sats).toBe(123456);
-    // No Hiro call — only the L1 mempool.space fetch happened.
     expect(fetchSpy).not.toHaveBeenCalledWith(
       expect.stringContaining("/balances"),
       expect.anything(),
@@ -71,55 +87,61 @@ describe("fetchBtcBalance — L2 sBTC cache", () => {
 
   it("writes a fresh L2 answer (incl. genuine 0) to KV with a TTL", async () => {
     const kv = mockKv();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url.includes("mempool.space")) {
-          return { ok: true, json: async () => ({ chain_stats: {} }) };
-        }
-        return balancesResponse("0"); // genuine zero balance
-      }),
-    );
+    stubFetch({ l1: FAIL, l2: l2Ok("0") });
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
     expect(bal.l2Sats).toBe(0);
-    expect(kv.put).toHaveBeenCalledWith(
-      `cache:sbtc-balance:${STX}`,
-      "0",
-      { expirationTtl: 90 },
-    );
+    expect(kv.put).toHaveBeenCalledWith(L2_KEY, "0", { expirationTtl: 90 });
   });
 
   it("does NOT cache a transient Hiro failure", async () => {
     const kv = mockKv();
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url.includes("mempool.space")) {
-          return { ok: true, json: async () => ({ chain_stats: {} }) };
-        }
-        return { ok: false, json: async () => ({}) }; // Hiro 5xx/429
-      }),
-    );
+    stubFetch({ l1: FAIL, l2: FAIL });
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
     expect(bal.l2Sats).toBe(0);
-    // Nothing written — the next profile view will retry the upstream.
-    expect(kv.put).not.toHaveBeenCalled();
+    expect(kv.put).not.toHaveBeenCalledWith(L2_KEY, expect.anything(), expect.anything());
+  });
+});
+
+describe("fetchBtcBalance — L1 (native BTC / mempool.space) cache", () => {
+  it("serves the L1 balance from KV without calling mempool.space on a cache hit", async () => {
+    const kv = mockKv({ [L1_KEY]: "55555" });
+    const fetchSpy = stubFetch({ l1: l1Ok(999), l2: FAIL });
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l1Sats).toBe(55555);
+    expect(fetchSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining("mempool.space"),
+      expect.anything(),
+    );
   });
 
-  it("still works with no KV binding (falls straight through to Hiro)", async () => {
-    vi.stubGlobal(
-      "fetch",
-      vi.fn(async (url: string) => {
-        if (url.includes("mempool.space")) {
-          return { ok: true, json: async () => ({ chain_stats: {} }) };
-        }
-        return balancesResponse("777");
-      }),
-    );
+  it("writes a fresh L1 answer to KV with a TTL", async () => {
+    const kv = mockKv();
+    stubFetch({ l1: l1Ok(88), l2: FAIL });
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l1Sats).toBe(88);
+    expect(kv.put).toHaveBeenCalledWith(L1_KEY, "88", { expirationTtl: 90 });
+  });
+
+  it("does NOT cache a transient mempool.space failure", async () => {
+    const kv = mockKv();
+    stubFetch({ l1: FAIL, l2: FAIL });
+
+    const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
+    expect(bal.l1Sats).toBe(0);
+    expect(kv.put).not.toHaveBeenCalledWith(L1_KEY, expect.anything(), expect.anything());
+  });
+});
+
+describe("fetchBtcBalance — no KV binding", () => {
+  it("falls straight through to both upstreams", async () => {
+    stubFetch({ l1: l1Ok(777), l2: l2Ok("888") });
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key");
-    expect(bal.l2Sats).toBe(777);
+    expect(bal.l1Sats).toBe(777);
+    expect(bal.l2Sats).toBe(888);
   });
 });

--- a/lib/balances/__tests__/btc.test.ts
+++ b/lib/balances/__tests__/btc.test.ts
@@ -91,7 +91,7 @@ describe("fetchBtcBalance — L2 (sBTC / Hiro) cache", () => {
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
     expect(bal.l2Sats).toBe(0);
-    expect(kv.put).toHaveBeenCalledWith(L2_KEY, "0", { expirationTtl: 90 });
+    expect(kv.put).toHaveBeenCalledWith(L2_KEY, "0", { expirationTtl: 1800 });
   });
 
   it("does NOT cache a transient Hiro failure", async () => {
@@ -123,7 +123,7 @@ describe("fetchBtcBalance — L1 (native BTC / mempool.space) cache", () => {
 
     const bal = await fetchBtcBalance(BTC, STX, "hiro-key", kv);
     expect(bal.l1Sats).toBe(88);
-    expect(kv.put).toHaveBeenCalledWith(L1_KEY, "88", { expirationTtl: 90 });
+    expect(kv.put).toHaveBeenCalledWith(L1_KEY, "88", { expirationTtl: 1800 });
   });
 
   it("does NOT cache a transient mempool.space failure", async () => {

--- a/lib/balances/btc.ts
+++ b/lib/balances/btc.ts
@@ -3,22 +3,24 @@
  * Stacks). Used on the agent profile page; non-critical, so failures on
  * either side degrade to 0 rather than throwing.
  *
- * Caching: the L1 leg (mempool.space) is genuinely public and off-quota, so
- * it stays uncached. The L2 leg hits Hiro's `/balances` under the shared
- * HIRO_API_KEY, which IS metered — and the profile page is SSR'd on every
- * view (crawlers/OG bots included), so an uncached L2 call is one metered
- * Hiro request per hit. `fetchL2Sats` therefore reads/writes a short-TTL KV
- * cache when a namespace is supplied, collapsing repeat views of the same
- * profile into one upstream call. Balances change slowly relative to crawler
+ * Caching: BOTH legs make an external call on every profile SSR (which runs
+ * on every view, crawlers/OG bots included), so both are cached when a KV
+ * namespace is supplied. The L2 leg hits Hiro's `/balances` under the shared
+ * HIRO_API_KEY (metered against quota); the L1 leg hits mempool.space, which
+ * is public but rate-limited — an uncached call per hit risks throttling and
+ * adds an avoidable round-trip. `fetchL1Sats` / `fetchL2Sats` therefore each
+ * read/write a short-TTL KV cache, collapsing repeat views of the same profile
+ * into one upstream call per leg. Balances change slowly relative to crawler
  * cadence, so a ~90s TTL is a good staleness/quota trade.
  */
 
 import { SBTC_CONTRACTS } from "@/lib/inbox/constants";
 import { STACKS_API_BASE } from "@/lib/identity/constants";
 
-/** KV key prefix + TTL for the L2 (sBTC) balance cache. */
+/** KV key prefixes + shared TTL for the balance caches (one key per leg). */
+const L1_BALANCE_CACHE_PREFIX = "cache:btc-balance:";
 const L2_BALANCE_CACHE_PREFIX = "cache:sbtc-balance:";
-const L2_BALANCE_CACHE_TTL_SECONDS = 90;
+const BALANCE_CACHE_TTL_SECONDS = 90;
 
 export interface BtcBalance {
   /** Native L1 BTC balance in satoshis. 0 if fetch failed or address has no history. */
@@ -51,9 +53,19 @@ function parseSatsString(raw: string): number {
   return big > ceiling ? Number.MAX_SAFE_INTEGER : Number(big);
 }
 
-async function fetchL1Sats(btcAddress: string): Promise<number> {
+async function fetchL1Sats(btcAddress: string, kv?: KVNamespace): Promise<number> {
+  const cacheKey = `${L1_BALANCE_CACHE_PREFIX}${btcAddress}`;
+
+  // Cache hit: one KV read replaces a rate-limited mempool.space call.
+  if (kv) {
+    const cached = await kv.get(cacheKey);
+    if (cached !== null) return parseSatsString(cached);
+  }
+
   const url = `https://mempool.space/api/address/${btcAddress}`;
   const res = await fetch(url, { headers: { Accept: "application/json" } });
+  // Only cache authoritative answers — a transient failure returns 0 uncached
+  // so the next view retries.
   if (!res.ok) return 0;
   // mempool.space returns funded_txo_sum / spent_txo_sum as JSON numbers.
   // JSON.parse loses precision past 2^53 silently, so re-narrow with BigInt
@@ -68,7 +80,19 @@ async function fetchL1Sats(btcAddress: string): Promise<number> {
     typeof fundedRaw === "number" && Number.isFinite(fundedRaw) ? fundedRaw : 0;
   const spent =
     typeof spentRaw === "number" && Number.isFinite(spentRaw) ? spentRaw : 0;
-  return Math.max(0, funded - spent);
+  const sats = Math.max(0, funded - spent);
+
+  if (kv) {
+    // Best-effort write — a cache-write failure must never fail the read.
+    try {
+      await kv.put(cacheKey, String(sats), {
+        expirationTtl: BALANCE_CACHE_TTL_SECONDS,
+      });
+    } catch {
+      // ignore: the balance is still returned; only the cache write was lost.
+    }
+  }
+  return sats;
 }
 
 async function fetchL2Sats(
@@ -105,7 +129,7 @@ async function fetchL2Sats(
     // Best-effort write — a cache-write failure must never fail the read.
     try {
       await kv.put(cacheKey, String(sats), {
-        expirationTtl: L2_BALANCE_CACHE_TTL_SECONDS,
+        expirationTtl: BALANCE_CACHE_TTL_SECONDS,
       });
     } catch {
       // ignore: the balance is still returned; only the cache write was lost.
@@ -121,7 +145,7 @@ export async function fetchBtcBalance(
   kv?: KVNamespace
 ): Promise<BtcBalance> {
   const [l1, l2] = await Promise.allSettled([
-    fetchL1Sats(btcAddress),
+    fetchL1Sats(btcAddress, kv),
     fetchL2Sats(stxAddress, hiroApiKey, kv),
   ]);
   return {

--- a/lib/balances/btc.ts
+++ b/lib/balances/btc.ts
@@ -11,7 +11,7 @@
  * adds an avoidable round-trip. `fetchL1Sats` / `fetchL2Sats` therefore each
  * read/write a short-TTL KV cache, collapsing repeat views of the same profile
  * into one upstream call per leg. Balances change slowly relative to crawler
- * cadence, so a ~90s TTL is a good staleness/quota trade.
+ * cadence, so a 30-minute TTL is a good staleness/quota trade.
  */
 
 import { SBTC_CONTRACTS } from "@/lib/inbox/constants";
@@ -20,7 +20,7 @@ import { STACKS_API_BASE } from "@/lib/identity/constants";
 /** KV key prefixes + shared TTL for the balance caches (one key per leg). */
 const L1_BALANCE_CACHE_PREFIX = "cache:btc-balance:";
 const L2_BALANCE_CACHE_PREFIX = "cache:sbtc-balance:";
-const BALANCE_CACHE_TTL_SECONDS = 90;
+const BALANCE_CACHE_TTL_SECONDS = 30 * 60; // 30 minutes
 
 export interface BtcBalance {
   /** Native L1 BTC balance in satoshis. 0 if fetch failed or address has no history. */

--- a/lib/balances/btc.ts
+++ b/lib/balances/btc.ts
@@ -3,13 +3,22 @@
  * Stacks). Used on the agent profile page; non-critical, so failures on
  * either side degrade to 0 rather than throwing.
  *
- * Both APIs are public and free; no caching layer here — profile pages are
- * SSR'd, low-volume, and balances change frequently enough that a cache
- * would mostly serve stale numbers anyway.
+ * Caching: the L1 leg (mempool.space) is genuinely public and off-quota, so
+ * it stays uncached. The L2 leg hits Hiro's `/balances` under the shared
+ * HIRO_API_KEY, which IS metered — and the profile page is SSR'd on every
+ * view (crawlers/OG bots included), so an uncached L2 call is one metered
+ * Hiro request per hit. `fetchL2Sats` therefore reads/writes a short-TTL KV
+ * cache when a namespace is supplied, collapsing repeat views of the same
+ * profile into one upstream call. Balances change slowly relative to crawler
+ * cadence, so a ~90s TTL is a good staleness/quota trade.
  */
 
 import { SBTC_CONTRACTS } from "@/lib/inbox/constants";
 import { STACKS_API_BASE } from "@/lib/identity/constants";
+
+/** KV key prefix + TTL for the L2 (sBTC) balance cache. */
+const L2_BALANCE_CACHE_PREFIX = "cache:sbtc-balance:";
+const L2_BALANCE_CACHE_TTL_SECONDS = 90;
 
 export interface BtcBalance {
   /** Native L1 BTC balance in satoshis. 0 if fetch failed or address has no history. */
@@ -62,7 +71,19 @@ async function fetchL1Sats(btcAddress: string): Promise<number> {
   return Math.max(0, funded - spent);
 }
 
-async function fetchL2Sats(stxAddress: string, hiroApiKey?: string): Promise<number> {
+async function fetchL2Sats(
+  stxAddress: string,
+  hiroApiKey?: string,
+  kv?: KVNamespace
+): Promise<number> {
+  const cacheKey = `${L2_BALANCE_CACHE_PREFIX}${stxAddress}`;
+
+  // Cache hit: one KV read replaces a metered Hiro call.
+  if (kv) {
+    const cached = await kv.get(cacheKey);
+    if (cached !== null) return parseSatsString(cached);
+  }
+
   const url = `${STACKS_API_BASE}/extended/v1/address/${stxAddress}/balances`;
   const headers: Record<string, string> = { Accept: "application/json" };
   if (hiroApiKey) {
@@ -71,22 +92,37 @@ async function fetchL2Sats(stxAddress: string, hiroApiKey?: string): Promise<num
     headers["x-hiro-api-key"] = hiroApiKey;
   }
   const res = await fetch(url, { headers });
+  // Only cache authoritative answers (a real balance, including a genuine 0).
+  // A transient upstream failure returns 0 uncached so the next view retries.
   if (!res.ok) return 0;
   const body = (await res.json()) as {
     fungible_tokens?: Record<string, { balance?: string }>;
   };
   const raw = body.fungible_tokens?.[SBTC_ASSET_ID]?.balance ?? "0";
-  return parseSatsString(raw);
+  const sats = parseSatsString(raw);
+
+  if (kv) {
+    // Best-effort write — a cache-write failure must never fail the read.
+    try {
+      await kv.put(cacheKey, String(sats), {
+        expirationTtl: L2_BALANCE_CACHE_TTL_SECONDS,
+      });
+    } catch {
+      // ignore: the balance is still returned; only the cache write was lost.
+    }
+  }
+  return sats;
 }
 
 export async function fetchBtcBalance(
   btcAddress: string,
   stxAddress: string,
-  hiroApiKey?: string
+  hiroApiKey?: string,
+  kv?: KVNamespace
 ): Promise<BtcBalance> {
   const [l1, l2] = await Promise.allSettled([
     fetchL1Sats(btcAddress),
-    fetchL2Sats(stxAddress, hiroApiKey),
+    fetchL2Sats(stxAddress, hiroApiKey, kv),
   ]);
   return {
     l1Sats: l1.status === "fulfilled" ? l1.value : 0,

--- a/migrations/025_competition_round_results_agent_index.sql
+++ b/migrations/025_competition_round_results_agent_index.sql
@@ -1,0 +1,22 @@
+-- Migration 025: per-agent index on competition_round_results.
+--
+-- getLatestFinalizedRoundResultForAgent (lib/competition/finalize/read.ts) and
+-- getRoundResultForAgent filter competition_round_results by stx_address alone:
+--
+--   SELECT ... FROM competition_round_results crr
+--   JOIN competition_rounds cr ON cr.round_id = crr.round_id
+--   WHERE crr.stx_address = ?1 AND cr.status IN (...)
+--   ORDER BY cr.starts_at DESC LIMIT 1
+--
+-- Migration 017 gives this table only two indexes — the PK (round_id,
+-- stx_address) and idx_competition_round_results_rank (round_id, rank) — both
+-- of which LEAD with round_id. A filter on stx_address with no round_id can use
+-- neither, so SQLite full-scans competition_round_results. The table gains one
+-- row per eligible agent per finalized round, so that scan cost grows linearly
+-- and permanently with every weekly round.
+--
+-- This is on the /api/competition/status read path (the endpoint agents poll
+-- for standings, edge cache only s-maxage=10), so most distinct-address
+-- requests reach D1. Leading on stx_address turns the scan into a point-seek.
+CREATE INDEX IF NOT EXISTS idx_competition_round_results_agent
+  ON competition_round_results(stx_address);


### PR DESCRIPTION
Two remaining metered/rate-limited read leaks surfaced by the post-#1027 cost audit (the D1 / KV / external-API sweep). KV came back clean; these are the only two hot-path findings worth acting on.

## 1. Uncached external balance calls on every profile render
`lib/balances/btc.ts` · `app/agents/[address]/page.tsx`

The agent-profile page is dynamic (no `revalidate`), so **every view — crawlers and OG bots included — made two uncached external calls**: Hiro `/balances` (sBTC, L2) under the shared `HIRO_API_KEY` (metered against quota), and mempool.space (native BTC, L1, public but rate-limited). Identity + BNS on the same page were already KV-cached; these balance calls were the leaks left on the path.

Both legs are now cached in KV (30-minute TTL), one key per leg:
- `cache:sbtc-balance:{stxAddress}` (L2 / Hiro)
- `cache:btc-balance:{btcAddress}` (L1 / mempool.space)

Per leg:
- **Cache hit → zero upstream calls.** Repeat views of the same profile within the window reuse the cached number.
- **Only authoritative answers are cached** (a real balance, including a genuine 0). A transient upstream failure returns 0 **uncached**, so the next view retries.
- **Best-effort write** — a KV write failure never fails the balance read.

Corrected the file's stale "L1 is public and free, no caching" comment.

## 2. Full-table scan on `/api/competition/status`
`migrations/025_competition_round_results_agent_index.sql`

`getLatestFinalizedRoundResultForAgent` filters `competition_round_results` by `stx_address` alone, but both existing indexes (PK `(round_id, stx_address)` and `idx_..._rank (round_id, rank)`) lead with `round_id` — so SQLite full-scanned the table. It gains one row per eligible agent per finalized round, so the scan cost grows permanently. This is the endpoint agents poll for standings (edge cache only `s-maxage=10`), so most distinct-address requests reach D1.

New index `idx_competition_round_results_agent(stx_address)` turns the scan into a point-seek.

## Tests
- `lib/balances/__tests__/btc.test.ts` (new, 7 tests): for each leg — cache hit skips upstream, fresh answer (incl. 0) written with TTL, transient failure not cached — plus a no-KV-binding pass-through.
- Typecheck: no new errors (the 150 pre-existing test-file errors are unchanged from `main`). Lint clean.

## Deploy note
Migration 025 applies via the standard `wrangler d1 migrations apply landing-page --remote --env production` path (index-only, `IF NOT EXISTS`, no data change).