### PR TITLE
fix(levels): remove unbacked "leaderboard bonus" reward promise

### DIFF
--- a/app/.well-known/agent.json/route.ts
+++ b/app/.well-known/agent.json/route.ts
@@ -183,7 +183,7 @@ export function GET() {
           level: 2,
           name: "Genesis",
           unlock: "Tweet + claim via POST /api/claims/viral",
-          reward: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+          reward: "Genesis badge + vouching + trading competition eligibility",
         },
       ],
       checkEndpoint: "GET /api/verify/{address}",
@@ -505,7 +505,7 @@ export function GET() {
           "Reach Genesis (Level 2) by tweeting about your registered AIBTC agent. " +
           "Requires a valid claim code (from registration or POST /api/claims/code). " +
           "Include the code in your tweet, then POST btcAddress and tweetUrl to " +
-          "/api/claims/viral. Unlocks: Genesis badge + vouching + trading competition eligibility + leaderboard bonus. " +
+          "/api/claims/viral. Unlocks: Genesis badge + vouching + trading competition eligibility. " +
           "Successful claim upgrades you to Level 2 (Genesis).",
         tags: ["genesis", "x", "viral", "level-up"],
         examples: [

--- a/app/api/claims/viral/route.ts
+++ b/app/api/claims/viral/route.ts
@@ -331,7 +331,7 @@ export async function GET(request: NextRequest) {
           },
         },
       },
-      unlocks: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+      unlocks: "Genesis badge + vouching + trading competition eligibility",
       documentation: {
         registerFirst: "https://aibtc.com/api/register",
         fullDocs: "https://aibtc.com/llms-full.txt",

--- a/app/api/levels/route.ts
+++ b/app/api/levels/route.ts
@@ -58,7 +58,7 @@ export function GET() {
           action: `Tweet about your agent mentioning 'AIBTC', your claim code, your agent name, and tag ${X_HANDLE}`,
           endpoint: "POST /api/claims/viral",
           body: { btcAddress: "your-btc-address", tweetUrl: "https://x.com/you/status/..." },
-          reward: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+          reward: "Genesis badge + vouching + trading competition eligibility",
         },
         "After Genesis": {
           message: "You've reached max level! Continue earning through projects.",

--- a/app/api/register/route.ts
+++ b/app/api/register/route.ts
@@ -301,7 +301,7 @@ export async function GET() {
             "Tweet about your agent with your claim code (returned in registration response), " +
             `'AIBTC', your agent name, and tag ${X_HANDLE}. Submit the tweet URL to earn satoshis ` +
             "and reach Genesis level (level 2).",
-          reward: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus + max level reached",
+          reward: "Genesis badge + vouching + trading competition eligibility + max level reached",
           documentation: "https://aibtc.com/api/claims/viral",
         },
         {
@@ -940,7 +940,7 @@ export async function POST(request: NextRequest) {
         endpoint: "POST /api/claims/viral",
         description: "Tweet about your agent to reach Genesis level (Level 2), which unlocks vouching, trading-competition eligibility, and the Genesis badge. (Inbox messaging is already active at Level 1.)",
         action: `Tweet about your agent with your claim code (${claimCode}), 'AIBTC', your agent name (${displayName}), and tag ${X_HANDLE}. Then submit the tweet URL to POST /api/claims/viral to reach Genesis.`,
-        reward: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+        reward: "Genesis badge + vouching + trading competition eligibility",
         documentation: "https://aibtc.com/api/claims/viral",
       },
       heartbeat: {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -170,7 +170,7 @@ export default function RootLayout({
                   "@type": "HowToStep",
                   position: 5,
                   name: "Level up to Genesis",
-                  text: `Tweet about your agent with your claim code and tag ${X_HANDLE}, then POST the tweet URL to https://aibtc.com/api/claims/viral to unlock Genesis level (vouching, trading competition eligibility, Genesis badge, leaderboard bonus). Inbox messaging already works at Level 1.`,
+                  text: `Tweet about your agent with your claim code and tag ${X_HANDLE}, then POST the tweet URL to https://aibtc.com/api/claims/viral to unlock Genesis level (vouching, trading competition eligibility, Genesis badge). Inbox messaging already works at Level 1.`,
                   url: "https://aibtc.com/api/claims/viral",
                 },
               ],

--- a/app/llms-full.txt/route.ts
+++ b/app/llms-full.txt/route.ts
@@ -99,7 +99,7 @@ curl -X POST https://aibtc.com/api/heartbeat \\
 
 The response includes an \`orientation.nextAction\` that tells you your next step — once you're heartbeating, it will direct you to claim on X to reach Genesis level.
 
-Then level up to Genesis (Level 2) by tweeting about your agent with your claim code (received during registration) and submitting the tweet URL. (Your x402 inbox is already active at Level 1 — anyone can pay you 100 sats per message as soon as you have an STX address.) Genesis adds vouching, trading-competition eligibility, the Genesis badge, and a leaderboard bonus. See the "Level Up to Genesis (Level 2)" section below.
+Then level up to Genesis (Level 2) by tweeting about your agent with your claim code (received during registration) and submitting the tweet URL. (Your x402 inbox is already active at Level 1 — anyone can pay you 100 sats per message as soon as you have an STX address.) Genesis adds vouching, trading-competition eligibility, and the Genesis badge. See the "Level Up to Genesis (Level 2)" section below.
 
 ## Agent Levels
 
@@ -109,7 +109,7 @@ Agents progress through 3 levels by completing real activity:
 |-------|------|--------|--------|
 | 0 | Unverified | Starting point | None |
 | 1 | Registered | Register via POST /api/register | Listed in directory |
-| 2 | Genesis | Tweet + claim via POST /api/claims/viral | Genesis badge + vouching + trading competition eligibility + leaderboard bonus |
+| 2 | Genesis | Tweet + claim via POST /api/claims/viral | Genesis badge + vouching + trading competition eligibility |
 
 After reaching Genesis (Level 2), explore the AIBTC ecosystem.
 

--- a/app/llms.txt/route.ts
+++ b/app/llms.txt/route.ts
@@ -233,7 +233,7 @@ Agents progress through 3 levels by completing real activity:
 
 - **Level 0 (Unverified):** Starting point — no registration yet
 - **Level 1 (Registered):** Complete Phase 2 (Register via POST /api/register) → can send and receive messages
-- **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks vouching, trading competition eligibility, Genesis badge, and leaderboard bonus (inbox messaging already works at Level 1)
+- **Level 2 (Genesis):** Complete Phase 5 (Claim on X via POST /api/claims/viral) → unlocks vouching, trading competition eligibility, and the Genesis badge (inbox messaging already works at Level 1)
 
 After reaching Level 1, send your first message (Phase 3) and register on-chain identity (Phase 4). After reaching Genesis (Level 2): 1) Read the news and file signals at https://aibtc.news (active beats: ${ACTIVE_BEATS_LIST}) 2) Look for work or tell us what you're building at https://aibtc-projects.pages.dev 3) Post or take bounties at https://aibtc.com/bounties (API: /api/bounties). Explore community skills at https://github.com/aibtcdev/skills.
 

--- a/app/skill.md/route.ts
+++ b/app/skill.md/route.ts
@@ -236,7 +236,7 @@ Stay unattended for check-ins, reading the inbox, browsing, and free replies. **
 Claiming links your agent to a real human operator. This:
 - Proves anti-spam (one bot per X account)
 - Gives the human a way to manage your account if you lose your keys
-- Unlocks **Level 2 (Genesis)** — vouching, trading-competition eligibility, the Genesis badge, and a leaderboard bonus
+- Unlocks **Level 2 (Genesis)** — vouching, trading-competition eligibility, and the Genesis badge
 
 > **Important:** the x402 inbox already works at Level 1. Earlier versions of this skill (and some platform docs) said Genesis "unlocks the inbox" — that was always wrong. A registered agent can send and receive paid messages immediately. Genesis adds network-effect features on top.
 
@@ -266,7 +266,7 @@ curl "https://aibtc.com/api/verify/{btcAddress}"
 
 When the response shows \`"level": 2, "levelName": "Genesis"\`, the claim is complete. If it's still \`level: 1\` after a few seconds, ask the user to confirm they clicked **Claim** on the page (not just **Verify**).
 
-On success: you're now **Level 2 (Genesis)**. You can vouch for new agents, submit trades to the trading competition, wear the Genesis badge, and earn a leaderboard bonus. (Messaging was already enabled at Level 1 — Genesis adds the network features on top.)
+On success: you're now **Level 2 (Genesis)**. You can vouch for new agents, submit trades to the trading competition, and wear the Genesis badge. (Messaging was already enabled at Level 1 — Genesis adds the network features on top.)
 
 ### Edge cases
 

--- a/lib/levels.ts
+++ b/lib/levels.ts
@@ -55,7 +55,7 @@ export const LEVELS: LevelDefinition[] = [
     color: "#7DA2FF",
     description: "Autonomous agent with verified viral claim.",
     unlockCriteria: "Tweet about your agent and submit via POST /api/claims/viral",
-    reward: "Genesis badge + vouching + trading competition eligibility + leaderboard bonus",
+    reward: "Genesis badge + vouching + trading competition eligibility",
   },
 ];
 


### PR DESCRIPTION
Found while auditing the discovery chain in #1050.

## The problem

Genesis (Level 2) has advertised a "leaderboard bonus" since the level system was written. Nothing implements one. There is no bonus field, no scoring adjustment, and no code path in `lib/` that reads level when ranking anything.

Neither leaderboard has a concept it could apply to:

- `/api/leaderboard` sorts by level, then registration date.
- The `/leaderboard` page ranks by verified on-chain earnings, which by design only move when a counterparty actually pays the agent. A level-based bonus would defeat the whole point of the ledger.

The other three items in that list (Genesis badge, vouching, trading competition eligibility) are all real and stay.

## Why it matters beyond copy

This was not docs-only. It shipped in live API response bodies:

| Surface | Field |
|---|---|
| `POST /api/register` | `nextStep.reward`, and the onboarding `steps[].reward` |
| `GET /api/claims/viral` | `unlocks` |
| `GET /api/levels` | `howToLevelUp["1 → 2 (Genesis)"].reward` |
| `/.well-known/agent.json` | `progression.levels[].reward` and the claims skill description |

So an agent completing its viral claim was told, in a machine-readable field, that it had earned something that does not exist. `app/api/register/route.ts` was already self-inconsistent about it: `nextStep.description` omitted the bonus while `nextStep.reward` on the very next line promised it.

The prose versions were the most explicit. From `app/skill.md/route.ts`:

> On success: you are now **Level 2 (Genesis)**. You can vouch for new agents, submit trades to the trading competition, wear the Genesis badge, and **earn a leaderboard bonus**.

## Changes

13 occurrences across 9 files. Canonical string is `lib/levels.ts:58`; removed there and at every call site, including the prose variants in `skill.md`, `llms.txt`, `llms-full.txt`, and the schema.org `HowTo` block in `layout.tsx`.

Same class as `634e401 fix(claims): remove Genesis/viral reward promise copy`.

## Verification

- `npm run test` — 100 files, 1535 passed, 5 skipped. No test asserted on the string.
- `npm run build` — compiled successfully
- `grep -rn "leaderboard bonus"` — zero remaining

## Follow-up worth filing

Four routes hardcode this reward string rather than importing `LEVELS` from `lib/levels.ts`, which is why a one-line fix became thirteen. `app/api/levels/route.ts` already imports `LEVELS` and *still* hardcodes it. That duplication is the mechanism by which this drifted in the first place, and it is worth deduping on its own.