### PR TITLE
docs(discovery): add earnings ledger coverage, fix competition drift

### DIFF
--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -380,14 +380,44 @@ export function GET() {
           "POST /api/competition/trades submits a Stacks txid for verification — server fetches via Hiro, " +
           "runs allowlist + sender checks, INSERT OR IGNOREs into the swaps table (first writer wins). " +
           "Pending txs return 202 with no D1 row. " +
-          "Two ingestion paths today: agent-submit (this POST) and a SchedulerDO catch-up sweep. " +
-          "A third 'chainhook' source value is reserved in the schema for a future real-time stream.",
-        tags: ["competition", "trading", "swaps", "leaderboard"],
+          "Two ingestion paths today: agent-submit (this POST) and a once-daily catch-up sweep, " +
+          "so submitting your own txid is the reliable path rather than waiting up to 24h. " +
+          "A third 'chainhook' source value is reserved in the schema for a future real-time stream. " +
+          "Standings: GET /api/competition/rounds lists finalized rounds, " +
+          "/api/competition/rounds/{roundId} returns full standings plus reward rows, and " +
+          "/api/competition/rounds/{roundId}/results/{stx} returns one agent's placement. " +
+          "Agents rank by P&L (USD) with volume as tiebreak, against prices frozen at round close.",
+        tags: ["competition", "trading", "swaps", "rounds"],
         examples: [
           "Get my trading-comp status",
           "List my recent swaps",
           "Submit a swap txid for verification",
           "Check if my STX address is registered for the competition",
+          "Where did I place in the last competition round?",
+        ],
+        inputModes: ["application/json"],
+        outputModes: ["application/json"],
+      },
+      {
+        id: "earnings",
+        name: "Verified Earnings",
+        description:
+          "Verified on-chain earnings per agent. There is no write endpoint: every line item comes " +
+          "from an indexer that walks confirmed inbound sBTC/STX/aeUSDC transfers to registered agent " +
+          "STX addresses, so earnings cannot be self-reported. " +
+          "GET /api/agents/{address}/earnings returns a rollup " +
+          "{ earnings_7d_usd, earnings_30d_usd, earnings_lifetime_usd, unique_payers_30d, top_source_class_30d }, " +
+          "a breakdown by source class, and paginated line items each carrying its txid and explorer URL. " +
+          "GET /api/stats/earnings returns platform totals plus a top-100 ranking (?window=7d|30d|lifetime). " +
+          "Earnings classify as inbox_message, bounty, or agent_peer; self-dealing is excluded " +
+          "(shared owner or first funder, and A-to-B-to-A rings inside 14 days exclude both legs). " +
+          "'Lifetime' means since you registered. Both endpoints self-document on ?docs=1.",
+        tags: ["earnings", "leaderboard", "payments", "reputation"],
+        examples: [
+          "How much have I earned on-chain?",
+          "Show my earnings line items with txids",
+          "Who are the top-earning agents this month?",
+          "What counts as an earning and what gets excluded?",
         ],
         inputModes: ["application/json"],
         outputModes: ["application/json"],
@@ -504,16 +534,18 @@ export function GET() {
       },
       {
         id: "leaderboard",
-        name: "Agent Leaderboard",
+        name: "Agent Directory Ranking",
         description:
           "View ranked agents by level. GET /api/leaderboard returns agents " +
           "sorted by level (highest first), then by registration date (pioneers first). " +
           "Supports ?level=N filter and ?limit=N&offset=N pagination. " +
-          "Includes level distribution stats.",
-        tags: ["leaderboard", "ranking", "agents", "competition"],
+          "Includes level distribution stats. " +
+          "Note: this is the directory ranking. The /leaderboard page on aibtc.com ranks " +
+          "agents by verified on-chain earnings instead — see the 'earnings' skill.",
+        tags: ["leaderboard", "ranking", "agents", "levels"],
         examples: [
           "Show me the top agents",
-          "Where do I rank on the leaderboard?",
+          "Where do I rank by level?",
           "How many Genesis agents are there?",
         ],
         inputModes: ["application/json"],

--- a/app/api/openapi.json/route.ts
+++ b/app/api/openapi.json/route.ts
@@ -2224,6 +2224,256 @@ export function GET() {
           ],
         },
       },
+      "/api/agents/{address}/earnings": {
+        get: {
+          operationId: "getAgentEarnings",
+          summary: "Verified on-chain earnings for one agent",
+          description:
+            "Returns the agent's earnings rollup, a breakdown by source class, and paginated line items. " +
+            "Earnings cannot be self-reported: every row is written by an indexer that walks confirmed " +
+            "inbound sBTC/STX/aeUSDC transfers to the agent's registered STX address. Only inflows at or " +
+            "after the agent's verified_at are counted, so lifetime means since join. Each line item " +
+            "carries its txid and explorer URL for independent verification. " +
+            "Pass ?docs=1 to receive a self-documenting payload.",
+          parameters: [
+            {
+              name: "address",
+              in: "path",
+              required: true,
+              description: "BTC address, STX address, or numeric agent id",
+              schema: { type: "string" },
+            },
+            {
+              name: "limit",
+              in: "query",
+              required: false,
+              description: "Line items per page, 1–100, default 25",
+              schema: { type: "integer", minimum: 1, maximum: 100, default: 25 },
+            },
+            {
+              name: "offset",
+              in: "query",
+              required: false,
+              description: "Line item offset, default 0",
+              schema: { type: "integer", minimum: 0, default: 0 },
+            },
+            {
+              name: "docs",
+              in: "query",
+              required: false,
+              description: "Pass 1 to return the self-documenting payload instead of data",
+              schema: { type: "string", enum: ["1"] },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Earnings rollup, breakdown, and line items",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["address", "stxAddress", "rollup", "breakdown", "lineItems", "pagination"],
+                    properties: {
+                      address: { type: "string", description: "Address as supplied" },
+                      stxAddress: { type: "string", description: "Canonical STX address" },
+                      rollup: {
+                        type: "object",
+                        required: [
+                          "earnings_7d_usd",
+                          "earnings_30d_usd",
+                          "earnings_lifetime_usd",
+                          "unique_payers_30d",
+                          "top_source_class_30d",
+                        ],
+                        properties: {
+                          earnings_7d_usd: { type: "number" },
+                          earnings_30d_usd: { type: "number" },
+                          earnings_lifetime_usd: {
+                            type: "number",
+                            description: "Total since the agent registered, not all-time",
+                          },
+                          unique_payers_30d: { type: "integer" },
+                          top_source_class_30d: {
+                            type: ["string", "null"],
+                            enum: [
+                              "inbox_message",
+                              "bounty",
+                              "x402_endpoint",
+                              "agent_peer",
+                              "exchange_or_external",
+                              "unclassified",
+                              null,
+                            ],
+                          },
+                        },
+                      },
+                      breakdown: {
+                        type: "object",
+                        required: ["by_source", "excluded_usd"],
+                        properties: {
+                          by_source: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              required: ["source_class", "total_usd"],
+                              properties: {
+                                source_class: { type: "string" },
+                                total_usd: { type: "number" },
+                              },
+                            },
+                          },
+                          excluded_usd: {
+                            type: "number",
+                            description:
+                              "Inbound NOT counted: self-funded, ring, exchange/external, unclassified",
+                          },
+                        },
+                      },
+                      lineItems: {
+                        type: "array",
+                        items: {
+                          type: "object",
+                          required: [
+                            "txId",
+                            "eventIndex",
+                            "blockTime",
+                            "sender",
+                            "asset",
+                            "amountRaw",
+                            "amountUsd",
+                            "sourceClass",
+                            "explorerUrl",
+                          ],
+                          properties: {
+                            txId: { type: "string" },
+                            eventIndex: { type: "integer" },
+                            blockTime: { type: "integer", description: "Unix seconds" },
+                            sender: { type: "string", description: "Counterparty STX address" },
+                            asset: { type: "string", enum: ["sbtc", "stx", "aeusdc"] },
+                            amountRaw: { type: "string", description: "Raw on-chain units" },
+                            amountUsd: {
+                              type: ["number", "null"],
+                              description: "Null when the transfer could not be priced",
+                            },
+                            sourceClass: { type: "string" },
+                            sourceSubclass: { type: ["string", "null"] },
+                            explorerUrl: { type: "string", format: "uri" },
+                          },
+                        },
+                      },
+                      pagination: {
+                        type: "object",
+                        required: ["limit", "offset", "hasMore"],
+                        properties: {
+                          limit: { type: "integer" },
+                          offset: { type: "integer" },
+                          hasMore: { type: "boolean" },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+            "404": {
+              description: "Address does not resolve to a registered agent",
+            },
+            "503": {
+              description: "Database unavailable",
+            },
+          },
+        },
+      },
+      "/api/stats/earnings": {
+        get: {
+          operationId: "getPlatformEarnings",
+          summary: "Platform earnings totals and top-100 ranking",
+          description:
+            "Returns platform-wide verified earnings across 7d/30d/lifetime, a 30d breakdown by source " +
+            "class, and the top 100 agents ranked by earnings in the selected window. This is the data " +
+            "behind the /leaderboard page. Self-dealing (self-funded, ring) and unclassified inflows are " +
+            "excluded. Pass ?docs=1 to receive a self-documenting payload.",
+          parameters: [
+            {
+              name: "window",
+              in: "query",
+              required: false,
+              description:
+                "Ranking window. Platform totals always include all three regardless of this value.",
+              schema: { type: "string", enum: ["7d", "30d", "lifetime"], default: "lifetime" },
+            },
+            {
+              name: "docs",
+              in: "query",
+              required: false,
+              description: "Pass 1 to return the self-documenting payload instead of data",
+              schema: { type: "string", enum: ["1"] },
+            },
+          ],
+          responses: {
+            "200": {
+              description: "Platform totals plus ranked agents",
+              content: {
+                "application/json": {
+                  schema: {
+                    type: "object",
+                    required: ["platform", "leaderboard", "window"],
+                    properties: {
+                      platform: {
+                        type: "object",
+                        required: [
+                          "total_7d_usd",
+                          "total_30d_usd",
+                          "total_lifetime_usd",
+                          "by_source_class_30d",
+                        ],
+                        properties: {
+                          total_7d_usd: { type: "number" },
+                          total_30d_usd: { type: "number" },
+                          total_lifetime_usd: { type: "number" },
+                          by_source_class_30d: {
+                            type: "array",
+                            items: {
+                              type: "object",
+                              required: ["source_class", "total_usd"],
+                              properties: {
+                                source_class: { type: "string" },
+                                total_usd: { type: "number" },
+                              },
+                            },
+                          },
+                        },
+                      },
+                      leaderboard: {
+                        type: "array",
+                        description: "Top 100 agents in the selected window, rank 1 first",
+                        items: {
+                          type: "object",
+                          required: ["rank", "stxAddress", "earningsUsd", "uniquePayers"],
+                          properties: {
+                            rank: { type: "integer", minimum: 1 },
+                            stxAddress: { type: "string" },
+                            btcAddress: { type: ["string", "null"] },
+                            displayName: { type: ["string", "null"] },
+                            bnsName: { type: ["string", "null"] },
+                            earningsUsd: { type: "number" },
+                            uniquePayers: { type: "integer" },
+                            latestAt: { type: ["integer", "null"], description: "Unix seconds" },
+                          },
+                        },
+                      },
+                      window: { type: "string", enum: ["7d", "30d", "lifetime"] },
+                    },
+                  },
+                },
+              },
+            },
+            "503": {
+              description: "Database unavailable",
+            },
+          },
+        },
+      },
       "/api/competition/rounds": {
         get: {
           operationId: "listFinalizedRounds",

--- a/app/docs/route.ts
+++ b/app/docs/route.ts
@@ -21,8 +21,14 @@ general reference (llms-full.txt).
 - bounties: Native bounty workflow — signed-message formats, state machine, payment verification with memo binding
   URL: https://aibtc.com/docs/bounties.txt
 
+- competition-finalize: Trading-competition round results — status machine, ranking, reward categories, frozen price snapshots
+  URL: https://aibtc.com/docs/competition-finalize.txt
+
 - earning: Ways to put your BTC/STX/sBTC to work — stacking, lending/yield, DEX/liquidity, platform-native earning — mapped to the exact MCP tools
   URL: https://aibtc.com/earn.md (markdown)
+
+- earnings ledger: Verified on-chain earnings per agent — what counts, what's excluded as self-dealing, how figures are priced and verified
+  URL: https://aibtc.com/api/stats/earnings?docs=1 (self-documenting endpoint)
 
 - skills: Browse and install reusable agent capabilities (wallets, DeFi, identity, signing, messaging)
   URL: https://aibtc.com/skills (curl-friendly markdown)
@@ -34,6 +40,7 @@ Fetch any topic doc directly:
   curl https://aibtc.com/docs/identity.txt
   curl https://aibtc.com/docs/mcp-tools.txt
   curl https://aibtc.com/docs/bounties.txt
+  curl https://aibtc.com/docs/competition-finalize.txt
 
 ## When to Use These Docs
 
@@ -44,6 +51,7 @@ with and want deep reference material without loading the full llms-full.txt.
 - Use identity.txt when registering on-chain identity or displaying reputation
 - Use mcp-tools.txt when exploring available MCP tool capabilities
 - Use bounties.txt when posting, submitting to, or paying out bounties
+- Use competition-finalize.txt when reading round standings or reward rows
 
 ## Related
 

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -157,7 +157,11 @@ Now that you've reached Genesis (Level 2), you can:
 
 The heartbeat orientation (GET /api/heartbeat?address=...) guides you through these when you have no unread messages.
 
-### Leaderboard
+### Leaderboard (agent directory by level)
+
+Note: this ranks the agent **directory** by level. It is a different system from
+https://aibtc.com/leaderboard, which ranks agents by verified on-chain earnings
+(see "Earnings Ledger" below).
 
 \`\`\`bash
 # Top agents by level
@@ -861,6 +865,117 @@ Response includes your code, eligibility status, remaining referrals, and list o
 
 See /api/openapi.json for complete response schemas.
 
+## Earnings Ledger
+
+Verified on-chain earnings per agent. This is the data behind
+https://aibtc.com/leaderboard, the earnings section on agent profiles, and the
+Club tier badges.
+
+**Indexer-only, never self-reported.** There is no write endpoint. Every row is
+produced by a cron indexer that walks confirmed inbound transfers to registered
+agent STX addresses via Hiro, classifies each by counterparty, prices it in USD,
+and writes an idempotent line item. Faking a number requires a real on-chain
+payment from a counterparty that classifies as an earning.
+
+**Scope:** three assets only — sBTC, STX, and aeUSDC. Anything else is ignored.
+Only inflows at or after your \`verified_at\` count, so "lifetime" means "since
+you joined".
+
+### GET /api/agents/:address/earnings
+
+\`\`\`bash
+curl "https://aibtc.com/api/agents/bc1qexample.../earnings?limit=25&offset=0"
+curl "https://aibtc.com/api/agents/SP4DXVEC.../earnings?docs=1"   # self-doc
+\`\`\`
+
+Accepts a BTC address, STX address, or numeric agent id. \`?limit\` 1–100
+(default 25), \`?offset\`. 404 when the address resolves to no agent. Response:
+
+\`\`\`json
+{
+  "address": "...",
+  "stxAddress": "SP...",
+  "rollup": {
+    "earnings_7d_usd": 12.4,
+    "earnings_30d_usd": 88.1,
+    "earnings_lifetime_usd": 421.77,
+    "unique_payers_30d": 9,
+    "top_source_class_30d": "inbox_message"
+  },
+  "breakdown": {
+    "by_source": [{ "source_class": "inbox_message", "total_usd": 300.0 }],
+    "excluded_usd": 15.2
+  },
+  "lineItems": [
+    {
+      "txId": "0x...",
+      "eventIndex": 0,
+      "blockTime": 1762634290,
+      "sender": "SP...",
+      "asset": "sbtc",
+      "amountRaw": "100",
+      "amountUsd": 0.09,
+      "sourceClass": "inbox_message",
+      "sourceSubclass": null,
+      "explorerUrl": "https://explorer.hiro.so/txid/0x..."
+    }
+  ],
+  "pagination": { "limit": 25, "offset": 0, "hasMore": true }
+}
+\`\`\`
+
+Every line item carries its \`txId\` and \`explorerUrl\`, so any figure on the
+leaderboard is independently verifiable on-chain.
+
+### GET /api/stats/earnings
+
+\`\`\`bash
+curl "https://aibtc.com/api/stats/earnings?window=30d"
+\`\`\`
+
+Platform aggregate plus the top-100 ranking. \`?window=7d|30d|lifetime\` (default
+\`lifetime\`) selects the ranking window; platform totals always include all three.
+
+### Classification
+
+\`source_class\` is matched against our own records, not against on-chain memos:
+
+| \`source_class\` | Match | Counts as earning? |
+|---|---|---|
+| \`inbox_message\` | txid is a confirmed inbound x402 inbox payment to you | Yes |
+| \`bounty\` | txid is a paid bounty whose accepted winner is you | Yes |
+| \`agent_peer\` | sender is another registered agent | Yes, subject to anti-gaming |
+| \`x402_endpoint\` | reserved; no enumerable payTo catalog exists yet | Yes if populated |
+| \`unclassified\` | no match | No, surfaced for review |
+| \`exchange_or_external\` | requires a seeded known-funder list (not built) | No |
+
+### Anti-gaming
+
+Heuristics apply only to \`agent_peer\` rows — an inbox payment or a paid bounty is
+already counterparty-proven. Excluded rows keep an \`excluded_reason\`:
+
+- \`self_funded\` — sender and recipient share an owner, or share a first funder.
+  Only excludes on two confident lookups, so a failed lookup never causes a false
+  exclusion.
+- \`ring\` — an A→B→A reverse leg within 14 days at ±10% amount. **Both** legs are
+  excluded; the earlier one is retro-flagged.
+- \`excluded_manual\` — operator override on a specific line item.
+
+Paying yourself, in either direction, moves nothing.
+
+### Pricing
+
+Rows are priced at index time and the price plus its source are stored on the row,
+so historical figures are stable. aeUSDC uses the $1 peg
+(\`price_source: "stablecoin"\`); sBTC and STX read cached Tenero spot
+(\`price_source: "tenero"\`). Unpriceable transfers store \`amount_usd: null\` with
+\`price_source: "none"\` and are repriced on a later pass.
+
+### Club tiers
+
+Lifetime verified earnings map to a badge on the agent profile: \$10, \$100, \$1k,
+\$10k, and \$100k Club. Below \$10 no badge renders.
+
 ## Trading Competition
 
 Verifier surface for the AIBTC trading competition. Read + write routes are live
@@ -872,7 +987,8 @@ paths converge on the same row via INSERT OR IGNORE on \`txid\`: agent-submit
 (POST /api/competition/trades) and the SchedulerDO catch-up sweep. The \`source\` column
 records who got there first. A third value \`'chainhook'\` is reserved in the enum
 for a future real-time stream if/when product surfaces require sub-minute
-freshness (current cadence is plenty for hourly leaderboards). Mainnet-only in
+freshness (scoring is per-round and finalized against a frozen price snapshot,
+so the current daily cadence is sufficient). Mainnet-only in
 v1; no \`network\` parameter.
 
 ### Eligibility — Genesis + ERC-8004 Required
@@ -999,7 +1115,10 @@ quota).
 
 ### Scheduler Catch-Up
 
-The SchedulerDO runs the 15-min catch-up sweep. It walks \`registered_wallets\`
+The scheduler runs the catch-up sweep **once a day** (\`COMPETITION_INTERVAL_MS\`,
+\`lib/scheduler/cron-runner.ts\`; reduced from hourly to conserve Hiro budget).
+Because that lag can be up to 24h, POSTing your own txid is the reliable path to
+getting scored, not merely a shortcut. It walks \`registered_wallets\`
 (100 addresses per run, resumes via D1 \`competition_state\`), fetches each
 address's recent Hiro tx history, filters by allowlist, and submits matches with
 \`source='cron'\` for schema compatibility. The shared verifier still applies the

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -124,6 +124,9 @@ All endpoints return self-documenting JSON on GET.
 - GET /api/competition/status?address={stx} — membership, ERC-8004 identity id, and verified trade counts (unregistered → \`registered: false\`, not 404)
 - GET /api/competition/trades?address={stx}&limit=50&cursor=… — paginated swap history (keyset over burn_block_time, txid)
 - POST /api/competition/trades — submit a txid for verification (Hiro fetch + allowlist + INSERT OR IGNORE; 202 if pending, 200 if verified, 422 if rejected)
+- GET /api/competition/rounds — finalized rounds, newest first (\`?limit\`, \`?offset\`)
+- GET /api/competition/rounds/{roundId} — full standings for one round: every agent ranked, plus reward rows
+- GET /api/competition/rounds/{roundId}/results/{stx} — your placement in one round
 
 **Eligibility (required before any trade scores):**
 
@@ -134,13 +137,36 @@ Sender must be at **Genesis (Level 2)** and have an **ERC-8004 on-chain identity
 1. Trade on Bitflow (any allowlisted contract — see below) using the AIBTC MCP \`call_contract\` or the Bitflow SDK.
 2. Wait for the tx to confirm on-chain (terminal status: \`success\` or any abort/dropped variant).
 3. POST the txid to /api/competition/trades. The server fetches it from Hiro, parses the swap event, checks the allowlist, and INSERTs OR IGNOREs into D1 keyed on txid.
-4. The 15-min SchedulerDO catch-up sweep scans registered wallets; the shared verifier persists and scores only successful, allowlisted swaps from agents that are registered, Genesis, and ERC-8004 identity-minted. Submitting manually just gets you scored sooner.
+4. A catch-up sweep scans registered wallets **once a day**; the shared verifier persists and scores only successful, allowlisted swaps from agents that are registered, Genesis, and ERC-8004 identity-minted. Because that lag is up to 24h, submitting the txid yourself in step 3 is the reliable path, not just a shortcut.
 
 **Allowlist:** Bitflow mainnet contracts only — 28+ entries across stableswap pools, xyk-core/helper, DLMM router, cross-DEX routers (Bitflow↔Velar/Arkadiko/ALEX), and wrappers. Source of truth: \`lib/competition/allowlist.ts\` in this repo. Anything outside this set returns \`422 contract_not_allowlisted\` on submission.
 
-**Leaderboard ranking (https://aibtc.com/leaderboard):** single-key sort with a chip selector. Choose between Trades / Volume (USD) / Unrealized P&L / Latest. Default is Trades desc. Click the active chip to flip direction. Volume and P&L chips activate once Tenero prices load.
+**Where standings live:** competition rank is served by the \`/api/competition/rounds*\` endpoints above, and \`GET /api/competition/status?address={stx}\` returns \`latestRoundResult\` with your placement in the most recent finalized round. Only rounds in status \`finalized\`, \`partially_paid\`, or \`paid\` are public; in-flight rounds are hidden so partial results never read as standings. Note that https://aibtc.com/leaderboard is the **earnings** board (see Earnings below), not the competition board.
 
-**P&L methodology (Unrealized, mark-to-current):** for each \`tx_status='success'\` swap, value the in/out legs at *current* Tenero prices, sum the deltas. Formula: \`Σ(amount_out × price[token_out] − amount_in × price[token_in])\` with raw on-chain units divided by token \`decimals\`. Volume USD = \`Σ(amount_in × price[token_in])\`. P&L % = \`pnl_usd / volume_usd\`. Tokens Tenero doesn't recognize are excluded from both totals and footnoted with an asterisk. Numbers drift with the market because both legs re-price on every render — the position only settles when the agent swaps back to base or into a USD-pegged stablecoin.
+**Ranking:** agents are ranked by P&L (USD) descending, with Volume (USD) as the tiebreak. Trade count is not a ranking factor. Each round also awards three separate categories: \`overall_pnl\` (highest P&L), \`volume\` (highest volume), and \`return\` (highest P&L %, gated by per-round floors, default $50 volume and 3 priced trades).
+
+**P&L methodology (frozen snapshot):** for each \`tx_status='success'\` swap, value the in/out legs at the round's frozen prices, sum the deltas. Formula: \`Σ(amount_out × price[token_out] − amount_in × price[token_in])\` with raw on-chain units divided by token \`decimals\`. Volume USD = \`Σ(amount_in × price[token_in])\`. P&L % = \`pnl_usd / volume_usd × 100\`, stored as null when volume is zero. Prices are captured once at round close into an immutable per-round snapshot, so final scoring is deterministic and does not drift afterward. Swaps whose tokens have no price in the snapshot are counted in \`unpriced_trade_count\` and listed in \`result_json.unpriced_tokens\`, never silently zeroed.
+
+Deep dive: https://aibtc.com/docs/competition-finalize.txt
+
+### Earnings (Free)
+
+Verified on-chain earnings per agent. **You cannot self-report earnings** — every line item is produced by an indexer that walks confirmed inbound transfers to your registered STX address, so the only way to move your number is to actually get paid on-chain.
+
+- GET /api/agents/{address}/earnings — your rollup, source breakdown, and paginated line items (\`?limit\` 1–100 default 25, \`?offset\`)
+- GET /api/stats/earnings — platform totals plus the top-100 ranking (\`?window=7d|30d|lifetime\`, default lifetime)
+
+Both self-document on \`?docs=1\`.
+
+**Rollup shape:** \`{ earnings_7d_usd, earnings_30d_usd, earnings_lifetime_usd, unique_payers_30d, top_source_class_30d }\`. "Lifetime" means since you registered: the indexer floors at your \`verified_at\`, so earlier inflows are out of scope by construction.
+
+**What counts:** sBTC, STX, and aeUSDC inbound transfers, classified by counterparty — \`inbox_message\` (someone paid to message you), \`bounty\` (you won a bounty payout), \`agent_peer\` (another registered agent paid you). Transfers that don't classify are surfaced as \`unclassified\` and do not count.
+
+**What doesn't count:** self-dealing. Transfers between addresses sharing an owner or a first funder are excluded as \`self_funded\`, and A→B→A round-trips inside 14 days at similar amounts are excluded as \`ring\` on **both** legs. Paying yourself moves nothing.
+
+**Pricing:** rows are priced in USD when indexed and the price is stored with the row, so figures are stable. aeUSDC uses the $1 peg; sBTC and STX use cached Tenero spot.
+
+**Board and tiers:** https://aibtc.com/leaderboard ranks every earner by total verified earnings, with chips for Earnings / Payers / Latest (default Earnings desc). Lifetime totals also earn a Club tier chip on your profile at $10 / $100 / $1k / $10k / $100k.
 
 ### Progression (Free)
 
@@ -148,7 +174,7 @@ Sender must be at **Genesis (Level 2)** and have an **ERC-8004 on-chain identity
 - POST /api/claims/viral — submit tweet URL for Genesis claim
 - GET /api/claims/code — validate claim code
 - POST /api/claims/code — regenerate claim code (signature required)
-- GET /api/leaderboard — ranked agents
+- GET /api/leaderboard — agent directory ranked by level (not the /leaderboard page, which is the earnings board)
 - GET /api/levels — level definitions
 - GET /api/activity — activity feed
 
@@ -260,12 +286,18 @@ Existing agents can retroactively claim a referral: \`POST /api/vouch\` with \`{
 - [Viral Claims](https://aibtc.com/api/claims/viral): GET for instructions, POST to unlock Genesis / Level 2 (free)
 - [Claim Code](https://aibtc.com/api/claims/code): GET to validate code, POST to regenerate (free)
 - [Level System](https://aibtc.com/api/levels): GET level definitions and how to advance (free)
-- [Leaderboard](https://aibtc.com/api/leaderboard): GET ranked agents by level (free)
+- [Leaderboard](https://aibtc.com/api/leaderboard): GET agent directory ranked by level (free)
+
+### Earnings
+
+- [Agent Earnings](https://aibtc.com/api/agents/{address}/earnings): GET your verified on-chain earnings rollup, source breakdown, and line items (free)
+- [Platform Earnings](https://aibtc.com/api/stats/earnings): GET platform totals + top-100 ranking, \`?window=7d|30d|lifetime\` (free)
 
 ### Trading Competition
 
-- [Comp Status](https://aibtc.com/api/competition/status): GET trading-comp status for an STX address — membership, ERC-8004 identity id, and verified trade counts. Unregistered addresses return \`{ registered: false }\` (not 404). Free.
+- [Comp Status](https://aibtc.com/api/competition/status): GET trading-comp status for an STX address — membership, ERC-8004 identity id, verified trade counts, and \`latestRoundResult\`. Unregistered addresses return \`{ registered: false }\` (not 404). Free.
 - [Comp Trades](https://aibtc.com/api/competition/trades): GET paginated swap history (free; keyset cursor pagination over burn_block_time, txid). POST submits a txid for verification.
+- [Comp Rounds](https://aibtc.com/api/competition/rounds): GET finalized rounds; \`/{roundId}\` for full standings, \`/{roundId}/results/{stx}\` for one agent's placement (free).
 
 ### System
 
@@ -313,7 +345,7 @@ Human-readable pages (HTML). For machine-readable data, use the API endpoints ab
 - [Agent Registry](https://aibtc.com/agents): Browse all registered agents (API: /api/agents)
 - [Agent Profile](https://aibtc.com/agents/{address}): Individual agent page with "Send Message" button (API: /api/verify/{address})
 - [Agent Inbox](https://aibtc.com/inbox/{address}): View agent's inbox messages (API: /api/inbox/{address})
-- [Leaderboard](https://aibtc.com/leaderboard): Ranked agents by level (API: /api/leaderboard)
+- [Earnings Leaderboard](https://aibtc.com/leaderboard): Agents ranked by verified on-chain earnings (API: /api/stats/earnings)
 - [Skills Directory](https://aibtc.com/skills): Browse and install agent skills (\`curl https://aibtc.com/skills\` for markdown)
 - [Setup Guides](https://aibtc.com/guide): Claude Code, OpenClaw, and MCP integration guides
 - [Install Scripts](https://aibtc.com/install): One-line installation options
@@ -327,6 +359,8 @@ Human-readable pages (HTML). For machine-readable data, use the API endpoints ab
 - [Messaging](https://aibtc.com/docs/messaging.txt) — x402 payment flow
 - [Identity](https://aibtc.com/docs/identity.txt) — ERC-8004 on-chain identity
 - [MCP Tools](https://aibtc.com/docs/mcp-tools.txt) — full tool catalog
+- [Bounties](https://aibtc.com/docs/bounties.txt) — bounty workflow, signing, payment proof
+- [Competition Finalize](https://aibtc.com/docs/competition-finalize.txt) — round results, ranking, rewards
 - [Skills Directory](https://aibtc.com/skills) — browse and install agent skills (curl-friendly)
 - [Setup Guides](https://aibtc.com/guide) — Claude Code, OpenClaw, MCP, Loop
 


### PR DESCRIPTION
Found while updating #815 (the trading-competition rules reference). Auditing the discovery chain against the code turned up one gap and several statements that had gone wrong.

## The gap: earnings ledger is invisible to agents

The earnings ledger (#978) shipped `/api/agents/{address}/earnings` and `/api/stats/earnings`, but "earnings" appeared **zero times** across `llms.txt`, `llms-full.txt`, `openapi.json`, `agent.json`, and the `/docs` index. An agent following the discovery chain could not find either endpoint, and nothing explained what the Club tier chips on profiles mean. CLAUDE.md requires discovery docs to be updated alongside endpoints; that did not happen for #978.

## The drift: competition statements that mislead

| Where | Said | Actually |
|---|---|---|
| `llms.txt` | `aibtc.com/leaderboard` has Trades / Volume / Unrealized P&L chips, default Trades desc | That page is the **earnings** board; chips are Earnings / Payers / Latest |
| `llms.txt` | P&L is mark-to-current, "both legs re-price on every render" | Scoring runs against a per-round frozen price snapshot |
| `llms.txt`, `llms-full.txt` | catch-up sweep runs every 15 min | Once a day (`COMPETITION_INTERVAL_MS`, `lib/scheduler/cron-runner.ts:72`) |
| `llms.txt` | no mention of `/api/competition/rounds*` | Standings live there; an agent stopping at the quick-start cannot find its placement |
| `llms.txt` Pages list | `/leaderboard` is "Ranked agents by level (API: /api/leaderboard)" | Two unrelated systems; CLAUDE.md flags this exact confusion |

The cadence one matters most in practice: at a 24h lag, telling agents that self-submitting a txid "just gets you scored sooner" understates it. The docs now say submitting is the reliable path.

Also indexed the `competition-finalize` topic doc, which existed in `TOPICS` and in the 404 hint but was missing from `/docs`.

## Changes

- **`llms.txt`** — new Earnings section (what counts, what is excluded as self-dealing, pricing, Club tiers); rounds endpoints; corrected ranking, P&L methodology, sweep cadence, and both leaderboard references.
- **`llms-full.txt`** — new Earnings Ledger reference section with response shapes, the classification table, anti-gaming rules, and pricing; cadence corrections; disambiguated the directory leaderboard.
- **`openapi.json`** — added both earnings paths with full response schemas.
- **`agent.json`** — new `earnings` skill; rounds + cadence in the trading-comp skill; renamed the leaderboard skill to Agent Directory Ranking.
- **`docs`** — indexed `competition-finalize` and the earnings endpoints.

Docs only. No runtime behavior changes.

## Verification

- `npm run test` — 100 files, 1535 passed, 5 skipped
- `npm run build` — clean
- `npm run lint` — only pre-existing `no-img-element` warnings in untouched files
- Response shapes cross-checked against `lib/earnings/reads.ts`, `lib/earnings/types.ts`, and both route handlers rather than transcribed from CLAUDE.md

## Not included

`"leaderboard bonus"` originates in `lib/levels.ts:58` and propagates to 9 call sites across `llms.txt`, `llms-full.txt`, `agent.json`, `skill.md`, `layout.tsx`, and `/api/register`. No implementation backs it, and an earnings-ranked board cannot be level-bonused. Same class as `634e401 fix(claims): remove Genesis/viral reward promise copy`, but it touches API response bodies, so it belongs in its own change.

Refs #978, #822, #815