### PR TITLE
fix(deps): bump postcss to 8.5.18, fixes CVE-2026-45623

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "eslint": "^9",
         "eslint-config-next": "^15.1.3",
         "patch-package": "^8.0.1",
+        "postcss": "^8.5.18",
         "tailwindcss": "^4.1.18",
         "typescript": "^5",
         "vitest": "^4.0.18",
@@ -11150,9 +11151,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",
@@ -11822,9 +11823,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.6",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
-      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "version": "8.5.18",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.18.tgz",
+      "integrity": "sha512-xdB1oSLHbz1vRWgCDalrCqEFTWzFlhqFC5tIHLMOSUIjhm3XXQ1qrFy8S/ESr1JYRRXqM3c1QFiMZUJdUTqyMQ==",
       "dev": true,
       "funding": [
         {
@@ -11842,7 +11843,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "eslint": "^9",
     "eslint-config-next": "^15.1.3",
     "patch-package": "^8.0.1",
+    "postcss": "^8.5.18",
     "tailwindcss": "^4.1.18",
     "typescript": "^5",
     "vitest": "^4.0.18",


### PR DESCRIPTION
## Summary
- Bumps the top-level `postcss` devDependency from `^8.5.6` to `^8.5.18`, resolving Dependabot alerts #156 and #157 (CVE-2026-45623, GHSA path-traversal in `previous-map.js` sourceMappingURL auto-loading, CVSS 7.5).
- `next`'s internally-pinned `postcss@8.4.31` (its own dependency, unrelated to our `package.json`) is untouched — even `next@latest` still pins exactly `8.4.31` for its internal build pipeline, so it's not something we control. It's also low-risk here: Next only runs postcss over our own trusted source CSS at build time, not attacker-supplied CSS at request time, which is what this CVE requires.

## Test plan
- [x] `npx tsc --noEmit` — same pre-existing failures on base branch and this branch (unrelated test-type errors, confirmed via `git stash` diff)
- [x] `npx next build` — succeeds, CSS/Tailwind output generated correctly
- [ ] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)