### PR TITLE
fix(activity): build the feed from all messages, not the top-20 active recipients

### DIFF
--- a/app/api/activity/route.ts
+++ b/app/api/activity/route.ts
@@ -95,13 +95,17 @@ export async function GET(request: NextRequest) {
     return NextResponse.json({
       endpoint: "/api/activity",
       method: "GET",
-      description: "Get recent network activity across all agents. Returns events (messages, registrations) and aggregate statistics. Cached for 2 minutes.",
+      description: "Get recent network activity across all agents. Returns the newest events network-wide (paid inbox messages, registrations from the last 30 days) plus aggregate statistics. Cached for 2 minutes.",
       queryParameters: {
         docs: {
           type: "string",
           description: "Pass ?docs=1 to return this documentation payload instead of data",
           example: "?docs=1",
         },
+      },
+      unsupportedQueryParameters: {
+        description: "This endpoint takes no filtering or paging parameters. Anything other than ?docs=1 (address, btcAddress, agent, limit, ...) is ignored, and the full unfiltered feed is returned. For a single agent's messages use /api/inbox/:address.",
+        ignored: ["address", "btcAddress", "agent", "limit", "offset"],
       },
       responseFormat: {
         events: [
@@ -126,7 +130,7 @@ export async function GET(request: NextRequest) {
         },
       },
       cachingStrategy: {
-        description: "Response is cached in caches.default (the Cloudflare edge cache) for 2 minutes via s-maxage. Cache scope is per-colo, not global. Stats derived from shared agent-list cache (no independent O(N) scan). Only event detail fetches for top 20 active agents remain as targeted KV reads.",
+        description: "Response is cached in caches.default (the Cloudflare edge cache) for 2 minutes via s-maxage. Cache scope is per-colo, not global. Stats derived from shared agent-list cache (no independent O(N) scan). Message events come from a single indexed D1 query over the newest inbound messages network-wide.",
         ttl: RESPONSE_S_MAXAGE,
         sMaxAgeSeconds: RESPONSE_S_MAXAGE,
       },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -111,9 +111,9 @@ async function fetchHomeData() {
     }));
 
     // Build activity data for server-side rendering.
-    // buildActivityData() reads the warm agent-list cache for the top-agent
-    // set, then fans out to D1 via getRecentInboxEventsFromD1 (one indexed
-    // SELECT per agent on idx_inbox_to_btc_sent_at) — not an O(N) scan.
+    // buildActivityData() reads the warm agent-list cache for stats and
+    // display names, then runs one indexed D1 SELECT for the newest messages
+    // network-wide (idx_inbox_sent_at), not an O(N) scan.
     let activityData: ActivityResponse | undefined;
     try {
       activityData = await buildActivityData(kv, db);

--- a/lib/__tests__/activity.test.ts
+++ b/lib/__tests__/activity.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Tests for buildActivityData, issue #1058.
+ *
+ * The regression under test: the feed used to collect message events by
+ * fanning out over the 20 most-recently-active agents and reading each
+ * one's newest inbound messages, so a message to a dormant recipient was
+ * structurally invisible and the feed looked frozen. These tests pin the
+ * global-query behaviour that replaced it.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { InboxMessage } from "@/lib/inbox/types";
+import type { CachedAgent, CachedAgentList } from "@/lib/cache/types";
+
+const getCachedAgentListMock = vi.fn();
+const getRecentGlobalInboxEventsFromD1Mock = vi.fn();
+
+vi.mock("@/lib/cache", () => ({
+  getCachedAgentList: (...args: unknown[]) => getCachedAgentListMock(...args),
+}));
+
+vi.mock("@/lib/inbox/d1-reads", () => ({
+  getRecentGlobalInboxEventsFromD1: (...args: unknown[]) =>
+    getRecentGlobalInboxEventsFromD1Mock(...args),
+}));
+
+import { buildActivityData } from "../activity";
+
+const kv = {} as KVNamespace;
+const db = {} as D1Database;
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const iso = (offsetMs: number) => new Date(Date.now() - offsetMs).toISOString();
+
+function agent(overrides: Partial<CachedAgent>): CachedAgent {
+  return {
+    stxAddress: "SP_DEFAULT",
+    btcAddress: "bc1_default",
+    stxPublicKey: "",
+    btcPublicKey: "",
+    taprootAddress: null,
+    displayName: null,
+    description: null,
+    bnsName: null,
+    owner: null,
+    verifiedAt: iso(200 * DAY_MS),
+    lastActiveAt: null,
+    erc8004AgentId: null,
+    nostrPublicKey: null,
+    lastIdentityCheck: null,
+    referredBy: null,
+    githubUsername: null,
+    level: 1,
+    levelName: "Registered",
+    messageCount: 0,
+    unreadCount: 0,
+    ...overrides,
+  } as CachedAgent;
+}
+
+function message(overrides: Partial<InboxMessage>): InboxMessage {
+  return {
+    messageId: "msg_default",
+    fromAddress: "SP_SENDER",
+    toBtcAddress: "bc1_recipient",
+    toStxAddress: "SP_RECIPIENT",
+    content: "hello",
+    paymentSatoshis: 100,
+    sentAt: iso(60 * 1000),
+    authenticated: true,
+    ...overrides,
+  } as InboxMessage;
+}
+
+function cacheSnapshot(agents: CachedAgent[]): CachedAgentList {
+  return {
+    agents,
+    stats: {
+      total: agents.length,
+      genesisCount: agents.filter((a) => a.level >= 2).length,
+      messageCount: agents.reduce((sum, a) => sum + a.messageCount, 0),
+    },
+    cachedAt: new Date().toISOString(),
+  };
+}
+
+beforeEach(() => {
+  getCachedAgentListMock.mockReset();
+  getRecentGlobalInboxEventsFromD1Mock.mockReset();
+  getRecentGlobalInboxEventsFromD1Mock.mockResolvedValue([]);
+});
+
+describe("buildActivityData", () => {
+  it("surfaces a message to a dormant recipient (the #1058 blind spot)", async () => {
+    const sender = agent({
+      stxAddress: "SP_SENDER",
+      btcAddress: "bc1_sender",
+      displayName: "Tiny Marten",
+      lastActiveAt: iso(60 * 1000),
+    });
+    // Recipient has not checked in for a year. Under the old top-20-active
+    // fan-out this message could never appear in the feed.
+    const dormant = agent({
+      stxAddress: "SP_DORMANT",
+      btcAddress: "bc1_dormant",
+      displayName: "Dormant Agent",
+      lastActiveAt: iso(365 * DAY_MS),
+    });
+
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot([sender, dormant]));
+    getRecentGlobalInboxEventsFromD1Mock.mockResolvedValue([
+      message({
+        messageId: "msg_outreach",
+        fromAddress: "SP_SENDER",
+        toBtcAddress: "bc1_dormant",
+      }),
+    ]);
+
+    const data = await buildActivityData(kv, db);
+
+    const event = data.events.find((e) => e.messageId === "msg_outreach");
+    expect(event).toBeDefined();
+    expect(event?.agent.displayName).toBe("Tiny Marten");
+    expect(event?.recipient?.displayName).toBe("Dormant Agent");
+    expect(event?.recipient?.btcAddress).toBe("bc1_dormant");
+  });
+
+  it("queries messages once globally rather than fanning out per agent", async () => {
+    const agents = Array.from({ length: 30 }, (_, i) =>
+      agent({
+        stxAddress: `SP_${i}`,
+        btcAddress: `bc1_${i}`,
+        lastActiveAt: iso(i * 1000),
+      })
+    );
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot(agents));
+
+    await buildActivityData(kv, db);
+
+    expect(getRecentGlobalInboxEventsFromD1Mock).toHaveBeenCalledTimes(1);
+    expect(getRecentGlobalInboxEventsFromD1Mock).toHaveBeenCalledWith(db, 40);
+  });
+
+  it("falls back to raw addresses when either side is unregistered", async () => {
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot([]));
+    getRecentGlobalInboxEventsFromD1Mock.mockResolvedValue([
+      message({
+        messageId: "msg_stranger",
+        fromAddress: "SP_UNKNOWN",
+        toBtcAddress: "bc1_unknown",
+      }),
+    ]);
+
+    const data = await buildActivityData(kv, db);
+
+    expect(data.events[0].agent.btcAddress).toBe("SP_UNKNOWN");
+    expect(data.events[0].agent.displayName).toBe("Unknown Agent");
+    expect(data.events[0].recipient?.displayName).toBe("bc1_unknown");
+  });
+
+  it("includes registrations from the last 30 days and excludes older ones", async () => {
+    const fresh = agent({
+      btcAddress: "bc1_fresh",
+      displayName: "Fresh Agent",
+      verifiedAt: iso(2 * DAY_MS),
+    });
+    const old = agent({
+      btcAddress: "bc1_old",
+      displayName: "Old Agent",
+      verifiedAt: iso(90 * DAY_MS),
+    });
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot([fresh, old]));
+
+    const data = await buildActivityData(kv, db);
+
+    const registrations = data.events.filter((e) => e.type === "registration");
+    expect(registrations.map((e) => e.agent.btcAddress)).toEqual(["bc1_fresh"]);
+  });
+
+  it("returns events newest-first, capped at 40", async () => {
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot([]));
+    getRecentGlobalInboxEventsFromD1Mock.mockResolvedValue(
+      Array.from({ length: 40 }, (_, i) =>
+        message({ messageId: `msg_${i}`, sentAt: iso(i * 60 * 1000) })
+      )
+    );
+
+    const data = await buildActivityData(kv, db);
+
+    expect(data.events).toHaveLength(40);
+    const timestamps = data.events.map((e) => Date.parse(e.timestamp));
+    expect(timestamps).toEqual([...timestamps].sort((a, b) => b - a));
+  });
+
+  it("still returns stats when the D1 read yields nothing (fail-open)", async () => {
+    const agents = [
+      agent({ btcAddress: "bc1_a", lastActiveAt: iso(DAY_MS), messageCount: 3 }),
+      agent({ btcAddress: "bc1_b", lastActiveAt: iso(30 * DAY_MS), messageCount: 1 }),
+    ];
+    getCachedAgentListMock.mockResolvedValue(cacheSnapshot(agents));
+
+    const data = await buildActivityData(kv, undefined);
+
+    expect(data.stats.totalAgents).toBe(2);
+    expect(data.stats.activeAgents).toBe(1);
+    expect(data.stats.totalMessages).toBe(4);
+    expect(data.stats.totalSatsTransacted).toBe(400);
+  });
+});

--- a/lib/activity.ts
+++ b/lib/activity.ts
@@ -12,31 +12,45 @@
  * returns live events. `db` is optional — when undefined the per-agent event
  * collection returns empty (fail-open; stats from the agent-list cache still
  * render correctly).
+ *
+ * Issue #1058: the message half of the feed is now a single global query
+ * instead of a fan-out over the top-20 most-recently-active recipients. See
+ * `buildActivityData` for why.
  */
 
 import type { InboxMessage } from "@/lib/inbox/types";
 import { INBOX_PRICE_SATS } from "@/lib/inbox/constants";
-import { getRecentInboxEventsFromD1 } from "@/lib/inbox/d1-reads";
+import { getRecentGlobalInboxEventsFromD1 } from "@/lib/inbox/d1-reads";
 import { getCachedAgentList } from "@/lib/cache";
 import type { ActivityEvent, ActivityResponse } from "@/app/components/activity-shared";
 
 const MAX_EVENTS = 40;
-const TOP_ACTIVE_AGENTS = 20;
 const ACTIVE_DAYS_THRESHOLD = 7;
+const REGISTRATION_WINDOW_DAYS = 30;
 
 /**
  * Assemble activity data using the shared agent-list cache.
  *
- * Uses getCachedAgentList() (single KV read on cache hit) instead of
- * an independent O(N) KV scan. Per-agent event detail fetches use D1
- * (`getRecentInboxEventsFromD1`) instead of the frozen-at-Step-4 KV index
- * reads — O(20) D1 queries each selecting up to 3 rows, rather than
- * O(20 * 1 KV + 20 * 3 KV). When `db` is undefined the event collection
- * falls back to empty (fail-open), but stats still render from the cache.
+ * Uses getCachedAgentList() (single KV read on cache hit) for stats and for
+ * resolving addresses to display names. Message events come from one global
+ * D1 query (`getRecentGlobalInboxEventsFromD1`).
+ *
+ * The previous shape collected messages by fanning out over the 20
+ * most-recently-active agents and reading each one's 3 newest inbound
+ * messages. That made the feed recipient-scoped: a message sent *to* a
+ * dormant agent (reactivation outreach, say) could never appear, because
+ * its recipient never made the top-20 cut. Reported as "the feed is frozen"
+ * (#1058), since a quiet stretch among the currently-active 20 pins the
+ * newest visible event in place while messages keep landing elsewhere.
+ * Taking the newest N messages network-wide removes both the blind spot and
+ * the 20-query fan-out.
+ *
+ * Registrations likewise come from the whole agent list within
+ * REGISTRATION_WINDOW_DAYS rather than from the top-20 slice.
  *
  * @param kv - VERIFIED_AGENTS KV namespace (agent-list cache layer)
  * @param db - D1 database binding for live inbox event reads (#746).
- *   Pass undefined to skip per-agent event collection (fail-open).
+ *   Pass undefined to skip message events (fail-open).
  */
 export async function buildActivityData(kv: KVNamespace, db?: D1Database): Promise<ActivityResponse> {
   // --- 1. Get agent data from the shared cache (single KV read on hit) ---
@@ -44,6 +58,7 @@ export async function buildActivityData(kv: KVNamespace, db?: D1Database): Promi
 
   const now = Date.now();
   const activeCutoff = now - ACTIVE_DAYS_THRESHOLD * 24 * 60 * 60 * 1000;
+  const registrationCutoff = now - REGISTRATION_WINDOW_DAYS * 24 * 60 * 60 * 1000;
 
   // Derive stats from cached agent list
   const activeAgents = cachedAgents.filter((agent) => {
@@ -56,76 +71,56 @@ export async function buildActivityData(kv: KVNamespace, db?: D1Database): Promi
   const totalMessages = agentStats.messageCount;
   const totalSatsTransacted = totalMessages * INBOX_PRICE_SATS;
 
-  // --- 2. Identify top 20 active agents for event collection ---
-  const sortedAgents = [...cachedAgents]
-    .filter((a) => a.lastActiveAt)
-    .sort((a, b) => {
-      const aTime = new Date(a.lastActiveAt!).getTime();
-      const bTime = new Date(b.lastActiveAt!).getTime();
-      return bTime - aTime;
-    })
-    .slice(0, TOP_ACTIVE_AGENTS);
-
-  // --- 3. Precompute agent lookup map for O(1) sender resolution ---
+  // --- 2. Address → agent maps for O(1) display-name resolution ---
+  // Senders are identified by STX address on the message row, recipients by
+  // BTC address. Both sides may be unregistered, hence the fallbacks below.
   const agentByStx = new Map(cachedAgents.map((a) => [a.stxAddress, a]));
+  const agentByBtc = new Map(cachedAgents.map((a) => [a.btcAddress, a]));
 
-  // --- 4. Collect events from top active agents ---
-  // O(TOP_ACTIVE_AGENTS) D1 queries, each selecting up to 3 rows.
-  // Replaces the two-step KV pattern (inbox:agent:{btcAddress} index read +
-  // per-message inbox:message:{id} reads) that served frozen-at-Step-4 data.
-  // When db is undefined, per-agent message events are empty (fail-open).
-  const eventPromises = sortedAgents.map(async (agent) => {
-    const agentEvents: ActivityEvent[] = [];
+  // --- 3. Message events: newest MAX_EVENTS network-wide, one D1 query ---
+  // Returns [] when db is undefined or on D1 error (fail-open).
+  const messages: InboxMessage[] = await getRecentGlobalInboxEventsFromD1(db, MAX_EVENTS);
 
-    // Fetch 3 most recent inbound messages for this agent from D1.
-    // Returns [] when db is undefined or on D1 error (fail-open).
-    const messages: InboxMessage[] = await getRecentInboxEventsFromD1(db, agent.btcAddress, 3);
+  const messageEvents: ActivityEvent[] = messages.map((message) => {
+    const senderAgent = agentByStx.get(message.fromAddress);
+    const recipientAgent = agentByBtc.get(message.toBtcAddress);
 
-    // Add message events
-    for (const message of messages) {
-      // Find sender agent for display name (O(1) Map lookup)
-      const senderAgent = agentByStx.get(message.fromAddress);
-
-      agentEvents.push({
-        type: "message",
-        timestamp: message.sentAt,
-        agent: {
-          btcAddress: senderAgent?.btcAddress || message.fromAddress,
-          displayName: senderAgent?.displayName || "Unknown Agent",
-        },
-        recipient: {
-          btcAddress: agent.btcAddress,
-          displayName: agent.displayName || agent.btcAddress,
-        },
-        paymentSatoshis: message.paymentSatoshis,
-        messagePreview: message.content.length > 80
-          ? message.content.slice(0, 80) + "…"
-          : message.content,
-        messageId: message.messageId,
-      });
-    }
-
-    // Add registration event (if agent recently verified)
-    const verifiedTime = new Date(agent.verifiedAt).getTime();
-    const daysSinceVerified = (now - verifiedTime) / (1000 * 60 * 60 * 24);
-    if (daysSinceVerified <= 30) {
-      agentEvents.push({
-        type: "registration",
-        timestamp: agent.verifiedAt,
-        agent: {
-          btcAddress: agent.btcAddress,
-          displayName: agent.displayName || agent.btcAddress,
-        },
-      });
-    }
-
-    return agentEvents;
+    return {
+      type: "message",
+      timestamp: message.sentAt,
+      agent: {
+        btcAddress: senderAgent?.btcAddress || message.fromAddress,
+        displayName: senderAgent?.displayName || "Unknown Agent",
+      },
+      recipient: {
+        btcAddress: message.toBtcAddress,
+        displayName: recipientAgent?.displayName || message.toBtcAddress,
+      },
+      paymentSatoshis: message.paymentSatoshis,
+      messagePreview: message.content.length > 80
+        ? message.content.slice(0, 80) + "…"
+        : message.content,
+      messageId: message.messageId,
+    };
   });
 
-  const allEvents = (await Promise.all(eventPromises)).flat();
+  // --- 4. Registration events: every agent verified in the last 30 days ---
+  const registrationEvents: ActivityEvent[] = cachedAgents
+    .filter((agent) => {
+      const verifiedTime = new Date(agent.verifiedAt).getTime();
+      return !Number.isNaN(verifiedTime) && verifiedTime >= registrationCutoff;
+    })
+    .map((agent) => ({
+      type: "registration" as const,
+      timestamp: agent.verifiedAt,
+      agent: {
+        btcAddress: agent.btcAddress,
+        displayName: agent.displayName || agent.btcAddress,
+      },
+    }));
 
   // Sort all events by timestamp descending, take top N
-  const sortedEvents = allEvents
+  const sortedEvents = [...messageEvents, ...registrationEvents]
     .sort((a, b) => {
       const aTime = new Date(a.timestamp).getTime();
       const bTime = new Date(b.timestamp).getTime();

--- a/lib/inbox/__tests__/d1-reads.test.ts
+++ b/lib/inbox/__tests__/d1-reads.test.ts
@@ -30,7 +30,7 @@ import {
   getReplyForMessageFromD1,
   getAgentInboxFromD1,
   getSentIndexFromD1,
-  getRecentInboxEventsFromD1,
+  getRecentGlobalInboxEventsFromD1,
   checkRedeemedTxidInD1,
 } from "../d1-reads";
 
@@ -761,17 +761,17 @@ describe("getSentIndexFromD1", () => {
   });
 });
 
-// ── getRecentInboxEventsFromD1 (Phase 2.5 #746) ───────────────────────────────
+// ── getRecentGlobalInboxEventsFromD1 (activity feed, #1058) ────────────────
 
-describe("getRecentInboxEventsFromD1", () => {
+describe("getRecentGlobalInboxEventsFromD1", () => {
   it("returns empty array immediately when db is undefined (fail-open)", async () => {
-    const result = await getRecentInboxEventsFromD1(undefined, BTC_ADDRESS, 3);
+    const result = await getRecentGlobalInboxEventsFromD1(undefined, 40);
     expect(result).toEqual([]);
   });
 
-  it("returns InboxMessage[] for the agent when rows exist", async () => {
+  it("returns InboxMessage[] when rows exist", async () => {
     const db = createMockD1([INBOUND_ROW]);
-    const result = await getRecentInboxEventsFromD1(db, BTC_ADDRESS, 3);
+    const result = await getRecentGlobalInboxEventsFromD1(db, 40);
     expect(result).toHaveLength(1);
     expect(result[0].messageId).toBe(INBOUND_ROW.message_id);
     expect(result[0].content).toBe(INBOUND_ROW.content);
@@ -779,7 +779,7 @@ describe("getRecentInboxEventsFromD1", () => {
 
   it("returns empty array when no rows", async () => {
     const db = createMockD1([]);
-    const result = await getRecentInboxEventsFromD1(db, BTC_ADDRESS, 3);
+    const result = await getRecentGlobalInboxEventsFromD1(db, 40);
     expect(result).toEqual([]);
   });
 
@@ -788,27 +788,28 @@ describe("getRecentInboxEventsFromD1", () => {
       prepare: vi.fn().mockImplementation(() => { throw new Error("D1 unavailable"); }),
       batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
     } as unknown as D1Database;
-    const result = await getRecentInboxEventsFromD1(db, BTC_ADDRESS, 3);
+    const result = await getRecentGlobalInboxEventsFromD1(db, 40);
     expect(result).toEqual([]);
   });
 
-  it("SQL queries to_btc_address = ? AND is_reply = 0 ORDER BY sent_at DESC LIMIT ?", async () => {
+  it("SQL is unscoped by recipient: WHERE is_reply = 0 ORDER BY sent_at DESC LIMIT ?", async () => {
     const stmtMock = createPreparedStatement([INBOUND_ROW]);
     const db = {
       prepare: vi.fn().mockReturnValue(stmtMock),
       batch: vi.fn(), dump: vi.fn(), exec: vi.fn(),
     } as unknown as D1Database;
 
-    await getRecentInboxEventsFromD1(db, BTC_ADDRESS, 3);
+    await getRecentGlobalInboxEventsFromD1(db, 40);
     const sql: string = (db.prepare as ReturnType<typeof vi.fn>).mock.calls[0][0];
-    expect(sql).toContain("WHERE to_btc_address = ?");
-    expect(sql).toContain("AND is_reply = 0");
+    // The #1058 regression guard: no recipient predicate, so a message to a
+    // dormant agent is as visible as one to an active agent.
+    expect(sql).not.toContain("to_btc_address = ?");
+    expect(sql).toContain("WHERE is_reply = 0");
     expect(sql).toContain("ORDER BY sent_at DESC");
     expect(sql).toContain("LIMIT ?");
 
     const bindArgs: unknown[] = stmtMock.bind.mock.calls[0];
-    expect(bindArgs[0]).toBe(BTC_ADDRESS);
-    expect(bindArgs[1]).toBe(3); // limit
+    expect(bindArgs[0]).toBe(40); // limit is the only bound param
   });
 });
 
@@ -880,7 +881,7 @@ describe("cache-key invariants (structural verification)", () => {
     // Phase 2.5 #746 enrichment helpers (db is optional — fail-open when undefined)
     expect(getAgentInboxFromD1.length).toBe(2);       // (db, btcAddress)
     expect(getSentIndexFromD1.length).toBe(2);         // (db, btcAddress)
-    expect(getRecentInboxEventsFromD1.length).toBe(3); // (db, btcAddress, limit)
+    expect(getRecentGlobalInboxEventsFromD1.length).toBe(2); // (db, limit)
     // Phase 2.5 Step 4 double-redemption guard
     expect(checkRedeemedTxidInD1.length).toBe(2);      // (db, paymentTxid)
   });

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -532,58 +532,9 @@ export async function getSentIndexFromD1(
 // ---------------------------------------------------------------------------
 
 /**
- * Fetch the N most recent inbound messages for an agent from D1.
- *
- * Phase 2.5 #746 — replaces the two-step KV pattern in lib/activity.ts:
- *   1. kv.get(`inbox:agent:${btcAddress}`)  → get messageIds array
- *   2. kv.get(`inbox:message:${id}`)        → fetch each message
- *
- * This consolidates into a single SELECT … ORDER BY sent_at DESC LIMIT ?.
- * The SQL path hits the `idx_inbox_to_btc_sent_at` partial index
- * (on `inbox_messages(to_btc_address, sent_at DESC) WHERE is_reply = 0`).
- *
- * Returns empty array when `db` is undefined, no messages exist, or on D1
- * error (fail-open — activity feed gracefully degrades to no events).
- *
- * SQL:
- *   SELECT … FROM inbox_messages
- *   WHERE to_btc_address = ? AND is_reply = 0
- *   ORDER BY sent_at DESC
- *   LIMIT ?
- */
-export async function getRecentInboxEventsFromD1(
-  db: D1Database | undefined,
-  btcAddress: string,
-  limit: number
-): Promise<InboxMessage[]> {
-  if (!db) return [];
-  try {
-    const sql = `
-      SELECT
-        message_id, from_stx_address, to_btc_address, to_stx_address,
-        content, payment_txid, payment_satoshis, payment_status,
-        payment_id, receipt_id, recovered_via_txid, authenticated,
-        bitcoin_signature, sender_btc_address,
-        sent_at, read_at, replied_at, reply_to_message_id
-      FROM inbox_messages
-      WHERE to_btc_address = ? AND is_reply = 0
-      ORDER BY sent_at DESC
-      LIMIT ?
-    `;
-    const result = await db
-      .prepare(sql)
-      .bind(btcAddress, limit)
-      .all<D1InboxRow>();
-    return (result.results ?? []).map(rowToInboxMessage);
-  } catch {
-    return [];
-  }
-}
-
-/**
  * Fetch the N most recent inbound messages across the whole network.
  *
- * Issue #1058: the activity feed used to fan out `getRecentInboxEventsFromD1`
+ * Issue #1058: the activity feed used to fan out a per-recipient query
  * over the top-20 most-recently-active agents, which made it a
  * "recent messages to currently-active recipients" feed rather than a network
  * feed: a message sent to a dormant agent could never appear, no matter how

--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -579,3 +579,51 @@ export async function getRecentInboxEventsFromD1(
     return [];
   }
 }
+
+/**
+ * Fetch the N most recent inbound messages across the whole network.
+ *
+ * Issue #1058: the activity feed used to fan out `getRecentInboxEventsFromD1`
+ * over the top-20 most-recently-active agents, which made it a
+ * "recent messages to currently-active recipients" feed rather than a network
+ * feed: a message sent to a dormant agent could never appear, no matter how
+ * fresh it was. That looked from the outside like a frozen cache.
+ *
+ * One global ordered scan replaces the 20-query fan-out. Served by
+ * `idx_inbox_sent_at` (migration 023) on `inbox_messages(sent_at DESC)
+ * WHERE is_reply = 0`, so it seeks the newest rows instead of scanning the
+ * table and sorting.
+ *
+ * Returns empty array when `db` is undefined or on D1 error (fail-open:
+ * the activity feed degrades to stats-only).
+ *
+ * SQL:
+ *   SELECT … FROM inbox_messages
+ *   WHERE is_reply = 0
+ *   ORDER BY sent_at DESC
+ *   LIMIT ?
+ */
+export async function getRecentGlobalInboxEventsFromD1(
+  db: D1Database | undefined,
+  limit: number
+): Promise<InboxMessage[]> {
+  if (!db) return [];
+  try {
+    const sql = `
+      SELECT
+        message_id, from_stx_address, to_btc_address, to_stx_address,
+        content, payment_txid, payment_satoshis, payment_status,
+        payment_id, receipt_id, recovered_via_txid, authenticated,
+        bitcoin_signature, sender_btc_address,
+        sent_at, read_at, replied_at, reply_to_message_id
+      FROM inbox_messages
+      WHERE is_reply = 0
+      ORDER BY sent_at DESC
+      LIMIT ?
+    `;
+    const result = await db.prepare(sql).bind(limit).all<D1InboxRow>();
+    return (result.results ?? []).map(rowToInboxMessage);
+  } catch {
+    return [];
+  }
+}

--- a/migrations/023_inbox_global_sent_at_index.sql
+++ b/migrations/023_inbox_global_sent_at_index.sql
@@ -1,0 +1,14 @@
+-- Migration 023: global activity-feed index on inbox_messages (issue #1058).
+--
+-- /api/activity now takes the N newest inbound messages network-wide in one
+-- query instead of fanning out over the top-20 most-recently-active
+-- recipients. Every existing inbox index leads with an address column
+-- (to_btc_address / from_btc_address / from_stx_address), so an unqualified
+--   SELECT … WHERE is_reply = 0 ORDER BY sent_at DESC LIMIT 40
+-- planned as SCAN inbox_messages + temp B-tree sort (~13k rows read per
+-- rebuild, every 2 minutes).
+--
+-- Partial on is_reply = 0 because the feed only ever surfaces inbound
+-- messages; replies are excluded and keep their own index.
+CREATE INDEX IF NOT EXISTS idx_inbox_sent_at
+  ON inbox_messages (sent_at DESC) WHERE is_reply = 0;


### PR DESCRIPTION
Closes #1058

## The report

`/api/activity` looked frozen: newest event ~19h old while `x-cache: MISS` proved the route rebuilt on every request, and four confirmed on-chain sends from Tiny Marten were nowhere in the feed. The issue guessed a stuck `getCachedAgentList` SWR snapshot or a wedged `BUILDING_KEY` lock.

## What it actually was

The caches were fine. The sampling was wrong. Verified against prod D1:

1. D1 held 5 inbound messages newer than anything the feed showed, including all 4 Tiny Marten sends.
2. The feed's newest visible event, `2026-08-17T13:34:22.746Z`, was exactly the newest message whose recipient sat in the top-20-most-recently-active agents. Every newer message went to a recipient outside that window.
3. Two fetches minutes apart returned different newest events (13:34 yesterday, then 03:41 today) with no deploy in between, because Tiny Marten rotated into the top-20. Nothing frozen behaves that way.

`buildActivityData` collected message events by fanning out over the 20 most-recently-active agents and reading each one's 3 newest inbound messages. That made `/api/activity` a "recent messages to whoever checked in most recently" feed rather than a network feed. Over 20 agents check in within any given 5-minute stretch here, so that window is minutes wide, and a message to anyone outside it is invisible permanently. Reactivation outreach, the case that surfaced this, could never appear by construction.

The "freeze" and the "separate design gap" in the issue are the same defect.

## Changes

- `lib/activity.ts`: message events come from one global query for the newest 40 inbound messages network-wide. Registrations come from the whole agent list within the 30-day window instead of the top-20 slice. Display names still resolve off the shared agent-list cache, now keyed by STX (sender) and BTC (recipient), falling back to the raw address when a counterparty is not registered.
- `lib/inbox/d1-reads.ts`: new `getRecentGlobalInboxEventsFromD1`.
- `migrations/023_inbox_global_sent_at_index.sql`: `inbox_messages(sent_at DESC) WHERE is_reply = 0`. Every existing inbox index leads with an address column, so an unqualified `ORDER BY sent_at` planned as a table scan plus temp B-tree sort (~13k rows read per rebuild, every 2 minutes). Read cost drops from 20 indexed queries to one.
- `lib/inbox/d1-reads.ts`: removed `getRecentInboxEventsFromD1`. It existed only to serve the top-20 fan-out and had no production callers left once that was gone, just its own tests. Coverage moved to `getRecentGlobalInboxEventsFromD1`, including a guard that the SQL carries no recipient predicate.
- `?docs=1` now states the endpoint takes no filter or paging params, since `?address` / `?btcAddress` / `?agent` were silently ignored. Per-agent views belong to `/api/inbox/:address`.

## Tests

6 new tests in `lib/__tests__/activity.test.ts`, including the dormant-recipient blind spot, the single-global-query assertion, unregistered-counterparty fallbacks, the 30-day registration window, ordering and the 40-event cap, and stats fail-open when D1 is absent. All 14 activity tests pass; typecheck clean on changed files.

## Deploy note

Migration 023 is **not** applied yet. It needs `wrangler d1 migrations apply landing-page --remote` before or with the deploy. Without the index the feed is still correct, just a ~13k-row scan per rebuild.