### PR TITLE
fix(migrations): renumber the activity-feed index to 026

### DIFF
--- a/lib/inbox/d1-reads.ts
+++ b/lib/inbox/d1-reads.ts
@@ -541,7 +541,7 @@ export async function getSentIndexFromD1(
  * fresh it was. That looked from the outside like a frozen cache.
  *
  * One global ordered scan replaces the 20-query fan-out. Served by
- * `idx_inbox_sent_at` (migration 023) on `inbox_messages(sent_at DESC)
+ * `idx_inbox_sent_at` (migration 026) on `inbox_messages(sent_at DESC)
  * WHERE is_reply = 0`, so it seeks the newest rows instead of scanning the
  * table and sorting.
  *

--- a/migrations/026_inbox_global_sent_at_index.sql
+++ b/migrations/026_inbox_global_sent_at_index.sql
@@ -1,4 +1,4 @@
--- Migration 023: global activity-feed index on inbox_messages (issue #1058).
+-- Migration 026: global activity-feed index on inbox_messages (issue #1058).
 --
 -- /api/activity now takes the N newest inbound messages network-wide in one
 -- query instead of fanning out over the top-20 most-recently-active


### PR DESCRIPTION
Follow-up to #1059.

That PR added `migrations/023_inbox_global_sent_at_index.sql`, but 023 is already taken by `023_legion_snapshot.sql`, which is applied in prod (`d1_migrations` is at 025). Two files sharing a number breaks the ordering wrangler applies migrations in.

Renamed to `026_inbox_global_sent_at_index.sql`. Contents are unchanged apart from the header comment and the one docstring reference in `lib/inbox/d1-reads.ts`. Nothing had been applied to the database yet, so there is no bookkeeping to unwind.