### PR TITLE
fix(deps): bump js-yaml 4.3.0 -> 4.3.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9607,9 +9607,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
+      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
       "dev": true,
       "funding": [
         {


### PR DESCRIPTION
## Summary
- Fixes Dependabot alert #171 (js-yaml, high severity, no CVE, CVSS 7.5)
- js-yaml is a dev-only transitive dependency of `@eslint/eslintrc` (`^4.1.1` range) — not shipped in production
- Bumped pinned lockfile version from 4.3.0 to 4.3.1, satisfies existing semver range, no other lockfile entries changed

## Test plan
- [x] Verified `package-lock.json` remains valid JSON after edit
- [x] Confirmed js-yaml is the only affected entry (no other packages pin a different js-yaml version)
- [ ] CI install/build should pass unchanged since this is a dev-dependency patch bump within its existing semver range

🤖 Generated with [Claude Code](https://claude.com/claude-code)