### PR TITLE
fix(bounties): exclude abandoned from the default active filter

### DIFF
--- a/lib/bounty/__tests__/status-sql.test.ts
+++ b/lib/bounty/__tests__/status-sql.test.ts
@@ -1,0 +1,145 @@
+/**
+ * `statusToSql()` compiles a status filter to a SQL predicate, while
+ * `bountyStatus()` derives the same status in TS. The two must agree, or the
+ * board shows rows whose rendered status contradicts the filter that fetched
+ * them.
+ *
+ * These tests evaluate each SQL predicate in JS against representative records
+ * and assert the result matches `bountyStatus()`. That is the invariant that
+ * broke: `active` was `cancelled_at IS NULL AND paid_at IS NULL`, which admits
+ * `abandoned` (terminal, but both fields NULL).
+ */
+
+import { describe, it, expect } from "vitest";
+import { bountyStatus, type BountyRecord, type BountyStatus } from "../types";
+import { statusToSql } from "../d1-helpers";
+import { ACCEPT_GRACE_MS, PAY_GRACE_MS } from "../constants";
+
+const NOW = new Date("2026-09-01T00:00:00.000Z");
+const t = NOW.getTime();
+const iso = (ms: number) => new Date(ms).toISOString();
+
+function rec(over: Partial<BountyRecord>): BountyRecord {
+  return {
+    id: "b1",
+    posterBtcAddress: "bc1qposter",
+    posterStxAddress: "SPPOSTER",
+    title: "t",
+    description: "d",
+    rewardSats: 1000,
+    submissionCount: 0,
+    createdAt: iso(t - 60 * 86_400_000),
+    expiresAt: iso(t + 86_400_000),
+    updatedAt: iso(t),
+    ...over,
+  };
+}
+
+/** The six canonical records, one per derived status. */
+const FIXTURES: Record<BountyStatus, BountyRecord> = {
+  open: rec({ expiresAt: iso(t + 86_400_000) }),
+  judging: rec({ expiresAt: iso(t - 86_400_000) }),
+  "winner-announced": rec({
+    expiresAt: iso(t - 86_400_000),
+    acceptedAt: iso(t - 86_400_000),
+    acceptedSubmissionId: "s1",
+  }),
+  paid: rec({
+    expiresAt: iso(t - 86_400_000),
+    acceptedAt: iso(t - 86_400_000),
+    acceptedSubmissionId: "s1",
+    paidAt: iso(t - 3_600_000),
+    paidTxid: "0xabc",
+  }),
+  abandoned: rec({ expiresAt: iso(t - ACCEPT_GRACE_MS - 86_400_000) }),
+  cancelled: rec({ cancelledAt: iso(t - 86_400_000) }),
+};
+
+/**
+ * Evaluate a `statusToSql` predicate in JS. Supports exactly the operators the
+ * bounty predicates use, positionally binding `?` in source order.
+ */
+function evalSql(sql: string, bindings: string[], b: BountyRecord): boolean {
+  const col: Record<string, string | null> = {
+    cancelled_at: b.cancelledAt ?? null,
+    paid_at: b.paidAt ?? null,
+    accepted_at: b.acceptedAt ?? null,
+    expires_at: b.expiresAt,
+  };
+  let i = 0;
+  const js = sql
+    .replace(/(\w+) IS NOT NULL/g, (_m, c) => JSON.stringify(col[c] !== null))
+    .replace(/(\w+) IS NULL/g, (_m, c) => JSON.stringify(col[c] === null))
+    .replace(/(\w+)\s*(<=|>=|<|>)\s*\?/g, (_m, c, op) => {
+      const lhs = col[c];
+      const rhs = bindings[i++];
+      if (lhs === null) return "false";
+      const l = Date.parse(lhs);
+      const r = Date.parse(rhs);
+      const res = op === "<=" ? l <= r : op === ">=" ? l >= r : op === "<" ? l < r : l > r;
+      return JSON.stringify(res);
+    })
+    .replace(/\bAND\b/g, "&&")
+    .replace(/\bOR\b/g, "||");
+  return Function(`"use strict";return (${js});`)() as boolean;
+}
+
+const ALL: BountyStatus[] = [
+  "open",
+  "judging",
+  "winner-announced",
+  "paid",
+  "abandoned",
+  "cancelled",
+];
+
+describe("statusToSql agrees with bountyStatus", () => {
+  it("fixtures derive the status they are named for", () => {
+    for (const s of ALL) {
+      expect(bountyStatus(FIXTURES[s], NOW), `fixture ${s}`).toBe(s);
+    }
+  });
+
+  it.each(ALL)("status=%s matches exactly its own fixture", (target) => {
+    const { sql, bindings } = statusToSql(target, NOW);
+    for (const s of ALL) {
+      expect(evalSql(sql, bindings, FIXTURES[s]), `filter ${target} vs ${s}`).toBe(s === target);
+    }
+  });
+});
+
+describe("active", () => {
+  const { sql, bindings } = statusToSql("active", NOW);
+  const NON_TERMINAL: BountyStatus[] = ["open", "judging", "winner-announced"];
+  const TERMINAL: BountyStatus[] = ["paid", "abandoned", "cancelled"];
+
+  it.each(NON_TERMINAL)("includes %s", (s) => {
+    expect(evalSql(sql, bindings, FIXTURES[s])).toBe(true);
+  });
+
+  // The regression: `abandoned` is terminal but leaves cancelled_at and
+  // paid_at NULL, so the old predicate admitted it onto the live board.
+  it.each(TERMINAL)("excludes %s", (s) => {
+    expect(evalSql(sql, bindings, FIXTURES[s])).toBe(false);
+  });
+
+  it("excludes a bounty abandoned via an unpaid acceptance", () => {
+    const stale = rec({
+      expiresAt: iso(t - 30 * 86_400_000),
+      acceptedAt: iso(t - PAY_GRACE_MS - 86_400_000),
+      acceptedSubmissionId: "s1",
+    });
+    expect(bountyStatus(stale, NOW)).toBe("abandoned");
+    expect(evalSql(sql, bindings, stale)).toBe(false);
+  });
+
+  it("includes a bounty accepted just inside the pay grace window", () => {
+    const fresh = rec({
+      expiresAt: iso(t - 30 * 86_400_000),
+      acceptedAt: iso(t - PAY_GRACE_MS + 60_000),
+      acceptedSubmissionId: "s1",
+    });
+    expect(bountyStatus(fresh, NOW)).toBe("winner-announced");
+    expect(evalSql(sql, bindings, fresh)).toBe(true);
+  });
+});

--- a/lib/bounty/d1-helpers.ts
+++ b/lib/bounty/d1-helpers.ts
@@ -149,7 +149,16 @@ export function statusToSql(
     case "cancelled":
       return { sql: "cancelled_at IS NOT NULL", bindings: [] };
     case "active":
-      return { sql: "cancelled_at IS NULL AND paid_at IS NULL", bindings: [] };
+      // Non-terminal only: open + judging + winner-announced. `abandoned` is
+      // terminal but leaves cancelled_at and paid_at NULL, so it has to be
+      // excluded explicitly or dead bounties leak onto the live board.
+      // Written as the positive complement of the `abandoned` predicate above
+      // rather than a NOT(...) wrapper, so NULL accepted_at never yields NULL.
+      return {
+        sql:
+          "cancelled_at IS NULL AND paid_at IS NULL AND ((accepted_at IS NULL AND expires_at > ?) OR (accepted_at IS NOT NULL AND accepted_at > ?))",
+        bindings: [acceptCutoffIso, payCutoffIso],
+      };
     case undefined:
       return { sql: "1=1", bindings: [] };
   }


### PR DESCRIPTION
`statusToSql("active")` compiled to:

```sql
cancelled_at IS NULL AND paid_at IS NULL
```

It is documented as "non-terminal only", but `abandoned` is a terminal state that leaves **both** of those columns NULL, so abandoned bounties matched it.

`active` is the default when `GET /api/bounties` is called without a `status` param, so any API consumer taking the default was served dead bounties presented as live ones. On production right now that is 7 rows returned where only 2 are actually accepting work: 2 open plus 5 abandoned.

## The fix

Rewritten as the positive complement of the `abandoned` predicate rather than a `NOT (...)` wrapper, so a NULL `accepted_at` never makes the expression evaluate to NULL:

```sql
cancelled_at IS NULL AND paid_at IS NULL
AND ((accepted_at IS NULL AND expires_at > ?) OR (accepted_at IS NOT NULL AND accepted_at > ?))
```

That admits exactly `open` + `judging` + `winner-announced`.

## Test

Adds `lib/bounty/__tests__/status-sql.test.ts`. `statusToSql()` compiles a filter to SQL while `bountyStatus()` derives the same status in TypeScript, and the two must agree or the board renders rows whose status contradicts the filter that fetched them. That agreement was never pinned by a test, which is how this drifted.

The suite builds one fixture per derived status, evaluates each compiled predicate in JS against all six, and asserts the filter matches exactly its own fixture. Verified to fail on the old predicate (`× excludes abandoned`) and pass on the new one. 15 tests.

## Scope

Does not change the default. `active` remaining the default, and therefore `paid` and `cancelled` being hidden unless asked for, is deliberate and documented in the endpoint's self-doc. This only stops `active` from including a terminal state it claims to exclude.

The `/bounties` page is unaffected: it calls `listBounties` with no status filter at all, which hits the `undefined` branch (`1=1`) and fetches everything.

## Verification

1556 tests pass, lint clean, production build succeeds.