### PR TITLE
chore(scheduler): run competition Hiro sweep daily instead of hourly

### DIFF
--- a/lib/scheduler/cron-runner.ts
+++ b/lib/scheduler/cron-runner.ts
@@ -62,13 +62,14 @@ import type {
 // interval or upgrade the Tenero plan. The minute cap is handled separately by
 // TENERO_REQUEST_SPACING_MS (inter-request spacing within a run).
 export const TENERO_INTERVAL_MS = 60 * 60 * 1000;
-// Competition Hiro catch-up sweep — HOURLY. Widened from 15 min (#933): the
-// sweep shares the single HIRO_API_KEY with reputation/identity lookups, and a
-// 15-min cadence monopolized that budget and 429-starved those endpoints. The
-// agent self-submit fast path (POST /api/competition/trades) is the primary
-// ingestion route; this sweep is only catch-up, so 4x fewer Hiro calls is a
-// safe trade. Can be gated off entirely via COMPETITION_SWEEP_ENABLED="false".
-export const COMPETITION_INTERVAL_MS = 60 * 60 * 1000;
+// Competition Hiro catch-up sweep — DAILY. Widened from 15 min → hourly (#933),
+// then hourly → daily: the sweep shares the single HIRO_API_KEY (150k req/mo
+// free tier) with reputation/identity lookups and the earnings/Legion crons,
+// and a tight cadence exhausted that monthly budget and 429-starved those
+// endpoints. The agent self-submit fast path (POST /api/competition/trades) is
+// the primary ingestion route; this sweep is only catch-up, so once a day is
+// ample. Can be gated off entirely via COMPETITION_SWEEP_ENABLED="false".
+export const COMPETITION_INTERVAL_MS = 24 * 60 * 60 * 1000;
 // Legion snapshot — HOURLY (widened from every-tick). The snapshot fans out
 // a large, mostly-uncached set of Hiro reads per tick (per-member stake+balance,
 // per-proposal status, per-voter records) on the SAME shared HIRO_API_KEY as


### PR DESCRIPTION
## What

Widen the competition Hiro catch-up sweep cadence from **hourly → once a day** (`COMPETITION_INTERVAL_MS` in `lib/scheduler/cron-runner.ts`).

## Why

The sweep shares the single `HIRO_API_KEY` (150k requests/month on the free tier) with reputation/identity lookups and the earnings + Legion crons. Even at hourly it competed for that monthly budget; when the budget is exhausted, every Hiro call — including user-facing agent profile/reputation/BNS lookups — starts 429ing.

The sweep is only a **catch-up** net: the agent self-submit fast path (`POST /api/competition/trades`) is the primary ingestion route, and both converge on the same `swaps` row via `INSERT OR IGNORE` on `txid`. So dropping the sweep from ~24 runs/day to 1 is a safe way to hand the monthly Hiro headroom back to the request-time lookups.

## Scope

- One constant: `60 * 60 * 1000` → `24 * 60 * 60 * 1000`, plus its explanatory comment.
- No test pins the interval value; the only consumer is the due-check at `cron-runner.ts:441`.
- Takes effect on the next scheduler-worker deploy.
- Orthogonal to `COMPETITION_SWEEP_ENABLED` — that kill-switch (no redeploy) is still the lever for full competition sunset.