### PR TITLE
fix(claims): remove Genesis/viral reward promise copy

### DIFF
--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -456,7 +456,7 @@ export function GET() {
         id: "claim-code",
         name: "Claim Code Management",
         description:
-          "Manage claim codes for the viral reward flow. " +
+          "Manage claim codes for the viral claim flow. " +
           "GET /api/claims/code?btcAddress=...&code=... to validate a code. " +
           "POST /api/claims/code with btcAddress and bitcoinSignature to regenerate. " +
           "Codes are generated at registration and required before tweeting.",
@@ -470,16 +470,16 @@ export function GET() {
       },
       {
         id: "viral-claims",
-        name: "Viral Claim Rewards",
+        name: "Genesis Claim (Level 2)",
         description:
-          "Earn Bitcoin rewards by tweeting about your registered AIBTC agent. " +
+          "Reach Genesis (Level 2) by tweeting about your registered AIBTC agent. " +
           "Requires a valid claim code (from registration or POST /api/claims/code). " +
           "Include the code in your tweet, then POST btcAddress and tweetUrl to " +
-          "/api/claims/viral. Unlocks: Genesis badge + vouching + trading competition eligibility + leaderboard bonus." +
+          "/api/claims/viral. Unlocks: Genesis badge + vouching + trading competition eligibility + leaderboard bonus. " +
           "Successful claim upgrades you to Level 2 (Genesis).",
-        tags: ["rewards", "x", "viral", "earn", "level-up"],
+        tags: ["genesis", "x", "viral", "level-up"],
         examples: [
-          "How do I claim my tweet reward?",
+          "How do I reach Genesis level?",
           "Check my viral claim status",
         ],
         inputModes: ["application/json"],

--- a/app/agents/AgentList.tsx
+++ b/app/agents/AgentList.tsx
@@ -245,7 +245,7 @@ export default function AgentList({ agents }: AgentListProps) {
                 className="cursor-pointer px-2.5 py-3 text-center text-[11px] font-semibold uppercase tracking-wider text-white/50 transition-colors hover:text-white/70 whitespace-nowrap"
                 onClick={() => handleSort("level")}
               >
-                <Tooltip text="Agent progression tier. Registered = verified keys. Genesis = completed viral claim + earns satoshis.">
+                <Tooltip text="Agent progression tier. Registered = verified keys. Genesis = completed viral claim (unlocks vouching + trading competition).">
                   <div className="inline-flex items-center gap-1.5">
                     Level
                     <SortIcon active={sortBy === "level"} order={sortOrder} />

--- a/app/agents/[address]/AgentProfile.tsx
+++ b/app/agents/[address]/AgentProfile.tsx
@@ -427,12 +427,7 @@ export default function AgentProfile({
                           </span>
                         )}
                       </div>
-                      {claim!.status === "rewarded" && (
-                        <span className="text-xs font-medium text-[#F7931A]">{claim!.rewardSatoshis.toLocaleString()} sats</span>
-                      )}
-                      {claim!.status !== "rewarded" && (
-                        <span className="text-xs font-medium text-white/50">Rewards pending</span>
-                      )}
+                      <span className="text-xs font-medium text-[#7DA2FF]">Genesis · Level 2</span>
                     </div>
                     {claim!.tweetUrl && (
                       <a href={claim!.tweetUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 text-xs text-white/40 hover:text-white/60 transition-colors">

--- a/app/api/claims/viral/route.ts
+++ b/app/api/claims/viral/route.ts
@@ -14,13 +14,6 @@ import {
   type Logger,
 } from "@/lib/logging";
 
-const MIN_REWARD_SATS = 5000;
-const MAX_REWARD_SATS = 10000;
-
-function getRandomReward(): number {
-  return Math.floor(Math.random() * (MAX_REWARD_SATS - MIN_REWARD_SATS + 1)) + MIN_REWARD_SATS;
-}
-
 function normalizeTweetUrl(
   url: string,
   logger: Logger = createNoopLogger()
@@ -134,29 +127,16 @@ export async function POST(request: NextRequest) {
     if (existingClaim) {
       const claim = JSON.parse(existingClaim) as ClaimRecord;
 
-      if (claim.status === "rewarded") {
+      if (claim.status === "rewarded" || claim.status === "verified" || claim.status === "pending") {
         return NextResponse.json({
           claimed: true,
-          message: "Reward already sent!",
+          eligible: false,
+          message: "Claim already submitted — you're at Genesis (Level 2).",
           claim: {
             displayName: claim.displayName,
-            rewardSatoshis: claim.rewardSatoshis,
-            rewardTxid: claim.rewardTxid,
-            claimedAt: claim.claimedAt,
-            status: claim.status,
-          },
-        });
-      }
-
-      if (claim.status === "verified" || claim.status === "pending") {
-        return NextResponse.json({
-          eligible: true,
-          message: "Claim already submitted. Reward will be sent shortly.",
-          claim: {
-            displayName: claim.displayName,
-            rewardSatoshis: claim.rewardSatoshis,
             status: claim.status,
             tweetUrl: claim.tweetUrl,
+            claimedAt: claim.claimedAt,
           },
         });
       }
@@ -242,14 +222,13 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    const rewardAmount = getRandomReward();
     const claimRecord: ClaimRecord = {
       btcAddress,
       displayName,
       tweetUrl: normalizedUrl,
       tweetAuthor: ownerHandle,
       claimedAt: new Date().toISOString(),
-      rewardSatoshis: rewardAmount,
+      rewardSatoshis: 0,
       rewardTxid: null,
       status: "verified",
     };
@@ -280,14 +259,13 @@ export async function POST(request: NextRequest) {
 
     return NextResponse.json({
       success: true,
-      eligible: true,
-      message: "Tweet verified! Your reward will be sent shortly.",
+      eligible: false,
+      message: "Tweet verified! You've reached Genesis (Level 2).",
       claim: {
         displayName,
         btcAddress,
         tweetUrl: normalizedUrl,
         tweetAuthor: ownerHandle,
-        rewardSatoshis: rewardAmount,
         status: "verified",
       },
       level: 2,
@@ -325,14 +303,13 @@ export async function GET(request: NextRequest) {
   if (!btcAddress) {
     return NextResponse.json({
       endpoint: "/api/claims/viral",
-      description: "Viral claim system: tweet about your AIBTC agent to earn a Bitcoin reward.",
+      description: "Viral claim system: tweet about your AIBTC agent to unlock Genesis (Level 2).",
       methods: {
         GET: {
           description: "Check claim status for an agent. Pass btcAddress as query parameter.",
           example: "GET /api/claims/viral?btcAddress=bc1q...",
           responseFields: {
-            claimed: "true if a claim has been submitted (pending, verified, or rewarded)",
-            rewarded: "true if the Bitcoin reward has been paid out",
+            claimed: "true if a claim has been submitted (pending or verified)",
             eligible: "true if the agent can submit a new claim",
             claim: "Claim details (only present if a claim exists)",
           },
@@ -354,13 +331,13 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      rewardInfo: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+      unlocks: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
       documentation: {
         registerFirst: "https://aibtc.com/api/register",
         fullDocs: "https://aibtc.com/llms-full.txt",
       },
       nextStep: {
-        title: "After Claiming Your Viral Reward",
+        title: "After Reaching Genesis (Level 2)",
         description: "Continue earning through projects.",
         heartbeat: {
           endpoint: "POST /api/heartbeat",
@@ -413,17 +390,13 @@ export async function GET(request: NextRequest) {
 
     const claim = JSON.parse(claimData) as ClaimRecord;
     const isClaimed = claim.status === "verified" || claim.status === "rewarded" || claim.status === "pending";
-    const isRewarded = claim.status === "rewarded";
 
     return NextResponse.json({
       claimed: isClaimed,
-      rewarded: isRewarded,
       eligible: !isClaimed,
       claim: {
         displayName: claim.displayName,
         status: claim.status,
-        rewardSatoshis: claim.rewardSatoshis,
-        rewardTxid: claim.rewardTxid,
         tweetUrl: claim.tweetUrl,
         tweetAuthor: claim.tweetAuthor,
         claimedAt: claim.claimedAt,

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2937,7 +2937,7 @@ export function GET() {
           summary: "Get viral claim information or check status",
           description:
             "Without btcAddress parameter: returns usage documentation with claim requirements " +
-            "and reward details. With btcAddress parameter: returns claim status for the address.",
+            "and Genesis unlock details. With btcAddress parameter: returns claim status for the address.",
           parameters: [
             {
               name: "btcAddress",
@@ -2980,9 +2980,9 @@ export function GET() {
         },
         post: {
           operationId: "submitViralClaim",
-          summary: "Submit a viral claim to earn Bitcoin rewards",
+          summary: "Submit a viral claim to reach Genesis (Level 2)",
           description:
-            "Submit a tweet about your registered AIBTC agent to earn satoshis. " +
+            "Submit a tweet about your registered AIBTC agent to unlock Genesis (Level 2). " +
             "Prerequisites: agent must be registered, tweet must include your claim code " +
             `(from registration or POST /api/claims/code), mention your agent, and tag ${X_HANDLE}. ` +
             "One claim per registered agent.",
@@ -3015,12 +3015,12 @@ export function GET() {
           },
           responses: {
             "200": {
-              description: "Claim submitted successfully, reward sent",
+              description: "Tweet verified — agent upgraded to Genesis (Level 2)",
               content: {
                 "application/json": {
                   schema: {
                     type: "object",
-                    required: ["success", "message", "reward", "txid"],
+                    required: ["success", "message", "level"],
                     properties: {
                       success: {
                         type: "boolean",
@@ -3028,16 +3028,16 @@ export function GET() {
                       },
                       message: {
                         type: "string",
-                        examples: ["Viral claim submitted successfully"],
+                        examples: ["Tweet verified! You've reached Genesis (Level 2)."],
                       },
-                      reward: {
+                      level: {
                         type: "integer",
-                        description: "Reward amount in satoshis",
-                        examples: [7500],
+                        description: "Agent level after the claim (2 = Genesis)",
+                        examples: [2],
                       },
-                      txid: {
+                      levelName: {
                         type: "string",
-                        description: "Bitcoin transaction ID",
+                        examples: ["Genesis"],
                       },
                     },
                   },
@@ -3895,7 +3895,7 @@ export function GET() {
             },
             claimCode: {
               type: "string",
-              description: "6-character claim code for the viral reward flow. Save this!",
+              description: "6-character claim code for the viral claim flow. Save this!",
               examples: ["ABC123"],
             },
             claimInstructions: {

--- a/app/erc8004/page.tsx
+++ b/app/erc8004/page.tsx
@@ -5,7 +5,7 @@ import Link from "next/link";
 export const metadata = {
   title: "Register On-Chain Identity | AIBTC",
   description:
-    "Register your on-chain identity via ERC-8004. Establish verifiable identity before claiming rewards.",
+    "Register your on-chain identity via ERC-8004. Establish verifiable identity before leveling up to Genesis.",
 };
 
 export default function ERC8004Page() {
@@ -41,8 +41,8 @@ export default function ERC8004Page() {
           Register On-Chain Identity
         </h1>
         <p className="mb-12 text-lg text-white/60">
-          Establish verifiable on-chain identity via ERC-8004 before claiming
-          rewards. Recommended as your first action after registration.
+          Establish verifiable on-chain identity via ERC-8004 before leveling
+          up to Genesis. Recommended as your first action after registration.
         </p>
 
         {/* Why Register First */}
@@ -68,7 +68,7 @@ export default function ERC8004Page() {
                   Permanent Trust Signal
                 </h3>
                 <p className="text-sm text-white/60">
-                  Register your identity before claiming rewards. Shows
+                  Register your identity before leveling up to Genesis. Shows
                   commitment and permanence to potential clients from day one.
                 </p>
               </div>
@@ -276,7 +276,7 @@ export default function ERC8004Page() {
               </h3>
               <p className="ml-8 text-sm text-white/60">
                 After registration confirms, continue to the heartbeat check-in
-                and viral claim to start earning satoshis. Your on-chain
+                and viral claim to reach Genesis (Level 2). Your on-chain
                 identity will be detected and displayed on your profile.
               </p>
             </div>

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -105,7 +105,7 @@ Then level up to Genesis (Level 2) by tweeting about your agent with your claim 
 
 Agents progress through 3 levels by completing real activity:
 
-| Level | Name | Unlock | Reward |
+| Level | Name | Unlock | Unlocks |
 |-------|------|--------|--------|
 | 0 | Unverified | Starting point | None |
 | 1 | Registered | Register via POST /api/register | Listed in directory |
@@ -482,7 +482,7 @@ Requires the X402_RELAY RPC service binding (deployed Workers only; returns 503 
 
 See /api/openapi.json for complete request/response schemas.
 
-## Claims & Rewards
+## Claims & Genesis
 
 ### Claim Code API
 
@@ -500,7 +500,7 @@ curl "https://aibtc.com/api/claims/code?btcAddress=bc1...&code=ABC123"
 
 ### Viral Claims API
 
-Earn Bitcoin rewards by tweeting about your registered AIBTC agent.
+Reach Genesis (Level 2) by tweeting about your registered AIBTC agent.
 Requires a valid claim code (from registration or POST /api/claims/code).
 
 **GET /api/claims/viral?btcAddress=bc1...** — Check claim status for an address.

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -257,7 +257,7 @@ Existing agents can retroactively claim a referral: \`POST /api/vouch\` with \`{
 
 ### Earning & Progression (All Free — You Earn, Not Pay)
 
-- [Viral Claims](https://aibtc.com/api/claims/viral): GET for instructions, POST to claim tweet reward (free)
+- [Viral Claims](https://aibtc.com/api/claims/viral): GET for instructions, POST to unlock Genesis / Level 2 (free)
 - [Claim Code](https://aibtc.com/api/claims/code): GET to validate code, POST to regenerate (free)
 - [Level System](https://aibtc.com/api/levels): GET level definitions and how to advance (free)
 - [Leaderboard](https://aibtc.com/api/leaderboard): GET ranked agents by level (free)

--- a/lib/types.ts
+++ b/lib/types.ts
@@ -50,8 +50,10 @@ export interface AgentRecord {
 }
 
 /**
- * Claim status record for viral tweet rewards (minimal type for level computation).
+ * Claim status record for viral tweet claims (minimal type for level computation).
  * Used by computeLevel() to determine if an agent has reached Genesis (Level 2).
+ * reward* fields are retained for historical/admin-recorded payouts only — the
+ * viral claim itself does not pay out.
  */
 export interface ClaimStatus {
   status: "pending" | "verified" | "rewarded" | "failed";


### PR DESCRIPTION
## Problem

The viral (Genesis) claim flow advertised a Bitcoin/sats reward — agents saw **"~9,222 sats will be sent shortly!"** — but the platform does **not** pay out on joining. A claim is stored as `status: "verified"` with no transaction; nothing is sent automatically. The copy set a false expectation and produced missing-reward reports (e.g. aibtcdev/aibtc-mcp-server#453).

There is **no reward for Genesis / joining right now.** This PR removes every place that promised or implied one, and keeps the honest "unlocks Genesis (Level 2)" framing.

## Changes

**Claim API — `app/api/claims/viral/route.ts`**
- Removed `getRandomReward()` + `MIN/MAX_REWARD_SATS`; new claims store `rewardSatoshis: 0`.
- Dropped `rewardSatoshis` from all POST/GET responses so clients can no longer render a sats figure.
- Reframed messages: *"…reward will be sent shortly"* → *"You've reached Genesis (Level 2)."* Self-doc `rewardInfo`→`unlocks`; "Viral Reward" heading updated.

**Discovery docs (AX, kept in sync)**
- `agent.json`: skill *"Viral Claim Rewards"* → *"Genesis Claim (Level 2)"*; de-reward-ified description/tags/examples.
- `openapi.json`: viral summary/description reframed; 200 response schema no longer claims `reward`+`txid` were sent (now `level`/`levelName`).
- `llms-full.txt`: level table "Reward" column → "Unlocks"; "Earn Bitcoin rewards…" → "Reach Genesis…".
- `llms.txt`: "claim tweet reward" → "unlock Genesis / Level 2".

**UX**
- `AgentProfile.tsx`: removed the "N sats / Rewards pending" badge; shows a neutral "Genesis · Level 2" chip.
- `AgentList.tsx` tooltip + `erc8004/page.tsx` copy: "earns satoshis / claiming rewards" → "reach Genesis / level up".

## Preserved intentionally

`ClaimRecord.rewardSatoshis` / `rewardTxid`, the `rewarded` status, and the admin `genesis-payout` path are kept so any manual/discretionary operator payout still works and historical records stay intact. Only the automatic-reward **promise** is gone.

## Notes

Local `typecheck`/`test` could not be run — this checkout's `node_modules` is in a broken partial state (empty `.bin`, TypeScript `lib/` missing), unrelated to these edits. Changes are copy strings plus removal of one unused helper. CI will typecheck/test on the PR.
