### PR TITLE
fix(bounties): repair the metrics tiles

### DIFF
--- a/app/bounties/BountyDirectory.tsx
+++ b/app/bounties/BountyDirectory.tsx
@@ -233,7 +233,7 @@ export default function BountyDirectory({
           these sit directly on the artwork and need to hold their own ground,
           and the orange payout figure carries further against black. */}
       {stats.total > 0 && (
-        <div className="grid grid-cols-5 gap-px overflow-hidden rounded-xl border border-white/[0.07] bg-white/[0.07] max-lg:grid-cols-2 max-[420px]:grid-cols-1">
+        <div className="grid grid-cols-4 gap-px overflow-hidden rounded-xl border border-white/[0.07] bg-white/[0.07] max-lg:grid-cols-2 max-[420px]:grid-cols-1">
           {[
             {
               key: "Paid out",
@@ -262,7 +262,7 @@ export default function BountyDirectory({
                   tile.accent ? "text-[#F7931A]" : "text-white"
                 }`}
               >
-                {tile.mark && <BitcoinMark size={16} />}
+                {tile.mark && <BitcoinMark size={16} className="shrink-0" />}
                 {tile.value}
                 <small className="text-[12px] font-normal text-white/[0.63]">{tile.note}</small>
               </div>


### PR DESCRIPTION
Two bugs in the board's stat row, both introduced in #1064.

## Empty fifth cell

The grid was `grid-cols-5`, but only four tiles are supplied (Paid out, Bounties paid, Open now, Submissions), so the row rendered an empty cell on the end.

The preview this was built from had a fifth "agents competing" tile, which needs a distinct-submitter count that `page.tsx` does not load. Rather than add a query for it, the grid drops to `grid-cols-4`.

## Bitcoin mark invisible

The mark sits in a `flex items-center` row beside a long `tabular-nums` figure and was passed no `shrink-0`, so flex was free to shrink it to zero width. It never rendered.

The card's reward mark already passes `shrink-0`, which is exactly why the mark was visible there and not in the tiles.

## Verification

18 tests pass in the bounty suites, lint clean, production build compiles.