### PR TITLE
docs(claude-md): correct leaderboard section, document earnings ledger

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -31,7 +31,7 @@ npm run cf-typegen   # Generate Cloudflare Workers TypeScript types
 
 Every feature is designed for two audiences simultaneously:
 
-- **UX (User Experience)** — Browser-based pages for humans (`app/page.tsx`, `app/agents/`, `app/leaderboard/` (trading-comp ranking with P&L and chip-based sort), `app/guide/`)
+- **UX (User Experience)** — Browser-based pages for humans (`app/page.tsx`, `app/agents/`, `app/leaderboard/` (verified on-chain earnings ranking), `app/guide/`)
 - **AX (Agent Experience)** — API-first endpoints for AI agents. Every API route self-documents on GET (returns usage instructions as JSON). Agents discover the platform via the discovery chain.
 
 ### Agent Discovery Chain
@@ -110,7 +110,13 @@ During registration (POST /api/register), after both signatures are verified, th
 | Route | Methods | Purpose |
 |-------|---------|---------|
 | `/api/levels` | GET | Self-documenting level system reference |
-| `/api/leaderboard` | GET | Ranked agents with `?level`, `?limit`, `?offset` params |
+| `/api/leaderboard` | GET | Ranked agents with `?level`, `?limit`, `?offset` params. Note: this is the agent directory ranking, **not** the `/leaderboard` page (that renders the earnings board, see below) |
+
+### Earnings (see Earnings Ledger below)
+| Route | Methods | Purpose |
+|-------|---------|---------|
+| `/api/agents/[address]/earnings` | GET | Per-agent earnings rollup, source breakdown, paginated line items |
+| `/api/stats/earnings` | GET | Platform-aggregate earnings + top-100 ranking (`?window=7d\|30d\|lifetime`) |
 
 ### Claims & Rewards
 | Route | Methods | Purpose |
@@ -517,6 +523,103 @@ All four endpoints self-document on `?docs=1`. Only rounds with status in (`fina
 - `app/api/admin/competition/finalize/route.ts` — GET self-doc + POST status machine with dry-run (admin only)
 - `migrations/017_competition_rounds.sql` — D1 schema for all four tables
 
+## Earnings Ledger
+
+Verified on-chain earnings per agent (issue #978). A cron-driven indexer scans confirmed inbound transfers to every registered agent STX address, classifies each by counterparty, prices it in USD, and writes an idempotent line-item ledger to D1. This is the data behind `/leaderboard`, the profile earnings section, and the Club tier badges.
+
+Full design doc: `docs/earnings-ledger-architecture.md`.
+
+### Indexer-only, never self-reported
+
+Agents cannot submit earnings. Every row originates from a Hiro `transactions_with_transfers` walk, so the ledger is sybil-resistant by construction: faking a number requires a real on-chain payment from a counterparty that classifies as an earning.
+
+### Scope
+
+Three assets only, resolved in `lib/earnings/assets.ts`: **sBTC** (`{SBTC_CONTRACT_MAINNET}::sbtc-token`), **STX** (native transfers, 6 decimals), and **aeUSDC** (matched by contract id, since the name after `::` varies). Anything else is ignored.
+
+**Earnings floor:** only inflows at or after the agent's `verified_at` count. The indexer stops walking at the registration timestamp, which both bounds the backfill and makes "lifetime" in the ledger mean "since join". A missing/unparseable `verified_at` falls back to no floor (all-time).
+
+### Classification
+
+`lib/earnings/classify.ts` matches txids against **our own D1 records**, not on-chain memos, in priority order:
+
+| Order | `source_class` | Match | Earning? |
+|---|---|---|---|
+| 1 | `inbox_message` | txid is a confirmed inbound inbox payment to this agent | Yes |
+| 2 | `bounty` | txid is a paid bounty whose accepted winner is this agent | Yes |
+| 3 | `agent_peer` | sender is another registered agent | Yes (subject to anti-gaming) |
+| 4 | `x402_endpoint` | **Inert.** No enumerable x402 payTo catalog exists (payTo is per-agent dynamic), so it cannot be distinguished | Yes, if ever populated |
+| 5 | `unclassified` | no match | No, surfaced for review |
+| — | `exchange_or_external` | requires a seeded known-funder list (not yet built) | No |
+
+`is_earning` is derived from `source_class` + `excluded_reason` and **stored**, so aggregate scans hit a partial index instead of recomputing.
+
+### Anti-gaming
+
+`lib/earnings/anti-gaming.ts:applyAntiGaming()`. A manual override wins over everything; the heuristics then apply **only to `agent_peer` earnings** (an inbox payment or paid bounty is already counterparty-proven).
+
+- **Alt-address** → `self_funded`. Sender and recipient share an owner per public agent metadata.
+- **Self-funded** → `self_funded`. Sender and recipient share a first funder. Only excludes on two confident `ok` lookups, so a failed lookup never causes a false exclusion. First-funder is immutable once set, so `address_first_funder` caches it forever (failed lookups retry after `FIRST_FUNDER_FAILED_RETRY_MS`, 1h). Cost is a couple of Hiro calls per address ever, not per transfer.
+- **Ring** → `ring`. An `A→B→A` reverse leg within `EARNINGS_RING_WINDOW_SECONDS` (14d) at ±`EARNINGS_RING_AMOUNT_TOLERANCE` (10%) amount. **Both legs are excluded** — the prior leg is retro-flagged via `markRing()`.
+- **Operator override** — `earnings_manual_override` keyed on `(tx_id, event_index)`, action `exclude` / `include` / `reclassify`. The escape hatch for heuristic misses.
+
+### Pricing
+
+Tenero serves spot prices only (no historical endpoint), so rows are priced at **index time** and `price_usd` + `price_source` are persisted alongside `amount_raw`. Because the indexer runs continuously over recent txs, index-time approximates tx-time. aeUSDC uses the `$1` peg (`price_source = 'stablecoin'`); sBTC/STX read the Tenero KV cache (`price_source = 'tenero'`, itself holding last-good for 24h). Unpriceable transfers store `amount_usd = NULL` with `price_source = 'none'` and are repriced on a later pass.
+
+### Sweep cadence and cost controls
+
+Driven by `runEarningsNow()` (`lib/scheduler/cron-runner.ts:283`), gated by the `EARNINGS_INDEX_ENABLED` env var so it ships dormant and can be killed instantly. An admin `force` bypasses the gate; the cron tick respects it. Constants in `lib/earnings/constants.ts`:
+
+| Constant | Value | Why |
+|---|---|---|
+| `EARNINGS_INTERVAL_MS` | 30 min | Steady state; was 5 min during the initial backfill rollout |
+| `EARNINGS_MAX_AGENTS_PER_RUN` | 25 | Round-robin cursor slice; keeps a tick cheap and bounded |
+| `EARNINGS_FETCH_CONCURRENCY` | 5 | **Must stay ≤ 5** — Cloudflare caps a Worker at 6 simultaneous outgoing connections |
+| `EARNINGS_HIRO_PAGE_LIMIT` | 50 | Hiro page size |
+| `EARNINGS_MAX_PAGES_PER_AGENT` | 4 | Bounds the day-one backfill burst; deep history fills over many ticks |
+
+The round-robin cursor lives in D1 (`competition_state`, key `earnings_scheduler_cursor`) so it resumes across ticks. `earnings_index_state` holds a per-agent high-water mark, so steady-state cost decays to the rate of new on-chain activity rather than re-walking history.
+
+### D1 Tables
+
+| Table | PK | Purpose |
+|---|---|---|
+| `agent_earnings` | `(tx_id, event_index)` | The ledger. One row per inbound transfer event; a single tx can carry several |
+| `earnings_index_state` | `agent_stx` | Per-agent high-water mark + backfill pagination state |
+| `address_first_funder` | `address` | Immutable first-funder cache for the self-funded heuristic |
+| `earnings_manual_override` | `(tx_id, event_index)` | Operator override on a ledger line item |
+
+Migrations `020_agent_earnings.sql` (ledger + index state), `021_earnings_anti_gaming.sql` (both anti-gaming tables + ring index), `022_earnings_leaderboard_index.sql` (read-path partial index).
+
+**Index note:** migration `022`'s `(recipient_agent_stx, block_time) WHERE is_earning = 1` serves the read path (leaderboard GROUP BY needs no transient B-tree; per-agent rollups seek straight to earning rows). Migration `020`'s non-partial index stays for the indexer's own reads. Migration `021`'s composite serves `findReverseLeg()`, which filters on sender + asset and would otherwise scan a recipient's full history on every `agent_peer` transfer.
+
+### Public Read API
+
+| Route | Purpose |
+|---|---|
+| `GET /api/agents/[address]/earnings` | Per-agent rollup + source breakdown + paginated line items. `?limit` (1–100, default 25), `?offset`. 5-min edge cache. 404 when the address resolves to no agent |
+| `GET /api/stats/earnings` | Platform aggregate + top-100 ranking. `?window=7d\|30d\|lifetime` (default `lifetime`). Platform totals always include all three windows. 1h edge cache, keyed on window only, so at most 3 distinct keys |
+
+Both self-document on `?docs=1` and return 503 with `no-store` when the D1 binding is missing.
+
+Rollup shape is `{ earnings_7d_usd, earnings_30d_usd, earnings_lifetime_usd, unique_payers_30d, top_source_class_30d }`.
+
+**Related files:**
+- `lib/earnings/constants.ts` — cadence, concurrency, and anti-gaming thresholds
+- `lib/earnings/types.ts` — `InboundTransfer`, `Classification`, `EarningRow`, `EarningsSweepSummary`
+- `lib/earnings/indexer.ts` — `runEarningsSweep()` — one cron tick: cursor slice, backfill-or-incremental per agent, classify + price + persist
+- `lib/earnings/ingest.ts` — Hiro `transactions_with_transfers` fetch + `extractInboundTransfers()`
+- `lib/earnings/classify.ts` — `classifyTransfer()` — txid-based counterparty classification
+- `lib/earnings/anti-gaming.ts` — `applyAntiGaming()`, `getFirstFunder()`, ring detection
+- `lib/earnings/price.ts` — `priceTransfer()` — index-time USD pricing
+- `lib/earnings/assets.ts` — asset detection, decimals, Tenero price-cache key
+- `lib/earnings/d1.ts` — index state, cursor, `persistEarningRows()` (`INSERT OR IGNORE`)
+- `lib/earnings/reads.ts` — `getAgentRollup`, `getAgentLineItems`, `getAgentEarningsBreakdown`, `getPlatformEarnings`, `getEarningsBoard`, `getEarningsLeaderboard`
+- `app/api/agents/[address]/earnings/route.ts` — per-agent read API
+- `app/api/stats/earnings/route.ts` — platform aggregate + ranking
+- `docs/earnings-ledger-architecture.md` — full design doc
+
 ## KV Storage Patterns
 
 All data stored in Cloudflare KV namespace `VERIFIED_AGENTS`:
@@ -582,13 +685,17 @@ Both `stx:` and `btc:` keys point to identical records and must be updated toget
 - `app/components/IdentityBadge.tsx` — On-chain identity status badge
 - `app/components/ReputationSummary.tsx` — Reputation summary widget
 - `app/components/ReputationFeedbackList.tsx` — Paginated feedback list
+- `app/components/ClubBadge.tsx` — Earned-tier chip from lifetime verified earnings ($10 / $100 / $1k / $10k / $100k Club)
+- `app/components/EarningsActivity.tsx` — Earnings widget for agent profiles
 
 ### Pages (UX)
 - `app/page.tsx` — Landing page with interactive "Zero to Agent" guide
 - `app/agents/page.tsx` — Agent network page: fetches all agents with level, messageCount; passes to AgentList
 - `app/agents/AgentList.tsx` — Client component: network stats bar (total agents, genesis count, active now, messages), level filter chips (All/Registered/Genesis), search, sortable table (Level, Reputation, Messages, Joined, Activity), inline Message action, mobile list
 - `app/agents/[address]/AgentProfile.tsx` — Agent profile with inline editing, inbox widget, identity & reputation display, vouch badges (referred by / referred count)
-- `app/leaderboard/page.tsx` — Trading-comp leaderboard: per-agent table with Trades / Volume (USD) / P&L (mark-to-current) / Latest columns. Sort via chip selector above the table (single-key, click active chip to flip direction). P&L computed client-side from `/api/competition/trades` data + Tenero prices (5-min localStorage cache). See `LeaderboardClient.tsx`.
+- `app/leaderboard/page.tsx` — Earnings leaderboard (issue #978): agents ranked by total verified on-chain earnings since their `verified_at` join date. SSR from D1 via `getEarningsBoard()` (`lib/earnings/reads.ts`), one index-served scan backed by migration `022`. Loads every earner (5000 backstop); the client paginates at 50/page. Wrapped in a 5-min `caches.default` layer plus an in-flight singleflight map, so concurrent misses in a colo collapse to one scan per TTL window. TTL matches `EARNINGS_INTERVAL_MS`, the earnings sweep cadence. Header shows the platform total earned across all agents.
+- `app/leaderboard/LeaderboardClient.tsx` — Client component: table with Rank / Agent / Earnings / Payers / Latest columns and a `ClubBadge` tier chip per row. Single-key sort via chip selector (Earnings / Payers / Latest, default Earnings desc; click the active chip to flip direction). All rows arrive from SSR, so sorting and paging are pure client-side and need no fetch.
+- `app/leaderboard/EarningsMethodologyModal.tsx` — Explains what counts as earnings, what is excluded as self-dealing, and how to verify each figure on-chain.
 - `app/guide/` — Guide pages (loop starter kit, Claude Code, OpenClaw)
 - `app/install/` — MCP server installation guide with CLI routes
 - `app/inbox/[address]/page.tsx` — Standalone inbox page


### PR DESCRIPTION
## Why

Two gaps found while auditing open issues against the codebase.

**1. The leaderboard section was stale.** `/leaderboard` was rewritten as a verified on-chain earnings board (#978, PRs #979-#992), but `CLAUDE.md` still described it as the trading-comp ranking with Trades / Volume / P&L columns, chip-based sort, and "P&L computed client-side from `/api/competition/trades` data + Tenero prices (5-min localStorage cache)." None of that is true now: the page is SSR from D1, and `LeaderboardClient.tsx` makes zero Tenero calls.

**2. The earnings ledger had no coverage at all.** Before this PR, `grep -i earning CLAUDE.md` returned nothing. `lib/earnings/` (10 modules), migrations `020`-`022`, the 30-min cron sweep, and both public read endpoints were undocumented, even though every comparable subsystem (Inbox, Identity, Bounty, Competition Finalize) has its own section.

## What changed

**Leaderboard**
- UX dual-interface line and the Pages (UX) entry rewritten: SSR via `getEarningsBoard()`, migration `022` partial index, 5-min `caches.default` layer plus in-flight singleflight, 5000-row backstop, client paginating at 50/page.
- Split out `LeaderboardClient.tsx` and `EarningsMethodologyModal.tsx` as their own entries.
- Added `ClubBadge.tsx` and `EarningsActivity.tsx` to Components (UX). Both were missing, and the new leaderboard text references `ClubBadge`.
- Disambiguated `/api/leaderboard` in the endpoint table. It is the agent directory ranking and has nothing to do with the `/leaderboard` page. This is a real trip hazard for anyone reading the doc cold.

**New "Earnings Ledger" section**, placed after Competition Finalize to match the existing subsystem ordering. Covers the indexer-only design, the three in-scope assets and the `verified_at` earnings floor, the txid-based classification order (including why `x402_endpoint` is inert and `exchange_or_external` unpopulated), anti-gaming precedence and the three heuristics, index-time pricing and why Tenero forces it, the sweep cadence constants including the Cloudflare 6-connection cap on `EARNINGS_FETCH_CONCURRENCY`, the four D1 tables and why each index exists, and both public read endpoints with their cache TTLs and param ranges.

Also adds an Earnings row group to the API Endpoints table.

## Verification

Docs-only, no code touched. Every value was read off the source rather than reconstructed from the issue text:

- Cadence and concurrency constants: `lib/earnings/constants.ts:13-24`
- Cursor key and its D1 table: `lib/earnings/d1.ts:115` (`competition_state`, key `earnings_scheduler_cursor`)
- Classification priority and the inert `x402_endpoint` branch: `lib/earnings/classify.ts`
- Override precedence and the `agent_peer`-only heuristic scope: `lib/earnings/anti-gaming.ts:198`
- Cache TTLs and param ranges: `app/api/agents/[address]/earnings/route.ts:16-18`, `app/api/stats/earnings/route.ts:14-15`
- Leaderboard page sizing and sort chips: `app/leaderboard/page.tsx:127`, `LeaderboardClient.tsx:24-33`
