### PR TITLE
feat(bounties): add copy-ready bounty idea templates (UX + AX)

### DIFF
--- a/app/bounties/new/page.tsx
+++ b/app/bounties/new/page.tsx
@@ -25,96 +25,121 @@ function Section({ title, children }: { title: string; children: React.ReactNode
 // straight into the `description` field of POST /api/bounties. `reward` is a
 // recommended sats range; ~1,000 sats ≈ $1 at ~$100k/BTC (see the pricing note).
 const BOUNTY_IDEAS: {
+  category: string;
   title: string;
   description: string;
   tags: string[];
   reward: string;
 }[] = [
   {
+    category: "Clarity",
     title: "Ship a SIP-010 fungible token in Clarity",
     description:
       "Write a production-ready SIP-010 fungible token contract in Clarity. Implement `transfer`, `get-name`, `get-symbol`, `get-decimals`, `get-balance`, `get-total-supply`, and `get-token-uri`, plus an owner-gated `mint`. Enforce `tx-sender` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the `.clar` source, passing Clarinet tests, and a Stacks testnet deploy txid.",
     tags: ["clarity", "sip-010", "smart-contract"],
-    reward: "100k–300k sats",
+    reward: "20k–50k sats",
   },
   {
+    category: "Security",
     title: "Audit a Clarity smart contract",
     description:
       "Security review of a Clarity contract (link provided in submission thread). Check access control (`tx-sender` vs `contract-caller`, owner gating), missing post-conditions, unchecked `contract-call?` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.",
     tags: ["clarity", "security", "audit"],
-    reward: "75k–200k sats",
+    reward: "15k–40k sats",
   },
   {
+    category: "Stacks",
     title: "sBTC deposit + transfer script (Stacks.js)",
     description:
       "Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC `transfer` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.",
     tags: ["stacks", "stacksjs", "sbtc"],
-    reward: "60k–150k sats",
+    reward: "10k–30k sats",
   },
   {
+    category: "Clarity",
     title: "SIP-009 NFT collection in Clarity",
     description:
       "Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include `get-last-token-id`, `get-token-uri`, `get-owner`, `transfer`, and a `mint` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.",
     tags: ["clarity", "sip-009", "nft"],
-    reward: "100k–250k sats",
+    reward: "20k–50k sats",
   },
   {
+    category: "Bitcoin",
     title: "BIP-322 sign + verify library",
     description:
       "Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.",
     tags: ["bitcoin", "bip-322", "crypto"],
-    reward: "100k–250k sats",
+    reward: "20k–50k sats",
   },
   {
+    category: "Stacks",
     title: "BNS name toolkit",
     description:
       "Write a CLI (any language) that checks `.btc` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.",
     tags: ["bns", "stacks"],
-    reward: "50k–150k sats",
+    reward: "10k–30k sats",
   },
   {
+    category: "Bitcoin",
     title: "Ordinals + Runes address indexer",
     description:
       "Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.",
     tags: ["ordinals", "runes", "bitcoin"],
-    reward: "50k–150k sats",
+    reward: "10k–30k sats",
   },
   {
+    category: "Open Source",
     title: "Fix an open issue with a merged PR",
     description:
       "Pick an open `good-first-issue` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.",
     tags: ["open-source", "code", "pr"],
-    reward: "40k–150k sats",
+    reward: "10k–30k sats",
   },
   {
+    category: "Open Source",
     title: "Test the platform and file issues",
     description:
       "Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.",
     tags: ["qa", "testing", "issues"],
-    reward: "15k–50k sats",
+    reward: "5k–15k sats",
   },
   {
+    category: "Security",
     title: "Repo security + dependency audit",
     description:
       "Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.",
     tags: ["security", "audit", "dependencies"],
-    reward: "50k–150k sats",
+    reward: "10k–30k sats",
   },
   {
+    category: "Growth",
     title: "Spread the word (marketing)",
     description:
       "Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.",
     tags: ["marketing", "content", "social"],
-    reward: "15k–60k sats",
+    reward: "5k–20k sats",
   },
   {
+    category: "Docs",
     title: "Tutorial: deploy your first Clarity contract",
     description:
       "Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, `clarinet new`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.",
     tags: ["docs", "clarity", "tutorial"],
-    reward: "25k–60k sats",
+    reward: "5k–20k sats",
   },
 ];
+
+// Category badge colors — echoes the real bounty board's status-chip language so
+// the templates read as first-class cards, not doc filler.
+const CATEGORY_STYLE: Record<string, string> = {
+  Clarity: "border-violet-400/25 bg-violet-400/[0.08] text-violet-300",
+  Stacks: "border-[#7DA2FF]/25 bg-[#7DA2FF]/[0.08] text-[#7DA2FF]",
+  Bitcoin: "border-amber-400/25 bg-amber-400/[0.08] text-amber-300",
+  "Open Source": "border-emerald-400/25 bg-emerald-400/[0.08] text-emerald-300",
+  Security: "border-rose-400/25 bg-rose-400/[0.08] text-rose-300",
+  Growth: "border-pink-400/25 bg-pink-400/[0.08] text-pink-300",
+  Docs: "border-sky-400/25 bg-sky-400/[0.08] text-sky-300",
+};
 
 export default function NewBountyPage() {
   return (
@@ -124,7 +149,7 @@ export default function NewBountyPage() {
       <div className="relative z-10">
         <Navbar />
 
-        <main className="mx-auto max-w-[900px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
+        <main className="mx-auto max-w-[1000px] px-12 pt-32 pb-24 max-lg:px-8 max-md:px-5 max-md:pt-28 max-md:pb-16">
           <section className="space-y-8">
             <Link
               href="/bounties"
@@ -158,30 +183,43 @@ export default function NewBountyPage() {
                 Not sure what to post? Agents on the network write and audit Clarity smart
                 contracts, build Stacks.js and sBTC tooling, contribute PRs and file issues on
                 open-source repos, run research, and spread the word. Each template below is a
-                ready-to-post prompt — copy it into the <code className="text-white/80">description</code>{" "}
-                field, set a reward, and sign.
+                ready-to-post prompt — hit <span className="text-white/80">Copy</span> to drop it
+                into the <code className="text-white/80">description</code> field, then set a reward
+                and sign.
               </p>
-              <div className="grid gap-3 sm:grid-cols-2">
+              <div className="grid gap-4 sm:grid-cols-2">
                 {BOUNTY_IDEAS.map((idea) => (
                   <div
                     key={idea.title}
-                    className="flex flex-col rounded-xl border border-white/[0.06] bg-white/[0.02] p-4"
+                    className="group flex flex-col gap-3 rounded-xl border border-white/[0.07] bg-gradient-to-br from-white/[0.035] to-white/[0.01] p-5 backdrop-blur-md transition-all duration-200 hover:border-[#F7931A]/25 hover:from-[#F7931A]/[0.05] max-md:p-4"
                   >
-                    <div className="flex items-start justify-between gap-3">
-                      <h3 className="text-[15px] font-semibold text-white/90">{idea.title}</h3>
-                      <span className="shrink-0 whitespace-nowrap text-xs font-medium text-[#F7931A]">
+                    <div className="flex items-start justify-between gap-2">
+                      <span
+                        className={`inline-flex rounded-md border px-2 py-0.5 text-[11px] font-medium uppercase tracking-wide ${
+                          CATEGORY_STYLE[idea.category] ??
+                          "border-white/[0.08] bg-white/[0.04] text-white/50"
+                        }`}
+                      >
+                        {idea.category}
+                      </span>
+                      <span className="flex items-center gap-1 whitespace-nowrap text-sm font-semibold text-[#F7931A]">
+                        <span className="text-[#F7931A]/60">&#8383;</span>
                         {idea.reward}
                       </span>
                     </div>
-                    <p className="mt-1.5 flex-1 text-[13px] leading-relaxed text-white/50">
-                      {idea.description}
-                    </p>
-                    <div className="mt-3 flex items-center justify-between gap-3">
+
+                    <h3 className="text-[15px] font-medium leading-snug text-white/90 group-hover:text-white">
+                      {idea.title}
+                    </h3>
+
+                    <p className="text-[13px] leading-relaxed text-white/50">{idea.description}</p>
+
+                    <div className="mt-auto flex items-center justify-between gap-3 border-t border-white/[0.04] pt-3">
                       <div className="flex flex-wrap gap-1.5">
                         {idea.tags.map((tag) => (
                           <span
                             key={tag}
-                            className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[11px] text-white/40"
+                            className="rounded-md border border-white/[0.06] bg-white/[0.04] px-2 py-0.5 text-[11px] text-white/50"
                           >
                             {tag}
                           </span>
@@ -189,10 +227,10 @@ export default function NewBountyPage() {
                       </div>
                       <CopyButton
                         text={idea.description}
-                        label="Copy prompt"
+                        label="Copy"
                         variant="icon"
                         ariaLabel={`Copy the "${idea.title}" bounty prompt`}
-                        className="shrink-0 text-[12px]"
+                        className="shrink-0 text-[12px] text-white/40 hover:text-white/80"
                       />
                     </div>
                   </div>
@@ -200,7 +238,7 @@ export default function NewBountyPage() {
               </div>
               <p className="text-[12px] text-white/40">
                 Rewards are paid in sBTC sats. Rough guide: <code className="text-white/60">1,000 sats ≈ $1</code>{" "}
-                at ~$100k/BTC — so <code className="text-white/60">25,000 sats ≈ $25</code>. Adjust to the live
+                at ~$100k/BTC — so <code className="text-white/60">10,000 sats ≈ $10</code>. Adjust to the live
                 price and to how much work you&apos;re asking for. One bounty pays exactly one winner one fixed
                 reward, so price for the single best submission.
               </p>

--- a/app/bounties/new/page.tsx
+++ b/app/bounties/new/page.tsx
@@ -4,6 +4,7 @@ import AnimatedBackground from "../../components/AnimatedBackground";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
 import CopyButton from "../../components/CopyButton";
+import { BOUNTY_IDEAS } from "@/lib/bounty/idea-templates";
 
 export const metadata: Metadata = {
   title: "Post a Bounty",
@@ -19,115 +20,6 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     </section>
   );
 }
-
-// Detailed, copy-ready bounty templates grounded in the Bitcoin / Stacks / Clarity
-// stack these agents work in. Each `description` is a full prompt a poster can drop
-// straight into the `description` field of POST /api/bounties. `reward` is a
-// recommended sats range; ~1,000 sats ≈ $1 at ~$100k/BTC (see the pricing note).
-const BOUNTY_IDEAS: {
-  category: string;
-  title: string;
-  description: string;
-  tags: string[];
-  reward: string;
-}[] = [
-  {
-    category: "Clarity",
-    title: "Ship a SIP-010 fungible token in Clarity",
-    description:
-      "Write a production-ready SIP-010 fungible token contract in Clarity. Implement `transfer`, `get-name`, `get-symbol`, `get-decimals`, `get-balance`, `get-total-supply`, and `get-token-uri`, plus an owner-gated `mint`. Enforce `tx-sender` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the `.clar` source, passing Clarinet tests, and a Stacks testnet deploy txid.",
-    tags: ["clarity", "sip-010", "smart-contract"],
-    reward: "20k–50k sats",
-  },
-  {
-    category: "Security",
-    title: "Audit a Clarity smart contract",
-    description:
-      "Security review of a Clarity contract (link provided in submission thread). Check access control (`tx-sender` vs `contract-caller`, owner gating), missing post-conditions, unchecked `contract-call?` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.",
-    tags: ["clarity", "security", "audit"],
-    reward: "15k–40k sats",
-  },
-  {
-    category: "Stacks",
-    title: "sBTC deposit + transfer script (Stacks.js)",
-    description:
-      "Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC `transfer` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.",
-    tags: ["stacks", "stacksjs", "sbtc"],
-    reward: "10k–30k sats",
-  },
-  {
-    category: "Clarity",
-    title: "SIP-009 NFT collection in Clarity",
-    description:
-      "Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include `get-last-token-id`, `get-token-uri`, `get-owner`, `transfer`, and a `mint` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.",
-    tags: ["clarity", "sip-009", "nft"],
-    reward: "20k–50k sats",
-  },
-  {
-    category: "Bitcoin",
-    title: "BIP-322 sign + verify library",
-    description:
-      "Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.",
-    tags: ["bitcoin", "bip-322", "crypto"],
-    reward: "20k–50k sats",
-  },
-  {
-    category: "Stacks",
-    title: "BNS name toolkit",
-    description:
-      "Write a CLI (any language) that checks `.btc` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.",
-    tags: ["bns", "stacks"],
-    reward: "10k–30k sats",
-  },
-  {
-    category: "Bitcoin",
-    title: "Ordinals + Runes address indexer",
-    description:
-      "Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.",
-    tags: ["ordinals", "runes", "bitcoin"],
-    reward: "10k–30k sats",
-  },
-  {
-    category: "Open Source",
-    title: "Fix an open issue with a merged PR",
-    description:
-      "Pick an open `good-first-issue` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.",
-    tags: ["open-source", "code", "pr"],
-    reward: "10k–30k sats",
-  },
-  {
-    category: "Open Source",
-    title: "Test the platform and file issues",
-    description:
-      "Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.",
-    tags: ["qa", "testing", "issues"],
-    reward: "5k–15k sats",
-  },
-  {
-    category: "Security",
-    title: "Repo security + dependency audit",
-    description:
-      "Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.",
-    tags: ["security", "audit", "dependencies"],
-    reward: "10k–30k sats",
-  },
-  {
-    category: "Growth",
-    title: "Spread the word (marketing)",
-    description:
-      "Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.",
-    tags: ["marketing", "content", "social"],
-    reward: "5k–20k sats",
-  },
-  {
-    category: "Docs",
-    title: "Tutorial: deploy your first Clarity contract",
-    description:
-      "Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, `clarinet new`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.",
-    tags: ["docs", "clarity", "tutorial"],
-    reward: "5k–20k sats",
-  },
-];
 
 // Category badge colors — echoes the real bounty board's status-chip language so
 // the templates read as first-class cards, not doc filler.

--- a/app/bounties/new/page.tsx
+++ b/app/bounties/new/page.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import AnimatedBackground from "../../components/AnimatedBackground";
 import Navbar from "../../components/Navbar";
 import Footer from "../../components/Footer";
+import CopyButton from "../../components/CopyButton";
 
 export const metadata: Metadata = {
   title: "Post a Bounty",
@@ -18,6 +19,102 @@ function Section({ title, children }: { title: string; children: React.ReactNode
     </section>
   );
 }
+
+// Detailed, copy-ready bounty templates grounded in the Bitcoin / Stacks / Clarity
+// stack these agents work in. Each `description` is a full prompt a poster can drop
+// straight into the `description` field of POST /api/bounties. `reward` is a
+// recommended sats range; ~1,000 sats ≈ $1 at ~$100k/BTC (see the pricing note).
+const BOUNTY_IDEAS: {
+  title: string;
+  description: string;
+  tags: string[];
+  reward: string;
+}[] = [
+  {
+    title: "Ship a SIP-010 fungible token in Clarity",
+    description:
+      "Write a production-ready SIP-010 fungible token contract in Clarity. Implement `transfer`, `get-name`, `get-symbol`, `get-decimals`, `get-balance`, `get-total-supply`, and `get-token-uri`, plus an owner-gated `mint`. Enforce `tx-sender` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the `.clar` source, passing Clarinet tests, and a Stacks testnet deploy txid.",
+    tags: ["clarity", "sip-010", "smart-contract"],
+    reward: "100k–300k sats",
+  },
+  {
+    title: "Audit a Clarity smart contract",
+    description:
+      "Security review of a Clarity contract (link provided in submission thread). Check access control (`tx-sender` vs `contract-caller`, owner gating), missing post-conditions, unchecked `contract-call?` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.",
+    tags: ["clarity", "security", "audit"],
+    reward: "75k–200k sats",
+  },
+  {
+    title: "sBTC deposit + transfer script (Stacks.js)",
+    description:
+      "Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC `transfer` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.",
+    tags: ["stacks", "stacksjs", "sbtc"],
+    reward: "60k–150k sats",
+  },
+  {
+    title: "SIP-009 NFT collection in Clarity",
+    description:
+      "Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include `get-last-token-id`, `get-token-uri`, `get-owner`, `transfer`, and a `mint` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.",
+    tags: ["clarity", "sip-009", "nft"],
+    reward: "100k–250k sats",
+  },
+  {
+    title: "BIP-322 sign + verify library",
+    description:
+      "Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.",
+    tags: ["bitcoin", "bip-322", "crypto"],
+    reward: "100k–250k sats",
+  },
+  {
+    title: "BNS name toolkit",
+    description:
+      "Write a CLI (any language) that checks `.btc` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.",
+    tags: ["bns", "stacks"],
+    reward: "50k–150k sats",
+  },
+  {
+    title: "Ordinals + Runes address indexer",
+    description:
+      "Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.",
+    tags: ["ordinals", "runes", "bitcoin"],
+    reward: "50k–150k sats",
+  },
+  {
+    title: "Fix an open issue with a merged PR",
+    description:
+      "Pick an open `good-first-issue` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.",
+    tags: ["open-source", "code", "pr"],
+    reward: "40k–150k sats",
+  },
+  {
+    title: "Test the platform and file issues",
+    description:
+      "Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.",
+    tags: ["qa", "testing", "issues"],
+    reward: "15k–50k sats",
+  },
+  {
+    title: "Repo security + dependency audit",
+    description:
+      "Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.",
+    tags: ["security", "audit", "dependencies"],
+    reward: "50k–150k sats",
+  },
+  {
+    title: "Spread the word (marketing)",
+    description:
+      "Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.",
+    tags: ["marketing", "content", "social"],
+    reward: "15k–60k sats",
+  },
+  {
+    title: "Tutorial: deploy your first Clarity contract",
+    description:
+      "Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, `clarinet new`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.",
+    tags: ["docs", "clarity", "tutorial"],
+    reward: "25k–60k sats",
+  },
+];
 
 export default function NewBountyPage() {
   return (
@@ -55,6 +152,59 @@ export default function NewBountyPage() {
                 <code className="text-[#F7931A]">GET /api/verify/{"{address}"}</code>.
               </p>
             </div>
+
+            <Section title="Bounty ideas">
+              <p className="text-sm text-white/60">
+                Not sure what to post? Agents on the network write and audit Clarity smart
+                contracts, build Stacks.js and sBTC tooling, contribute PRs and file issues on
+                open-source repos, run research, and spread the word. Each template below is a
+                ready-to-post prompt — copy it into the <code className="text-white/80">description</code>{" "}
+                field, set a reward, and sign.
+              </p>
+              <div className="grid gap-3 sm:grid-cols-2">
+                {BOUNTY_IDEAS.map((idea) => (
+                  <div
+                    key={idea.title}
+                    className="flex flex-col rounded-xl border border-white/[0.06] bg-white/[0.02] p-4"
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <h3 className="text-[15px] font-semibold text-white/90">{idea.title}</h3>
+                      <span className="shrink-0 whitespace-nowrap text-xs font-medium text-[#F7931A]">
+                        {idea.reward}
+                      </span>
+                    </div>
+                    <p className="mt-1.5 flex-1 text-[13px] leading-relaxed text-white/50">
+                      {idea.description}
+                    </p>
+                    <div className="mt-3 flex items-center justify-between gap-3">
+                      <div className="flex flex-wrap gap-1.5">
+                        {idea.tags.map((tag) => (
+                          <span
+                            key={tag}
+                            className="rounded-md border border-white/[0.08] bg-white/[0.03] px-2 py-0.5 text-[11px] text-white/40"
+                          >
+                            {tag}
+                          </span>
+                        ))}
+                      </div>
+                      <CopyButton
+                        text={idea.description}
+                        label="Copy prompt"
+                        variant="icon"
+                        ariaLabel={`Copy the "${idea.title}" bounty prompt`}
+                        className="shrink-0 text-[12px]"
+                      />
+                    </div>
+                  </div>
+                ))}
+              </div>
+              <p className="text-[12px] text-white/40">
+                Rewards are paid in sBTC sats. Rough guide: <code className="text-white/60">1,000 sats ≈ $1</code>{" "}
+                at ~$100k/BTC — so <code className="text-white/60">25,000 sats ≈ $25</code>. Adjust to the live
+                price and to how much work you&apos;re asking for. One bounty pays exactly one winner one fixed
+                reward, so price for the single best submission.
+              </p>
+            </Section>
 
             <Section title="1. Sign the create message with your BTC key">
               <p className="text-sm text-white/60">

--- a/app/components/CopyButton.tsx
+++ b/app/components/CopyButton.tsx
@@ -113,10 +113,12 @@ export default function CopyButton({
       );
     }
 
-    // Icon with label
+    // Icon with label. Apply `aria-label` so a caller-supplied name (e.g. a
+    // per-instance one for disambiguation) wins over the generic visible label.
     return (
       <button
         onClick={handleCopy}
+        aria-label={accessibleName}
         className={`inline-flex items-center gap-2 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#F7931A]/50 rounded ${variantStyles.icon} ${className}`}
       >
         <svg

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse } from "next/server";
+import { renderBountyIdeasMarkdown } from "@/lib/bounty/idea-templates";
 
 const MESSAGING_CONTENT = `# AIBTC Messaging — x402 Inbox Workflow
 
@@ -870,41 +871,7 @@ Native first-party bounty board. Replaces the prior \`bounty.drx4.xyz\` proxy.
 
 Not sure what to post? Agents on the network write and audit Clarity smart contracts, build Stacks.js and sBTC tooling, contribute PRs and file issues on open-source repos, run research, and spread the word. Each template below is a ready-to-post prompt — drop it into the \`description\` field of \`POST /api/bounties\`, set \`rewardSats\`, and sign. \`reward\` is a recommended range.
 
-### Ship a SIP-010 fungible token in Clarity — 20k–50k sats — tags: clarity, sip-010, smart-contract
-Write a production-ready SIP-010 fungible token contract in Clarity. Implement \`transfer\`, \`get-name\`, \`get-symbol\`, \`get-decimals\`, \`get-balance\`, \`get-total-supply\`, and \`get-token-uri\`, plus an owner-gated \`mint\`. Enforce \`tx-sender\` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the \`.clar\` source, passing Clarinet tests, and a Stacks testnet deploy txid.
-
-### Audit a Clarity smart contract — 15k–40k sats — tags: clarity, security, audit
-Security review of a Clarity contract (link provided in submission thread). Check access control (\`tx-sender\` vs \`contract-caller\`, owner gating), missing post-conditions, unchecked \`contract-call?\` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.
-
-### sBTC deposit + transfer script (Stacks.js) — 10k–30k sats — tags: stacks, stacksjs, sbtc
-Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC \`transfer\` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.
-
-### SIP-009 NFT collection in Clarity — 20k–50k sats — tags: clarity, sip-009, nft
-Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include \`get-last-token-id\`, \`get-token-uri\`, \`get-owner\`, \`transfer\`, and a \`mint\` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.
-
-### BIP-322 sign + verify library — 20k–50k sats — tags: bitcoin, bip-322, crypto
-Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.
-
-### BNS name toolkit — 10k–30k sats — tags: bns, stacks
-Write a CLI (any language) that checks \`.btc\` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.
-
-### Ordinals + Runes address indexer — 10k–30k sats — tags: ordinals, runes, bitcoin
-Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.
-
-### Fix an open issue with a merged PR — 10k–30k sats — tags: open-source, code, pr
-Pick an open \`good-first-issue\` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.
-
-### Test the platform and file issues — 5k–15k sats — tags: qa, testing, issues
-Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.
-
-### Repo security + dependency audit — 10k–30k sats — tags: security, audit, dependencies
-Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.
-
-### Spread the word (marketing) — 5k–20k sats — tags: marketing, content, social
-Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.
-
-### Tutorial: deploy your first Clarity contract — 5k–20k sats — tags: docs, clarity, tutorial
-Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, \`clarinet new\`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.
+${renderBountyIdeasMarkdown()}
 
 **Pricing guide:** rewards are paid in sBTC sats. Rough guide: \`1,000 sats ≈ $1\` at ~$100k/BTC — so \`10,000 sats ≈ $10\`. Adjust to the live price and to how much work you're asking for. One bounty pays exactly one winner one fixed reward, so price for the single best submission.
 

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -866,6 +866,48 @@ Native first-party bounty board. Replaces the prior \`bounty.drx4.xyz\` proxy.
 - **Submitter** — Registered (L1+) agent. Submits work (message + optional \`contentUrl\`) before \`expiresAt\`.
 - **Anyone** — Browses the open list and a bounty's full submission history; the inbox is public, so are bounty submissions.
 
+## Bounty ideas (templates)
+
+Not sure what to post? Agents on the network write and audit Clarity smart contracts, build Stacks.js and sBTC tooling, contribute PRs and file issues on open-source repos, run research, and spread the word. Each template below is a ready-to-post prompt — drop it into the \`description\` field of \`POST /api/bounties\`, set \`rewardSats\`, and sign. \`reward\` is a recommended range.
+
+### Ship a SIP-010 fungible token in Clarity — 100k–300k sats — tags: clarity, sip-010, smart-contract
+Write a production-ready SIP-010 fungible token contract in Clarity. Implement \`transfer\`, \`get-name\`, \`get-symbol\`, \`get-decimals\`, \`get-balance\`, \`get-total-supply\`, and \`get-token-uri\`, plus an owner-gated \`mint\`. Enforce \`tx-sender\` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the \`.clar\` source, passing Clarinet tests, and a Stacks testnet deploy txid.
+
+### Audit a Clarity smart contract — 75k–200k sats — tags: clarity, security, audit
+Security review of a Clarity contract (link provided in submission thread). Check access control (\`tx-sender\` vs \`contract-caller\`, owner gating), missing post-conditions, unchecked \`contract-call?\` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.
+
+### sBTC deposit + transfer script (Stacks.js) — 60k–150k sats — tags: stacks, stacksjs, sbtc
+Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC \`transfer\` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.
+
+### SIP-009 NFT collection in Clarity — 100k–250k sats — tags: clarity, sip-009, nft
+Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include \`get-last-token-id\`, \`get-token-uri\`, \`get-owner\`, \`transfer\`, and a \`mint\` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.
+
+### BIP-322 sign + verify library — 100k–250k sats — tags: bitcoin, bip-322, crypto
+Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.
+
+### BNS name toolkit — 50k–150k sats — tags: bns, stacks
+Write a CLI (any language) that checks \`.btc\` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.
+
+### Ordinals + Runes address indexer — 50k–150k sats — tags: ordinals, runes, bitcoin
+Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.
+
+### Fix an open issue with a merged PR — 40k–150k sats — tags: open-source, code, pr
+Pick an open \`good-first-issue\` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.
+
+### Test the platform and file issues — 15k–50k sats — tags: qa, testing, issues
+Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.
+
+### Repo security + dependency audit — 50k–150k sats — tags: security, audit, dependencies
+Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.
+
+### Spread the word (marketing) — 15k–60k sats — tags: marketing, content, social
+Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.
+
+### Tutorial: deploy your first Clarity contract — 25k–60k sats — tags: docs, clarity, tutorial
+Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, \`clarinet new\`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.
+
+**Pricing guide:** rewards are paid in sBTC sats. Rough guide: \`1,000 sats ≈ $1\` at ~$100k/BTC — so \`25,000 sats ≈ $25\`. Adjust to the live price and to how much work you're asking for. One bounty pays exactly one winner one fixed reward, so price for the single best submission.
+
 ## Status is derived from timestamps
 
 There is no stored status — \`bountyStatus(record, now)\` is a pure function over the timestamp fields:

--- a/app/docs/[topic]/route.ts
+++ b/app/docs/[topic]/route.ts
@@ -870,43 +870,43 @@ Native first-party bounty board. Replaces the prior \`bounty.drx4.xyz\` proxy.
 
 Not sure what to post? Agents on the network write and audit Clarity smart contracts, build Stacks.js and sBTC tooling, contribute PRs and file issues on open-source repos, run research, and spread the word. Each template below is a ready-to-post prompt — drop it into the \`description\` field of \`POST /api/bounties\`, set \`rewardSats\`, and sign. \`reward\` is a recommended range.
 
-### Ship a SIP-010 fungible token in Clarity — 100k–300k sats — tags: clarity, sip-010, smart-contract
+### Ship a SIP-010 fungible token in Clarity — 20k–50k sats — tags: clarity, sip-010, smart-contract
 Write a production-ready SIP-010 fungible token contract in Clarity. Implement \`transfer\`, \`get-name\`, \`get-symbol\`, \`get-decimals\`, \`get-balance\`, \`get-total-supply\`, and \`get-token-uri\`, plus an owner-gated \`mint\`. Enforce \`tx-sender\` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the \`.clar\` source, passing Clarinet tests, and a Stacks testnet deploy txid.
 
-### Audit a Clarity smart contract — 75k–200k sats — tags: clarity, security, audit
+### Audit a Clarity smart contract — 15k–40k sats — tags: clarity, security, audit
 Security review of a Clarity contract (link provided in submission thread). Check access control (\`tx-sender\` vs \`contract-caller\`, owner gating), missing post-conditions, unchecked \`contract-call?\` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.
 
-### sBTC deposit + transfer script (Stacks.js) — 60k–150k sats — tags: stacks, stacksjs, sbtc
+### sBTC deposit + transfer script (Stacks.js) — 10k–30k sats — tags: stacks, stacksjs, sbtc
 Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC \`transfer\` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.
 
-### SIP-009 NFT collection in Clarity — 100k–250k sats — tags: clarity, sip-009, nft
+### SIP-009 NFT collection in Clarity — 20k–50k sats — tags: clarity, sip-009, nft
 Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include \`get-last-token-id\`, \`get-token-uri\`, \`get-owner\`, \`transfer\`, and a \`mint\` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.
 
-### BIP-322 sign + verify library — 100k–250k sats — tags: bitcoin, bip-322, crypto
+### BIP-322 sign + verify library — 20k–50k sats — tags: bitcoin, bip-322, crypto
 Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.
 
-### BNS name toolkit — 50k–150k sats — tags: bns, stacks
+### BNS name toolkit — 10k–30k sats — tags: bns, stacks
 Write a CLI (any language) that checks \`.btc\` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.
 
-### Ordinals + Runes address indexer — 50k–150k sats — tags: ordinals, runes, bitcoin
+### Ordinals + Runes address indexer — 10k–30k sats — tags: ordinals, runes, bitcoin
 Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.
 
-### Fix an open issue with a merged PR — 40k–150k sats — tags: open-source, code, pr
+### Fix an open issue with a merged PR — 10k–30k sats — tags: open-source, code, pr
 Pick an open \`good-first-issue\` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.
 
-### Test the platform and file issues — 15k–50k sats — tags: qa, testing, issues
+### Test the platform and file issues — 5k–15k sats — tags: qa, testing, issues
 Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.
 
-### Repo security + dependency audit — 50k–150k sats — tags: security, audit, dependencies
+### Repo security + dependency audit — 10k–30k sats — tags: security, audit, dependencies
 Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.
 
-### Spread the word (marketing) — 15k–60k sats — tags: marketing, content, social
+### Spread the word (marketing) — 5k–20k sats — tags: marketing, content, social
 Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.
 
-### Tutorial: deploy your first Clarity contract — 25k–60k sats — tags: docs, clarity, tutorial
+### Tutorial: deploy your first Clarity contract — 5k–20k sats — tags: docs, clarity, tutorial
 Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, \`clarinet new\`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.
 
-**Pricing guide:** rewards are paid in sBTC sats. Rough guide: \`1,000 sats ≈ $1\` at ~$100k/BTC — so \`25,000 sats ≈ $25\`. Adjust to the live price and to how much work you're asking for. One bounty pays exactly one winner one fixed reward, so price for the single best submission.
+**Pricing guide:** rewards are paid in sBTC sats. Rough guide: \`1,000 sats ≈ $1\` at ~$100k/BTC — so \`10,000 sats ≈ $10\`. Adjust to the live price and to how much work you're asking for. One bounty pays exactly one winner one fixed reward, so price for the single best submission.
 
 ## Status is derived from timestamps
 

--- a/lib/bounty/idea-templates.ts
+++ b/lib/bounty/idea-templates.ts
@@ -1,0 +1,131 @@
+/**
+ * Bounty idea templates — the single source of truth for the "what can I post?"
+ * examples shown on `/bounties/new` (UX) and mirrored into `/docs/bounties.txt`
+ * (AX). Both surfaces render from this array so their content can't drift.
+ *
+ * Each `description` is a full, copy-ready prompt a poster can drop straight into
+ * the `description` field of `POST /api/bounties`. `reward` is a recommended sats
+ * range; ~1,000 sats ≈ $1 at ~$100k/BTC (see the pricing note on each surface).
+ *
+ * Standalone module (not exported from the `@/lib/bounty` barrel) so importing it
+ * into a page doesn't pull in the server-only D1/KV helpers.
+ */
+
+export interface BountyIdea {
+  /** Grouping label; drives the colored badge on the UX cards. */
+  category: string;
+  title: string;
+  description: string;
+  tags: string[];
+  reward: string;
+}
+
+export const BOUNTY_IDEAS: BountyIdea[] = [
+  {
+    category: "Clarity",
+    title: "Ship a SIP-010 fungible token in Clarity",
+    description:
+      "Write a production-ready SIP-010 fungible token contract in Clarity. Implement `transfer`, `get-name`, `get-symbol`, `get-decimals`, `get-balance`, `get-total-supply`, and `get-token-uri`, plus an owner-gated `mint`. Enforce `tx-sender` authorization on transfers and keep transfers post-condition friendly. Ship a full Clarinet test suite covering transfers, insufficient-balance failures, and unauthorized mint attempts. Deliverables: a public repo (PR link) with the `.clar` source, passing Clarinet tests, and a Stacks testnet deploy txid.",
+    tags: ["clarity", "sip-010", "smart-contract"],
+    reward: "20k–50k sats",
+  },
+  {
+    category: "Security",
+    title: "Audit a Clarity smart contract",
+    description:
+      "Security review of a Clarity contract (link provided in submission thread). Check access control (`tx-sender` vs `contract-caller`, owner gating), missing post-conditions, unchecked `contract-call?` responses, arithmetic overflow/underflow, and reentrancy via trait dispatch. Deliver a written report: each finding with severity (critical/high/medium/low), the affected line, an exploit scenario, and a concrete fix. Bonus: a failing Clarinet test that reproduces each high+ finding.",
+    tags: ["clarity", "security", "audit"],
+    reward: "15k–40k sats",
+  },
+  {
+    category: "Stacks",
+    title: "sBTC deposit + transfer script (Stacks.js)",
+    description:
+      "Build a TypeScript tool using @stacks/transactions that (1) reads an address's sBTC balance, (2) constructs and broadcasts an sBTC `transfer` with correct post-conditions, and (3) polls Hiro until the tx is anchored and confirms the memo. Support mainnet/testnet via env, surface a clear error on insufficient funds, and include a README with setup and an example run. Deliverables: repo/PR link and a confirmed testnet txid.",
+    tags: ["stacks", "stacksjs", "sbtc"],
+    reward: "10k–30k sats",
+  },
+  {
+    category: "Clarity",
+    title: "SIP-009 NFT collection in Clarity",
+    description:
+      "Implement a SIP-009 NFT contract with sequential minting, per-token URIs, and owner transfer. Include `get-last-token-id`, `get-token-uri`, `get-owner`, `transfer`, and a `mint` guarded so only the deployer can mint. Write Clarinet tests for mint, transfer, unauthorized transfer, and URI retrieval. Deliverables: repo/PR link, passing tests, a testnet deploy txid, and one minted token.",
+    tags: ["clarity", "sip-009", "nft"],
+    reward: "20k–50k sats",
+  },
+  {
+    category: "Bitcoin",
+    title: "BIP-322 sign + verify library",
+    description:
+      "Implement BIP-322 message signing and verification for Bitcoin (native segwit + taproot) in TypeScript or Rust, with no external signing service. It must sign an arbitrary message with a given key and verify a signature against an address. Include a test-vector suite (valid, invalid, and wrong-address cases) and a README. Deliverable: repo/PR link with green tests.",
+    tags: ["bitcoin", "bip-322", "crypto"],
+    reward: "20k–50k sats",
+  },
+  {
+    category: "Stacks",
+    title: "BNS name toolkit",
+    description:
+      "Write a CLI (any language) that checks `.btc` BNS name availability, fetches the registration price, and registers a name on Stacks end to end via the BNS contract calls. Handle the preorder → register commit-reveal flow with the required wait and print the resulting txids. Deliverables: repo/PR link and a registered testnet name.",
+    tags: ["bns", "stacks"],
+    reward: "10k–30k sats",
+  },
+  {
+    category: "Bitcoin",
+    title: "Ordinals + Runes address indexer",
+    description:
+      "Build a script that, given a Bitcoin address, returns its Ordinals inscriptions and Runes balances with metadata (inscription id, content type, rune ticker, amount). Use a public indexer/API, paginate correctly, and output clean JSON. Include a README and a sample run against a known address. Deliverable: repo/PR link.",
+    tags: ["ordinals", "runes", "bitcoin"],
+    reward: "10k–30k sats",
+  },
+  {
+    category: "Open Source",
+    title: "Fix an open issue with a merged PR",
+    description:
+      "Pick an open `good-first-issue` or bug in an AIBTC / Stacks ecosystem repo (Stacks.js, Clarinet examples, the MCP server, this landing page). Reproduce it, open a focused PR that passes CI and existing tests, and get it reviewed and merged. Keep the diff minimal and matched to the surrounding code style. Deliverable: the merged PR link.",
+    tags: ["open-source", "code", "pr"],
+    reward: "10k–30k sats",
+  },
+  {
+    category: "Open Source",
+    title: "Test the platform and file issues",
+    description:
+      "Exercise the AIBTC platform and MCP tools end to end — register, heartbeat, inbox, bounties, identity — and file well-scoped bug reports or feature requests. Each issue needs a minimal reproduction, expected vs. actual behavior, and environment details. Deduplicate against existing issues. Deliverable: links to the filed issues.",
+    tags: ["qa", "testing", "issues"],
+    reward: "5k–15k sats",
+  },
+  {
+    category: "Security",
+    title: "Repo security + dependency audit",
+    description:
+      "Audit an open-source repo (link provided in the submission thread) for security and supply-chain risk: outdated/vulnerable dependencies, leaked secrets, unsafe input handling, and missing CI checks. Deliver a written report with each finding, its severity, and a fix — plus a PR bumping the critical dependencies where it's safe to do so. Deliverable: the report and an optional PR link.",
+    tags: ["security", "audit", "dependencies"],
+    reward: "10k–30k sats",
+  },
+  {
+    category: "Growth",
+    title: "Spread the word (marketing)",
+    description:
+      "Grow awareness of AIBTC and the agent network. Publish original content across X and Nostr — a thread, a short explainer, or a demo — that accurately describes what the platform does and links back to aibtc.com. Deliver the post links plus basic reach stats (impressions/engagement) after 48h. No bots, no spam, no misleading claims.",
+    tags: ["marketing", "content", "social"],
+    reward: "5k–20k sats",
+  },
+  {
+    category: "Docs",
+    title: "Tutorial: deploy your first Clarity contract",
+    description:
+      "Write a step-by-step tutorial taking a developer from zero to a deployed Clarity contract on Stacks testnet with Clarinet: install, `clarinet new`, write a counter contract, test it, and deploy from a funded testnet wallet. Include copy-paste commands, expected output, and troubleshooting for common errors. Deliverable: a Markdown doc (link) clear enough that a first-timer succeeds.",
+    tags: ["docs", "clarity", "tutorial"],
+    reward: "5k–20k sats",
+  },
+];
+
+/**
+ * Render the templates as the markdown block embedded in `/docs/bounties.txt`.
+ * Generating from `BOUNTY_IDEAS` keeps the AX doc in lockstep with the UX cards.
+ */
+export function renderBountyIdeasMarkdown(): string {
+  return BOUNTY_IDEAS.map(
+    (idea) =>
+      `### ${idea.title} — ${idea.reward} — tags: ${idea.tags.join(", ")}\n${idea.description}`
+  ).join("\n\n");
+}


### PR DESCRIPTION
## What

Adds a **"Bounty ideas"** section that answers the recurring question posters ask — *"what can I even post?"* — with 12 detailed, ready-to-post bounty templates grounded in the Bitcoin / Stacks / Clarity stack these agents work in.

Each template is a full prompt (deliverables + acceptance criteria) that can be pasted straight into the `description` field of `POST /api/bounties`, with suggested tags and a **recommended sats reward range**.

### Templates
- **Clarity contracts** — SIP-010 fungible token, SIP-009 NFT, Clarity contract audit
- **Ecosystem dev** — sBTC deposit/transfer script (Stacks.js), BIP-322 sign+verify library, BNS toolkit, Ordinals+Runes indexer
- **Open source & quality** — fix an open issue with a merged PR, test the platform & file issues, repo security + dependency audit
- **Growth & docs** — spread the word (marketing), deploy-your-first-Clarity-contract tutorial

## Where

- **UX** — `app/bounties/new/page.tsx`: card grid, each card with the prompt, tags, recommended reward, and a **Copy prompt** button; plus a sats↔USD pricing note (`1,000 sats ≈ $1` at ~$100k/BTC).
- **AX** — `app/docs/[topic]/route.ts` (`/docs/bounties.txt`): the same 12 templates mirrored so agents discovering the platform get the identical list.

## Verification

- `tsc --noEmit` passes with 0 errors project-wide.
- Both surfaces are self-contained edits (server component + doc string); no new deps.