### PR TITLE
fix(bounties): tighten the card and detail type scale

### DIFF
--- a/app/bounties/BountyDirectory.tsx
+++ b/app/bounties/BountyDirectory.tsx
@@ -17,7 +17,7 @@ import AgentBadge from "./AgentBadge";
 import BitcoinMark from "../components/BitcoinMark";
 
 /** Excerpt length before a card falls back to "Read more". */
-const EXCERPT_CHARS = 210;
+const EXCERPT_CHARS = 165;
 
 function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
   const tags = bounty.tags ?? [];
@@ -32,14 +32,14 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
         terminal ? "opacity-65 hover:opacity-100" : ""
       }`}
     >
-      <div className="flex flex-1 flex-col gap-3 p-[22px] max-md:p-4">
+      <div className="flex flex-1 flex-col gap-2.5 p-[18px] max-md:p-4">
         <div className="flex items-center justify-between gap-3">
-          <span className={`inline-flex items-center gap-1.5 text-[13.5px] ${statusText(bounty.status)}`}>
+          <span className={`inline-flex items-center gap-1.5 text-[12.5px] ${statusText(bounty.status)}`}>
             <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
             {statusLabel(bounty.status)}
           </span>
           <span
-            className={`whitespace-nowrap text-[13.5px] ${
+            className={`whitespace-nowrap text-[12.5px] ${
               windowLabel === "Submissions closed" ? "text-rose-400/70" : "text-white/45"
             }`}
           >
@@ -50,21 +50,21 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
         {/* Full title — these run long ("Audit fakfun-wallet-v18: NEW
             smart-router trading…") and clamping cut the part that says what
             the job is. Two per row is what makes the room for it. */}
-        <h3 className="text-[21px] font-medium leading-[1.33] tracking-[-0.006em] text-pretty text-white">
+        <h3 className="text-[17px] font-medium leading-[1.35] tracking-[-0.004em] text-pretty text-white">
           {bounty.title}
         </h3>
 
         {/* The reward is the deciding number, so it gets display weight and
             every digit. No USD — sats are the unit the board pays in. */}
         <div className="flex items-baseline gap-2 tabular-nums">
-          <BitcoinMark size={24} className="shrink-0 self-center" />
-          <span className="text-[30px] font-medium leading-none tracking-[-0.022em] text-[#F7931A]">
+          <BitcoinMark size={18} className="shrink-0 self-center" />
+          <span className="text-[22px] font-medium leading-none tracking-[-0.018em] text-[#F7931A]">
             {formatSatsFull(bounty.rewardSats)}
           </span>
-          <span className="text-[14px] uppercase tracking-[0.09em] text-white/45">sats</span>
+          <span className="text-[12px] uppercase tracking-[0.08em] text-white/45">sats</span>
         </div>
 
-        <p className="text-[15.5px] leading-[1.65] text-white/[0.63]">
+        <p className="text-[14px] leading-[1.6] text-white/[0.63]">
           {excerpt.text}
           {excerpt.truncated && (
             <>
@@ -81,25 +81,25 @@ function BountyCard({ bounty }: { bounty: BountyWithStatus }) {
             {tags.slice(0, 4).map((tag) => (
               <span
                 key={tag}
-                className="rounded-md border border-white/[0.07] bg-white/[0.05] px-2 py-0.5 text-[12.5px] text-white/[0.63]"
+                className="rounded-md border border-white/[0.07] bg-white/[0.05] px-2 py-0.5 text-[11.5px] text-white/[0.63]"
               >
                 {tag}
               </span>
             ))}
             {tags.length > 4 && (
-              <span className="px-1 text-[12.5px] text-white/40">+{tags.length - 4}</span>
+              <span className="px-1 text-[11.5px] text-white/40">+{tags.length - 4}</span>
             )}
           </div>
         )}
       </div>
 
-      <div className="flex items-center gap-2.5 border-t border-white/[0.05] bg-white/[0.02] px-[22px] py-3.5 max-md:px-4">
+      <div className="flex items-center gap-2.5 border-t border-white/[0.05] bg-white/[0.02] px-[18px] py-3 max-md:px-4">
         <AgentBadge
           address={bounty.posterBtcAddress}
           name={bounty.posterDisplayName}
-          textClass="text-white/[0.63] text-[14.5px]"
+          textClass="text-white/[0.63] text-[13px]"
         />
-        <span className="ml-auto whitespace-nowrap text-[14.5px] tabular-nums text-white/[0.63]">
+        <span className="ml-auto whitespace-nowrap text-[13px] tabular-nums text-white/[0.63]">
           {bounty.submissionCount > 0 ? (
             <>
               {bounty.submissionCount} submission{bounty.submissionCount !== 1 ? "s" : ""}
@@ -252,19 +252,19 @@ export default function BountyDirectory({
           ].map((tile) => (
             <div
               key={tile.key}
-              className="bg-gradient-to-br from-black/[0.55] to-black/[0.38] px-[18px] py-4 backdrop-blur-md"
+              className="bg-gradient-to-br from-black/[0.55] to-black/[0.38] px-4 py-3.5 backdrop-blur-md"
             >
-              <div className="text-[11.5px] uppercase tracking-[0.11em] text-white/45">
+              <div className="text-[10.5px] uppercase tracking-[0.11em] text-white/45">
                 {tile.key}
               </div>
               <div
-                className={`mt-1.5 flex items-center gap-1.5 text-[28px] font-medium tracking-[-0.012em] tabular-nums ${
+                className={`mt-1 flex items-center gap-1.5 text-[22px] font-medium tracking-[-0.012em] tabular-nums ${
                   tile.accent ? "text-[#F7931A]" : "text-white"
                 }`}
               >
-                {tile.mark && <BitcoinMark size={20} />}
+                {tile.mark && <BitcoinMark size={16} />}
                 {tile.value}
-                <small className="text-[13.5px] font-normal text-white/[0.63]">{tile.note}</small>
+                <small className="text-[12px] font-normal text-white/[0.63]">{tile.note}</small>
               </div>
             </div>
           ))}

--- a/app/bounties/BountyMarkdown.tsx
+++ b/app/bounties/BountyMarkdown.tsx
@@ -98,7 +98,7 @@ const components: Components = {
 
 export default function BountyMarkdown({ children }: { children: string }) {
   return (
-    <div className="text-[16.5px] leading-[1.72] text-white/[0.81]">
+    <div className="text-[15px] leading-[1.68] text-white/[0.78]">
       <ReactMarkdown remarkPlugins={[remarkGfm, remarkBreaks]} components={components}>
         {children}
       </ReactMarkdown>

--- a/app/bounties/[id]/BountyDetail.tsx
+++ b/app/bounties/[id]/BountyDetail.tsx
@@ -244,23 +244,23 @@ function BountyDetailView({
         <div className="flex flex-wrap items-start justify-between gap-x-7 gap-y-4">
           <div className="min-w-0 flex-1 basis-[460px]">
             <span
-              className={`inline-flex items-center gap-1.5 text-[13.5px] ${statusText(bounty.status)}`}
+              className={`inline-flex items-center gap-1.5 text-[12.5px] ${statusText(bounty.status)}`}
             >
               <span className="size-1.5 rounded-full bg-current" aria-hidden="true" />
               {statusLabel(bounty.status)}
             </span>
-            <h1 className="mt-3 break-words text-[30px] font-medium leading-[1.28] tracking-[-0.015em] text-pretty text-white max-md:text-2xl">
+            <h1 className="mt-2.5 break-words text-[23px] font-medium leading-[1.3] tracking-[-0.012em] text-pretty text-white max-md:text-xl">
               {bounty.title}
             </h1>
           </div>
           <div className="shrink-0 text-right">
             <div className="flex items-center justify-end gap-2 tabular-nums">
-              <BitcoinMark size={34} />
-              <span className="text-[40px] font-medium leading-none tracking-[-0.022em] text-[#F7931A]">
+              <BitcoinMark size={24} />
+              <span className="text-[28px] font-medium leading-none tracking-[-0.02em] text-[#F7931A]">
                 {formatSatsFull(bounty.rewardSats)}
               </span>
             </div>
-            <div className="mt-2 text-[12px] uppercase tracking-[0.1em] text-white/45">
+            <div className="mt-1.5 text-[11px] uppercase tracking-[0.1em] text-white/45">
               sats reward
             </div>
           </div>
@@ -270,24 +270,24 @@ function BountyDetailView({
         <div className="mt-5 flex flex-col gap-4 sm:flex-row sm:gap-10">
           {/* Submissions */}
           <div>
-            <div className="text-[11.5px] uppercase tracking-[0.11em] text-white/45">Submissions</div>
-            <div className="mt-1.5 text-[16.5px] tabular-nums text-white/85">{submissionCount}</div>
+            <div className="text-[10.5px] uppercase tracking-[0.11em] text-white/45">Submissions</div>
+            <div className="mt-1.5 text-[15px] tabular-nums text-white/85">{submissionCount}</div>
           </div>
 
           {/* Deadline — single countdown value (exact date on hover), kept to two
               lines so it matches Reward and Submissions. */}
           <div>
-            <div className="text-[11.5px] uppercase tracking-[0.11em] text-white/45">Deadline</div>
+            <div className="text-[10.5px] uppercase tracking-[0.11em] text-white/45">Deadline</div>
             {windowLabel ? (
               <div
-                className={`mt-1.5 text-[16.5px] ${submissionsClosed ? "text-rose-400/80" : "text-emerald-400"}`}
+                className={`mt-1.5 text-[15px] ${submissionsClosed ? "text-rose-400/80" : "text-emerald-400"}`}
                 title={new Date(bounty.expiresAt).toLocaleString()}
               >
                 {windowLabel}
               </div>
             ) : (
               <div
-                className="mt-1.5 text-[16.5px] text-white/85"
+                className="mt-1.5 text-[15px] text-white/85"
                 title={new Date(bounty.expiresAt).toLocaleString()}
               >
                 {formatDateOnly(bounty.expiresAt)}


### PR DESCRIPTION
Follow-up to #1064. The type scale there overshot and the cards ended up too large. This steps everything back about one notch, keeping the hierarchy (reward still leads, title still full, description still readable) while shrinking the box.

## Board card

| | Before | After |
|---|---|---|
| Title | 21px | 17px |
| Reward | 30px (mark 24) | 22px (mark 18) |
| Description | 15.5px | 14px |
| Status / date | 13.5px | 12.5px |
| Poster / submissions | 14.5px | 13px |
| Tags | 12.5px | 11.5px |
| Padding | 22px | 18px |
| Stat tiles | 28px | 22px |

Excerpt drops from 210 to 165 characters, so a card reaches "Read more" sooner and is shorter overall.

## Detail page

Title 30px to 23px, reward 40px to 28px (mark 34 to 24), metric labels 11.5px to 10.5px and values 16.5px to 15px.

`BountyMarkdown` body settles at 15px, down from 16.5px. Still well clear of the 13px it was before #1064, which failed contrast at `white/70`.

## Verification

75 tests pass across the bounty suites, lint clean, production build compiles.