### PR TITLE
fix(deps): bump nanoid to 3.3.16 (CVE-2026-67213, CVE-2026-67214)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11150,9 +11150,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary
- Bumps transitive `nanoid` dependency (via `postcss`) from 3.3.11 to 3.3.16
- Patches Dependabot alerts #169, #170 (high severity, CVSS 5.9): CVE-2026-67213, CVE-2026-67214
- Lockfile-only change; 3.3.16 satisfies postcss's existing `^3.3.6`/`^3.3.11` range, no `package.json` change needed

## Test plan
- [x] `npm install nanoid@3.3.16 --package-lock-only` then reverted the unintended `package.json` direct-dependency add, keeping only the lockfile bump
- [ ] CI passes

Closes dependabot alerts aibtcdev/landing-page#169, #170.